### PR TITLE
Publish @next npm package

### DIFF
--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -1,0 +1,27 @@
+name: Release @next
+on:
+  push:
+    branches:
+      - release/*
+
+jobs:
+  release:
+    if: github.repository == 'hashicorp/terraform-cdk'
+    runs-on: ubuntu-latest
+    container:
+      image: hashicorp/jsii-terraform
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: installing dependencies
+        run: |
+          yarn install
+      - run: tools/align-version.sh "-pre.${{ github.sha }}"
+      - run: yarn build
+      - run: yarn test
+      - run: yarn package
+      - run: yarn integration
+      - run: npx -p jsii-release jsii-release-npm
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_DIST_TAG: next


### PR DESCRIPTION
Let's publish npm packges with the `@next` tag, to enable easy usage outside of this repo.

For now from `release/*`, but should be switched to master once we get back to a normal workflow where we'll have explicit regular releases tagged from master