### PR TITLE
Remove "remote" wording when talking about state

### DIFF
--- a/packages/cdktf-cli/bin/cmds/init.ts
+++ b/packages/cdktf-cli/bin/cmds/init.ts
@@ -29,7 +29,7 @@ class Command implements yargs.CommandModule {
     .option('project-name', { type: 'string', desc: 'The name of the project.'})
     .option('project-description', { type: 'string', desc: 'The description of the project.'})
     .option('dist', { type: 'string', desc: 'Install dependencies from a "dist" directory (for development)' })
-    .option('local', { type: 'boolean', desc: 'Use local remote state storage for generated Terraform.', default: false})
+    .option('local', { type: 'boolean', desc: 'Use local state storage for generated Terraform.', default: false})
     .option('cdktf-version', { type: 'string', desc: 'The cdktf version to use while creating a new project.', default: pkg.version })
     .strict()
     .choices('template', templates);


### PR DESCRIPTION
The help text said "local remote state storage" but that doesn't make sense. It
should be either "local" or "remote." This commit removes "remote" so it talks
about local storage only.