### PR TITLE
Avoid conflicts with resource attributes called "node"

### DIFF
--- a/packages/cdktf/lib/terraform-element.ts
+++ b/packages/cdktf/lib/terraform-element.ts
@@ -14,11 +14,11 @@ export class TerraformElement extends Construct {
   constructor(scope: Construct, id: string) {
     super(scope, id)
 
-    this.node.addMetadata('stacktrace', 'trace')
+    this.constructsNode.addMetadata('stacktrace', 'trace')
     this.stack = TerraformStack.of(this);
   }
 
-  public get node(): Node {
+  public get constructsNode(): Node {
     return Node.of(this)
   }
 
@@ -27,7 +27,7 @@ export class TerraformElement extends Construct {
   }
 
   public get friendlyUniqueId() {
-    const node = this.node
+    const node = this.constructsNode
     const components = node.scopes.slice(1).map(c => Node.of(c).id);
     return components.length > 0 ? makeUniqueId(components) : '';
   }
@@ -35,9 +35,9 @@ export class TerraformElement extends Construct {
   protected get nodeMetadata(): {[key: string]: any} {
     return {
       metadata: {
-        path: this.node.path,
+        path: this.constructsNode.path,
         uniqueId: this.friendlyUniqueId,
-        stackTrace: this.node.metadata.find((e) => e.type === 'stacktrace')?.trace
+        stackTrace: this.constructsNode.metadata.find((e) => e.type === 'stacktrace')?.trace
       } as TerraformElementMetadata
     }
   }

--- a/packages/cdktf/lib/terraform-element.ts
+++ b/packages/cdktf/lib/terraform-element.ts
@@ -14,11 +14,11 @@ export class TerraformElement extends Construct {
   constructor(scope: Construct, id: string) {
     super(scope, id)
 
-    this.constructsNode.addMetadata('stacktrace', 'trace')
+    this.constructNode.addMetadata('stacktrace', 'trace')
     this.stack = TerraformStack.of(this);
   }
 
-  public get constructsNode(): Node {
+  public get constructNode(): Node {
     return Node.of(this)
   }
 
@@ -27,7 +27,7 @@ export class TerraformElement extends Construct {
   }
 
   public get friendlyUniqueId() {
-    const node = this.constructsNode
+    const node = this.constructNode
     const components = node.scopes.slice(1).map(c => Node.of(c).id);
     return components.length > 0 ? makeUniqueId(components) : '';
   }
@@ -35,9 +35,9 @@ export class TerraformElement extends Construct {
   protected get nodeMetadata(): {[key: string]: any} {
     return {
       metadata: {
-        path: this.constructsNode.path,
+        path: this.constructNode.path,
         uniqueId: this.friendlyUniqueId,
-        stackTrace: this.constructsNode.metadata.find((e) => e.type === 'stacktrace')?.trace
+        stackTrace: this.constructNode.metadata.find((e) => e.type === 'stacktrace')?.trace
       } as TerraformElementMetadata
     }
   }

--- a/test/test-providers/main.ts
+++ b/test/test-providers/main.ts
@@ -11,7 +11,7 @@ import * as Kubernetes from "./.gen/providers/kubernetes";
 //
 // import * as Nomad from "./.gen/providers/nomad";
 // import * as Vault from "./.gen/providers/vault";
-// import * as Consul from "./.gen/providers/consul";
+import * as Consul from "./.gen/providers/consul";
 
 export class HelloTerra extends TerraformStack {
   constructor(scope: Construct, id: string) {
@@ -27,7 +27,7 @@ export class HelloTerra extends TerraformStack {
       },
     ]);
 
-    [Aws, Azure, Google, Kubernetes];
+    [Aws, Azure, Google, Kubernetes, Consul];
   }
 }
 

--- a/test/test-providers/main.ts
+++ b/test/test-providers/main.ts
@@ -6,7 +6,6 @@ import * as Azure from "./.gen/providers/azurerm";
 import * as Google from "./.gen/providers/google";
 import * as Kubernetes from "./.gen/providers/kubernetes";
 // The following providers still have bugs
-// - https://github.com/hashicorp/terraform-cdk/issues/125
 // - https://github.com/hashicorp/terraform-cdk/issues/124
 //
 // import * as Nomad from "./.gen/providers/nomad";


### PR DESCRIPTION
The `consul` provider has an attribute called `node`, which conflicts with the function in `TerraformElement`.

This introduces a more specific name `constructNode` to avoid conflicts like this.

Fixes #125