### PR TITLE
Don't run Terraform Cloud integration test on external PRs

### DIFF
--- a/test/test-terraform-cloud/test.sh
+++ b/test/test-terraform-cloud/test.sh
@@ -4,6 +4,10 @@ set -e
 # Disable spinner even when we have a TTY
 export CI='1'
 
+# Don't run on external Pull Requests - Will be addressed properly with
+# https://github.com/hashicorp/terraform-cdk/issues/200
+[ -z "$TERRAFORM_CLOUD_TOKEN" ] && echo "Need to set TERRAFORM_CLOUD_TOKEN - skipping" && exit 0;
+
 scriptdir=$(cd $(dirname $0) && pwd)
 
 cd $(mktemp -d)


### PR DESCRIPTION
The `terraform cloud integration test` requires a Github Actions secret to be set. This won't be set for external Pull Requests due to security concerns and it doesn't look like there's a way to enable them even manually on a per build basis. 

Therefore, this PR will make the Terraform Cloud integration skip if the `TERRAFORM_CLOUD_TOKEN` is not set. It's not ideal, and should be considered a temporary "fix", until we've settled on a proper solution for this.

Relates to #200 