### PR TITLE
Fix cdktf init on Windows

### DIFF
--- a/packages/cdktf-cli/templates/typescript/.hooks.sscaff.js
+++ b/packages/cdktf-cli/templates/typescript/.hooks.sscaff.js
@@ -27,7 +27,10 @@ exports.post = ctx => {
 function installDeps(deps, isDev) {
   const devDep = isDev ? '-D' : '';
   // make sure we're installing dev dependencies as well
-  execSync(`NODE_ENV=development npm install ${devDep} ${deps.join(' ')}`, { stdio: 'inherit' });
+  const env = Object.assign({}, process.env)
+  env['NODE_ENV'] = 'development'
+
+  execSync(`npm install ${devDep} ${deps.join(' ')}`, { stdio: 'inherit', env });
 }
 
 function terraformCloudConfig(baseName, organizationName, workspaceName) {


### PR DESCRIPTION
Since setting envs differs on Windows, the way is was set before wasn't compatible. 

To prevent platform dependent issues we should have Windows based builds. That's tracked in #201 

Related #194  #198 