### PR TITLE
Fix external provider

### DIFF
--- a/packages/cdktf-cli/lib/get/generator/provider-generator.ts
+++ b/packages/cdktf-cli/lib/get/generator/provider-generator.ts
@@ -77,7 +77,7 @@ export class TerraformGenerator {
     if (!name) { throw new Error(`can't handle ${fqpn}`) }
 
     const files: string[] = []
-    for (const [type, resource] of Object.entries(provider.resource_schemas)) {
+    for (const [type, resource] of Object.entries(provider.resource_schemas || [])) {
       files.push(this.emitResourceFile(this.resourceParser.parse(name, type, resource, 'resource')));
     }
 

--- a/packages/cdktf-cli/test/get/generator/empty-provider-resources.test.ts
+++ b/packages/cdktf-cli/test/get/generator/empty-provider-resources.test.ts
@@ -1,0 +1,13 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { TerraformGenerator } from '../../../lib/get/generator/provider-generator';
+import { CodeMaker } from 'codemaker';
+
+test('provider with no resources', async () => {
+  const code = new CodeMaker()
+  const workdir = fs.mkdtempSync(path.join(os.tmpdir(), 'empty-provider-resources.test'));
+  const spec = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures', 'empty-provider-resources.test.fixture.json'), 'utf-8'));
+  new TerraformGenerator(code, spec);
+  await code.save(workdir);
+});

--- a/packages/cdktf-cli/test/get/generator/fixtures/empty-provider-resources.test.fixture.json
+++ b/packages/cdktf-cli/test/get/generator/fixtures/empty-provider-resources.test.fixture.json
@@ -1,0 +1,7 @@
+{
+  "provider_schemas": {
+    "aws": {
+      "resource_schemas": null
+    }
+  }
+}

--- a/test/test-providers/cdktf.json
+++ b/test/test-providers/cdktf.json
@@ -10,6 +10,7 @@
     "consul",
     "vault",
     "nomad",
+    "external",
     "terraform-providers/openstack"
   ]
 }

--- a/test/test-providers/main.ts
+++ b/test/test-providers/main.ts
@@ -9,6 +9,7 @@ import * as Openstack from "./.gen/providers/openstack";
 import * as Nomad from "./.gen/providers/nomad";
 import * as Vault from "./.gen/providers/vault";
 import * as Consul from "./.gen/providers/consul";
+import * as External from "./.gen/providers/external";
 
 export class HelloTerra extends TerraformStack {
   constructor(scope: Construct, id: string) {
@@ -24,7 +25,7 @@ export class HelloTerra extends TerraformStack {
       },
     ]);
 
-    [Aws, Azure, Google, Kubernetes, Nomad, Vault, Openstack, Consul];
+    [Aws, Azure, Google, Kubernetes, Nomad, Vault, Openstack, Consul, External];
   }
 }
 


### PR DESCRIPTION
The external provider doesn't have any resources, only data sources. This makes sure the provider generates the classes and compiles.