### PR TITLE
Fix interpolation bug in complex computed list of data sources

### DIFF
--- a/packages/cdktf/lib/complex-computed-list.ts
+++ b/packages/cdktf/lib/complex-computed-list.ts
@@ -53,6 +53,6 @@ export class ComplexComputedList extends ComplexComputedAttribute {
   }
 
   protected interpolationForAttribute(property: string) {
-    return `\${${this.terraformResource.terraformResourceType}.${this.terraformResource.friendlyUniqueId}.${this.terraformAttribute}.${this.index}.${property}}`;
+    return this.terraformResource.interpolationForAttribute(`${this.terraformAttribute}.${this.index}.${property}`);
   }
 }

--- a/packages/cdktf/lib/terraform-data-source.ts
+++ b/packages/cdktf/lib/terraform-data-source.ts
@@ -108,7 +108,7 @@ export class TerraformDataSource extends TerraformElement implements ITerraformR
     };
   }
 
-  private interpolationForAttribute(terraformAttribute: string) {
+  public interpolationForAttribute(terraformAttribute: string) {
     return `\${data.${this.terraformResourceType}.${this.friendlyUniqueId}.${terraformAttribute}}`;
   }
 }

--- a/packages/cdktf/lib/terraform-resource.ts
+++ b/packages/cdktf/lib/terraform-resource.ts
@@ -13,6 +13,8 @@ export interface ITerraformResource {
   count?: number;
   provider?: TerraformProvider;
   lifecycle?: TerraformResourceLifecycle;
+
+  interpolationForAttribute(terraformAttribute: string): string;
 }
 
 export interface TerraformResourceLifecycle {
@@ -141,7 +143,7 @@ export class TerraformResource extends TerraformElement implements ITerraformRes
     };
   }
 
-  private interpolationForAttribute(terraformAttribute: string) {
+  public interpolationForAttribute(terraformAttribute: string) {
     return `\${${this.terraformResourceType}.${this.friendlyUniqueId}.${terraformAttribute}}`;
   }
 }

--- a/packages/cdktf/test/__snapshots__/data-source.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/data-source.test.js.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`minimal configuration 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"data\\": {
+    \\"test_data_source\\": {
+      \\"test_DBA94737\\": {
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/test\\",
+            \\"uniqueId\\": \\"test_DBA94737\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`with complex computed list 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test-data-source\\"
+    }
+  },
+  \\"data\\": {
+    \\"test_data_source\\": {
+      \\"testdatasource_test_18A2C18D\\": {
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test-data-source/test\\",
+            \\"uniqueId\\": \\"testdatasource_test_18A2C18D\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"test_resource\\": {
+      \\"testdatasource_testresource_11F97659\\": {
+        \\"name\\": \\"\${data.test_data_source.testdatasource_test_18A2C18D.complex_computed_list.0.id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test-data-source/test-resource\\",
+            \\"uniqueId\\": \\"testdatasource_testresource_11F97659\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;

--- a/packages/cdktf/test/__snapshots__/resource.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/resource.test.js.snap
@@ -145,6 +145,40 @@ exports[`serialize list interpolation 1`] = `
 }"
 `;
 
+exports[`with complex computed list 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"tests\\"
+    }
+  },
+  \\"resource\\": {
+    \\"other_test_resource\\": {
+      \\"tests_othertest_E4B4389F\\": {
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"tests/othertest\\",
+            \\"uniqueId\\": \\"tests_othertest_E4B4389F\\"
+          }
+        }
+      }
+    },
+    \\"test_resource\\": {
+      \\"tests_test_A231270F\\": {
+        \\"name\\": \\"\${other_test_resource.tests_othertest_E4B4389F.complex_computed_list.0.id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"tests/test\\",
+            \\"uniqueId\\": \\"tests_test_A231270F\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
 exports[`with provider alias 1`] = `
 "{
   \\"//\\": {

--- a/packages/cdktf/test/data-source.test.ts
+++ b/packages/cdktf/test/data-source.test.ts
@@ -1,0 +1,28 @@
+import { TerraformStack, Testing } from '../lib';
+import { TestResource } from './helper';
+import { TestDataSource } from './helper/data-source';
+
+test('minimal configuration', () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, 'test');
+
+  new TestDataSource(stack, 'test', {
+    name: 'foo'
+  });
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test('with complex computed list', () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, 'test-data-source');
+
+  const dataSource = new TestDataSource(stack, 'test', {
+    name: 'foo'
+  });
+  new TestResource(stack, 'test-resource', {
+    name: dataSource.complexComputedList('0').id,
+  })
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});
+

--- a/packages/cdktf/test/helper/data-source.ts
+++ b/packages/cdktf/test/helper/data-source.ts
@@ -1,0 +1,38 @@
+import { Construct } from 'constructs';
+import { ComplexComputedList, TerraformDataSource, TerraformMetaArguments } from '../../lib';
+import { TestProviderMetadata } from './provider';
+
+export interface TestDataSourceConfig extends TerraformMetaArguments {
+  name: string;
+}
+
+export class TestDataSource extends TerraformDataSource {
+
+  public name: string;
+
+  constructor(scope: Construct, id: string, config: TestDataSourceConfig) {
+    super(scope, id, {
+      terraformResourceType: 'test_data_source',
+      terraformGeneratorMetadata: {
+        providerName: TestProviderMetadata.TYPE,
+        providerVersionConstraint: '~> 2.0'
+      },
+      provider: config.provider,
+    });
+    this.name = config.name;
+  }
+
+  public complexComputedList(index: string) {
+    return new TestComplexComputedList(this, 'complex_computed_list', index);
+  }
+
+  protected synthesizeAttributes(): { [p: string]: any } {
+    return {};
+  }
+}
+
+class TestComplexComputedList extends ComplexComputedList {
+  public get id() {
+    return this.getStringAttribute('id');
+  }
+}

--- a/packages/cdktf/test/helper/resource.ts
+++ b/packages/cdktf/test/helper/resource.ts
@@ -1,5 +1,5 @@
 
-import { TerraformResource, TerraformMetaArguments } from '../../lib';
+import { TerraformResource, TerraformMetaArguments, ComplexComputedList } from '../../lib';
 import { Construct } from 'constructs';
 import { TestProviderMetadata } from './provider'
 
@@ -56,8 +56,17 @@ export class OtherTestResource extends TerraformResource {
     return this.getListAttribute("names")
   }
 
+  public complexComputedList(index: string) {
+    return new TestComplexComputedList(this, 'complex_computed_list', index);
+  }
+
   public synthesizeAttributes(): { [name: string]: any } {
     return {}
   }
 }
 
+class TestComplexComputedList extends ComplexComputedList {
+  public get id() {
+    return this.getStringAttribute('id');
+  }
+}

--- a/packages/cdktf/test/resource.test.ts
+++ b/packages/cdktf/test/resource.test.ts
@@ -75,6 +75,19 @@ test('serialize list interpolation', () => {
   expect(Testing.synth(stack)).toMatchSnapshot();
 });
 
+test('with complex computed list', () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, 'tests');
+
+  const otherResource = new OtherTestResource(stack, 'othertest', {});
+
+  new TestResource(stack, 'test', {
+    name: otherResource.complexComputedList('0').id
+  });
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
 test('do not change capitalization of tags', () => {
   const app = Testing.app();
   const stack = new TerraformStack(app, 'tests');


### PR DESCRIPTION
Interpolation of `ComplexComputedList` for `TerraformDataSource`s should starts with `data.` prefix.