### PR TITLE
Prepare release 0.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Fixed bugs:**
 
 - Terraform 0.13 Compatibility for 3rd Party Providers (e.g. Docker) in Python [\#309](https://github.com/hashicorp/terraform-cdk/issues/309)
+- Fix Naming Collision with Config interfaces [\#300](https://github.com/hashicorp/terraform-cdk/issues/300)
 
 ## 0.0.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.15
+
+**Fixed bugs:**
+
+- Terraform 0.13 Compatibility for 3rd Party Providers (e.g. Docker) in Python [\#309](https://github.com/hashicorp/terraform-cdk/issues/309)
+
 ## 0.0.14
 
 **Implemented enhancements:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Terraform 0.13 Compatibility for 3rd Party Providers (e.g. Docker) in Python [\#309](https://github.com/hashicorp/terraform-cdk/issues/309)
 - Fix Naming Collision with Config interfaces [\#300](https://github.com/hashicorp/terraform-cdk/issues/300)
 
+**Implemented enhancements:**
+
+- Use remote backend class for typescript template [\#313](https://github.com/hashicorp/terraform-cdk/issues/313)
+
 ## 0.0.14
 
 **Implemented enhancements:**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "private": true,
   "scripts": {
     "build": "lerna run build",


### PR DESCRIPTION
Since #309 fixed a Python bug and we don't provide pre-release versions in Python (see #293), let's do another release.