### PR TITLE
Use current version of Terraform 0.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM jsii/superchain
 
 RUN yum install -y unzip && curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
 
-ENV DEFAULT_TERRAFORM_VERSION=0.13.0-rc1
+ENV DEFAULT_TERRAFORM_VERSION=0.13.0
 
 # Install Terraform
 RUN AVAILABLE_TERRAFORM_VERSIONS="0.12.29 ${DEFAULT_TERRAFORM_VERSION}" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN yum install -y unzip && curl https://raw.githubusercontent.com/pypa/pipenv/m
 ENV DEFAULT_TERRAFORM_VERSION=0.13.0
 
 # Install Terraform
-RUN AVAILABLE_TERRAFORM_VERSIONS="0.12.29 ${DEFAULT_TERRAFORM_VERSION}" && \
+RUN AVAILABLE_TERRAFORM_VERSIONS="0.12.29 0.13.0-rc1 ${DEFAULT_TERRAFORM_VERSION}" && \
     for VERSION in ${AVAILABLE_TERRAFORM_VERSIONS}; do curl -LOk https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_linux_amd64.zip && \
     mkdir -p /usr/local/bin/tf/versions/${VERSION} && \
     unzip terraform_${VERSION}_linux_amd64.zip -d /usr/local/bin/tf/versions/${VERSION} && \


### PR DESCRIPTION
There should be a way to easily track latest for a certain version. However, here's a manual bump.