### PR TITLE
Add Google Cloud Example

### DIFF
--- a/examples/typescript-google/.gitignore
+++ b/examples/typescript-google/.gitignore
@@ -1,0 +1,8 @@
+*.d.ts
+*.js
+node_modules
+cdktf.out
+terraform.tfstate*
+.gen
+.terraform
+google.json

--- a/examples/typescript-google/.gitignore
+++ b/examples/typescript-google/.gitignore
@@ -6,3 +6,4 @@ terraform.tfstate*
 .gen
 .terraform
 google.json
+!tsconfig.json

--- a/examples/typescript-google/Readme.md
+++ b/examples/typescript-google/Readme.md
@@ -1,0 +1,33 @@
+# Example for Google Cloud based on Typescript
+
+This resembles the example for the Google Cloud at [Hashicorp Learn](https://learn.hashicorp.com/terraform/gcp/build)
+
+## Usage
+
+Install project dependencies
+
+```shell
+yarn install
+```
+
+Generate CDK for Terraform constructs for Terraform provides and modules used in the project.
+
+```bash
+cdktf get
+```
+
+You can now edit the `main.ts` file if you want to modify any code.
+
+Make sure to create your credential file `google.json` to make this example usable.
+
+Generate Terraform configuration
+
+```bash
+cdktf synth
+```
+
+The above command will create a folder called `cdktf.out` that contains all Terraform JSON configuration that was generated.
+
+See changes `cdktf diff` and deploy via `cdktf deploy`.
+
+When you're done run `cdktf destroy`.

--- a/examples/typescript-google/cdktf.json
+++ b/examples/typescript-google/cdktf.json
@@ -1,0 +1,7 @@
+{
+  "language": "typescript",
+  "app": "npm run --silent compile && node main.js",
+  "terraformProviders": [
+    "google@~> 3.0"
+  ]
+}

--- a/examples/typescript-google/help
+++ b/examples/typescript-google/help
@@ -1,0 +1,30 @@
+========================================================================================================
+
+  Your cdktf typescript project is ready!
+
+  cat help              Print this message
+
+  Compile:
+    npm run compile     Compile typescript code to javascript (or "yarn watch")
+    npm run watch       Watch for changes and compile typescript in the background
+    npm run build       cdktf get and compile typescript
+
+  Synthesize:
+    cdktf synth         Synthesize Terraform resources from stacks to cdktf.out/ (ready for 'terraform apply')
+
+  Diff:
+    cdktf diff          Perform a diff (terraform plan) for the given stack
+
+  Deploy:
+    cdktf deploy        Deploy the given stack
+
+  Destroy:
+    cdktf destroy       Destroy the stack
+   
+
+ Upgrades:
+   npm run get           Import/update Terraform providers and modules (you should check-in this directory)
+   npm run upgrade       Upgrade cdktf modules to latest version
+   npm run upgrade:next  Upgrade cdktf modules to latest "@next" version (last commit)
+
+========================================================================================================

--- a/examples/typescript-google/main.ts
+++ b/examples/typescript-google/main.ts
@@ -1,0 +1,41 @@
+import { Construct } from 'constructs';
+import { App, TerraformStack } from 'cdktf';
+import { GoogleProvider, ComputeNetwork, ComputeInstance } from './.gen/providers/google'
+import * as path from 'path'
+import * as fs from 'fs'
+
+class MyStack extends TerraformStack {
+  constructor(scope: Construct, name: string) {
+    super(scope, name);
+
+    new GoogleProvider(this, 'Google', {
+      region: "us-central1",
+      zone: "us-central1-c",
+      project: "terraform-cdk",
+      credentials: fs.readFileSync(path.join(process.cwd(), 'google.json')).toString()
+    })
+
+    const network = new ComputeNetwork(this, 'Network', {
+      name: 'cdktf-network'
+    })
+
+    new ComputeInstance(this, 'ComputeInstance', {
+      name: 'cdktf-instance',
+      machineType: 'f1-micro',
+      bootDisk: [{
+        initializeParams: [{
+          image: 'debian-cloud/debian-9'
+        }]
+      }],
+      networkInterface: [{
+        network: network.name
+      }],
+      tags: ["web", "dev"],
+      dependsOn: [network]
+    })
+  }
+}
+
+const app = new App();
+new MyStack(app, 'typescript-gcp');
+app.synth();

--- a/examples/typescript-google/package.json
+++ b/examples/typescript-google/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "typescript-google",
+  "version": "1.0.0",
+  "main": "main.js",
+  "types": "main.ts",
+  "license": "MPL-2.0",
+  "private": true,
+  "scripts": {
+    "get": "cdktf get",
+    "build": "yarn get && tsc",
+    "synth": "cdktf synth",
+    "compile": "tsc --pretty",
+    "watch": "tsc -w",
+    "test": "echo ok",
+    "upgrade": "npm i cdktf@latest cdktf-cli@latest",
+    "upgrade:next": "npm i cdktf@next cdktf-cli@next"
+  },
+  "engines": {
+    "node": ">=10.12"
+  },
+  "dependencies": {
+    "cdktf": "0.0.0",
+    "constructs": "^3.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^14.0.23",
+    "cdktf-cli": "0.0.0",
+    "typescript": "^3.9.6"
+  }
+}

--- a/examples/typescript-google/tsconfig.json
+++ b/examples/typescript-google/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "alwaysStrict": true,
+    "charset": "utf8",
+    "declaration": true,
+    "experimentalDecorators": true,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "lib": [
+      "es2018"
+    ],
+    "module": "CommonJS",
+    "noEmitOnError": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "stripInternal": true,
+    "target": "ES2018"
+  },
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1529,6 +1529,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.14.tgz#24a0b5959f16ac141aeb0c5b3cd7a15b7c64cbce"
   integrity sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ==
 
+"@types/node@^14.0.23":
+  version "14.0.23"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.23.tgz#676fa0883450ed9da0bb24156213636290892806"
+  integrity sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
@@ -8041,6 +8046,11 @@ typescript@^3.7.4, typescript@^3.7.5, typescript@^3.8.3, typescript@~3.9.5:
   version "3.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
   integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
+
+typescript@^3.9.6:
+  version "3.9.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
+  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
 
 typescript@~3.8.3:
   version "3.8.3"


### PR DESCRIPTION
This adds an example for the Google Cloud based on the [Hashicorp Learn](https://learn.hashicorp.com/terraform/gcp/build) guide.

Fixes https://github.com/hashicorp/terraform-cdk/issues/175