### PR TITLE
Python: setup imports dir as a package

### DIFF
--- a/packages/cdktf-cli/lib/get/base.ts
+++ b/packages/cdktf-cli/lib/get/base.ts
@@ -71,6 +71,8 @@ export abstract class GetBase {
   private async harvestPython(targetdir: string, targetName: string) {
     const target = path.join(targetdir, targetName);
     await fs.move(`dist/python/src/${targetName}`, target, { overwrite: true });
+    // Make the codeMakerOutput dir a Python package for IDEs and linting
+    fs.writeFileSync(path.join(targetdir, '__init__.py'), '', 'utf-8');
   }
 
   protected abstract typesPath(name: string): string;

--- a/packages/cdktf-cli/templates/python/{{}}.gitignore
+++ b/packages/cdktf-cli/templates/python/{{}}.gitignore
@@ -1,5 +1,6 @@
 dist/
-imports/
+imports/*
+!imports/__init__.py
 .terraform
 cdktf.out
 terraform.tfstate*


### PR DESCRIPTION
Running `pylint main.py` warns:

```
main.py:4:0: E0611: No name 'aws' in module 'imports' (no-name-in-module)
```

This change gets rid of that warning.
