### PR TITLE
Don't rely on Yarn for template workflows

### DIFF
--- a/packages/cdktf-cli/templates/typescript/cdktf.json
+++ b/packages/cdktf-cli/templates/typescript/cdktf.json
@@ -1,5 +1,7 @@
 {
   "language": "typescript",
-  "app": "yarn compile && node main.js",
-  "terraformProviders": ["aws@~> 2.0"]
+  "app": "npm run compile && node main.js",
+  "terraformProviders": [
+    "aws@~> 2.0"
+  ]
 }

--- a/packages/cdktf-cli/templates/typescript/package.json
+++ b/packages/cdktf-cli/templates/typescript/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "scripts": {
     "get": "cdktf get",
-    "build": "yarn get && tsc",
+    "build": "cdktf get && tsc",
     "synth": "cdktf synth",
     "compile": "tsc",
     "watch": "tsc -w",


### PR DESCRIPTION
Since we can't be sure that Yarn is installed, the template should use `npm` only.