### PR TITLE
Fix Naming of Generated Package Paths for Python 

### DIFF
--- a/packages/cdktf-cli/bin/cmds/helper/constructs-maker.ts
+++ b/packages/cdktf-cli/bin/cmds/helper/constructs-maker.ts
@@ -11,14 +11,14 @@ export class ConstructsMaker {
 
     public async getModules(constructsOptions: ConstructsOptions, modules: string[]): Promise<void> {
         if (modules.length > 0) {
-            await new GetModule().get(Object.assign({}, { codeMakerOutput: constructsOptions.codeMakerOutput, 
-                targetLanguage: constructsOptions.language }, { targetNames: modules }));
+            await new GetModule().get(Object.assign({}, { codeMakerOutput: constructsOptions.codeMakerOutput,
+                targetLanguage: constructsOptions.language, isModule: true }, { targetNames: modules }));
         }
     }
-    
+
     public async getProviders(constructsOptions: ConstructsOptions, providers: string[]): Promise<void> {
         if (providers.length > 0) {
-            await new GetProvider().get(Object.assign({}, { codeMakerOutput: constructsOptions.codeMakerOutput, 
+            await new GetProvider().get(Object.assign({}, { codeMakerOutput: constructsOptions.codeMakerOutput,
                 targetLanguage: constructsOptions.language }, { targetNames: providers }));
         }
     }

--- a/packages/cdktf-cli/lib/get/base.ts
+++ b/packages/cdktf-cli/lib/get/base.ts
@@ -18,6 +18,7 @@ export interface GetOptions {
   readonly targetLanguage: Language;
   readonly codeMakerOutput: string;
   readonly targetNames: string[];
+  readonly isModule?: boolean;
 }
 
 export abstract class GetBase {
@@ -26,6 +27,7 @@ export abstract class GetBase {
   public async get(options: GetOptions) {
     const code = new CodeMaker();
 
+    const { isModule = false } = options;
     const codeMakerOutdir = path.resolve(options.codeMakerOutput);
     await fs.mkdirp(codeMakerOutdir);
     const isTypescript = options.targetLanguage === Language.TYPESCRIPT
@@ -40,7 +42,7 @@ export abstract class GetBase {
       // this is not typescript, so we generate in a staging directory and harvest the code
       await withTempDir('get', async () => {
         const terraformProvider = new TerraformProviderConstraint(name)
-        const source = terraformProvider.name
+        const source = isModule ? terraformProvider.fqn : terraformProvider.name;
         const compatibleName = source.replace(/\//gi, '_')
         await code.save('.');
         await jsiiCompile('.', {

--- a/packages/cdktf-cli/lib/get/base.ts
+++ b/packages/cdktf-cli/lib/get/base.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { CodeMaker } from 'codemaker';
 import { withTempDir, shell } from '../util';
 import { jsiiCompile } from './jsii';
+import { TerraformProviderConstraint } from './generator/provider-generator';
 
 export enum Language {
   TYPESCRIPT = 'typescript',
@@ -38,7 +39,8 @@ export abstract class GetBase {
     for (const name of options.targetNames) {
       // this is not typescript, so we generate in a staging directory and harvest the code
       await withTempDir('get', async () => {
-        const [ source ] = name.split('@');
+        const terraformProvider = new TerraformProviderConstraint(name)
+        const source = terraformProvider.name
         const compatibleName = source.replace(/\//gi, '_')
         await code.save('.');
         await jsiiCompile('.', {

--- a/test/test-python-third-party-provider/cdktf.json
+++ b/test/test-python-third-party-provider/cdktf.json
@@ -1,0 +1,8 @@
+{
+  "language": "python",
+  "app": "pipenv run ./main.py",
+  "terraformProviders": [
+    "terraform-providers/docker@~> 2.0"
+  ],
+  "codeMakerOutput": "imports"
+}

--- a/test/test-python-third-party-provider/expected/cdk.tf.json
+++ b/test/test-python-third-party-provider/expected/cdk.tf.json
@@ -1,0 +1,54 @@
+{
+  "//": {
+    "metadata": {
+      "version": "stubbed",
+      "stackName": "python-third-party-provider"
+    }
+  },
+  "terraform": {
+    "required_providers": {
+      "docker": {
+        "version": "~> 2.0",
+        "source": "terraform-providers/docker"
+      }
+    }
+  },
+  "provider": {
+    "docker": [
+      {}
+    ]
+  },
+  "resource": {
+    "docker_image": {
+      "pythonthirdpartyprovider_nginxlatest_F677E4EF": {
+        "keep_locally": false,
+        "name": "nginx:latest",
+        "//": {
+          "metadata": {
+            "path": "python-third-party-provider/nginx-latest",
+            "uniqueId": "pythonthirdpartyprovider_nginxlatest_F677E4EF"
+          }
+        }
+      }
+    },
+    "docker_container": {
+      "pythonthirdpartyprovider_nginxcdktf_C2D51A82": {
+        "image": "nginx:latest",
+        "name": "nginx-python-cdktf",
+        "privileged": false,
+        "ports": [
+          {
+            "internal": 80,
+            "external": 8000
+          }
+        ],
+        "//": {
+          "metadata": {
+            "path": "python-third-party-provider/nginx-cdktf",
+            "uniqueId": "pythonthirdpartyprovider_nginxcdktf_C2D51A82"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/test-python-third-party-provider/main.py
+++ b/test/test-python-third-party-provider/main.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python3 -tt
+from constructs import Construct
+from cdktf import App, TerraformStack, Testing
+from imports.docker import Image, Container, DockerProvider
+
+class MyStack(TerraformStack):
+    def __init__(self, scope: Construct, ns: str):
+        super().__init__(scope, ns)
+
+        DockerProvider(self, "provider")
+
+        docker_image = Image(self, 'nginx-latest', name='nginx:latest', keep_locally=False)
+
+        Container(self, 'nginx-cdktf', name='nginx-python-cdktf',
+                  image=docker_image.name, ports=[
+                      {
+                          'internal': 80,
+                          'external': 8000
+                      }], privileged=False)
+
+
+app = Testing.stub_version(App(stack_traces=False))
+MyStack(app, "python-third-party-provider")
+
+app.synth()

--- a/test/test-python-third-party-provider/test.sh
+++ b/test/test-python-third-party-provider/test.sh
@@ -25,9 +25,6 @@ pipenv run python ./main.py
 
 # get rid of downloaded Terraform providers, no point in diffing them
 rm -rf cdktf.out/.terraform
-echo '--'
-cat cdktf.out/cdk.tf.json
-echo '--'
 
 # show output
 diff cdktf.out ${scriptdir}/expected

--- a/test/test-python-third-party-provider/test.sh
+++ b/test/test-python-third-party-provider/test.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -e
+scriptdir=$(cd $(dirname $0) && pwd)
+cd $(mktemp -d)
+mkdir test && cd test
+
+# hidden files should be ignored
+touch .foo
+mkdir .bar
+
+# initialize an empty project
+cdktf init --template python --project-name="python-test" --project-description="python test app" --local
+
+# put some code in it
+cp ${scriptdir}/main.py .
+cp ${scriptdir}/cdktf.json .
+
+rm -rf cdktf.out
+
+# regenerate with module
+cdktf get
+
+# build
+pipenv run python ./main.py
+
+# get rid of downloaded Terraform providers, no point in diffing them
+rm -rf cdktf.out/.terraform
+echo '--'
+cat cdktf.out/cdk.tf.json
+echo '--'
+
+# show output
+diff cdktf.out ${scriptdir}/expected
+
+echo "PASS"


### PR DESCRIPTION
When generating non HashiCorp maintained provider bindings (e.g. Docker) for Python, the generated package was broken. It didn't contain any type informations, since the path where those classes were actually generated and looked up wasn't matching. 

This fixes the naming and adds an integration test. 

Closes https://github.com/hashicorp/terraform-cdk/issues/307 
Related to https://github.com/hashicorp/terraform-cdk/issues/303