### PR TITLE
Maintain dependencies between required construct properties

### DIFF
--- a/examples/python/kubernetes/main.py
+++ b/examples/python/kubernetes/main.py
@@ -17,7 +17,7 @@ class MyStack(TerraformStack):
         Deployment(self, 'nginx-deployment',
                    metadata=[{
                        'name': app_name,
-                       'namespace': example_namespace.metadata[0].name,
+                       'namespace': example_namespace.metadata_input[0].name,
                        'labels': {
                            'app': app_name
                        }

--- a/packages/cdktf-cli/lib/get/generator/emitter/attributes-emitter.ts
+++ b/packages/cdktf-cli/lib/get/generator/emitter/attributes-emitter.ts
@@ -105,7 +105,7 @@ export class AttributesEmitter {
     if (process.env.DEBUG) {
       console.error(`The attribute ${JSON.stringify(att)} isn't implemented yet`)
     }
-    return `'not implemented' as any`
+    return `this.interpolationForAttribute('${att.terraformName}') as any`
   }
 
   public determineMapType(att: AttributeModel): string {

--- a/packages/cdktf-cli/lib/get/generator/emitter/attributes-emitter.ts
+++ b/packages/cdktf-cli/lib/get/generator/emitter/attributes-emitter.ts
@@ -31,6 +31,11 @@ export class AttributesEmitter {
     this.code.openBlock(`public set ${att.name}(value: ${att.type.name} | undefined)`);
       this.code.line(`this.${att.storageName} = value;`);
     this.code.closeBlock();
+
+    this.code.line(`// Temporarily expose input value. Use with caution.`);
+    this.code.openBlock(`public get ${att.name}Input()`);
+      this.code.line(`return this.${att.storageName}`);
+    this.code.closeBlock();
   }
 
   private emitOptionalComputed(att: AttributeModel) {
@@ -41,6 +46,11 @@ export class AttributesEmitter {
 
     this.code.openBlock(`public set ${att.name}(value: ${att.type.name} | undefined)`);
       this.code.line(`this.${att.storageName} = value;`);
+    this.code.closeBlock();
+
+    this.code.line(`// Temporarily expose input value. Use with caution.`);
+    this.code.openBlock(`public get ${att.name}Input()`);
+      this.code.line(`return this.${att.storageName}`);
     this.code.closeBlock();
   }
 
@@ -65,6 +75,11 @@ export class AttributesEmitter {
     this.code.openBlock(`public set ${att.name}(value: ${att.type.name})`);
       this.code.line(`this.${att.storageName} = value;`);
     this.code.closeBlock();
+
+    this.code.line(`// Temporarily expose input value. Use with caution.`);
+    this.code.openBlock(`public get ${att.name}Input()`);
+      this.code.line(`return this.${att.storageName}`);
+    this.code.closeBlock();
   }
 
   private emitComputedComplexList(att: AttributeModel) {
@@ -87,6 +102,11 @@ export class AttributesEmitter {
 
     this.code.openBlock(`public set ${att.name}(value: ${att.type.name} | undefined)`);
       this.code.line(`this.${att.storageName} = value;`);
+    this.code.closeBlock();
+
+    this.code.line(`// Temporarily expose input value. Use with caution.`);
+    this.code.openBlock(`public get ${att.name}Input()`);
+      this.code.line(`return this.${att.storageName}`);
     this.code.closeBlock();
   }
 

--- a/packages/cdktf-cli/lib/get/generator/emitter/attributes-emitter.ts
+++ b/packages/cdktf-cli/lib/get/generator/emitter/attributes-emitter.ts
@@ -14,6 +14,7 @@ export class AttributesEmitter {
       case (att.computed && att.isOptional && att.type.isComputedComplex && att.type.isList): return this.emitComputedComplexOptional(att);
       case (att.computed && !att.isOptional && att.type.isComputedComplex && att.type.isMap): return this.emitComputedComplexMap(att);
       case (att.computed && att.isOptional && att.type.isComputedComplex && att.type.isMap): return this.emitComputedComplexOptional(att);
+      case (att.computed && att.optional && !att.isRequired && att.isConfigIgnored): return this.emitOptionalComputedIgnored(att);
       case (att.computed && att.isOptional): return this.emitOptionalComputed(att);
       case (att.computed): return this.emitComputed(att);
       case (att.isOptional): return this.emitOptional(att);
@@ -24,7 +25,7 @@ export class AttributesEmitter {
   private emitOptional(att: AttributeModel) {
     this.code.line(`private ${att.storageName}?: ${att.type.name};`);
     this.code.openBlock(`public get ${att.name}()`);
-      this.code.line(`return this.${att.storageName};`);
+      this.code.line(`return ${att.isProvider ? "this." + att.storageName : this.determineGetAttCall(att)};`);
     this.code.closeBlock();
 
     this.code.openBlock(`public set ${att.name}(value: ${att.type.name} | undefined)`);
@@ -35,11 +36,17 @@ export class AttributesEmitter {
   private emitOptionalComputed(att: AttributeModel) {
     this.code.line(`private ${att.storageName}?: ${att.type.name};`);
     this.code.openBlock(`public get ${att.name}()`);
-      this.code.line(`return this.${att.storageName} ?? ${this.determineGetAttCall(att)};`);
+      this.code.line(`return ${this.determineGetAttCall(att)};`);
     this.code.closeBlock();
 
     this.code.openBlock(`public set ${att.name}(value: ${att.type.name} | undefined)`);
       this.code.line(`this.${att.storageName} = value;`);
+    this.code.closeBlock();
+  }
+
+  private emitOptionalComputedIgnored(att: AttributeModel) {
+    this.code.openBlock(`public get ${att.name}()`);
+      this.code.line(`return ${this.determineGetAttCall(att)};`);
     this.code.closeBlock();
   }
 
@@ -52,7 +59,7 @@ export class AttributesEmitter {
   private emitRequired(att: AttributeModel) {
     this.code.line(`private ${att.storageName}: ${att.type.name};`);
     this.code.openBlock(`public get ${att.name}()`);
-      this.code.line(`return this.${att.storageName};`);
+      this.code.line(`return ${att.isProvider ? "this." + att.storageName : this.determineGetAttCall(att)};`);
     this.code.closeBlock();
 
     this.code.openBlock(`public set ${att.name}(value: ${att.type.name})`);

--- a/packages/cdktf-cli/lib/get/generator/emitter/attributes-emitter.ts
+++ b/packages/cdktf-cli/lib/get/generator/emitter/attributes-emitter.ts
@@ -28,8 +28,12 @@ export class AttributesEmitter {
       this.code.line(`return ${att.isProvider ? "this." + att.storageName : this.determineGetAttCall(att)};`);
     this.code.closeBlock();
 
-    this.code.openBlock(`public set ${att.name}(value: ${att.type.name} | undefined)`);
+    this.code.openBlock(`public set ${att.name}(value: ${att.type.name} ${att.isProvider ? ' | undefined' : ''})`);
       this.code.line(`this.${att.storageName} = value;`);
+    this.code.closeBlock();
+
+    this.code.openBlock(`public ${this.getResetName(att.name)}()`);
+      this.code.line(`this.${att.storageName} = undefined;`);
     this.code.closeBlock();
 
     this.code.line(`// Temporarily expose input value. Use with caution.`);
@@ -44,8 +48,12 @@ export class AttributesEmitter {
       this.code.line(`return ${this.determineGetAttCall(att)};`);
     this.code.closeBlock();
 
-    this.code.openBlock(`public set ${att.name}(value: ${att.type.name} | undefined)`);
+    this.code.openBlock(`public set ${att.name}(value: ${att.type.name})`);
       this.code.line(`this.${att.storageName} = value;`);
+    this.code.closeBlock();
+
+    this.code.openBlock(`public ${this.getResetName(att.name)}()`);
+      this.code.line(`this.${att.storageName} = undefined;`);
     this.code.closeBlock();
 
     this.code.line(`// Temporarily expose input value. Use with caution.`);
@@ -96,12 +104,16 @@ export class AttributesEmitter {
 
   private emitComputedComplexOptional(att: AttributeModel) {
     this.code.line(`private ${att.storageName}?: ${att.type.name}`);
-    this.code.openBlock(`public get ${att.name}(): ${att.type.name} | undefined`);
-      this.code.line(`return this.${att.storageName}; // Getting the computed value is not yet implemented`);
+    this.code.openBlock(`public get ${att.name}(): ${att.type.name}`);
+      this.code.line(`return this.interpolationForAttribute('${att.terraformName}') as any; // Getting the computed value is not yet implemented`);
     this.code.closeBlock();
 
-    this.code.openBlock(`public set ${att.name}(value: ${att.type.name} | undefined)`);
+    this.code.openBlock(`public set ${att.name}(value: ${att.type.name})`);
       this.code.line(`this.${att.storageName} = value;`);
+    this.code.closeBlock();
+
+    this.code.openBlock(`public ${this.getResetName(att.name)}()`);
+      this.code.line(`this.${att.storageName} = undefined;`);
     this.code.closeBlock();
 
     this.code.line(`// Temporarily expose input value. Use with caution.`);
@@ -137,5 +149,10 @@ export class AttributesEmitter {
       console.error(`The attribute ${JSON.stringify(att)} isn't implemented yet`)
     }
     return `any`
+  }
+
+  public getResetName(name: string) {
+    if (!name) return name;
+    return `reset${name[0].toUpperCase() + name.slice(1)}`;
   }
 }

--- a/packages/cdktf-cli/lib/get/generator/models/attribute-model.ts
+++ b/packages/cdktf-cli/lib/get/generator/models/attribute-model.ts
@@ -11,6 +11,7 @@ export interface AttributeModelOptions {
   description?: string;
   getAttCall?: string;
   provider: boolean;
+  required: boolean;
 }
 
 export class AttributeModel {
@@ -23,6 +24,7 @@ export class AttributeModel {
   public terraformFullName: string;
   private _description?: string;
   public provider: boolean;
+  public required: boolean;
 
   constructor(options: AttributeModelOptions) {
     this.storageName = options.storageName;
@@ -34,6 +36,7 @@ export class AttributeModel {
     this.terraformFullName = options.terraformFullName;
     this._description = options.description;
     this.provider = options.provider;
+    this.required = options.required;
   }
 
   public get typeDefinition() {
@@ -42,7 +45,7 @@ export class AttributeModel {
   }
 
   public get isAssignable() {
-    return !this.computed;
+    return this.required || this.optional;
   }
 
   public get isOptional(): boolean {
@@ -50,7 +53,7 @@ export class AttributeModel {
   }
 
   public get isRequired(): boolean {
-    return !this.isOptional
+    return this.required
   }
 
   public get isTokenizable(): boolean {
@@ -74,7 +77,7 @@ export class AttributeModel {
   }
 
   public get isConfigIgnored(): boolean {
-    if (this.isRequired || !this.computed) {
+    if (this.isAssignable && !this.computed) {
       return false;
     }
     const ignoreList = ['arn', 'id'];

--- a/packages/cdktf-cli/lib/get/generator/models/attribute-model.ts
+++ b/packages/cdktf-cli/lib/get/generator/models/attribute-model.ts
@@ -10,6 +10,7 @@ export interface AttributeModelOptions {
   terraformFullName: string;
   description?: string;
   getAttCall?: string;
+  provider: boolean;
 }
 
 export class AttributeModel {
@@ -21,6 +22,7 @@ export class AttributeModel {
   public terraformName: string;
   public terraformFullName: string;
   private _description?: string;
+  public provider: boolean;
 
   constructor(options: AttributeModelOptions) {
     this.storageName = options.storageName;
@@ -31,6 +33,7 @@ export class AttributeModel {
     this.terraformName = options.terraformName;
     this.terraformFullName = options.terraformFullName;
     this._description = options.description;
+    this.provider = options.provider;
   }
 
   public get typeDefinition() {
@@ -54,6 +57,10 @@ export class AttributeModel {
     return this.type.isTokenizable
   }
 
+  public get isProvider(): boolean {
+    return this.provider;
+  }
+
   public get name(): string {
     // `self` and `build` doesn't work in as property name in Python
     if (this._name === 'self' || this._name === 'build') return `${this._name}Attribute`;
@@ -64,5 +71,13 @@ export class AttributeModel {
 
   public get description(): string | undefined {
     return this._description?.replace(/(\*\/)/gi, `*\\/`)
+  }
+
+  public get isConfigIgnored(): boolean {
+    if (this.isRequired || !this.computed) {
+      return false;
+    }
+    const ignoreList = ['arn', 'id'];
+    return ignoreList.includes(this.name);
   }
 }

--- a/packages/cdktf-cli/lib/get/generator/models/attribute-type-model.ts
+++ b/packages/cdktf-cli/lib/get/generator/models/attribute-type-model.ts
@@ -5,6 +5,7 @@ export interface AttributeTypeModelOptions {
   isList?: boolean;
   isComputed?: boolean;
   isOptional?: boolean;
+  isRequired?: boolean;
   isMap?: boolean;
   level?: number;
 }
@@ -25,6 +26,7 @@ export class AttributeTypeModel {
   public isList: boolean;
   public isComputed: boolean;
   public isOptional: boolean;
+  public isRequired?: boolean;
   public isMap: boolean;
   public struct?: Struct;
   public level?: number;
@@ -34,6 +36,7 @@ export class AttributeTypeModel {
     this.isMap = !!options.isMap;
     this.isComputed = !!options.isComputed;
     this.isOptional = !!options.isOptional;
+    this.isRequired = !!options.isRequired;
     this.level = options.level
     this.struct = options.struct;
   }

--- a/packages/cdktf-cli/lib/get/generator/models/scope.ts
+++ b/packages/cdktf-cli/lib/get/generator/models/scope.ts
@@ -1,3 +1,3 @@
 export class Scope {
-  constructor(public readonly name: string, public readonly isProvider: boolean, public isComputed = false, public isOptional = true, public inBlockType = false) {}
+  constructor(public readonly name: string, public readonly isProvider: boolean, public isComputed = false, public isOptional = true, public isRequired = false, public inBlockType = false) {}
 }

--- a/packages/cdktf-cli/lib/get/generator/models/scope.ts
+++ b/packages/cdktf-cli/lib/get/generator/models/scope.ts
@@ -1,3 +1,26 @@
+export interface ScopeProps {
+  readonly name: string;
+  readonly isProvider: boolean;
+  readonly isComputed?: boolean;
+  readonly isOptional?: boolean;
+  readonly isRequired?: boolean;
+  readonly inBlockType?: boolean;
+}
+
 export class Scope {
-  constructor(public readonly name: string, public readonly isProvider: boolean, public isComputed = false, public isOptional = true, public isRequired = false, public inBlockType = false) {}
+  public readonly name: string;
+  public readonly isProvider: boolean;
+  public isComputed: boolean;
+  public isOptional: boolean;
+  public isRequired: boolean;
+  public inBlockType: boolean;
+
+  constructor(props: ScopeProps) {
+    this.name = props.name;
+    this.isProvider = props.isProvider;
+    this.isComputed = props.isComputed ?? false;
+    this.isOptional = props.isOptional ?? true;
+    this.isRequired = props.isRequired ?? false;
+    this.inBlockType = props.inBlockType ?? false;
+  }
 }

--- a/packages/cdktf-cli/lib/get/generator/models/scope.ts
+++ b/packages/cdktf-cli/lib/get/generator/models/scope.ts
@@ -1,3 +1,3 @@
 export class Scope {
-  constructor(public readonly name: string, public isComputed = false, public isOptional = true, public inBlockType = false) {}
+  constructor(public readonly name: string, public readonly isProvider: boolean, public isComputed = false, public isOptional = true, public inBlockType = false) {}
 }

--- a/packages/cdktf-cli/lib/get/generator/models/struct.ts
+++ b/packages/cdktf-cli/lib/get/generator/models/struct.ts
@@ -4,7 +4,7 @@ export class Struct {
   constructor(public readonly name: string, public readonly attributes: AttributeModel[], public readonly isClass = false, public readonly isAnonymous = false) {}
 
   public get assignableAttributes(): AttributeModel[] {
-    const attributes = this.isAnonymous ? this.attributes : this.attributes.filter(attribute => (!attribute.computed || (attribute.computed && attribute.optional)))
+    const attributes = this.isAnonymous ? this.attributes : this.attributes.filter(attribute => attribute.isAssignable)
     return this.filterIgnoredAttributes(attributes)
   }
 

--- a/packages/cdktf-cli/lib/get/generator/models/struct.ts
+++ b/packages/cdktf-cli/lib/get/generator/models/struct.ts
@@ -31,8 +31,7 @@ export class Struct {
 
 export class ConfigStruct extends Struct {
   protected filterIgnoredAttributes(attributes: AttributeModel[]): AttributeModel[] {
-    const ignoreList = ['arn', 'id']
-    return attributes.filter(attribute => !(ignoreList.includes(attribute.name) && !attribute.isRequired))
+    return attributes.filter(attribute => !attribute.isConfigIgnored)
   }
 
   public get extends(): string {

--- a/packages/cdktf-cli/test/get/generator/__snapshots__/complex-computed-types.test.ts.snap
+++ b/packages/cdktf-cli/test/get/generator/__snapshots__/complex-computed-types.test.ts.snap
@@ -25,22 +25,22 @@ export interface AcmCertificateConfig extends TerraformMetaArguments {
 }
 export class AcmCertificateDomainValidationOptions extends ComplexComputedList {
 
-  // domain_name - computed: true, optional: false, required: true
+  // domain_name - computed: true, optional: false, required: false
   public get domainName() {
     return this.getStringAttribute('domain_name');
   }
 
-  // resource_record_name - computed: true, optional: false, required: true
+  // resource_record_name - computed: true, optional: false, required: false
   public get resourceRecordName() {
     return this.getStringAttribute('resource_record_name');
   }
 
-  // resource_record_type - computed: true, optional: false, required: true
+  // resource_record_type - computed: true, optional: false, required: false
   public get resourceRecordType() {
     return this.getStringAttribute('resource_record_type');
   }
 
-  // resource_record_value - computed: true, optional: false, required: true
+  // resource_record_value - computed: true, optional: false, required: false
   public get resourceRecordValue() {
     return this.getStringAttribute('resource_record_value');
   }
@@ -83,7 +83,7 @@ export class AcmCertificate extends TerraformResource {
   // ATTRIBUTES
   // ==========
 
-  // arn - computed: true, optional: false, required: true
+  // arn - computed: true, optional: false, required: false
   public get arn() {
     return this.getStringAttribute('arn');
   }
@@ -91,7 +91,7 @@ export class AcmCertificate extends TerraformResource {
   // certificate_authority_arn - computed: false, optional: true, required: false
   private _certificateAuthorityArn?: string;
   public get certificateAuthorityArn() {
-    return this._certificateAuthorityArn;
+    return this.getStringAttribute('certificate_authority_arn');
   }
   public set certificateAuthorityArn(value: string | undefined) {
     this._certificateAuthorityArn = value;
@@ -100,7 +100,7 @@ export class AcmCertificate extends TerraformResource {
   // certificate_body - computed: false, optional: true, required: false
   private _certificateBody?: string;
   public get certificateBody() {
-    return this._certificateBody;
+    return this.getStringAttribute('certificate_body');
   }
   public set certificateBody(value: string | undefined) {
     this._certificateBody = value;
@@ -109,7 +109,7 @@ export class AcmCertificate extends TerraformResource {
   // certificate_chain - computed: false, optional: true, required: false
   private _certificateChain?: string;
   public get certificateChain() {
-    return this._certificateChain;
+    return this.getStringAttribute('certificate_chain');
   }
   public set certificateChain(value: string | undefined) {
     this._certificateChain = value;
@@ -118,30 +118,26 @@ export class AcmCertificate extends TerraformResource {
   // domain_name - computed: true, optional: true, required: false
   private _domainName?: string;
   public get domainName() {
-    return this._domainName ?? this.getStringAttribute('domain_name');
+    return this.getStringAttribute('domain_name');
   }
   public set domainName(value: string | undefined) {
     this._domainName = value;
   }
 
-  // domain_validation_options - computed: true, optional: false, required: true
+  // domain_validation_options - computed: true, optional: false, required: false
   public domainValidationOptions(index: string) {
     return new AcmCertificateDomainValidationOptions(this, 'domain_validation_options', index);
   }
 
   // id - computed: true, optional: true, required: false
-  private _id?: string;
   public get id() {
-    return this._id ?? this.getStringAttribute('id');
-  }
-  public set id(value: string | undefined) {
-    this._id = value;
+    return this.getStringAttribute('id');
   }
 
   // private_key - computed: false, optional: true, required: false
   private _privateKey?: string;
   public get privateKey() {
-    return this._privateKey;
+    return this.getStringAttribute('private_key');
   }
   public set privateKey(value: string | undefined) {
     this._privateKey = value;
@@ -150,7 +146,7 @@ export class AcmCertificate extends TerraformResource {
   // subject_alternative_names - computed: true, optional: true, required: false
   private _subjectAlternativeNames?: string[];
   public get subjectAlternativeNames() {
-    return this._subjectAlternativeNames ?? this.getListAttribute('subject_alternative_names');
+    return this.getListAttribute('subject_alternative_names');
   }
   public set subjectAlternativeNames(value: string[] | undefined) {
     this._subjectAlternativeNames = value;
@@ -159,13 +155,13 @@ export class AcmCertificate extends TerraformResource {
   // tags - computed: false, optional: true, required: false
   private _tags?: { [key: string]: string };
   public get tags() {
-    return this._tags;
+    return this.interpolationForAttribute('tags') as any;
   }
   public set tags(value: { [key: string]: string } | undefined) {
     this._tags = value;
   }
 
-  // validation_emails - computed: true, optional: false, required: true
+  // validation_emails - computed: true, optional: false, required: false
   public get validationEmails() {
     return this.getListAttribute('validation_emails');
   }
@@ -173,7 +169,7 @@ export class AcmCertificate extends TerraformResource {
   // validation_method - computed: true, optional: true, required: false
   private _validationMethod?: string;
   public get validationMethod() {
-    return this._validationMethod ?? this.getStringAttribute('validation_method');
+    return this.getStringAttribute('validation_method');
   }
   public set validationMethod(value: string | undefined) {
     this._validationMethod = value;
@@ -182,7 +178,7 @@ export class AcmCertificate extends TerraformResource {
   // options - computed: false, optional: true, required: false
   private _options?: AcmCertificateOptions[];
   public get options() {
-    return this._options;
+    return this.interpolationForAttribute('options') as any;
   }
   public set options(value: AcmCertificateOptions[] | undefined) {
     this._options = value;

--- a/packages/cdktf-cli/test/get/generator/__snapshots__/complex-computed-types.test.ts.snap
+++ b/packages/cdktf-cli/test/get/generator/__snapshots__/complex-computed-types.test.ts.snap
@@ -93,8 +93,11 @@ export class AcmCertificate extends TerraformResource {
   public get certificateAuthorityArn() {
     return this.getStringAttribute('certificate_authority_arn');
   }
-  public set certificateAuthorityArn(value: string | undefined) {
+  public set certificateAuthorityArn(value: string ) {
     this._certificateAuthorityArn = value;
+  }
+  public resetCertificateAuthorityArn() {
+    this._certificateAuthorityArn = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get certificateAuthorityArnInput() {
@@ -106,8 +109,11 @@ export class AcmCertificate extends TerraformResource {
   public get certificateBody() {
     return this.getStringAttribute('certificate_body');
   }
-  public set certificateBody(value: string | undefined) {
+  public set certificateBody(value: string ) {
     this._certificateBody = value;
+  }
+  public resetCertificateBody() {
+    this._certificateBody = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get certificateBodyInput() {
@@ -119,8 +125,11 @@ export class AcmCertificate extends TerraformResource {
   public get certificateChain() {
     return this.getStringAttribute('certificate_chain');
   }
-  public set certificateChain(value: string | undefined) {
+  public set certificateChain(value: string ) {
     this._certificateChain = value;
+  }
+  public resetCertificateChain() {
+    this._certificateChain = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get certificateChainInput() {
@@ -132,8 +141,11 @@ export class AcmCertificate extends TerraformResource {
   public get domainName() {
     return this.getStringAttribute('domain_name');
   }
-  public set domainName(value: string | undefined) {
+  public set domainName(value: string) {
     this._domainName = value;
+  }
+  public resetDomainName() {
+    this._domainName = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get domainNameInput() {
@@ -155,8 +167,11 @@ export class AcmCertificate extends TerraformResource {
   public get privateKey() {
     return this.getStringAttribute('private_key');
   }
-  public set privateKey(value: string | undefined) {
+  public set privateKey(value: string ) {
     this._privateKey = value;
+  }
+  public resetPrivateKey() {
+    this._privateKey = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get privateKeyInput() {
@@ -168,8 +183,11 @@ export class AcmCertificate extends TerraformResource {
   public get subjectAlternativeNames() {
     return this.getListAttribute('subject_alternative_names');
   }
-  public set subjectAlternativeNames(value: string[] | undefined) {
+  public set subjectAlternativeNames(value: string[]) {
     this._subjectAlternativeNames = value;
+  }
+  public resetSubjectAlternativeNames() {
+    this._subjectAlternativeNames = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get subjectAlternativeNamesInput() {
@@ -181,8 +199,11 @@ export class AcmCertificate extends TerraformResource {
   public get tags() {
     return this.interpolationForAttribute('tags') as any;
   }
-  public set tags(value: { [key: string]: string } | undefined) {
+  public set tags(value: { [key: string]: string } ) {
     this._tags = value;
+  }
+  public resetTags() {
+    this._tags = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get tagsInput() {
@@ -199,8 +220,11 @@ export class AcmCertificate extends TerraformResource {
   public get validationMethod() {
     return this.getStringAttribute('validation_method');
   }
-  public set validationMethod(value: string | undefined) {
+  public set validationMethod(value: string) {
     this._validationMethod = value;
+  }
+  public resetValidationMethod() {
+    this._validationMethod = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get validationMethodInput() {
@@ -212,8 +236,11 @@ export class AcmCertificate extends TerraformResource {
   public get options() {
     return this.interpolationForAttribute('options') as any;
   }
-  public set options(value: AcmCertificateOptions[] | undefined) {
+  public set options(value: AcmCertificateOptions[] ) {
     this._options = value;
+  }
+  public resetOptions() {
+    this._options = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get optionsInput() {

--- a/packages/cdktf-cli/test/get/generator/__snapshots__/complex-computed-types.test.ts.snap
+++ b/packages/cdktf-cli/test/get/generator/__snapshots__/complex-computed-types.test.ts.snap
@@ -96,6 +96,10 @@ export class AcmCertificate extends TerraformResource {
   public set certificateAuthorityArn(value: string | undefined) {
     this._certificateAuthorityArn = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get certificateAuthorityArnInput() {
+    return this._certificateAuthorityArn
+  }
 
   // certificate_body - computed: false, optional: true, required: false
   private _certificateBody?: string;
@@ -104,6 +108,10 @@ export class AcmCertificate extends TerraformResource {
   }
   public set certificateBody(value: string | undefined) {
     this._certificateBody = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get certificateBodyInput() {
+    return this._certificateBody
   }
 
   // certificate_chain - computed: false, optional: true, required: false
@@ -114,6 +122,10 @@ export class AcmCertificate extends TerraformResource {
   public set certificateChain(value: string | undefined) {
     this._certificateChain = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get certificateChainInput() {
+    return this._certificateChain
+  }
 
   // domain_name - computed: true, optional: true, required: false
   private _domainName?: string;
@@ -122,6 +134,10 @@ export class AcmCertificate extends TerraformResource {
   }
   public set domainName(value: string | undefined) {
     this._domainName = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get domainNameInput() {
+    return this._domainName
   }
 
   // domain_validation_options - computed: true, optional: false, required: false
@@ -142,6 +158,10 @@ export class AcmCertificate extends TerraformResource {
   public set privateKey(value: string | undefined) {
     this._privateKey = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get privateKeyInput() {
+    return this._privateKey
+  }
 
   // subject_alternative_names - computed: true, optional: true, required: false
   private _subjectAlternativeNames?: string[];
@@ -151,6 +171,10 @@ export class AcmCertificate extends TerraformResource {
   public set subjectAlternativeNames(value: string[] | undefined) {
     this._subjectAlternativeNames = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get subjectAlternativeNamesInput() {
+    return this._subjectAlternativeNames
+  }
 
   // tags - computed: false, optional: true, required: false
   private _tags?: { [key: string]: string };
@@ -159,6 +183,10 @@ export class AcmCertificate extends TerraformResource {
   }
   public set tags(value: { [key: string]: string } | undefined) {
     this._tags = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get tagsInput() {
+    return this._tags
   }
 
   // validation_emails - computed: true, optional: false, required: false
@@ -174,6 +202,10 @@ export class AcmCertificate extends TerraformResource {
   public set validationMethod(value: string | undefined) {
     this._validationMethod = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get validationMethodInput() {
+    return this._validationMethod
+  }
 
   // options - computed: false, optional: true, required: false
   private _options?: AcmCertificateOptions[];
@@ -182,6 +214,10 @@ export class AcmCertificate extends TerraformResource {
   }
   public set options(value: AcmCertificateOptions[] | undefined) {
     this._options = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get optionsInput() {
+    return this._options
   }
 
   // =========

--- a/packages/cdktf-cli/test/get/generator/__snapshots__/description-escaping.test.ts.snap
+++ b/packages/cdktf-cli/test/get/generator/__snapshots__/description-escaping.test.ts.snap
@@ -48,7 +48,7 @@ export class DescriptionEscaping extends TerraformResource {
   // broken_comments - computed: false, optional: false, required: true
   private _brokenComments: boolean;
   public get brokenComments() {
-    return this._brokenComments;
+    return this.getBooleanAttribute('broken_comments');
   }
   public set brokenComments(value: boolean) {
     this._brokenComments = value;

--- a/packages/cdktf-cli/test/get/generator/__snapshots__/description-escaping.test.ts.snap
+++ b/packages/cdktf-cli/test/get/generator/__snapshots__/description-escaping.test.ts.snap
@@ -53,6 +53,10 @@ export class DescriptionEscaping extends TerraformResource {
   public set brokenComments(value: boolean) {
     this._brokenComments = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get brokenCommentsInput() {
+    return this._brokenComments
+  }
 
   // =========
   // SYNTHESIS

--- a/packages/cdktf-cli/test/get/generator/__snapshots__/provider.test.ts.snap
+++ b/packages/cdktf-cli/test/get/generator/__snapshots__/provider.test.ts.snap
@@ -399,6 +399,10 @@ export class AwsProvider extends TerraformProvider {
   public set accessKey(value: string | undefined) {
     this._accessKey = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get accessKeyInput() {
+    return this._accessKey
+  }
 
   // allowed_account_ids - computed: false, optional: true, required: false
   private _allowedAccountIds?: string[];
@@ -407,6 +411,10 @@ export class AwsProvider extends TerraformProvider {
   }
   public set allowedAccountIds(value: string[] | undefined) {
     this._allowedAccountIds = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get allowedAccountIdsInput() {
+    return this._allowedAccountIds
   }
 
   // forbidden_account_ids - computed: false, optional: true, required: false
@@ -417,6 +425,10 @@ export class AwsProvider extends TerraformProvider {
   public set forbiddenAccountIds(value: string[] | undefined) {
     this._forbiddenAccountIds = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get forbiddenAccountIdsInput() {
+    return this._forbiddenAccountIds
+  }
 
   // insecure - computed: false, optional: true, required: false
   private _insecure?: boolean;
@@ -425,6 +437,10 @@ export class AwsProvider extends TerraformProvider {
   }
   public set insecure(value: boolean | undefined) {
     this._insecure = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get insecureInput() {
+    return this._insecure
   }
 
   // max_retries - computed: false, optional: true, required: false
@@ -435,6 +451,10 @@ export class AwsProvider extends TerraformProvider {
   public set maxRetries(value: number | undefined) {
     this._maxRetries = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get maxRetriesInput() {
+    return this._maxRetries
+  }
 
   // profile - computed: false, optional: true, required: false
   private _profile?: string;
@@ -443,6 +463,10 @@ export class AwsProvider extends TerraformProvider {
   }
   public set profile(value: string | undefined) {
     this._profile = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get profileInput() {
+    return this._profile
   }
 
   // region - computed: false, optional: false, required: true
@@ -453,6 +477,10 @@ export class AwsProvider extends TerraformProvider {
   public set region(value: string) {
     this._region = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get regionInput() {
+    return this._region
+  }
 
   // s3_force_path_style - computed: false, optional: true, required: false
   private _s3ForcePathStyle?: boolean;
@@ -461,6 +489,10 @@ export class AwsProvider extends TerraformProvider {
   }
   public set s3ForcePathStyle(value: boolean | undefined) {
     this._s3ForcePathStyle = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get s3ForcePathStyleInput() {
+    return this._s3ForcePathStyle
   }
 
   // secret_key - computed: false, optional: true, required: false
@@ -471,6 +503,10 @@ export class AwsProvider extends TerraformProvider {
   public set secretKey(value: string | undefined) {
     this._secretKey = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get secretKeyInput() {
+    return this._secretKey
+  }
 
   // shared_credentials_file - computed: false, optional: true, required: false
   private _sharedCredentialsFile?: string;
@@ -479,6 +515,10 @@ export class AwsProvider extends TerraformProvider {
   }
   public set sharedCredentialsFile(value: string | undefined) {
     this._sharedCredentialsFile = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get sharedCredentialsFileInput() {
+    return this._sharedCredentialsFile
   }
 
   // skip_credentials_validation - computed: false, optional: true, required: false
@@ -489,6 +529,10 @@ export class AwsProvider extends TerraformProvider {
   public set skipCredentialsValidation(value: boolean | undefined) {
     this._skipCredentialsValidation = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get skipCredentialsValidationInput() {
+    return this._skipCredentialsValidation
+  }
 
   // skip_get_ec2_platforms - computed: false, optional: true, required: false
   private _skipGetEc2Platforms?: boolean;
@@ -497,6 +541,10 @@ export class AwsProvider extends TerraformProvider {
   }
   public set skipGetEc2Platforms(value: boolean | undefined) {
     this._skipGetEc2Platforms = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get skipGetEc2PlatformsInput() {
+    return this._skipGetEc2Platforms
   }
 
   // skip_metadata_api_check - computed: false, optional: true, required: false
@@ -507,6 +555,10 @@ export class AwsProvider extends TerraformProvider {
   public set skipMetadataApiCheck(value: boolean | undefined) {
     this._skipMetadataApiCheck = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get skipMetadataApiCheckInput() {
+    return this._skipMetadataApiCheck
+  }
 
   // skip_region_validation - computed: false, optional: true, required: false
   private _skipRegionValidation?: boolean;
@@ -515,6 +567,10 @@ export class AwsProvider extends TerraformProvider {
   }
   public set skipRegionValidation(value: boolean | undefined) {
     this._skipRegionValidation = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get skipRegionValidationInput() {
+    return this._skipRegionValidation
   }
 
   // skip_requesting_account_id - computed: false, optional: true, required: false
@@ -525,6 +581,10 @@ export class AwsProvider extends TerraformProvider {
   public set skipRequestingAccountId(value: boolean | undefined) {
     this._skipRequestingAccountId = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get skipRequestingAccountIdInput() {
+    return this._skipRequestingAccountId
+  }
 
   // token - computed: false, optional: true, required: false
   private _token?: string;
@@ -533,6 +593,10 @@ export class AwsProvider extends TerraformProvider {
   }
   public set token(value: string | undefined) {
     this._token = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get tokenInput() {
+    return this._token
   }
 
   // alias - computed: false, optional: true, required: false
@@ -543,6 +607,10 @@ export class AwsProvider extends TerraformProvider {
   public set alias(value: string | undefined) {
     this._alias = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get aliasInput() {
+    return this._alias
+  }
 
   // assume_role - computed: false, optional: true, required: false
   private _assumeRole?: AwsProviderAssumeRole[];
@@ -551,6 +619,10 @@ export class AwsProvider extends TerraformProvider {
   }
   public set assumeRole(value: AwsProviderAssumeRole[] | undefined) {
     this._assumeRole = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get assumeRoleInput() {
+    return this._assumeRole
   }
 
   // endpoints - computed: false, optional: true, required: false
@@ -561,6 +633,10 @@ export class AwsProvider extends TerraformProvider {
   public set endpoints(value: AwsProviderEndpoints[] | undefined) {
     this._endpoints = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get endpointsInput() {
+    return this._endpoints
+  }
 
   // ignore_tags - computed: false, optional: true, required: false
   private _ignoreTags?: AwsProviderIgnoreTags[];
@@ -569,6 +645,10 @@ export class AwsProvider extends TerraformProvider {
   }
   public set ignoreTags(value: AwsProviderIgnoreTags[] | undefined) {
     this._ignoreTags = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get ignoreTagsInput() {
+    return this._ignoreTags
   }
 
   // =========

--- a/packages/cdktf-cli/test/get/generator/__snapshots__/provider.test.ts.snap
+++ b/packages/cdktf-cli/test/get/generator/__snapshots__/provider.test.ts.snap
@@ -396,8 +396,11 @@ export class AwsProvider extends TerraformProvider {
   public get accessKey() {
     return this._accessKey;
   }
-  public set accessKey(value: string | undefined) {
+  public set accessKey(value: string  | undefined) {
     this._accessKey = value;
+  }
+  public resetAccessKey() {
+    this._accessKey = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get accessKeyInput() {
@@ -409,8 +412,11 @@ export class AwsProvider extends TerraformProvider {
   public get allowedAccountIds() {
     return this._allowedAccountIds;
   }
-  public set allowedAccountIds(value: string[] | undefined) {
+  public set allowedAccountIds(value: string[]  | undefined) {
     this._allowedAccountIds = value;
+  }
+  public resetAllowedAccountIds() {
+    this._allowedAccountIds = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get allowedAccountIdsInput() {
@@ -422,8 +428,11 @@ export class AwsProvider extends TerraformProvider {
   public get forbiddenAccountIds() {
     return this._forbiddenAccountIds;
   }
-  public set forbiddenAccountIds(value: string[] | undefined) {
+  public set forbiddenAccountIds(value: string[]  | undefined) {
     this._forbiddenAccountIds = value;
+  }
+  public resetForbiddenAccountIds() {
+    this._forbiddenAccountIds = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get forbiddenAccountIdsInput() {
@@ -435,8 +444,11 @@ export class AwsProvider extends TerraformProvider {
   public get insecure() {
     return this._insecure;
   }
-  public set insecure(value: boolean | undefined) {
+  public set insecure(value: boolean  | undefined) {
     this._insecure = value;
+  }
+  public resetInsecure() {
+    this._insecure = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get insecureInput() {
@@ -448,8 +460,11 @@ export class AwsProvider extends TerraformProvider {
   public get maxRetries() {
     return this._maxRetries;
   }
-  public set maxRetries(value: number | undefined) {
+  public set maxRetries(value: number  | undefined) {
     this._maxRetries = value;
+  }
+  public resetMaxRetries() {
+    this._maxRetries = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get maxRetriesInput() {
@@ -461,8 +476,11 @@ export class AwsProvider extends TerraformProvider {
   public get profile() {
     return this._profile;
   }
-  public set profile(value: string | undefined) {
+  public set profile(value: string  | undefined) {
     this._profile = value;
+  }
+  public resetProfile() {
+    this._profile = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get profileInput() {
@@ -487,8 +505,11 @@ export class AwsProvider extends TerraformProvider {
   public get s3ForcePathStyle() {
     return this._s3ForcePathStyle;
   }
-  public set s3ForcePathStyle(value: boolean | undefined) {
+  public set s3ForcePathStyle(value: boolean  | undefined) {
     this._s3ForcePathStyle = value;
+  }
+  public resetS3ForcePathStyle() {
+    this._s3ForcePathStyle = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get s3ForcePathStyleInput() {
@@ -500,8 +521,11 @@ export class AwsProvider extends TerraformProvider {
   public get secretKey() {
     return this._secretKey;
   }
-  public set secretKey(value: string | undefined) {
+  public set secretKey(value: string  | undefined) {
     this._secretKey = value;
+  }
+  public resetSecretKey() {
+    this._secretKey = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get secretKeyInput() {
@@ -513,8 +537,11 @@ export class AwsProvider extends TerraformProvider {
   public get sharedCredentialsFile() {
     return this._sharedCredentialsFile;
   }
-  public set sharedCredentialsFile(value: string | undefined) {
+  public set sharedCredentialsFile(value: string  | undefined) {
     this._sharedCredentialsFile = value;
+  }
+  public resetSharedCredentialsFile() {
+    this._sharedCredentialsFile = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get sharedCredentialsFileInput() {
@@ -526,8 +553,11 @@ export class AwsProvider extends TerraformProvider {
   public get skipCredentialsValidation() {
     return this._skipCredentialsValidation;
   }
-  public set skipCredentialsValidation(value: boolean | undefined) {
+  public set skipCredentialsValidation(value: boolean  | undefined) {
     this._skipCredentialsValidation = value;
+  }
+  public resetSkipCredentialsValidation() {
+    this._skipCredentialsValidation = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get skipCredentialsValidationInput() {
@@ -539,8 +569,11 @@ export class AwsProvider extends TerraformProvider {
   public get skipGetEc2Platforms() {
     return this._skipGetEc2Platforms;
   }
-  public set skipGetEc2Platforms(value: boolean | undefined) {
+  public set skipGetEc2Platforms(value: boolean  | undefined) {
     this._skipGetEc2Platforms = value;
+  }
+  public resetSkipGetEc2Platforms() {
+    this._skipGetEc2Platforms = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get skipGetEc2PlatformsInput() {
@@ -552,8 +585,11 @@ export class AwsProvider extends TerraformProvider {
   public get skipMetadataApiCheck() {
     return this._skipMetadataApiCheck;
   }
-  public set skipMetadataApiCheck(value: boolean | undefined) {
+  public set skipMetadataApiCheck(value: boolean  | undefined) {
     this._skipMetadataApiCheck = value;
+  }
+  public resetSkipMetadataApiCheck() {
+    this._skipMetadataApiCheck = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get skipMetadataApiCheckInput() {
@@ -565,8 +601,11 @@ export class AwsProvider extends TerraformProvider {
   public get skipRegionValidation() {
     return this._skipRegionValidation;
   }
-  public set skipRegionValidation(value: boolean | undefined) {
+  public set skipRegionValidation(value: boolean  | undefined) {
     this._skipRegionValidation = value;
+  }
+  public resetSkipRegionValidation() {
+    this._skipRegionValidation = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get skipRegionValidationInput() {
@@ -578,8 +617,11 @@ export class AwsProvider extends TerraformProvider {
   public get skipRequestingAccountId() {
     return this._skipRequestingAccountId;
   }
-  public set skipRequestingAccountId(value: boolean | undefined) {
+  public set skipRequestingAccountId(value: boolean  | undefined) {
     this._skipRequestingAccountId = value;
+  }
+  public resetSkipRequestingAccountId() {
+    this._skipRequestingAccountId = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get skipRequestingAccountIdInput() {
@@ -591,8 +633,11 @@ export class AwsProvider extends TerraformProvider {
   public get token() {
     return this._token;
   }
-  public set token(value: string | undefined) {
+  public set token(value: string  | undefined) {
     this._token = value;
+  }
+  public resetToken() {
+    this._token = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get tokenInput() {
@@ -604,8 +649,11 @@ export class AwsProvider extends TerraformProvider {
   public get alias() {
     return this._alias;
   }
-  public set alias(value: string | undefined) {
+  public set alias(value: string  | undefined) {
     this._alias = value;
+  }
+  public resetAlias() {
+    this._alias = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get aliasInput() {
@@ -617,8 +665,11 @@ export class AwsProvider extends TerraformProvider {
   public get assumeRole() {
     return this._assumeRole;
   }
-  public set assumeRole(value: AwsProviderAssumeRole[] | undefined) {
+  public set assumeRole(value: AwsProviderAssumeRole[]  | undefined) {
     this._assumeRole = value;
+  }
+  public resetAssumeRole() {
+    this._assumeRole = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get assumeRoleInput() {
@@ -630,8 +681,11 @@ export class AwsProvider extends TerraformProvider {
   public get endpoints() {
     return this._endpoints;
   }
-  public set endpoints(value: AwsProviderEndpoints[] | undefined) {
+  public set endpoints(value: AwsProviderEndpoints[]  | undefined) {
     this._endpoints = value;
+  }
+  public resetEndpoints() {
+    this._endpoints = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get endpointsInput() {
@@ -643,8 +697,11 @@ export class AwsProvider extends TerraformProvider {
   public get ignoreTags() {
     return this._ignoreTags;
   }
-  public set ignoreTags(value: AwsProviderIgnoreTags[] | undefined) {
+  public set ignoreTags(value: AwsProviderIgnoreTags[]  | undefined) {
     this._ignoreTags = value;
+  }
+  public resetIgnoreTags() {
+    this._ignoreTags = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get ignoreTagsInput() {

--- a/packages/cdktf-cli/test/get/generator/__snapshots__/resource-types.test.ts.snap
+++ b/packages/cdktf-cli/test/get/generator/__snapshots__/resource-types.test.ts.snap
@@ -254,7 +254,7 @@ export class CloudfrontDistribution extends TerraformResource {
   // ATTRIBUTES
   // ==========
 
-  // active_trusted_signers - computed: true, optional: false, required: true
+  // active_trusted_signers - computed: true, optional: false, required: false
   public activeTrustedSigners(key: string): string {
     return new StringMap(this, 'active_trusted_signers').lookup(key);
   }
@@ -262,18 +262,18 @@ export class CloudfrontDistribution extends TerraformResource {
   // aliases - computed: false, optional: true, required: false
   private _aliases?: string[];
   public get aliases() {
-    return this._aliases;
+    return this.getListAttribute('aliases');
   }
   public set aliases(value: string[] | undefined) {
     this._aliases = value;
   }
 
-  // arn - computed: true, optional: false, required: true
+  // arn - computed: true, optional: false, required: false
   public get arn() {
     return this.getStringAttribute('arn');
   }
 
-  // caller_reference - computed: true, optional: false, required: true
+  // caller_reference - computed: true, optional: false, required: false
   public get callerReference() {
     return this.getStringAttribute('caller_reference');
   }
@@ -281,7 +281,7 @@ export class CloudfrontDistribution extends TerraformResource {
   // comment - computed: false, optional: true, required: false
   private _comment?: string;
   public get comment() {
-    return this._comment;
+    return this.getStringAttribute('comment');
   }
   public set comment(value: string | undefined) {
     this._comment = value;
@@ -290,13 +290,13 @@ export class CloudfrontDistribution extends TerraformResource {
   // default_root_object - computed: false, optional: true, required: false
   private _defaultRootObject?: string;
   public get defaultRootObject() {
-    return this._defaultRootObject;
+    return this.getStringAttribute('default_root_object');
   }
   public set defaultRootObject(value: string | undefined) {
     this._defaultRootObject = value;
   }
 
-  // domain_name - computed: true, optional: false, required: true
+  // domain_name - computed: true, optional: false, required: false
   public get domainName() {
     return this.getStringAttribute('domain_name');
   }
@@ -304,18 +304,18 @@ export class CloudfrontDistribution extends TerraformResource {
   // enabled - computed: false, optional: false, required: true
   private _enabled: boolean;
   public get enabled() {
-    return this._enabled;
+    return this.getBooleanAttribute('enabled');
   }
   public set enabled(value: boolean) {
     this._enabled = value;
   }
 
-  // etag - computed: true, optional: false, required: true
+  // etag - computed: true, optional: false, required: false
   public get etag() {
     return this.getStringAttribute('etag');
   }
 
-  // hosted_zone_id - computed: true, optional: false, required: true
+  // hosted_zone_id - computed: true, optional: false, required: false
   public get hostedZoneId() {
     return this.getStringAttribute('hosted_zone_id');
   }
@@ -323,22 +323,18 @@ export class CloudfrontDistribution extends TerraformResource {
   // http_version - computed: false, optional: true, required: false
   private _httpVersion?: string;
   public get httpVersion() {
-    return this._httpVersion;
+    return this.getStringAttribute('http_version');
   }
   public set httpVersion(value: string | undefined) {
     this._httpVersion = value;
   }
 
   // id - computed: true, optional: true, required: false
-  private _id?: string;
   public get id() {
-    return this._id ?? this.getStringAttribute('id');
-  }
-  public set id(value: string | undefined) {
-    this._id = value;
+    return this.getStringAttribute('id');
   }
 
-  // in_progress_validation_batches - computed: true, optional: false, required: true
+  // in_progress_validation_batches - computed: true, optional: false, required: false
   public get inProgressValidationBatches() {
     return this.getNumberAttribute('in_progress_validation_batches');
   }
@@ -346,13 +342,13 @@ export class CloudfrontDistribution extends TerraformResource {
   // is_ipv6_enabled - computed: false, optional: true, required: false
   private _isIpv6Enabled?: boolean;
   public get isIpv6Enabled() {
-    return this._isIpv6Enabled;
+    return this.getBooleanAttribute('is_ipv6_enabled');
   }
   public set isIpv6Enabled(value: boolean | undefined) {
     this._isIpv6Enabled = value;
   }
 
-  // last_modified_time - computed: true, optional: false, required: true
+  // last_modified_time - computed: true, optional: false, required: false
   public get lastModifiedTime() {
     return this.getStringAttribute('last_modified_time');
   }
@@ -360,7 +356,7 @@ export class CloudfrontDistribution extends TerraformResource {
   // price_class - computed: false, optional: true, required: false
   private _priceClass?: string;
   public get priceClass() {
-    return this._priceClass;
+    return this.getStringAttribute('price_class');
   }
   public set priceClass(value: string | undefined) {
     this._priceClass = value;
@@ -369,13 +365,13 @@ export class CloudfrontDistribution extends TerraformResource {
   // retain_on_delete - computed: false, optional: true, required: false
   private _retainOnDelete?: boolean;
   public get retainOnDelete() {
-    return this._retainOnDelete;
+    return this.getBooleanAttribute('retain_on_delete');
   }
   public set retainOnDelete(value: boolean | undefined) {
     this._retainOnDelete = value;
   }
 
-  // status - computed: true, optional: false, required: true
+  // status - computed: true, optional: false, required: false
   public get status() {
     return this.getStringAttribute('status');
   }
@@ -383,7 +379,7 @@ export class CloudfrontDistribution extends TerraformResource {
   // tags - computed: false, optional: true, required: false
   private _tags?: { [key: string]: string };
   public get tags() {
-    return this._tags;
+    return this.interpolationForAttribute('tags') as any;
   }
   public set tags(value: { [key: string]: string } | undefined) {
     this._tags = value;
@@ -392,7 +388,7 @@ export class CloudfrontDistribution extends TerraformResource {
   // wait_for_deployment - computed: false, optional: true, required: false
   private _waitForDeployment?: boolean;
   public get waitForDeployment() {
-    return this._waitForDeployment;
+    return this.getBooleanAttribute('wait_for_deployment');
   }
   public set waitForDeployment(value: boolean | undefined) {
     this._waitForDeployment = value;
@@ -401,7 +397,7 @@ export class CloudfrontDistribution extends TerraformResource {
   // web_acl_id - computed: false, optional: true, required: false
   private _webAclId?: string;
   public get webAclId() {
-    return this._webAclId;
+    return this.getStringAttribute('web_acl_id');
   }
   public set webAclId(value: string | undefined) {
     this._webAclId = value;
@@ -410,7 +406,7 @@ export class CloudfrontDistribution extends TerraformResource {
   // cache_behavior - computed: false, optional: true, required: false
   private _cacheBehavior?: CloudfrontDistributionCacheBehavior[];
   public get cacheBehavior() {
-    return this._cacheBehavior;
+    return this.interpolationForAttribute('cache_behavior') as any;
   }
   public set cacheBehavior(value: CloudfrontDistributionCacheBehavior[] | undefined) {
     this._cacheBehavior = value;
@@ -419,7 +415,7 @@ export class CloudfrontDistribution extends TerraformResource {
   // custom_error_response - computed: false, optional: true, required: false
   private _customErrorResponse?: CloudfrontDistributionCustomErrorResponse[];
   public get customErrorResponse() {
-    return this._customErrorResponse;
+    return this.interpolationForAttribute('custom_error_response') as any;
   }
   public set customErrorResponse(value: CloudfrontDistributionCustomErrorResponse[] | undefined) {
     this._customErrorResponse = value;
@@ -428,7 +424,7 @@ export class CloudfrontDistribution extends TerraformResource {
   // default_cache_behavior - computed: false, optional: false, required: true
   private _defaultCacheBehavior: CloudfrontDistributionDefaultCacheBehavior[];
   public get defaultCacheBehavior() {
-    return this._defaultCacheBehavior;
+    return this.interpolationForAttribute('default_cache_behavior') as any;
   }
   public set defaultCacheBehavior(value: CloudfrontDistributionDefaultCacheBehavior[]) {
     this._defaultCacheBehavior = value;
@@ -437,7 +433,7 @@ export class CloudfrontDistribution extends TerraformResource {
   // logging_config - computed: false, optional: true, required: false
   private _loggingConfig?: CloudfrontDistributionLoggingConfig[];
   public get loggingConfig() {
-    return this._loggingConfig;
+    return this.interpolationForAttribute('logging_config') as any;
   }
   public set loggingConfig(value: CloudfrontDistributionLoggingConfig[] | undefined) {
     this._loggingConfig = value;
@@ -446,7 +442,7 @@ export class CloudfrontDistribution extends TerraformResource {
   // ordered_cache_behavior - computed: false, optional: true, required: false
   private _orderedCacheBehavior?: CloudfrontDistributionOrderedCacheBehavior[];
   public get orderedCacheBehavior() {
-    return this._orderedCacheBehavior;
+    return this.interpolationForAttribute('ordered_cache_behavior') as any;
   }
   public set orderedCacheBehavior(value: CloudfrontDistributionOrderedCacheBehavior[] | undefined) {
     this._orderedCacheBehavior = value;
@@ -455,7 +451,7 @@ export class CloudfrontDistribution extends TerraformResource {
   // origin - computed: false, optional: false, required: true
   private _origin: CloudfrontDistributionOrigin[];
   public get origin() {
-    return this._origin;
+    return this.interpolationForAttribute('origin') as any;
   }
   public set origin(value: CloudfrontDistributionOrigin[]) {
     this._origin = value;
@@ -464,7 +460,7 @@ export class CloudfrontDistribution extends TerraformResource {
   // origin_group - computed: false, optional: true, required: false
   private _originGroup?: CloudfrontDistributionOriginGroup[];
   public get originGroup() {
-    return this._originGroup;
+    return this.interpolationForAttribute('origin_group') as any;
   }
   public set originGroup(value: CloudfrontDistributionOriginGroup[] | undefined) {
     this._originGroup = value;
@@ -473,7 +469,7 @@ export class CloudfrontDistribution extends TerraformResource {
   // restrictions - computed: false, optional: false, required: true
   private _restrictions: CloudfrontDistributionRestrictions[];
   public get restrictions() {
-    return this._restrictions;
+    return this.interpolationForAttribute('restrictions') as any;
   }
   public set restrictions(value: CloudfrontDistributionRestrictions[]) {
     this._restrictions = value;
@@ -482,7 +478,7 @@ export class CloudfrontDistribution extends TerraformResource {
   // viewer_certificate - computed: false, optional: false, required: true
   private _viewerCertificate: CloudfrontDistributionViewerCertificate[];
   public get viewerCertificate() {
-    return this._viewerCertificate;
+    return this.interpolationForAttribute('viewer_certificate') as any;
   }
   public set viewerCertificate(value: CloudfrontDistributionViewerCertificate[]) {
     this._viewerCertificate = value;
@@ -563,19 +559,15 @@ export class FmsAdminAccount extends TerraformResource {
   // account_id - computed: true, optional: true, required: false
   private _accountId?: string;
   public get accountId() {
-    return this._accountId ?? this.getStringAttribute('account_id');
+    return this.getStringAttribute('account_id');
   }
   public set accountId(value: string | undefined) {
     this._accountId = value;
   }
 
   // id - computed: true, optional: true, required: false
-  private _id?: string;
   public get id() {
-    return this._id ?? this.getStringAttribute('id');
-  }
-  public set id(value: string | undefined) {
-    this._id = value;
+    return this.getStringAttribute('id');
   }
 
   // =========
@@ -807,7 +799,7 @@ export class S3Bucket extends TerraformResource {
   // acceleration_status - computed: true, optional: true, required: false
   private _accelerationStatus?: string;
   public get accelerationStatus() {
-    return this._accelerationStatus ?? this.getStringAttribute('acceleration_status');
+    return this.getStringAttribute('acceleration_status');
   }
   public set accelerationStatus(value: string | undefined) {
     this._accelerationStatus = value;
@@ -816,31 +808,27 @@ export class S3Bucket extends TerraformResource {
   // acl - computed: false, optional: true, required: false
   private _acl?: string;
   public get acl() {
-    return this._acl;
+    return this.getStringAttribute('acl');
   }
   public set acl(value: string | undefined) {
     this._acl = value;
   }
 
   // arn - computed: true, optional: true, required: false
-  private _arn?: string;
   public get arn() {
-    return this._arn ?? this.getStringAttribute('arn');
-  }
-  public set arn(value: string | undefined) {
-    this._arn = value;
+    return this.getStringAttribute('arn');
   }
 
   // bucket - computed: true, optional: true, required: false
   private _bucket?: string;
   public get bucket() {
-    return this._bucket ?? this.getStringAttribute('bucket');
+    return this.getStringAttribute('bucket');
   }
   public set bucket(value: string | undefined) {
     this._bucket = value;
   }
 
-  // bucket_domain_name - computed: true, optional: false, required: true
+  // bucket_domain_name - computed: true, optional: false, required: false
   public get bucketDomainName() {
     return this.getStringAttribute('bucket_domain_name');
   }
@@ -848,13 +836,13 @@ export class S3Bucket extends TerraformResource {
   // bucket_prefix - computed: false, optional: true, required: false
   private _bucketPrefix?: string;
   public get bucketPrefix() {
-    return this._bucketPrefix;
+    return this.getStringAttribute('bucket_prefix');
   }
   public set bucketPrefix(value: string | undefined) {
     this._bucketPrefix = value;
   }
 
-  // bucket_regional_domain_name - computed: true, optional: false, required: true
+  // bucket_regional_domain_name - computed: true, optional: false, required: false
   public get bucketRegionalDomainName() {
     return this.getStringAttribute('bucket_regional_domain_name');
   }
@@ -862,7 +850,7 @@ export class S3Bucket extends TerraformResource {
   // force_destroy - computed: false, optional: true, required: false
   private _forceDestroy?: boolean;
   public get forceDestroy() {
-    return this._forceDestroy;
+    return this.getBooleanAttribute('force_destroy');
   }
   public set forceDestroy(value: boolean | undefined) {
     this._forceDestroy = value;
@@ -871,25 +859,21 @@ export class S3Bucket extends TerraformResource {
   // hosted_zone_id - computed: true, optional: true, required: false
   private _hostedZoneId?: string;
   public get hostedZoneId() {
-    return this._hostedZoneId ?? this.getStringAttribute('hosted_zone_id');
+    return this.getStringAttribute('hosted_zone_id');
   }
   public set hostedZoneId(value: string | undefined) {
     this._hostedZoneId = value;
   }
 
   // id - computed: true, optional: true, required: false
-  private _id?: string;
   public get id() {
-    return this._id ?? this.getStringAttribute('id');
-  }
-  public set id(value: string | undefined) {
-    this._id = value;
+    return this.getStringAttribute('id');
   }
 
   // policy - computed: false, optional: true, required: false
   private _policy?: string;
   public get policy() {
-    return this._policy;
+    return this.getStringAttribute('policy');
   }
   public set policy(value: string | undefined) {
     this._policy = value;
@@ -898,7 +882,7 @@ export class S3Bucket extends TerraformResource {
   // region - computed: true, optional: true, required: false
   private _region?: string;
   public get region() {
-    return this._region ?? this.getStringAttribute('region');
+    return this.getStringAttribute('region');
   }
   public set region(value: string | undefined) {
     this._region = value;
@@ -907,7 +891,7 @@ export class S3Bucket extends TerraformResource {
   // request_payer - computed: true, optional: true, required: false
   private _requestPayer?: string;
   public get requestPayer() {
-    return this._requestPayer ?? this.getStringAttribute('request_payer');
+    return this.getStringAttribute('request_payer');
   }
   public set requestPayer(value: string | undefined) {
     this._requestPayer = value;
@@ -916,7 +900,7 @@ export class S3Bucket extends TerraformResource {
   // tags - computed: false, optional: true, required: false
   private _tags?: { [key: string]: string };
   public get tags() {
-    return this._tags;
+    return this.interpolationForAttribute('tags') as any;
   }
   public set tags(value: { [key: string]: string } | undefined) {
     this._tags = value;
@@ -925,7 +909,7 @@ export class S3Bucket extends TerraformResource {
   // website_domain - computed: true, optional: true, required: false
   private _websiteDomain?: string;
   public get websiteDomain() {
-    return this._websiteDomain ?? this.getStringAttribute('website_domain');
+    return this.getStringAttribute('website_domain');
   }
   public set websiteDomain(value: string | undefined) {
     this._websiteDomain = value;
@@ -934,7 +918,7 @@ export class S3Bucket extends TerraformResource {
   // website_endpoint - computed: true, optional: true, required: false
   private _websiteEndpoint?: string;
   public get websiteEndpoint() {
-    return this._websiteEndpoint ?? this.getStringAttribute('website_endpoint');
+    return this.getStringAttribute('website_endpoint');
   }
   public set websiteEndpoint(value: string | undefined) {
     this._websiteEndpoint = value;
@@ -943,7 +927,7 @@ export class S3Bucket extends TerraformResource {
   // cors_rule - computed: false, optional: true, required: false
   private _corsRule?: S3BucketCorsRule[];
   public get corsRule() {
-    return this._corsRule;
+    return this.interpolationForAttribute('cors_rule') as any;
   }
   public set corsRule(value: S3BucketCorsRule[] | undefined) {
     this._corsRule = value;
@@ -952,7 +936,7 @@ export class S3Bucket extends TerraformResource {
   // grant - computed: false, optional: true, required: false
   private _grant?: S3BucketGrant[];
   public get grant() {
-    return this._grant;
+    return this.interpolationForAttribute('grant') as any;
   }
   public set grant(value: S3BucketGrant[] | undefined) {
     this._grant = value;
@@ -961,7 +945,7 @@ export class S3Bucket extends TerraformResource {
   // lifecycle_rule - computed: false, optional: true, required: false
   private _lifecycleRule?: S3BucketLifecycleRule[];
   public get lifecycleRule() {
-    return this._lifecycleRule;
+    return this.interpolationForAttribute('lifecycle_rule') as any;
   }
   public set lifecycleRule(value: S3BucketLifecycleRule[] | undefined) {
     this._lifecycleRule = value;
@@ -970,7 +954,7 @@ export class S3Bucket extends TerraformResource {
   // logging - computed: false, optional: true, required: false
   private _logging?: S3BucketLogging[];
   public get logging() {
-    return this._logging;
+    return this.interpolationForAttribute('logging') as any;
   }
   public set logging(value: S3BucketLogging[] | undefined) {
     this._logging = value;
@@ -979,7 +963,7 @@ export class S3Bucket extends TerraformResource {
   // object_lock_configuration - computed: false, optional: true, required: false
   private _objectLockConfiguration?: S3BucketObjectLockConfiguration[];
   public get objectLockConfiguration() {
-    return this._objectLockConfiguration;
+    return this.interpolationForAttribute('object_lock_configuration') as any;
   }
   public set objectLockConfiguration(value: S3BucketObjectLockConfiguration[] | undefined) {
     this._objectLockConfiguration = value;
@@ -988,7 +972,7 @@ export class S3Bucket extends TerraformResource {
   // replication_configuration - computed: false, optional: true, required: false
   private _replicationConfiguration?: S3BucketReplicationConfiguration[];
   public get replicationConfiguration() {
-    return this._replicationConfiguration;
+    return this.interpolationForAttribute('replication_configuration') as any;
   }
   public set replicationConfiguration(value: S3BucketReplicationConfiguration[] | undefined) {
     this._replicationConfiguration = value;
@@ -997,7 +981,7 @@ export class S3Bucket extends TerraformResource {
   // server_side_encryption_configuration - computed: false, optional: true, required: false
   private _serverSideEncryptionConfiguration?: S3BucketServerSideEncryptionConfiguration[];
   public get serverSideEncryptionConfiguration() {
-    return this._serverSideEncryptionConfiguration;
+    return this.interpolationForAttribute('server_side_encryption_configuration') as any;
   }
   public set serverSideEncryptionConfiguration(value: S3BucketServerSideEncryptionConfiguration[] | undefined) {
     this._serverSideEncryptionConfiguration = value;
@@ -1006,7 +990,7 @@ export class S3Bucket extends TerraformResource {
   // versioning - computed: false, optional: true, required: false
   private _versioning?: S3BucketVersioning[];
   public get versioning() {
-    return this._versioning;
+    return this.interpolationForAttribute('versioning') as any;
   }
   public set versioning(value: S3BucketVersioning[] | undefined) {
     this._versioning = value;
@@ -1015,7 +999,7 @@ export class S3Bucket extends TerraformResource {
   // website - computed: false, optional: true, required: false
   private _website?: S3BucketWebsite[];
   public get website() {
-    return this._website;
+    return this.interpolationForAttribute('website') as any;
   }
   public set website(value: S3BucketWebsite[] | undefined) {
     this._website = value;
@@ -1137,7 +1121,7 @@ export class SecurityGroup extends TerraformResource {
   // ATTRIBUTES
   // ==========
 
-  // arn - computed: true, optional: false, required: true
+  // arn - computed: true, optional: false, required: false
   public get arn() {
     return this.getStringAttribute('arn');
   }
@@ -1145,7 +1129,7 @@ export class SecurityGroup extends TerraformResource {
   // description - computed: false, optional: true, required: false
   private _description?: string;
   public get description() {
-    return this._description;
+    return this.getStringAttribute('description');
   }
   public set description(value: string | undefined) {
     this._description = value;
@@ -1161,12 +1145,8 @@ export class SecurityGroup extends TerraformResource {
   }
 
   // id - computed: true, optional: true, required: false
-  private _id?: string;
   public get id() {
-    return this._id ?? this.getStringAttribute('id');
-  }
-  public set id(value: string | undefined) {
-    this._id = value;
+    return this.getStringAttribute('id');
   }
 
   // ingress - computed: true, optional: true, required: false
@@ -1181,7 +1161,7 @@ export class SecurityGroup extends TerraformResource {
   // name - computed: true, optional: true, required: false
   private _name?: string;
   public get name() {
-    return this._name ?? this.getStringAttribute('name');
+    return this.getStringAttribute('name');
   }
   public set name(value: string | undefined) {
     this._name = value;
@@ -1190,13 +1170,13 @@ export class SecurityGroup extends TerraformResource {
   // name_prefix - computed: false, optional: true, required: false
   private _namePrefix?: string;
   public get namePrefix() {
-    return this._namePrefix;
+    return this.getStringAttribute('name_prefix');
   }
   public set namePrefix(value: string | undefined) {
     this._namePrefix = value;
   }
 
-  // owner_id - computed: true, optional: false, required: true
+  // owner_id - computed: true, optional: false, required: false
   public get ownerId() {
     return this.getStringAttribute('owner_id');
   }
@@ -1204,7 +1184,7 @@ export class SecurityGroup extends TerraformResource {
   // revoke_rules_on_delete - computed: false, optional: true, required: false
   private _revokeRulesOnDelete?: boolean;
   public get revokeRulesOnDelete() {
-    return this._revokeRulesOnDelete;
+    return this.getBooleanAttribute('revoke_rules_on_delete');
   }
   public set revokeRulesOnDelete(value: boolean | undefined) {
     this._revokeRulesOnDelete = value;
@@ -1213,7 +1193,7 @@ export class SecurityGroup extends TerraformResource {
   // tags - computed: false, optional: true, required: false
   private _tags?: { [key: string]: string };
   public get tags() {
-    return this._tags;
+    return this.interpolationForAttribute('tags') as any;
   }
   public set tags(value: { [key: string]: string } | undefined) {
     this._tags = value;
@@ -1222,7 +1202,7 @@ export class SecurityGroup extends TerraformResource {
   // vpc_id - computed: true, optional: true, required: false
   private _vpcId?: string;
   public get vpcId() {
-    return this._vpcId ?? this.getStringAttribute('vpc_id');
+    return this.getStringAttribute('vpc_id');
   }
   public set vpcId(value: string | undefined) {
     this._vpcId = value;
@@ -1231,7 +1211,7 @@ export class SecurityGroup extends TerraformResource {
   // timeouts - computed: false, optional: true, required: false
   private _timeouts?: SecurityGroupTimeouts;
   public get timeouts() {
-    return this._timeouts;
+    return this.interpolationForAttribute('timeouts') as any;
   }
   public set timeouts(value: SecurityGroupTimeouts | undefined) {
     this._timeouts = value;

--- a/packages/cdktf-cli/test/get/generator/__snapshots__/resource-types.test.ts.snap
+++ b/packages/cdktf-cli/test/get/generator/__snapshots__/resource-types.test.ts.snap
@@ -264,8 +264,11 @@ export class CloudfrontDistribution extends TerraformResource {
   public get aliases() {
     return this.getListAttribute('aliases');
   }
-  public set aliases(value: string[] | undefined) {
+  public set aliases(value: string[] ) {
     this._aliases = value;
+  }
+  public resetAliases() {
+    this._aliases = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get aliasesInput() {
@@ -287,8 +290,11 @@ export class CloudfrontDistribution extends TerraformResource {
   public get comment() {
     return this.getStringAttribute('comment');
   }
-  public set comment(value: string | undefined) {
+  public set comment(value: string ) {
     this._comment = value;
+  }
+  public resetComment() {
+    this._comment = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get commentInput() {
@@ -300,8 +306,11 @@ export class CloudfrontDistribution extends TerraformResource {
   public get defaultRootObject() {
     return this.getStringAttribute('default_root_object');
   }
-  public set defaultRootObject(value: string | undefined) {
+  public set defaultRootObject(value: string ) {
     this._defaultRootObject = value;
+  }
+  public resetDefaultRootObject() {
+    this._defaultRootObject = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get defaultRootObjectInput() {
@@ -341,8 +350,11 @@ export class CloudfrontDistribution extends TerraformResource {
   public get httpVersion() {
     return this.getStringAttribute('http_version');
   }
-  public set httpVersion(value: string | undefined) {
+  public set httpVersion(value: string ) {
     this._httpVersion = value;
+  }
+  public resetHttpVersion() {
+    this._httpVersion = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get httpVersionInput() {
@@ -364,8 +376,11 @@ export class CloudfrontDistribution extends TerraformResource {
   public get isIpv6Enabled() {
     return this.getBooleanAttribute('is_ipv6_enabled');
   }
-  public set isIpv6Enabled(value: boolean | undefined) {
+  public set isIpv6Enabled(value: boolean ) {
     this._isIpv6Enabled = value;
+  }
+  public resetIsIpv6Enabled() {
+    this._isIpv6Enabled = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get isIpv6EnabledInput() {
@@ -382,8 +397,11 @@ export class CloudfrontDistribution extends TerraformResource {
   public get priceClass() {
     return this.getStringAttribute('price_class');
   }
-  public set priceClass(value: string | undefined) {
+  public set priceClass(value: string ) {
     this._priceClass = value;
+  }
+  public resetPriceClass() {
+    this._priceClass = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get priceClassInput() {
@@ -395,8 +413,11 @@ export class CloudfrontDistribution extends TerraformResource {
   public get retainOnDelete() {
     return this.getBooleanAttribute('retain_on_delete');
   }
-  public set retainOnDelete(value: boolean | undefined) {
+  public set retainOnDelete(value: boolean ) {
     this._retainOnDelete = value;
+  }
+  public resetRetainOnDelete() {
+    this._retainOnDelete = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get retainOnDeleteInput() {
@@ -413,8 +434,11 @@ export class CloudfrontDistribution extends TerraformResource {
   public get tags() {
     return this.interpolationForAttribute('tags') as any;
   }
-  public set tags(value: { [key: string]: string } | undefined) {
+  public set tags(value: { [key: string]: string } ) {
     this._tags = value;
+  }
+  public resetTags() {
+    this._tags = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get tagsInput() {
@@ -426,8 +450,11 @@ export class CloudfrontDistribution extends TerraformResource {
   public get waitForDeployment() {
     return this.getBooleanAttribute('wait_for_deployment');
   }
-  public set waitForDeployment(value: boolean | undefined) {
+  public set waitForDeployment(value: boolean ) {
     this._waitForDeployment = value;
+  }
+  public resetWaitForDeployment() {
+    this._waitForDeployment = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get waitForDeploymentInput() {
@@ -439,8 +466,11 @@ export class CloudfrontDistribution extends TerraformResource {
   public get webAclId() {
     return this.getStringAttribute('web_acl_id');
   }
-  public set webAclId(value: string | undefined) {
+  public set webAclId(value: string ) {
     this._webAclId = value;
+  }
+  public resetWebAclId() {
+    this._webAclId = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get webAclIdInput() {
@@ -452,8 +482,11 @@ export class CloudfrontDistribution extends TerraformResource {
   public get cacheBehavior() {
     return this.interpolationForAttribute('cache_behavior') as any;
   }
-  public set cacheBehavior(value: CloudfrontDistributionCacheBehavior[] | undefined) {
+  public set cacheBehavior(value: CloudfrontDistributionCacheBehavior[] ) {
     this._cacheBehavior = value;
+  }
+  public resetCacheBehavior() {
+    this._cacheBehavior = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get cacheBehaviorInput() {
@@ -465,8 +498,11 @@ export class CloudfrontDistribution extends TerraformResource {
   public get customErrorResponse() {
     return this.interpolationForAttribute('custom_error_response') as any;
   }
-  public set customErrorResponse(value: CloudfrontDistributionCustomErrorResponse[] | undefined) {
+  public set customErrorResponse(value: CloudfrontDistributionCustomErrorResponse[] ) {
     this._customErrorResponse = value;
+  }
+  public resetCustomErrorResponse() {
+    this._customErrorResponse = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get customErrorResponseInput() {
@@ -491,8 +527,11 @@ export class CloudfrontDistribution extends TerraformResource {
   public get loggingConfig() {
     return this.interpolationForAttribute('logging_config') as any;
   }
-  public set loggingConfig(value: CloudfrontDistributionLoggingConfig[] | undefined) {
+  public set loggingConfig(value: CloudfrontDistributionLoggingConfig[] ) {
     this._loggingConfig = value;
+  }
+  public resetLoggingConfig() {
+    this._loggingConfig = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get loggingConfigInput() {
@@ -504,8 +543,11 @@ export class CloudfrontDistribution extends TerraformResource {
   public get orderedCacheBehavior() {
     return this.interpolationForAttribute('ordered_cache_behavior') as any;
   }
-  public set orderedCacheBehavior(value: CloudfrontDistributionOrderedCacheBehavior[] | undefined) {
+  public set orderedCacheBehavior(value: CloudfrontDistributionOrderedCacheBehavior[] ) {
     this._orderedCacheBehavior = value;
+  }
+  public resetOrderedCacheBehavior() {
+    this._orderedCacheBehavior = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get orderedCacheBehaviorInput() {
@@ -530,8 +572,11 @@ export class CloudfrontDistribution extends TerraformResource {
   public get originGroup() {
     return this.interpolationForAttribute('origin_group') as any;
   }
-  public set originGroup(value: CloudfrontDistributionOriginGroup[] | undefined) {
+  public set originGroup(value: CloudfrontDistributionOriginGroup[] ) {
     this._originGroup = value;
+  }
+  public resetOriginGroup() {
+    this._originGroup = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get originGroupInput() {
@@ -641,8 +686,11 @@ export class FmsAdminAccount extends TerraformResource {
   public get accountId() {
     return this.getStringAttribute('account_id');
   }
-  public set accountId(value: string | undefined) {
+  public set accountId(value: string) {
     this._accountId = value;
+  }
+  public resetAccountId() {
+    this._accountId = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get accountIdInput() {
@@ -885,8 +933,11 @@ export class S3Bucket extends TerraformResource {
   public get accelerationStatus() {
     return this.getStringAttribute('acceleration_status');
   }
-  public set accelerationStatus(value: string | undefined) {
+  public set accelerationStatus(value: string) {
     this._accelerationStatus = value;
+  }
+  public resetAccelerationStatus() {
+    this._accelerationStatus = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get accelerationStatusInput() {
@@ -898,8 +949,11 @@ export class S3Bucket extends TerraformResource {
   public get acl() {
     return this.getStringAttribute('acl');
   }
-  public set acl(value: string | undefined) {
+  public set acl(value: string ) {
     this._acl = value;
+  }
+  public resetAcl() {
+    this._acl = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get aclInput() {
@@ -916,8 +970,11 @@ export class S3Bucket extends TerraformResource {
   public get bucket() {
     return this.getStringAttribute('bucket');
   }
-  public set bucket(value: string | undefined) {
+  public set bucket(value: string) {
     this._bucket = value;
+  }
+  public resetBucket() {
+    this._bucket = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get bucketInput() {
@@ -934,8 +991,11 @@ export class S3Bucket extends TerraformResource {
   public get bucketPrefix() {
     return this.getStringAttribute('bucket_prefix');
   }
-  public set bucketPrefix(value: string | undefined) {
+  public set bucketPrefix(value: string ) {
     this._bucketPrefix = value;
+  }
+  public resetBucketPrefix() {
+    this._bucketPrefix = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get bucketPrefixInput() {
@@ -952,8 +1012,11 @@ export class S3Bucket extends TerraformResource {
   public get forceDestroy() {
     return this.getBooleanAttribute('force_destroy');
   }
-  public set forceDestroy(value: boolean | undefined) {
+  public set forceDestroy(value: boolean ) {
     this._forceDestroy = value;
+  }
+  public resetForceDestroy() {
+    this._forceDestroy = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get forceDestroyInput() {
@@ -965,8 +1028,11 @@ export class S3Bucket extends TerraformResource {
   public get hostedZoneId() {
     return this.getStringAttribute('hosted_zone_id');
   }
-  public set hostedZoneId(value: string | undefined) {
+  public set hostedZoneId(value: string) {
     this._hostedZoneId = value;
+  }
+  public resetHostedZoneId() {
+    this._hostedZoneId = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get hostedZoneIdInput() {
@@ -983,8 +1049,11 @@ export class S3Bucket extends TerraformResource {
   public get policy() {
     return this.getStringAttribute('policy');
   }
-  public set policy(value: string | undefined) {
+  public set policy(value: string ) {
     this._policy = value;
+  }
+  public resetPolicy() {
+    this._policy = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get policyInput() {
@@ -996,8 +1065,11 @@ export class S3Bucket extends TerraformResource {
   public get region() {
     return this.getStringAttribute('region');
   }
-  public set region(value: string | undefined) {
+  public set region(value: string) {
     this._region = value;
+  }
+  public resetRegion() {
+    this._region = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get regionInput() {
@@ -1009,8 +1081,11 @@ export class S3Bucket extends TerraformResource {
   public get requestPayer() {
     return this.getStringAttribute('request_payer');
   }
-  public set requestPayer(value: string | undefined) {
+  public set requestPayer(value: string) {
     this._requestPayer = value;
+  }
+  public resetRequestPayer() {
+    this._requestPayer = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get requestPayerInput() {
@@ -1022,8 +1097,11 @@ export class S3Bucket extends TerraformResource {
   public get tags() {
     return this.interpolationForAttribute('tags') as any;
   }
-  public set tags(value: { [key: string]: string } | undefined) {
+  public set tags(value: { [key: string]: string } ) {
     this._tags = value;
+  }
+  public resetTags() {
+    this._tags = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get tagsInput() {
@@ -1035,8 +1113,11 @@ export class S3Bucket extends TerraformResource {
   public get websiteDomain() {
     return this.getStringAttribute('website_domain');
   }
-  public set websiteDomain(value: string | undefined) {
+  public set websiteDomain(value: string) {
     this._websiteDomain = value;
+  }
+  public resetWebsiteDomain() {
+    this._websiteDomain = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get websiteDomainInput() {
@@ -1048,8 +1129,11 @@ export class S3Bucket extends TerraformResource {
   public get websiteEndpoint() {
     return this.getStringAttribute('website_endpoint');
   }
-  public set websiteEndpoint(value: string | undefined) {
+  public set websiteEndpoint(value: string) {
     this._websiteEndpoint = value;
+  }
+  public resetWebsiteEndpoint() {
+    this._websiteEndpoint = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get websiteEndpointInput() {
@@ -1061,8 +1145,11 @@ export class S3Bucket extends TerraformResource {
   public get corsRule() {
     return this.interpolationForAttribute('cors_rule') as any;
   }
-  public set corsRule(value: S3BucketCorsRule[] | undefined) {
+  public set corsRule(value: S3BucketCorsRule[] ) {
     this._corsRule = value;
+  }
+  public resetCorsRule() {
+    this._corsRule = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get corsRuleInput() {
@@ -1074,8 +1161,11 @@ export class S3Bucket extends TerraformResource {
   public get grant() {
     return this.interpolationForAttribute('grant') as any;
   }
-  public set grant(value: S3BucketGrant[] | undefined) {
+  public set grant(value: S3BucketGrant[] ) {
     this._grant = value;
+  }
+  public resetGrant() {
+    this._grant = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get grantInput() {
@@ -1087,8 +1177,11 @@ export class S3Bucket extends TerraformResource {
   public get lifecycleRule() {
     return this.interpolationForAttribute('lifecycle_rule') as any;
   }
-  public set lifecycleRule(value: S3BucketLifecycleRule[] | undefined) {
+  public set lifecycleRule(value: S3BucketLifecycleRule[] ) {
     this._lifecycleRule = value;
+  }
+  public resetLifecycleRule() {
+    this._lifecycleRule = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get lifecycleRuleInput() {
@@ -1100,8 +1193,11 @@ export class S3Bucket extends TerraformResource {
   public get logging() {
     return this.interpolationForAttribute('logging') as any;
   }
-  public set logging(value: S3BucketLogging[] | undefined) {
+  public set logging(value: S3BucketLogging[] ) {
     this._logging = value;
+  }
+  public resetLogging() {
+    this._logging = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get loggingInput() {
@@ -1113,8 +1209,11 @@ export class S3Bucket extends TerraformResource {
   public get objectLockConfiguration() {
     return this.interpolationForAttribute('object_lock_configuration') as any;
   }
-  public set objectLockConfiguration(value: S3BucketObjectLockConfiguration[] | undefined) {
+  public set objectLockConfiguration(value: S3BucketObjectLockConfiguration[] ) {
     this._objectLockConfiguration = value;
+  }
+  public resetObjectLockConfiguration() {
+    this._objectLockConfiguration = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get objectLockConfigurationInput() {
@@ -1126,8 +1225,11 @@ export class S3Bucket extends TerraformResource {
   public get replicationConfiguration() {
     return this.interpolationForAttribute('replication_configuration') as any;
   }
-  public set replicationConfiguration(value: S3BucketReplicationConfiguration[] | undefined) {
+  public set replicationConfiguration(value: S3BucketReplicationConfiguration[] ) {
     this._replicationConfiguration = value;
+  }
+  public resetReplicationConfiguration() {
+    this._replicationConfiguration = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get replicationConfigurationInput() {
@@ -1139,8 +1241,11 @@ export class S3Bucket extends TerraformResource {
   public get serverSideEncryptionConfiguration() {
     return this.interpolationForAttribute('server_side_encryption_configuration') as any;
   }
-  public set serverSideEncryptionConfiguration(value: S3BucketServerSideEncryptionConfiguration[] | undefined) {
+  public set serverSideEncryptionConfiguration(value: S3BucketServerSideEncryptionConfiguration[] ) {
     this._serverSideEncryptionConfiguration = value;
+  }
+  public resetServerSideEncryptionConfiguration() {
+    this._serverSideEncryptionConfiguration = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get serverSideEncryptionConfigurationInput() {
@@ -1152,8 +1257,11 @@ export class S3Bucket extends TerraformResource {
   public get versioning() {
     return this.interpolationForAttribute('versioning') as any;
   }
-  public set versioning(value: S3BucketVersioning[] | undefined) {
+  public set versioning(value: S3BucketVersioning[] ) {
     this._versioning = value;
+  }
+  public resetVersioning() {
+    this._versioning = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get versioningInput() {
@@ -1165,8 +1273,11 @@ export class S3Bucket extends TerraformResource {
   public get website() {
     return this.interpolationForAttribute('website') as any;
   }
-  public set website(value: S3BucketWebsite[] | undefined) {
+  public set website(value: S3BucketWebsite[] ) {
     this._website = value;
+  }
+  public resetWebsite() {
+    this._website = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get websiteInput() {
@@ -1299,8 +1410,11 @@ export class SecurityGroup extends TerraformResource {
   public get description() {
     return this.getStringAttribute('description');
   }
-  public set description(value: string | undefined) {
+  public set description(value: string ) {
     this._description = value;
+  }
+  public resetDescription() {
+    this._description = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get descriptionInput() {
@@ -1309,11 +1423,14 @@ export class SecurityGroup extends TerraformResource {
 
   // egress - computed: true, optional: true, required: false
   private _egress?: SecurityGroupEgress[]
-  public get egress(): SecurityGroupEgress[] | undefined {
-    return this._egress; // Getting the computed value is not yet implemented
+  public get egress(): SecurityGroupEgress[] {
+    return this.interpolationForAttribute('egress') as any; // Getting the computed value is not yet implemented
   }
-  public set egress(value: SecurityGroupEgress[] | undefined) {
+  public set egress(value: SecurityGroupEgress[]) {
     this._egress = value;
+  }
+  public resetEgress() {
+    this._egress = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get egressInput() {
@@ -1327,11 +1444,14 @@ export class SecurityGroup extends TerraformResource {
 
   // ingress - computed: true, optional: true, required: false
   private _ingress?: SecurityGroupIngress[]
-  public get ingress(): SecurityGroupIngress[] | undefined {
-    return this._ingress; // Getting the computed value is not yet implemented
+  public get ingress(): SecurityGroupIngress[] {
+    return this.interpolationForAttribute('ingress') as any; // Getting the computed value is not yet implemented
   }
-  public set ingress(value: SecurityGroupIngress[] | undefined) {
+  public set ingress(value: SecurityGroupIngress[]) {
     this._ingress = value;
+  }
+  public resetIngress() {
+    this._ingress = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get ingressInput() {
@@ -1343,8 +1463,11 @@ export class SecurityGroup extends TerraformResource {
   public get name() {
     return this.getStringAttribute('name');
   }
-  public set name(value: string | undefined) {
+  public set name(value: string) {
     this._name = value;
+  }
+  public resetName() {
+    this._name = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get nameInput() {
@@ -1356,8 +1479,11 @@ export class SecurityGroup extends TerraformResource {
   public get namePrefix() {
     return this.getStringAttribute('name_prefix');
   }
-  public set namePrefix(value: string | undefined) {
+  public set namePrefix(value: string ) {
     this._namePrefix = value;
+  }
+  public resetNamePrefix() {
+    this._namePrefix = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get namePrefixInput() {
@@ -1374,8 +1500,11 @@ export class SecurityGroup extends TerraformResource {
   public get revokeRulesOnDelete() {
     return this.getBooleanAttribute('revoke_rules_on_delete');
   }
-  public set revokeRulesOnDelete(value: boolean | undefined) {
+  public set revokeRulesOnDelete(value: boolean ) {
     this._revokeRulesOnDelete = value;
+  }
+  public resetRevokeRulesOnDelete() {
+    this._revokeRulesOnDelete = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get revokeRulesOnDeleteInput() {
@@ -1387,8 +1516,11 @@ export class SecurityGroup extends TerraformResource {
   public get tags() {
     return this.interpolationForAttribute('tags') as any;
   }
-  public set tags(value: { [key: string]: string } | undefined) {
+  public set tags(value: { [key: string]: string } ) {
     this._tags = value;
+  }
+  public resetTags() {
+    this._tags = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get tagsInput() {
@@ -1400,8 +1532,11 @@ export class SecurityGroup extends TerraformResource {
   public get vpcId() {
     return this.getStringAttribute('vpc_id');
   }
-  public set vpcId(value: string | undefined) {
+  public set vpcId(value: string) {
     this._vpcId = value;
+  }
+  public resetVpcId() {
+    this._vpcId = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get vpcIdInput() {
@@ -1413,8 +1548,11 @@ export class SecurityGroup extends TerraformResource {
   public get timeouts() {
     return this.interpolationForAttribute('timeouts') as any;
   }
-  public set timeouts(value: SecurityGroupTimeouts | undefined) {
+  public set timeouts(value: SecurityGroupTimeouts ) {
     this._timeouts = value;
+  }
+  public resetTimeouts() {
+    this._timeouts = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get timeoutsInput() {

--- a/packages/cdktf-cli/test/get/generator/__snapshots__/resource-types.test.ts.snap
+++ b/packages/cdktf-cli/test/get/generator/__snapshots__/resource-types.test.ts.snap
@@ -267,6 +267,10 @@ export class CloudfrontDistribution extends TerraformResource {
   public set aliases(value: string[] | undefined) {
     this._aliases = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get aliasesInput() {
+    return this._aliases
+  }
 
   // arn - computed: true, optional: false, required: false
   public get arn() {
@@ -286,6 +290,10 @@ export class CloudfrontDistribution extends TerraformResource {
   public set comment(value: string | undefined) {
     this._comment = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get commentInput() {
+    return this._comment
+  }
 
   // default_root_object - computed: false, optional: true, required: false
   private _defaultRootObject?: string;
@@ -294,6 +302,10 @@ export class CloudfrontDistribution extends TerraformResource {
   }
   public set defaultRootObject(value: string | undefined) {
     this._defaultRootObject = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get defaultRootObjectInput() {
+    return this._defaultRootObject
   }
 
   // domain_name - computed: true, optional: false, required: false
@@ -308,6 +320,10 @@ export class CloudfrontDistribution extends TerraformResource {
   }
   public set enabled(value: boolean) {
     this._enabled = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get enabledInput() {
+    return this._enabled
   }
 
   // etag - computed: true, optional: false, required: false
@@ -328,6 +344,10 @@ export class CloudfrontDistribution extends TerraformResource {
   public set httpVersion(value: string | undefined) {
     this._httpVersion = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get httpVersionInput() {
+    return this._httpVersion
+  }
 
   // id - computed: true, optional: true, required: false
   public get id() {
@@ -347,6 +367,10 @@ export class CloudfrontDistribution extends TerraformResource {
   public set isIpv6Enabled(value: boolean | undefined) {
     this._isIpv6Enabled = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get isIpv6EnabledInput() {
+    return this._isIpv6Enabled
+  }
 
   // last_modified_time - computed: true, optional: false, required: false
   public get lastModifiedTime() {
@@ -361,6 +385,10 @@ export class CloudfrontDistribution extends TerraformResource {
   public set priceClass(value: string | undefined) {
     this._priceClass = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get priceClassInput() {
+    return this._priceClass
+  }
 
   // retain_on_delete - computed: false, optional: true, required: false
   private _retainOnDelete?: boolean;
@@ -369,6 +397,10 @@ export class CloudfrontDistribution extends TerraformResource {
   }
   public set retainOnDelete(value: boolean | undefined) {
     this._retainOnDelete = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get retainOnDeleteInput() {
+    return this._retainOnDelete
   }
 
   // status - computed: true, optional: false, required: false
@@ -384,6 +416,10 @@ export class CloudfrontDistribution extends TerraformResource {
   public set tags(value: { [key: string]: string } | undefined) {
     this._tags = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get tagsInput() {
+    return this._tags
+  }
 
   // wait_for_deployment - computed: false, optional: true, required: false
   private _waitForDeployment?: boolean;
@@ -392,6 +428,10 @@ export class CloudfrontDistribution extends TerraformResource {
   }
   public set waitForDeployment(value: boolean | undefined) {
     this._waitForDeployment = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get waitForDeploymentInput() {
+    return this._waitForDeployment
   }
 
   // web_acl_id - computed: false, optional: true, required: false
@@ -402,6 +442,10 @@ export class CloudfrontDistribution extends TerraformResource {
   public set webAclId(value: string | undefined) {
     this._webAclId = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get webAclIdInput() {
+    return this._webAclId
+  }
 
   // cache_behavior - computed: false, optional: true, required: false
   private _cacheBehavior?: CloudfrontDistributionCacheBehavior[];
@@ -410,6 +454,10 @@ export class CloudfrontDistribution extends TerraformResource {
   }
   public set cacheBehavior(value: CloudfrontDistributionCacheBehavior[] | undefined) {
     this._cacheBehavior = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get cacheBehaviorInput() {
+    return this._cacheBehavior
   }
 
   // custom_error_response - computed: false, optional: true, required: false
@@ -420,6 +468,10 @@ export class CloudfrontDistribution extends TerraformResource {
   public set customErrorResponse(value: CloudfrontDistributionCustomErrorResponse[] | undefined) {
     this._customErrorResponse = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get customErrorResponseInput() {
+    return this._customErrorResponse
+  }
 
   // default_cache_behavior - computed: false, optional: false, required: true
   private _defaultCacheBehavior: CloudfrontDistributionDefaultCacheBehavior[];
@@ -428,6 +480,10 @@ export class CloudfrontDistribution extends TerraformResource {
   }
   public set defaultCacheBehavior(value: CloudfrontDistributionDefaultCacheBehavior[]) {
     this._defaultCacheBehavior = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get defaultCacheBehaviorInput() {
+    return this._defaultCacheBehavior
   }
 
   // logging_config - computed: false, optional: true, required: false
@@ -438,6 +494,10 @@ export class CloudfrontDistribution extends TerraformResource {
   public set loggingConfig(value: CloudfrontDistributionLoggingConfig[] | undefined) {
     this._loggingConfig = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get loggingConfigInput() {
+    return this._loggingConfig
+  }
 
   // ordered_cache_behavior - computed: false, optional: true, required: false
   private _orderedCacheBehavior?: CloudfrontDistributionOrderedCacheBehavior[];
@@ -446,6 +506,10 @@ export class CloudfrontDistribution extends TerraformResource {
   }
   public set orderedCacheBehavior(value: CloudfrontDistributionOrderedCacheBehavior[] | undefined) {
     this._orderedCacheBehavior = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get orderedCacheBehaviorInput() {
+    return this._orderedCacheBehavior
   }
 
   // origin - computed: false, optional: false, required: true
@@ -456,6 +520,10 @@ export class CloudfrontDistribution extends TerraformResource {
   public set origin(value: CloudfrontDistributionOrigin[]) {
     this._origin = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get originInput() {
+    return this._origin
+  }
 
   // origin_group - computed: false, optional: true, required: false
   private _originGroup?: CloudfrontDistributionOriginGroup[];
@@ -464,6 +532,10 @@ export class CloudfrontDistribution extends TerraformResource {
   }
   public set originGroup(value: CloudfrontDistributionOriginGroup[] | undefined) {
     this._originGroup = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get originGroupInput() {
+    return this._originGroup
   }
 
   // restrictions - computed: false, optional: false, required: true
@@ -474,6 +546,10 @@ export class CloudfrontDistribution extends TerraformResource {
   public set restrictions(value: CloudfrontDistributionRestrictions[]) {
     this._restrictions = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get restrictionsInput() {
+    return this._restrictions
+  }
 
   // viewer_certificate - computed: false, optional: false, required: true
   private _viewerCertificate: CloudfrontDistributionViewerCertificate[];
@@ -482,6 +558,10 @@ export class CloudfrontDistribution extends TerraformResource {
   }
   public set viewerCertificate(value: CloudfrontDistributionViewerCertificate[]) {
     this._viewerCertificate = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get viewerCertificateInput() {
+    return this._viewerCertificate
   }
 
   // =========
@@ -563,6 +643,10 @@ export class FmsAdminAccount extends TerraformResource {
   }
   public set accountId(value: string | undefined) {
     this._accountId = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get accountIdInput() {
+    return this._accountId
   }
 
   // id - computed: true, optional: true, required: false
@@ -804,6 +888,10 @@ export class S3Bucket extends TerraformResource {
   public set accelerationStatus(value: string | undefined) {
     this._accelerationStatus = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get accelerationStatusInput() {
+    return this._accelerationStatus
+  }
 
   // acl - computed: false, optional: true, required: false
   private _acl?: string;
@@ -812,6 +900,10 @@ export class S3Bucket extends TerraformResource {
   }
   public set acl(value: string | undefined) {
     this._acl = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get aclInput() {
+    return this._acl
   }
 
   // arn - computed: true, optional: true, required: false
@@ -827,6 +919,10 @@ export class S3Bucket extends TerraformResource {
   public set bucket(value: string | undefined) {
     this._bucket = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get bucketInput() {
+    return this._bucket
+  }
 
   // bucket_domain_name - computed: true, optional: false, required: false
   public get bucketDomainName() {
@@ -840,6 +936,10 @@ export class S3Bucket extends TerraformResource {
   }
   public set bucketPrefix(value: string | undefined) {
     this._bucketPrefix = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get bucketPrefixInput() {
+    return this._bucketPrefix
   }
 
   // bucket_regional_domain_name - computed: true, optional: false, required: false
@@ -855,6 +955,10 @@ export class S3Bucket extends TerraformResource {
   public set forceDestroy(value: boolean | undefined) {
     this._forceDestroy = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get forceDestroyInput() {
+    return this._forceDestroy
+  }
 
   // hosted_zone_id - computed: true, optional: true, required: false
   private _hostedZoneId?: string;
@@ -863,6 +967,10 @@ export class S3Bucket extends TerraformResource {
   }
   public set hostedZoneId(value: string | undefined) {
     this._hostedZoneId = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get hostedZoneIdInput() {
+    return this._hostedZoneId
   }
 
   // id - computed: true, optional: true, required: false
@@ -878,6 +986,10 @@ export class S3Bucket extends TerraformResource {
   public set policy(value: string | undefined) {
     this._policy = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get policyInput() {
+    return this._policy
+  }
 
   // region - computed: true, optional: true, required: false
   private _region?: string;
@@ -886,6 +998,10 @@ export class S3Bucket extends TerraformResource {
   }
   public set region(value: string | undefined) {
     this._region = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get regionInput() {
+    return this._region
   }
 
   // request_payer - computed: true, optional: true, required: false
@@ -896,6 +1012,10 @@ export class S3Bucket extends TerraformResource {
   public set requestPayer(value: string | undefined) {
     this._requestPayer = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get requestPayerInput() {
+    return this._requestPayer
+  }
 
   // tags - computed: false, optional: true, required: false
   private _tags?: { [key: string]: string };
@@ -904,6 +1024,10 @@ export class S3Bucket extends TerraformResource {
   }
   public set tags(value: { [key: string]: string } | undefined) {
     this._tags = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get tagsInput() {
+    return this._tags
   }
 
   // website_domain - computed: true, optional: true, required: false
@@ -914,6 +1038,10 @@ export class S3Bucket extends TerraformResource {
   public set websiteDomain(value: string | undefined) {
     this._websiteDomain = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get websiteDomainInput() {
+    return this._websiteDomain
+  }
 
   // website_endpoint - computed: true, optional: true, required: false
   private _websiteEndpoint?: string;
@@ -922,6 +1050,10 @@ export class S3Bucket extends TerraformResource {
   }
   public set websiteEndpoint(value: string | undefined) {
     this._websiteEndpoint = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get websiteEndpointInput() {
+    return this._websiteEndpoint
   }
 
   // cors_rule - computed: false, optional: true, required: false
@@ -932,6 +1064,10 @@ export class S3Bucket extends TerraformResource {
   public set corsRule(value: S3BucketCorsRule[] | undefined) {
     this._corsRule = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get corsRuleInput() {
+    return this._corsRule
+  }
 
   // grant - computed: false, optional: true, required: false
   private _grant?: S3BucketGrant[];
@@ -940,6 +1076,10 @@ export class S3Bucket extends TerraformResource {
   }
   public set grant(value: S3BucketGrant[] | undefined) {
     this._grant = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get grantInput() {
+    return this._grant
   }
 
   // lifecycle_rule - computed: false, optional: true, required: false
@@ -950,6 +1090,10 @@ export class S3Bucket extends TerraformResource {
   public set lifecycleRule(value: S3BucketLifecycleRule[] | undefined) {
     this._lifecycleRule = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get lifecycleRuleInput() {
+    return this._lifecycleRule
+  }
 
   // logging - computed: false, optional: true, required: false
   private _logging?: S3BucketLogging[];
@@ -958,6 +1102,10 @@ export class S3Bucket extends TerraformResource {
   }
   public set logging(value: S3BucketLogging[] | undefined) {
     this._logging = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get loggingInput() {
+    return this._logging
   }
 
   // object_lock_configuration - computed: false, optional: true, required: false
@@ -968,6 +1116,10 @@ export class S3Bucket extends TerraformResource {
   public set objectLockConfiguration(value: S3BucketObjectLockConfiguration[] | undefined) {
     this._objectLockConfiguration = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get objectLockConfigurationInput() {
+    return this._objectLockConfiguration
+  }
 
   // replication_configuration - computed: false, optional: true, required: false
   private _replicationConfiguration?: S3BucketReplicationConfiguration[];
@@ -976,6 +1128,10 @@ export class S3Bucket extends TerraformResource {
   }
   public set replicationConfiguration(value: S3BucketReplicationConfiguration[] | undefined) {
     this._replicationConfiguration = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get replicationConfigurationInput() {
+    return this._replicationConfiguration
   }
 
   // server_side_encryption_configuration - computed: false, optional: true, required: false
@@ -986,6 +1142,10 @@ export class S3Bucket extends TerraformResource {
   public set serverSideEncryptionConfiguration(value: S3BucketServerSideEncryptionConfiguration[] | undefined) {
     this._serverSideEncryptionConfiguration = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get serverSideEncryptionConfigurationInput() {
+    return this._serverSideEncryptionConfiguration
+  }
 
   // versioning - computed: false, optional: true, required: false
   private _versioning?: S3BucketVersioning[];
@@ -995,6 +1155,10 @@ export class S3Bucket extends TerraformResource {
   public set versioning(value: S3BucketVersioning[] | undefined) {
     this._versioning = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get versioningInput() {
+    return this._versioning
+  }
 
   // website - computed: false, optional: true, required: false
   private _website?: S3BucketWebsite[];
@@ -1003,6 +1167,10 @@ export class S3Bucket extends TerraformResource {
   }
   public set website(value: S3BucketWebsite[] | undefined) {
     this._website = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get websiteInput() {
+    return this._website
   }
 
   // =========
@@ -1134,6 +1302,10 @@ export class SecurityGroup extends TerraformResource {
   public set description(value: string | undefined) {
     this._description = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get descriptionInput() {
+    return this._description
+  }
 
   // egress - computed: true, optional: true, required: false
   private _egress?: SecurityGroupEgress[]
@@ -1142,6 +1314,10 @@ export class SecurityGroup extends TerraformResource {
   }
   public set egress(value: SecurityGroupEgress[] | undefined) {
     this._egress = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get egressInput() {
+    return this._egress
   }
 
   // id - computed: true, optional: true, required: false
@@ -1157,6 +1333,10 @@ export class SecurityGroup extends TerraformResource {
   public set ingress(value: SecurityGroupIngress[] | undefined) {
     this._ingress = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get ingressInput() {
+    return this._ingress
+  }
 
   // name - computed: true, optional: true, required: false
   private _name?: string;
@@ -1166,6 +1346,10 @@ export class SecurityGroup extends TerraformResource {
   public set name(value: string | undefined) {
     this._name = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get nameInput() {
+    return this._name
+  }
 
   // name_prefix - computed: false, optional: true, required: false
   private _namePrefix?: string;
@@ -1174,6 +1358,10 @@ export class SecurityGroup extends TerraformResource {
   }
   public set namePrefix(value: string | undefined) {
     this._namePrefix = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get namePrefixInput() {
+    return this._namePrefix
   }
 
   // owner_id - computed: true, optional: false, required: false
@@ -1189,6 +1377,10 @@ export class SecurityGroup extends TerraformResource {
   public set revokeRulesOnDelete(value: boolean | undefined) {
     this._revokeRulesOnDelete = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get revokeRulesOnDeleteInput() {
+    return this._revokeRulesOnDelete
+  }
 
   // tags - computed: false, optional: true, required: false
   private _tags?: { [key: string]: string };
@@ -1197,6 +1389,10 @@ export class SecurityGroup extends TerraformResource {
   }
   public set tags(value: { [key: string]: string } | undefined) {
     this._tags = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get tagsInput() {
+    return this._tags
   }
 
   // vpc_id - computed: true, optional: true, required: false
@@ -1207,6 +1403,10 @@ export class SecurityGroup extends TerraformResource {
   public set vpcId(value: string | undefined) {
     this._vpcId = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get vpcIdInput() {
+    return this._vpcId
+  }
 
   // timeouts - computed: false, optional: true, required: false
   private _timeouts?: SecurityGroupTimeouts;
@@ -1215,6 +1415,10 @@ export class SecurityGroup extends TerraformResource {
   }
   public set timeouts(value: SecurityGroupTimeouts | undefined) {
     this._timeouts = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get timeoutsInput() {
+    return this._timeouts
   }
 
   // =========

--- a/packages/cdktf-cli/test/get/generator/__snapshots__/types.test.ts.snap
+++ b/packages/cdktf-cli/test/get/generator/__snapshots__/types.test.ts.snap
@@ -45,7 +45,7 @@ export class BooleanList extends TerraformResource {
   // foo_required - computed: false, optional: false, required: true
   private _fooRequired: boolean[];
   public get fooRequired() {
-    return this._fooRequired;
+    return this.interpolationForAttribute('foo_required') as any;
   }
   public set fooRequired(value: boolean[]) {
     this._fooRequired = value;
@@ -54,7 +54,7 @@ export class BooleanList extends TerraformResource {
   // foo_optional - computed: false, optional: true, required: false
   private _fooOptional?: boolean[];
   public get fooOptional() {
-    return this._fooOptional;
+    return this.interpolationForAttribute('foo_optional') as any;
   }
   public set fooOptional(value: boolean[] | undefined) {
     this._fooOptional = value;
@@ -117,7 +117,7 @@ export class BooleanMap extends TerraformResource {
   // ATTRIBUTES
   // ==========
 
-  // foo_computed - computed: true, optional: false, required: true
+  // foo_computed - computed: true, optional: false, required: false
   public fooComputed(key: string): boolean {
     return new BooleanMap(this, 'foo_computed').lookup(key);
   }
@@ -134,7 +134,7 @@ export class BooleanMap extends TerraformResource {
   // foo_optional - computed: false, optional: true, required: false
   private _fooOptional?: { [key: string]: boolean };
   public get fooOptional() {
-    return this._fooOptional;
+    return this.interpolationForAttribute('foo_optional') as any;
   }
   public set fooOptional(value: { [key: string]: boolean } | undefined) {
     this._fooOptional = value;
@@ -169,47 +169,47 @@ export interface ComputedComplexConfig extends TerraformMetaArguments {
 }
 export class ComputedComplexEgress extends ComplexComputedList {
 
-  // cidr_blocks - computed: true, optional: false, required: true
+  // cidr_blocks - computed: true, optional: false, required: false
   public get cidrBlocks() {
     return this.getListAttribute('cidr_blocks');
   }
 
-  // description - computed: true, optional: false, required: true
+  // description - computed: true, optional: false, required: false
   public get description() {
     return this.getStringAttribute('description');
   }
 
-  // from_port - computed: true, optional: false, required: true
+  // from_port - computed: true, optional: false, required: false
   public get fromPort() {
     return this.getNumberAttribute('from_port');
   }
 
-  // ipv6_cidr_blocks - computed: true, optional: false, required: true
+  // ipv6_cidr_blocks - computed: true, optional: false, required: false
   public get ipv6CidrBlocks() {
     return this.getListAttribute('ipv6_cidr_blocks');
   }
 
-  // prefix_list_ids - computed: true, optional: false, required: true
+  // prefix_list_ids - computed: true, optional: false, required: false
   public get prefixListIds() {
     return this.getListAttribute('prefix_list_ids');
   }
 
-  // protocol - computed: true, optional: false, required: true
+  // protocol - computed: true, optional: false, required: false
   public get protocol() {
     return this.getStringAttribute('protocol');
   }
 
-  // security_groups - computed: true, optional: false, required: true
+  // security_groups - computed: true, optional: false, required: false
   public get securityGroups() {
     return this.getListAttribute('security_groups');
   }
 
-  // self - computed: true, optional: false, required: true
+  // self - computed: true, optional: false, required: false
   public get selfAttribute() {
     return this.getBooleanAttribute('self');
   }
 
-  // to_port - computed: true, optional: false, required: true
+  // to_port - computed: true, optional: false, required: false
   public get toPort() {
     return this.getNumberAttribute('to_port');
   }
@@ -240,7 +240,7 @@ export class ComputedComplex extends TerraformResource {
   // ATTRIBUTES
   // ==========
 
-  // egress - computed: true, optional: false, required: true
+  // egress - computed: true, optional: false, required: false
   public egress(index: string) {
     return new ComputedComplexEgress(this, 'egress', index);
   }
@@ -272,19 +272,19 @@ export interface ComputedComplexNestedConfig extends TerraformMetaArguments {
 }
 export class ComputedComplexNestedResourcesAutoscalingGroups extends ComplexComputedList {
 
-  // name - computed: true, optional: false, required: true
+  // name - computed: true, optional: false, required: false
   public get name() {
     return this.getStringAttribute('name');
   }
 }
 export class ComputedComplexNestedResources extends ComplexComputedList {
 
-  // autoscaling_groups - computed: true, optional: false, required: true
+  // autoscaling_groups - computed: true, optional: false, required: false
   public get autoscalingGroups() {
-    return 'not implemented' as any;
+    return this.interpolationForAttribute('autoscaling_groups') as any;
   }
 
-  // remote_access_security_group_id - computed: true, optional: false, required: true
+  // remote_access_security_group_id - computed: true, optional: false, required: false
   public get remoteAccessSecurityGroupId() {
     return this.getStringAttribute('remote_access_security_group_id');
   }
@@ -315,7 +315,7 @@ export class ComputedComplexNested extends TerraformResource {
   // ATTRIBUTES
   // ==========
 
-  // resources - computed: true, optional: false, required: true
+  // resources - computed: true, optional: false, required: false
   public resources(index: string) {
     return new ComputedComplexNestedResources(this, 'resources', index);
   }
@@ -379,7 +379,7 @@ export class BlockTypeNestedComputedList extends TerraformResource {
   // inputs - computed: false, optional: true, required: false
   private _inputs?: BlockTypeNestedComputedListInputs[];
   public get inputs() {
-    return this._inputs;
+    return this.interpolationForAttribute('inputs') as any;
   }
   public set inputs(value: BlockTypeNestedComputedListInputs[] | undefined) {
     this._inputs = value;
@@ -523,7 +523,7 @@ export class DeeplyNestedBlockTypes extends TerraformResource {
   // lifecycle_rule - computed: false, optional: true, required: false
   private _lifecycleRule?: DeeplyNestedBlockTypesLifecycleRule[];
   public get lifecycleRule() {
-    return this._lifecycleRule;
+    return this.interpolationForAttribute('lifecycle_rule') as any;
   }
   public set lifecycleRule(value: DeeplyNestedBlockTypesLifecycleRule[] | undefined) {
     this._lifecycleRule = value;
@@ -581,15 +581,11 @@ export class IgnoredAttributes extends TerraformResource {
   // ==========
 
   // id - computed: true, optional: true, required: false
-  private _id?: string;
   public get id() {
-    return this._id ?? this.getStringAttribute('id');
-  }
-  public set id(value: string | undefined) {
-    this._id = value;
+    return this.getStringAttribute('id');
   }
 
-  // arn - computed: true, optional: false, required: true
+  // arn - computed: true, optional: false, required: false
   public get arn() {
     return this.getStringAttribute('arn');
   }
@@ -651,7 +647,7 @@ export class IncompatibleAttributeNames extends TerraformResource {
   // get_password_data - computed: false, optional: true, required: false
   private _getPasswordData?: string;
   public get fetchPasswordData() {
-    return this._getPasswordData;
+    return this.getStringAttribute('get_password_data');
   }
   public set fetchPasswordData(value: string | undefined) {
     this._getPasswordData = value;
@@ -660,7 +656,7 @@ export class IncompatibleAttributeNames extends TerraformResource {
   // self - computed: false, optional: false, required: true
   private _self: string;
   public get selfAttribute() {
-    return this._self;
+    return this.getStringAttribute('self');
   }
   public set selfAttribute(value: string) {
     this._self = value;
@@ -719,7 +715,7 @@ export class ListOfStringMap extends TerraformResource {
   // ATTRIBUTES
   // ==========
 
-  // keys - computed: true, optional: false, required: true
+  // keys - computed: true, optional: false, required: false
   public keys(index: string, key: string): string {
     return new StringMap(this, \`keys.\${index}\`).lookup(key);
   }
@@ -781,7 +777,7 @@ export class NumberList extends TerraformResource {
   // foo_required - computed: false, optional: false, required: true
   private _fooRequired: number[];
   public get fooRequired() {
-    return this._fooRequired;
+    return this.interpolationForAttribute('foo_required') as any;
   }
   public set fooRequired(value: number[]) {
     this._fooRequired = value;
@@ -790,7 +786,7 @@ export class NumberList extends TerraformResource {
   // foo_optional - computed: false, optional: true, required: false
   private _fooOptional?: number[];
   public get fooOptional() {
-    return this._fooOptional;
+    return this.interpolationForAttribute('foo_optional') as any;
   }
   public set fooOptional(value: number[] | undefined) {
     this._fooOptional = value;
@@ -853,7 +849,7 @@ export class NumberMap extends TerraformResource {
   // ATTRIBUTES
   // ==========
 
-  // foo_computed - computed: true, optional: false, required: true
+  // foo_computed - computed: true, optional: false, required: false
   public fooComputed(key: string): number {
     return new NumberMap(this, 'foo_computed').lookup(key);
   }
@@ -870,7 +866,7 @@ export class NumberMap extends TerraformResource {
   // foo_optional - computed: false, optional: true, required: false
   private _fooOptional?: { [key: string]: number };
   public get fooOptional() {
-    return this._fooOptional;
+    return this.interpolationForAttribute('foo_optional') as any;
   }
   public set fooOptional(value: { [key: string]: number } | undefined) {
     this._fooOptional = value;
@@ -934,7 +930,7 @@ export class PrimitiveBoolean extends TerraformResource {
   // ATTRIBUTES
   // ==========
 
-  // foo_computed - computed: true, optional: false, required: true
+  // foo_computed - computed: true, optional: false, required: false
   public get fooComputed() {
     return this.getBooleanAttribute('foo_computed');
   }
@@ -942,7 +938,7 @@ export class PrimitiveBoolean extends TerraformResource {
   // foo_computed_optional - computed: true, optional: true, required: false
   private _fooComputedOptional?: boolean;
   public get fooComputedOptional() {
-    return this._fooComputedOptional ?? this.getBooleanAttribute('foo_computed_optional');
+    return this.getBooleanAttribute('foo_computed_optional');
   }
   public set fooComputedOptional(value: boolean | undefined) {
     this._fooComputedOptional = value;
@@ -951,7 +947,7 @@ export class PrimitiveBoolean extends TerraformResource {
   // foo_optional - computed: false, optional: true, required: false
   private _fooOptional?: boolean;
   public get fooOptional() {
-    return this._fooOptional;
+    return this.getBooleanAttribute('foo_optional');
   }
   public set fooOptional(value: boolean | undefined) {
     this._fooOptional = value;
@@ -960,7 +956,7 @@ export class PrimitiveBoolean extends TerraformResource {
   // foo_required - computed: false, optional: false, required: true
   private _fooRequired: boolean;
   public get fooRequired() {
-    return this._fooRequired;
+    return this.getBooleanAttribute('foo_required');
   }
   public set fooRequired(value: boolean) {
     this._fooRequired = value;
@@ -1025,7 +1021,7 @@ export class PrimitiveNumber extends TerraformResource {
   // ATTRIBUTES
   // ==========
 
-  // foo_computed - computed: true, optional: false, required: true
+  // foo_computed - computed: true, optional: false, required: false
   public get fooComputed() {
     return this.getNumberAttribute('foo_computed');
   }
@@ -1033,7 +1029,7 @@ export class PrimitiveNumber extends TerraformResource {
   // foo_computed_optional - computed: true, optional: true, required: false
   private _fooComputedOptional?: number;
   public get fooComputedOptional() {
-    return this._fooComputedOptional ?? this.getNumberAttribute('foo_computed_optional');
+    return this.getNumberAttribute('foo_computed_optional');
   }
   public set fooComputedOptional(value: number | undefined) {
     this._fooComputedOptional = value;
@@ -1042,7 +1038,7 @@ export class PrimitiveNumber extends TerraformResource {
   // foo_optional - computed: false, optional: true, required: false
   private _fooOptional?: number;
   public get fooOptional() {
-    return this._fooOptional;
+    return this.getNumberAttribute('foo_optional');
   }
   public set fooOptional(value: number | undefined) {
     this._fooOptional = value;
@@ -1051,7 +1047,7 @@ export class PrimitiveNumber extends TerraformResource {
   // foo_required - computed: false, optional: false, required: true
   private _fooRequired: number;
   public get fooRequired() {
-    return this._fooRequired;
+    return this.getNumberAttribute('foo_required');
   }
   public set fooRequired(value: number) {
     this._fooRequired = value;
@@ -1116,7 +1112,7 @@ export class PrimitiveString extends TerraformResource {
   // ATTRIBUTES
   // ==========
 
-  // foo_computed - computed: true, optional: false, required: true
+  // foo_computed - computed: true, optional: false, required: false
   public get fooComputed() {
     return this.getStringAttribute('foo_computed');
   }
@@ -1124,7 +1120,7 @@ export class PrimitiveString extends TerraformResource {
   // foo_computed_optional - computed: true, optional: true, required: false
   private _fooComputedOptional?: string;
   public get fooComputedOptional() {
-    return this._fooComputedOptional ?? this.getStringAttribute('foo_computed_optional');
+    return this.getStringAttribute('foo_computed_optional');
   }
   public set fooComputedOptional(value: string | undefined) {
     this._fooComputedOptional = value;
@@ -1133,7 +1129,7 @@ export class PrimitiveString extends TerraformResource {
   // foo_optional - computed: false, optional: true, required: false
   private _fooOptional?: string;
   public get fooOptional() {
-    return this._fooOptional;
+    return this.getStringAttribute('foo_optional');
   }
   public set fooOptional(value: string | undefined) {
     this._fooOptional = value;
@@ -1142,7 +1138,7 @@ export class PrimitiveString extends TerraformResource {
   // foo_required - computed: false, optional: false, required: true
   private _fooRequired: string;
   public get fooRequired() {
-    return this._fooRequired;
+    return this.getStringAttribute('foo_required');
   }
   public set fooRequired(value: string) {
     this._fooRequired = value;
@@ -1216,7 +1212,7 @@ export class BlockTypeSetList extends TerraformResource {
   // timeouts_set - computed: false, optional: true, required: false
   private _timeoutsSet?: BlockTypeSetListTimeoutsSet[];
   public get timeoutsSet() {
-    return this._timeoutsSet;
+    return this.interpolationForAttribute('timeouts_set') as any;
   }
   public set timeoutsSet(value: BlockTypeSetListTimeoutsSet[] | undefined) {
     this._timeoutsSet = value;
@@ -1225,7 +1221,7 @@ export class BlockTypeSetList extends TerraformResource {
   // timeouts_list - computed: false, optional: true, required: false
   private _timeoutsList?: BlockTypeSetListTimeoutsList[];
   public get timeoutsList() {
-    return this._timeoutsList;
+    return this.interpolationForAttribute('timeouts_list') as any;
   }
   public set timeoutsList(value: BlockTypeSetListTimeoutsList[] | undefined) {
     this._timeoutsList = value;
@@ -1292,7 +1288,7 @@ export class SingleBlockType extends TerraformResource {
   // timeouts - computed: false, optional: true, required: false
   private _timeouts?: SingleBlockTypeTimeouts;
   public get timeouts() {
-    return this._timeouts;
+    return this.interpolationForAttribute('timeouts') as any;
   }
   public set timeouts(value: SingleBlockTypeTimeouts | undefined) {
     this._timeouts = value;
@@ -1358,13 +1354,13 @@ export class StringList extends TerraformResource {
   // subject_alternative_names_optional_computed - computed: true, optional: true, required: false
   private _subjectAlternativeNamesOptionalComputed?: string[];
   public get subjectAlternativeNamesOptionalComputed() {
-    return this._subjectAlternativeNamesOptionalComputed ?? this.getListAttribute('subject_alternative_names_optional_computed');
+    return this.getListAttribute('subject_alternative_names_optional_computed');
   }
   public set subjectAlternativeNamesOptionalComputed(value: string[] | undefined) {
     this._subjectAlternativeNamesOptionalComputed = value;
   }
 
-  // subject_alternative_names_computed - computed: true, optional: false, required: true
+  // subject_alternative_names_computed - computed: true, optional: false, required: false
   public get subjectAlternativeNamesComputed() {
     return this.getListAttribute('subject_alternative_names_computed');
   }
@@ -1372,7 +1368,7 @@ export class StringList extends TerraformResource {
   // subject_alternative_names_required - computed: false, optional: false, required: true
   private _subjectAlternativeNamesRequired: string[];
   public get subjectAlternativeNamesRequired() {
-    return this._subjectAlternativeNamesRequired;
+    return this.getListAttribute('subject_alternative_names_required');
   }
   public set subjectAlternativeNamesRequired(value: string[]) {
     this._subjectAlternativeNamesRequired = value;
@@ -1381,7 +1377,7 @@ export class StringList extends TerraformResource {
   // subject_alternative_names_optional - computed: false, optional: true, required: false
   private _subjectAlternativeNamesOptional?: string[];
   public get subjectAlternativeNamesOptional() {
-    return this._subjectAlternativeNamesOptional;
+    return this.getListAttribute('subject_alternative_names_optional');
   }
   public set subjectAlternativeNamesOptional(value: string[] | undefined) {
     this._subjectAlternativeNamesOptional = value;
@@ -1445,7 +1441,7 @@ export class StringMap extends TerraformResource {
   // ATTRIBUTES
   // ==========
 
-  // subject_alternative_names_computed - computed: true, optional: false, required: true
+  // subject_alternative_names_computed - computed: true, optional: false, required: false
   public subjectAlternativeNamesComputed(key: string): string {
     return new StringMap(this, 'subject_alternative_names_computed').lookup(key);
   }
@@ -1462,7 +1458,7 @@ export class StringMap extends TerraformResource {
   // subject_alternative_names_optional - computed: false, optional: true, required: false
   private _subjectAlternativeNamesOptional?: { [key: string]: string };
   public get subjectAlternativeNamesOptional() {
-    return this._subjectAlternativeNamesOptional;
+    return this.interpolationForAttribute('subject_alternative_names_optional') as any;
   }
   public set subjectAlternativeNamesOptional(value: { [key: string]: string } | undefined) {
     this._subjectAlternativeNamesOptional = value;

--- a/packages/cdktf-cli/test/get/generator/__snapshots__/types.test.ts.snap
+++ b/packages/cdktf-cli/test/get/generator/__snapshots__/types.test.ts.snap
@@ -50,6 +50,10 @@ export class BooleanList extends TerraformResource {
   public set fooRequired(value: boolean[]) {
     this._fooRequired = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get fooRequiredInput() {
+    return this._fooRequired
+  }
 
   // foo_optional - computed: false, optional: true, required: false
   private _fooOptional?: boolean[];
@@ -58,6 +62,10 @@ export class BooleanList extends TerraformResource {
   }
   public set fooOptional(value: boolean[] | undefined) {
     this._fooOptional = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get fooOptionalInput() {
+    return this._fooOptional
   }
 
   // =========
@@ -130,6 +138,10 @@ export class BooleanMap extends TerraformResource {
   public set fooComputedOptional(value: { [key: string]: boolean } | undefined) {
     this._fooComputedOptional = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get fooComputedOptionalInput() {
+    return this._fooComputedOptional
+  }
 
   // foo_optional - computed: false, optional: true, required: false
   private _fooOptional?: { [key: string]: boolean };
@@ -138,6 +150,10 @@ export class BooleanMap extends TerraformResource {
   }
   public set fooOptional(value: { [key: string]: boolean } | undefined) {
     this._fooOptional = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get fooOptionalInput() {
+    return this._fooOptional
   }
 
   // =========
@@ -384,6 +400,10 @@ export class BlockTypeNestedComputedList extends TerraformResource {
   public set inputs(value: BlockTypeNestedComputedListInputs[] | undefined) {
     this._inputs = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get inputsInput() {
+    return this._inputs
+  }
 
   // =========
   // SYNTHESIS
@@ -457,6 +477,10 @@ export class ComputedOptionalComplex extends TerraformResource {
   public set egress(value: ComputedOptionalComplexEgress[] | undefined) {
     this._egress = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get egressInput() {
+    return this._egress
+  }
 
   // =========
   // SYNTHESIS
@@ -527,6 +551,10 @@ export class DeeplyNestedBlockTypes extends TerraformResource {
   }
   public set lifecycleRule(value: DeeplyNestedBlockTypesLifecycleRule[] | undefined) {
     this._lifecycleRule = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get lifecycleRuleInput() {
+    return this._lifecycleRule
   }
 
   // =========
@@ -652,6 +680,10 @@ export class IncompatibleAttributeNames extends TerraformResource {
   public set fetchPasswordData(value: string | undefined) {
     this._getPasswordData = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get fetchPasswordDataInput() {
+    return this._getPasswordData
+  }
 
   // self - computed: false, optional: false, required: true
   private _self: string;
@@ -660,6 +692,10 @@ export class IncompatibleAttributeNames extends TerraformResource {
   }
   public set selfAttribute(value: string) {
     this._self = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get selfAttributeInput() {
+    return this._self
   }
 
   // =========
@@ -782,6 +818,10 @@ export class NumberList extends TerraformResource {
   public set fooRequired(value: number[]) {
     this._fooRequired = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get fooRequiredInput() {
+    return this._fooRequired
+  }
 
   // foo_optional - computed: false, optional: true, required: false
   private _fooOptional?: number[];
@@ -790,6 +830,10 @@ export class NumberList extends TerraformResource {
   }
   public set fooOptional(value: number[] | undefined) {
     this._fooOptional = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get fooOptionalInput() {
+    return this._fooOptional
   }
 
   // =========
@@ -862,6 +906,10 @@ export class NumberMap extends TerraformResource {
   public set fooComputedOptional(value: { [key: string]: number } | undefined) {
     this._fooComputedOptional = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get fooComputedOptionalInput() {
+    return this._fooComputedOptional
+  }
 
   // foo_optional - computed: false, optional: true, required: false
   private _fooOptional?: { [key: string]: number };
@@ -870,6 +918,10 @@ export class NumberMap extends TerraformResource {
   }
   public set fooOptional(value: { [key: string]: number } | undefined) {
     this._fooOptional = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get fooOptionalInput() {
+    return this._fooOptional
   }
 
   // =========
@@ -943,6 +995,10 @@ export class PrimitiveBoolean extends TerraformResource {
   public set fooComputedOptional(value: boolean | undefined) {
     this._fooComputedOptional = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get fooComputedOptionalInput() {
+    return this._fooComputedOptional
+  }
 
   // foo_optional - computed: false, optional: true, required: false
   private _fooOptional?: boolean;
@@ -952,6 +1008,10 @@ export class PrimitiveBoolean extends TerraformResource {
   public set fooOptional(value: boolean | undefined) {
     this._fooOptional = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get fooOptionalInput() {
+    return this._fooOptional
+  }
 
   // foo_required - computed: false, optional: false, required: true
   private _fooRequired: boolean;
@@ -960,6 +1020,10 @@ export class PrimitiveBoolean extends TerraformResource {
   }
   public set fooRequired(value: boolean) {
     this._fooRequired = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get fooRequiredInput() {
+    return this._fooRequired
   }
 
   // =========
@@ -1034,6 +1098,10 @@ export class PrimitiveNumber extends TerraformResource {
   public set fooComputedOptional(value: number | undefined) {
     this._fooComputedOptional = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get fooComputedOptionalInput() {
+    return this._fooComputedOptional
+  }
 
   // foo_optional - computed: false, optional: true, required: false
   private _fooOptional?: number;
@@ -1043,6 +1111,10 @@ export class PrimitiveNumber extends TerraformResource {
   public set fooOptional(value: number | undefined) {
     this._fooOptional = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get fooOptionalInput() {
+    return this._fooOptional
+  }
 
   // foo_required - computed: false, optional: false, required: true
   private _fooRequired: number;
@@ -1051,6 +1123,10 @@ export class PrimitiveNumber extends TerraformResource {
   }
   public set fooRequired(value: number) {
     this._fooRequired = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get fooRequiredInput() {
+    return this._fooRequired
   }
 
   // =========
@@ -1125,6 +1201,10 @@ export class PrimitiveString extends TerraformResource {
   public set fooComputedOptional(value: string | undefined) {
     this._fooComputedOptional = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get fooComputedOptionalInput() {
+    return this._fooComputedOptional
+  }
 
   // foo_optional - computed: false, optional: true, required: false
   private _fooOptional?: string;
@@ -1134,6 +1214,10 @@ export class PrimitiveString extends TerraformResource {
   public set fooOptional(value: string | undefined) {
     this._fooOptional = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get fooOptionalInput() {
+    return this._fooOptional
+  }
 
   // foo_required - computed: false, optional: false, required: true
   private _fooRequired: string;
@@ -1142,6 +1226,10 @@ export class PrimitiveString extends TerraformResource {
   }
   public set fooRequired(value: string) {
     this._fooRequired = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get fooRequiredInput() {
+    return this._fooRequired
   }
 
   // =========
@@ -1217,6 +1305,10 @@ export class BlockTypeSetList extends TerraformResource {
   public set timeoutsSet(value: BlockTypeSetListTimeoutsSet[] | undefined) {
     this._timeoutsSet = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get timeoutsSetInput() {
+    return this._timeoutsSet
+  }
 
   // timeouts_list - computed: false, optional: true, required: false
   private _timeoutsList?: BlockTypeSetListTimeoutsList[];
@@ -1225,6 +1317,10 @@ export class BlockTypeSetList extends TerraformResource {
   }
   public set timeoutsList(value: BlockTypeSetListTimeoutsList[] | undefined) {
     this._timeoutsList = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get timeoutsListInput() {
+    return this._timeoutsList
   }
 
   // =========
@@ -1293,6 +1389,10 @@ export class SingleBlockType extends TerraformResource {
   public set timeouts(value: SingleBlockTypeTimeouts | undefined) {
     this._timeouts = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get timeoutsInput() {
+    return this._timeouts
+  }
 
   // =========
   // SYNTHESIS
@@ -1359,6 +1459,10 @@ export class StringList extends TerraformResource {
   public set subjectAlternativeNamesOptionalComputed(value: string[] | undefined) {
     this._subjectAlternativeNamesOptionalComputed = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get subjectAlternativeNamesOptionalComputedInput() {
+    return this._subjectAlternativeNamesOptionalComputed
+  }
 
   // subject_alternative_names_computed - computed: true, optional: false, required: false
   public get subjectAlternativeNamesComputed() {
@@ -1373,6 +1477,10 @@ export class StringList extends TerraformResource {
   public set subjectAlternativeNamesRequired(value: string[]) {
     this._subjectAlternativeNamesRequired = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get subjectAlternativeNamesRequiredInput() {
+    return this._subjectAlternativeNamesRequired
+  }
 
   // subject_alternative_names_optional - computed: false, optional: true, required: false
   private _subjectAlternativeNamesOptional?: string[];
@@ -1381,6 +1489,10 @@ export class StringList extends TerraformResource {
   }
   public set subjectAlternativeNamesOptional(value: string[] | undefined) {
     this._subjectAlternativeNamesOptional = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get subjectAlternativeNamesOptionalInput() {
+    return this._subjectAlternativeNamesOptional
   }
 
   // =========
@@ -1454,6 +1566,10 @@ export class StringMap extends TerraformResource {
   public set subjectAlternativeNamesComputedOptional(value: { [key: string]: string } | undefined) {
     this._subjectAlternativeNamesComputedOptional = value;
   }
+  // Temporarily expose input value. Use with caution.
+  public get subjectAlternativeNamesComputedOptionalInput() {
+    return this._subjectAlternativeNamesComputedOptional
+  }
 
   // subject_alternative_names_optional - computed: false, optional: true, required: false
   private _subjectAlternativeNamesOptional?: { [key: string]: string };
@@ -1462,6 +1578,10 @@ export class StringMap extends TerraformResource {
   }
   public set subjectAlternativeNamesOptional(value: { [key: string]: string } | undefined) {
     this._subjectAlternativeNamesOptional = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get subjectAlternativeNamesOptionalInput() {
+    return this._subjectAlternativeNamesOptional
   }
 
   // =========

--- a/packages/cdktf-cli/test/get/generator/__snapshots__/types.test.ts.snap
+++ b/packages/cdktf-cli/test/get/generator/__snapshots__/types.test.ts.snap
@@ -60,8 +60,11 @@ export class BooleanList extends TerraformResource {
   public get fooOptional() {
     return this.interpolationForAttribute('foo_optional') as any;
   }
-  public set fooOptional(value: boolean[] | undefined) {
+  public set fooOptional(value: boolean[] ) {
     this._fooOptional = value;
+  }
+  public resetFooOptional() {
+    this._fooOptional = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get fooOptionalInput() {
@@ -132,11 +135,14 @@ export class BooleanMap extends TerraformResource {
 
   // foo_computed_optional - computed: true, optional: true, required: false
   private _fooComputedOptional?: { [key: string]: boolean }
-  public get fooComputedOptional(): { [key: string]: boolean } | undefined {
-    return this._fooComputedOptional; // Getting the computed value is not yet implemented
+  public get fooComputedOptional(): { [key: string]: boolean } {
+    return this.interpolationForAttribute('foo_computed_optional') as any; // Getting the computed value is not yet implemented
   }
-  public set fooComputedOptional(value: { [key: string]: boolean } | undefined) {
+  public set fooComputedOptional(value: { [key: string]: boolean }) {
     this._fooComputedOptional = value;
+  }
+  public resetFooComputedOptional() {
+    this._fooComputedOptional = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get fooComputedOptionalInput() {
@@ -148,8 +154,11 @@ export class BooleanMap extends TerraformResource {
   public get fooOptional() {
     return this.interpolationForAttribute('foo_optional') as any;
   }
-  public set fooOptional(value: { [key: string]: boolean } | undefined) {
+  public set fooOptional(value: { [key: string]: boolean } ) {
     this._fooOptional = value;
+  }
+  public resetFooOptional() {
+    this._fooOptional = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get fooOptionalInput() {
@@ -397,8 +406,11 @@ export class BlockTypeNestedComputedList extends TerraformResource {
   public get inputs() {
     return this.interpolationForAttribute('inputs') as any;
   }
-  public set inputs(value: BlockTypeNestedComputedListInputs[] | undefined) {
+  public set inputs(value: BlockTypeNestedComputedListInputs[] ) {
     this._inputs = value;
+  }
+  public resetInputs() {
+    this._inputs = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get inputsInput() {
@@ -471,11 +483,14 @@ export class ComputedOptionalComplex extends TerraformResource {
 
   // egress - computed: true, optional: true, required: false
   private _egress?: ComputedOptionalComplexEgress[]
-  public get egress(): ComputedOptionalComplexEgress[] | undefined {
-    return this._egress; // Getting the computed value is not yet implemented
+  public get egress(): ComputedOptionalComplexEgress[] {
+    return this.interpolationForAttribute('egress') as any; // Getting the computed value is not yet implemented
   }
-  public set egress(value: ComputedOptionalComplexEgress[] | undefined) {
+  public set egress(value: ComputedOptionalComplexEgress[]) {
     this._egress = value;
+  }
+  public resetEgress() {
+    this._egress = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get egressInput() {
@@ -549,8 +564,11 @@ export class DeeplyNestedBlockTypes extends TerraformResource {
   public get lifecycleRule() {
     return this.interpolationForAttribute('lifecycle_rule') as any;
   }
-  public set lifecycleRule(value: DeeplyNestedBlockTypesLifecycleRule[] | undefined) {
+  public set lifecycleRule(value: DeeplyNestedBlockTypesLifecycleRule[] ) {
     this._lifecycleRule = value;
+  }
+  public resetLifecycleRule() {
+    this._lifecycleRule = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get lifecycleRuleInput() {
@@ -677,8 +695,11 @@ export class IncompatibleAttributeNames extends TerraformResource {
   public get fetchPasswordData() {
     return this.getStringAttribute('get_password_data');
   }
-  public set fetchPasswordData(value: string | undefined) {
+  public set fetchPasswordData(value: string ) {
     this._getPasswordData = value;
+  }
+  public resetFetchPasswordData() {
+    this._getPasswordData = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get fetchPasswordDataInput() {
@@ -828,8 +849,11 @@ export class NumberList extends TerraformResource {
   public get fooOptional() {
     return this.interpolationForAttribute('foo_optional') as any;
   }
-  public set fooOptional(value: number[] | undefined) {
+  public set fooOptional(value: number[] ) {
     this._fooOptional = value;
+  }
+  public resetFooOptional() {
+    this._fooOptional = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get fooOptionalInput() {
@@ -900,11 +924,14 @@ export class NumberMap extends TerraformResource {
 
   // foo_computed_optional - computed: true, optional: true, required: false
   private _fooComputedOptional?: { [key: string]: number }
-  public get fooComputedOptional(): { [key: string]: number } | undefined {
-    return this._fooComputedOptional; // Getting the computed value is not yet implemented
+  public get fooComputedOptional(): { [key: string]: number } {
+    return this.interpolationForAttribute('foo_computed_optional') as any; // Getting the computed value is not yet implemented
   }
-  public set fooComputedOptional(value: { [key: string]: number } | undefined) {
+  public set fooComputedOptional(value: { [key: string]: number }) {
     this._fooComputedOptional = value;
+  }
+  public resetFooComputedOptional() {
+    this._fooComputedOptional = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get fooComputedOptionalInput() {
@@ -916,8 +943,11 @@ export class NumberMap extends TerraformResource {
   public get fooOptional() {
     return this.interpolationForAttribute('foo_optional') as any;
   }
-  public set fooOptional(value: { [key: string]: number } | undefined) {
+  public set fooOptional(value: { [key: string]: number } ) {
     this._fooOptional = value;
+  }
+  public resetFooOptional() {
+    this._fooOptional = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get fooOptionalInput() {
@@ -992,8 +1022,11 @@ export class PrimitiveBoolean extends TerraformResource {
   public get fooComputedOptional() {
     return this.getBooleanAttribute('foo_computed_optional');
   }
-  public set fooComputedOptional(value: boolean | undefined) {
+  public set fooComputedOptional(value: boolean) {
     this._fooComputedOptional = value;
+  }
+  public resetFooComputedOptional() {
+    this._fooComputedOptional = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get fooComputedOptionalInput() {
@@ -1005,8 +1038,11 @@ export class PrimitiveBoolean extends TerraformResource {
   public get fooOptional() {
     return this.getBooleanAttribute('foo_optional');
   }
-  public set fooOptional(value: boolean | undefined) {
+  public set fooOptional(value: boolean ) {
     this._fooOptional = value;
+  }
+  public resetFooOptional() {
+    this._fooOptional = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get fooOptionalInput() {
@@ -1095,8 +1131,11 @@ export class PrimitiveNumber extends TerraformResource {
   public get fooComputedOptional() {
     return this.getNumberAttribute('foo_computed_optional');
   }
-  public set fooComputedOptional(value: number | undefined) {
+  public set fooComputedOptional(value: number) {
     this._fooComputedOptional = value;
+  }
+  public resetFooComputedOptional() {
+    this._fooComputedOptional = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get fooComputedOptionalInput() {
@@ -1108,8 +1147,11 @@ export class PrimitiveNumber extends TerraformResource {
   public get fooOptional() {
     return this.getNumberAttribute('foo_optional');
   }
-  public set fooOptional(value: number | undefined) {
+  public set fooOptional(value: number ) {
     this._fooOptional = value;
+  }
+  public resetFooOptional() {
+    this._fooOptional = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get fooOptionalInput() {
@@ -1198,8 +1240,11 @@ export class PrimitiveString extends TerraformResource {
   public get fooComputedOptional() {
     return this.getStringAttribute('foo_computed_optional');
   }
-  public set fooComputedOptional(value: string | undefined) {
+  public set fooComputedOptional(value: string) {
     this._fooComputedOptional = value;
+  }
+  public resetFooComputedOptional() {
+    this._fooComputedOptional = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get fooComputedOptionalInput() {
@@ -1211,8 +1256,11 @@ export class PrimitiveString extends TerraformResource {
   public get fooOptional() {
     return this.getStringAttribute('foo_optional');
   }
-  public set fooOptional(value: string | undefined) {
+  public set fooOptional(value: string ) {
     this._fooOptional = value;
+  }
+  public resetFooOptional() {
+    this._fooOptional = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get fooOptionalInput() {
@@ -1302,8 +1350,11 @@ export class BlockTypeSetList extends TerraformResource {
   public get timeoutsSet() {
     return this.interpolationForAttribute('timeouts_set') as any;
   }
-  public set timeoutsSet(value: BlockTypeSetListTimeoutsSet[] | undefined) {
+  public set timeoutsSet(value: BlockTypeSetListTimeoutsSet[] ) {
     this._timeoutsSet = value;
+  }
+  public resetTimeoutsSet() {
+    this._timeoutsSet = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get timeoutsSetInput() {
@@ -1315,8 +1366,11 @@ export class BlockTypeSetList extends TerraformResource {
   public get timeoutsList() {
     return this.interpolationForAttribute('timeouts_list') as any;
   }
-  public set timeoutsList(value: BlockTypeSetListTimeoutsList[] | undefined) {
+  public set timeoutsList(value: BlockTypeSetListTimeoutsList[] ) {
     this._timeoutsList = value;
+  }
+  public resetTimeoutsList() {
+    this._timeoutsList = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get timeoutsListInput() {
@@ -1386,8 +1440,11 @@ export class SingleBlockType extends TerraformResource {
   public get timeouts() {
     return this.interpolationForAttribute('timeouts') as any;
   }
-  public set timeouts(value: SingleBlockTypeTimeouts | undefined) {
+  public set timeouts(value: SingleBlockTypeTimeouts ) {
     this._timeouts = value;
+  }
+  public resetTimeouts() {
+    this._timeouts = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get timeoutsInput() {
@@ -1456,8 +1513,11 @@ export class StringList extends TerraformResource {
   public get subjectAlternativeNamesOptionalComputed() {
     return this.getListAttribute('subject_alternative_names_optional_computed');
   }
-  public set subjectAlternativeNamesOptionalComputed(value: string[] | undefined) {
+  public set subjectAlternativeNamesOptionalComputed(value: string[]) {
     this._subjectAlternativeNamesOptionalComputed = value;
+  }
+  public resetSubjectAlternativeNamesOptionalComputed() {
+    this._subjectAlternativeNamesOptionalComputed = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get subjectAlternativeNamesOptionalComputedInput() {
@@ -1487,8 +1547,11 @@ export class StringList extends TerraformResource {
   public get subjectAlternativeNamesOptional() {
     return this.getListAttribute('subject_alternative_names_optional');
   }
-  public set subjectAlternativeNamesOptional(value: string[] | undefined) {
+  public set subjectAlternativeNamesOptional(value: string[] ) {
     this._subjectAlternativeNamesOptional = value;
+  }
+  public resetSubjectAlternativeNamesOptional() {
+    this._subjectAlternativeNamesOptional = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get subjectAlternativeNamesOptionalInput() {
@@ -1560,11 +1623,14 @@ export class StringMap extends TerraformResource {
 
   // subject_alternative_names_computed_optional - computed: true, optional: true, required: false
   private _subjectAlternativeNamesComputedOptional?: { [key: string]: string }
-  public get subjectAlternativeNamesComputedOptional(): { [key: string]: string } | undefined {
-    return this._subjectAlternativeNamesComputedOptional; // Getting the computed value is not yet implemented
+  public get subjectAlternativeNamesComputedOptional(): { [key: string]: string } {
+    return this.interpolationForAttribute('subject_alternative_names_computed_optional') as any; // Getting the computed value is not yet implemented
   }
-  public set subjectAlternativeNamesComputedOptional(value: { [key: string]: string } | undefined) {
+  public set subjectAlternativeNamesComputedOptional(value: { [key: string]: string }) {
     this._subjectAlternativeNamesComputedOptional = value;
+  }
+  public resetSubjectAlternativeNamesComputedOptional() {
+    this._subjectAlternativeNamesComputedOptional = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get subjectAlternativeNamesComputedOptionalInput() {
@@ -1576,8 +1642,11 @@ export class StringMap extends TerraformResource {
   public get subjectAlternativeNamesOptional() {
     return this.interpolationForAttribute('subject_alternative_names_optional') as any;
   }
-  public set subjectAlternativeNamesOptional(value: { [key: string]: string } | undefined) {
+  public set subjectAlternativeNamesOptional(value: { [key: string]: string } ) {
     this._subjectAlternativeNamesOptional = value;
+  }
+  public resetSubjectAlternativeNamesOptional() {
+    this._subjectAlternativeNamesOptional = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get subjectAlternativeNamesOptionalInput() {

--- a/test/test-python-third-party-provider/expected/cdk.tf.json
+++ b/test/test-python-third-party-provider/expected/cdk.tf.json
@@ -33,7 +33,7 @@
     },
     "docker_container": {
       "pythonthirdpartyprovider_nginxcdktf_C2D51A82": {
-        "image": "nginx:latest",
+        "image": "${docker_image.pythonthirdpartyprovider_nginxlatest_F677E4EF.name}",
         "name": "nginx-python-cdktf",
         "privileged": false,
         "ports": [


### PR DESCRIPTION
Fixes #188 Also eliminates #214 

- Switch to always return attribute readers.
- Opted to not expose any set value publicly since there isn't a good indication of when it will work in local code.
- Changed behavior of attribute lookup of unknown type so that it has a chance of working correctly once synthesized.
- Use explicit required value from schema rather than assuming inverse of optional.

This ended being a lot more complicated than I expected: partially because providers and resources/data sources shared the same code, but mostly because of the complexities (and inconsistencies) of schema definition.

I'm pretty sure I fixed a couple bugs, but I'm not confident that I didn't introduce new ones, so I want to do some more testing before switching from draft.