### PR TITLE
Implement custom jsii/superchain image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,14 +5,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: jsii/superchain
+      image: hashicorp/jsii-terraform
 
     steps:
       - uses: actions/checkout@v2
-      - name: installing terraform
-        run: |
-          yum install -y jq
-          ./tools/install-terraform.sh
       - name: installing dependencies
         run: |
           yarn install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM jsii/superchain
+
+COPY tools/install-terraform.sh /tmp/
+
+RUN yum install -y jq && /tmp/install-terraform.sh
+
+RUN rm -f /tmp/install-terraform.sh && yum remove -y jq


### PR DESCRIPTION
Closes #14 

At present, requires manual build and push of image to Docker Hub since we do not have account access tokens I can inject into the workflow.