### PR TITLE
Define `NODE_ENV` as production to prevent react internal error messages

### DIFF
--- a/packages/cdktf-cli/bin/cdktf.ts
+++ b/packages/cdktf-cli/bin/cdktf.ts
@@ -1,3 +1,5 @@
+process.env.NODE_ENV = process.env.NODE_ENV || 'production'
+
 import * as yargs from 'yargs';
 import * as semver from 'semver';
 


### PR DESCRIPTION
By default:

<img width="728" alt="Screenshot 2020-07-09 at 16 51 08" src="https://user-images.githubusercontent.com/136789/87055336-78c42680-c204-11ea-99bb-6da2d71d44ac.png">

To see React internal errors:

<img width="1440" alt="Screenshot 2020-07-09 at 16 50 56" src="https://user-images.githubusercontent.com/136789/87055344-7bbf1700-c204-11ea-92d7-f037de589fd5.png">

Fixes #129 
