### PR TITLE
Fixed getting-started examples link

### DIFF
--- a/docs/getting-started/python.md
+++ b/docs/getting-started/python.md
@@ -64,7 +64,7 @@ MyStack(app, "hello-terraform")
 app.synth()
 ```
 
-Refer to the [examples](examples/) directory for additional examples.
+Refer to the [examples](../../examples/) directory for additional examples.
 
 Let's take a simple Python application that uses the CDK for Terraform package.
 

--- a/docs/getting-started/typescript.md
+++ b/docs/getting-started/typescript.md
@@ -63,7 +63,7 @@ new MyStack(app, 'hello-terraform');
 app.synth();
 ```
 
-Refer to the [examples](examples/) directory for additional examples.
+Refer to the [examples](../../examples/) directory for additional examples.
 
 Let's take a simple TypeScript application that uses the CDK for Terraform package.
 


### PR DESCRIPTION
Example links in the Python and Typescript getting-started pages go to a 404 because they use `./examples/` but it should be `../../examples/`