### PR TITLE
Force NODE_ENV so dev dependencies will actually install

### DIFF
--- a/packages/cdktf-cli/templates/typescript/.hooks.sscaff.js
+++ b/packages/cdktf-cli/templates/typescript/.hooks.sscaff.js
@@ -26,7 +26,8 @@ exports.post = ctx => {
 
 function installDeps(deps, isDev) {
   const devDep = isDev ? '-D' : '';
-  execSync(`npm install ${devDep} ${deps.join(' ')}`, { stdio: 'inherit' });
+  // make sure we're installing dev dependencies as well
+  execSync(`NODE_ENV=development npm install ${devDep} ${deps.join(' ')}`, { stdio: 'inherit' });
 }
 
 function terraformCloudConfig(baseName, organizationName, workspaceName) {


### PR DESCRIPTION
Init was broken, since `npm install` will apparently ignore dev dependencies when `NODE_ENV=production` is set. I tried to get a failing test case for the integration tests, but I haven't succeeded in reproducing it there (although `NODE_ENV` is set to production there as well). The only way to reproduce it was for me: Install the CLI from NPM and run `cdktf init`. 

Fixes #157  - This is a regression of 881087ba63e31c57a6c06cef1ba90472cedb4cb1