### PR TITLE
Improve contribution guide and global watch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,13 +74,15 @@ If you'd want this permanently, you can add this line to your profile settings (
 
 ### Create link
 
+Let's link `cdktf` and `cdktf-cli`, run the following the repository root folder:
+
 ```shell
-$ cd packages/cdktf-cli
-$ yarn link
-$ cd -
+$ yarn link-packages
 $ cdktf --version
 0.0.0
 ```
+
+When the version equals `0.0.0` everything worked as expected. If you see another version, try uninstalling `cdktf-cli` with `npm` or `yarn`.
 
 ### Build & Package 
 
@@ -99,14 +101,7 @@ $ cdktf init --template typescript --local
 
 Please note, that this will reference the built packages in `$CDKTF_DIST`. This means, it will reflect code changes only after repeating `yarn build && yarn package` and running an explicit `yarn install` again.
 
-To reference the `cdktf` package directly, let's create another link:
-
-```shell
-$ cd packages/cdktf
-$ yarn link
-```
-
-And reference this link in our newly created project:
+Reference the previously [linked](#create-link) `cdktf` package in our newly created project:
 
 ```shell
 $ cd ~/my-local-cdktf-example

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 To build and install `terraform-cdk` locally, Node version 12.16+
 
+## Getting Started
+
 Clone the repository:
 
 ```shell
@@ -14,6 +16,20 @@ To compile the `terraform-cdk` binary for your local machine:
 $ yarn install
 $ yarn build
 ```
+
+This will also build all [Typescript examples](./examples/typescript).
+
+## Development 
+
+For development, you'd likely want to run:
+
+```shell
+$ yarn watch
+```
+
+This will watch for changes for the packages `cdktf` and `cdktf-cli`.
+
+## Tests
 
 If you just want to run the tests:
 
@@ -28,7 +44,78 @@ $ yarn package
 $ yarn integration
 ```
 
-### Rebasing contributions against master
+## Local Usage
+
+### Monorepo Examples
+
+The easiest way to use this locally is using one of the [examples](./examples). They are setup as part of the monorepo and reference the local packages.
+
+#### Typescript
+
+All Typescript [examples](./examples/typescript) leverage yarn workspaces to directly reference symlinked packages. If you don't have `./node_modules/.bin` in your `$PATH`, you can use `$(yarn bin)/cdktf` to use the symlinked CLI. 
+
+#### Python
+
+Since Python packges are referenced from `./dist`, there's no symlinking possible for live code updates. You'll have to explictly run `yarn package` to create new packages to be referenced in the Pipefile.
+
+### Outside of this Monorepo
+
+If you want to use the libraries and cli from the repo for local development, you can make use of `yarn link`. 
+
+### Setup
+
+Unfortunately, there's an [issue](https://github.com/yarnpkg/yarn/issues/891) with globally linked binaries. This requires you to run the following:
+
+```
+yarn config set prefix $(npm config get prefix)
+```
+
+If you'd want this permanently, you can add this line to your profile settings (`~/.bashrc`, `~/.zshrc`, or `~/.profile`, etc.)
+
+### Create link
+
+```shell
+$ cd packages/cdktf-cli
+$ yarn link
+$ cd -
+$ cdktf --version
+0.0.0
+```
+
+### Build & Package 
+
+```shell
+$ yarn build && yarn package
+$ export CDKTF_DIST=$(pwd)/dist
+```
+
+### Create local project
+
+```shell
+$ mkdir ~/my-local-cdktf-example
+$ cd ~/my-local-cdktf-example
+$ cdktf init --template typescript --local
+```
+
+Please not, that this will reference the built packages in `$CDKTF_DIST`. This means, it will reflect code changes only after repeating `yarn build && yarn package` and running an explicit `yarn install` again.
+
+To reference the `cdktf` package directly, let's create another link:
+
+```shell
+$ cd packages/cdktf
+$ yarn link
+```
+
+And reference this link in our newly created project:
+
+```shell
+$ cd ~/my-local-cdktf-example
+$ yarn link "cdktf"
+```
+
+From here on both, the `cli` and the `cdktf` packages are linked and changes will be reflected immediatlely.
+
+## Rebasing contributions against master
 
 PRs in this repo are merged using the [`rebase`](https://git-scm.com/docs/git-rebase) method. This keeps
 the git history clean by adding the PR commits to the most recent end of the commit history. It also has

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ All Typescript [examples](./examples/typescript) leverage yarn workspaces to dir
 
 #### Python
 
-Since Python packges are referenced from `./dist`, there's no symlinking possible for live code updates. You'll have to explictly run `yarn package` to create new packages to be referenced in the Pipefile.
+For Python [examples](./examples/python), packages are referenced from `./dist`, there's no symlinking possible for live code updates. You'll have to explictly run `yarn package` to create new packages to be referenced in the Pipefile.
 
 ### Outside of this Monorepo
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ $ cd ~/my-local-cdktf-example
 $ cdktf init --template typescript --local
 ```
 
-Please not, that this will reference the built packages in `$CDKTF_DIST`. This means, it will reflect code changes only after repeating `yarn build && yarn package` and running an explicit `yarn install` again.
+Please note, that this will reference the built packages in `$CDKTF_DIST`. This means, it will reflect code changes only after repeating `yarn build && yarn package` and running an explicit `yarn install` again.
 
 To reference the `cdktf` package directly, let's create another link:
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "lerna run build",
     "package": "lerna run package && tools/collect-dist.sh",
     "test": "lerna run test",
+    "watch": "lerna run --parallel  --stream  --scope cdktf* watch-preserve-output",
     "integration": "test/run-against-dist test/test-all.sh",
     "release-github": "tools/release-github.sh"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "package": "lerna run package && tools/collect-dist.sh",
     "test": "lerna run test",
     "watch": "lerna run --parallel  --stream  --scope cdktf* watch-preserve-output",
+    "link-packages": "lerna exec --scope cdktf* yarn link",
     "integration": "test/run-against-dist test/test-all.sh",
     "release-github": "tools/release-github.sh"
   },

--- a/packages/cdktf-cli/package.json
+++ b/packages/cdktf-cli/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
+    "watch-preserve-output": "tsc -w --preserveWatchOutput",
     "lint": "eslint . --ext .ts",
     "test": "yarn lint && jest",
     "jest-watch": "jest --watch",

--- a/packages/cdktf/package.json
+++ b/packages/cdktf/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "jsii",
     "watch": "jsii -w",
+    "watch-preserve-output": "tsc -w --preserveWatchOutput",
     "package": "jsii-pacmak",
     "lint": "eslint . --ext .ts",
     "test": "jest --passWithNoTests && yarn lint"


### PR DESCRIPTION
As pointed out in https://github.com/hashicorp/terraform-cdk/issues/265 the current contribution guide is very basic. This PR improves this guide and adds a `yarn watch` command to build `cdktf` and `cdktf-cli` packages:

![Screenshot 2020-07-30 at 11 19 35](https://user-images.githubusercontent.com/136789/88906776-20f36b00-d258-11ea-8951-78a686dc3710.png)
