### PR TITLE
Release `pre` from master

### DIFF
--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -2,7 +2,7 @@ name: Release @next
 on:
   push:
     branches:
-      - release/*
+      - master
 
 jobs:
   release:


### PR DESCRIPTION
I think regular releases should be released via tagging, or explicit release branches. Therefore we should go back to integrate everything to master and release a `pre` version for each commit.