### PR TITLE
Suppress error logs for missing types in `cdktf get`

### DIFF
--- a/packages/cdktf-cli/lib/get/generator/emitter/attributes-emitter.ts
+++ b/packages/cdktf-cli/lib/get/generator/emitter/attributes-emitter.ts
@@ -88,7 +88,9 @@ export class AttributesEmitter {
     if (type.isStringList) { return `this.getListAttribute('${att.terraformName}')` }
     if (type.isNumber) { return `this.getNumberAttribute('${att.terraformName}')` }
     if (type.isBoolean) { return `this.getBooleanAttribute('${att.terraformName}')` }
-    console.error(`The attribute ${JSON.stringify(att)} isn't implemented yet`)
+    if (process.env.DEBUG) {
+      console.error(`The attribute ${JSON.stringify(att)} isn't implemented yet`)
+    }
     return `'not implemented' as any`
   }
 }


### PR DESCRIPTION
Until there's a full solution for #45 this suppresses the
warnings, since the user can't do anything about it.