### PR TITLE
Stack wide setting to use construct ids as names

### DIFF
--- a/packages/cdktf/lib/terraform-element.ts
+++ b/packages/cdktf/lib/terraform-element.ts
@@ -29,6 +29,10 @@ export class TerraformElement extends Construct {
 
   public get friendlyUniqueId() {
     const node = this.constructNode
+    if (this.stack.useStaticNames) {
+      return node.id;
+    }
+    
     const components = node.scopes.slice(1).map(c => Node.of(c).id);
     return components.length > 0 ? makeUniqueId(components) : '';
   }

--- a/packages/cdktf/lib/terraform-stack.ts
+++ b/packages/cdktf/lib/terraform-stack.ts
@@ -17,6 +17,7 @@ export class TerraformStack extends Construct {
   public readonly artifactFile: string;
   private readonly rawOverrides: any = {}
   private readonly cdktfVersion: string;
+  private staticNames = false;
 
   constructor(scope: Construct, id: string) {
     super(scope, id);
@@ -70,6 +71,14 @@ export class TerraformStack extends Construct {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const lastKey = parts.shift()!;
     curr[lastKey] = value;
+  }
+
+  public useConstructIdsAsNames() {
+    this.staticNames = true;
+  }
+
+  public get useStaticNames(): boolean {
+    return this.staticNames;
   }
 
   public allProviders(): TerraformProvider[] {

--- a/packages/cdktf/test/__snapshots__/stack.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/stack.test.js.snap
@@ -87,3 +87,91 @@ exports[`stack synthesis merges all elements into a single output 1`] = `
   }
 }"
 `;
+
+exports[`use static names 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"MyStack\\"
+    }
+  },
+  \\"provider\\": {
+    \\"test\\": [
+      {
+        \\"access_key\\": \\"foo\\"
+      }
+    ]
+  },
+  \\"resource\\": {
+    \\"aws_bucket\\": {
+      \\"Resource1\\": {
+        \\"foo\\": \\"Resource1\\",
+        \\"prop1\\": \\"bar1\\",
+        \\"prop2\\": 1234,
+        \\"prop3\\": {
+          \\"name\\": \\"should be overwritten in resource 2\\",
+          \\"value\\": 5678
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"MyStack/Resource1\\",
+            \\"uniqueId\\": \\"Resource1\\"
+          }
+        }
+      }
+    },
+    \\"aws_topic\\": {
+      \\"Resource2\\": {
+        \\"foo\\": \\"Resource2\\",
+        \\"prop1\\": \\"bar1\\",
+        \\"prop3\\": {
+          \\"name\\": \\"test\\",
+          \\"value\\": 5678
+        },
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"MyStack/Resource2\\",
+            \\"uniqueId\\": \\"Resource2\\"
+          }
+        },
+        \\"provisioner\\": [
+          {
+            \\"local-exec\\": {
+              \\"command\\": \\"echo 'Hello World' >example.txt\\"
+            }
+          }
+        ]
+      }
+    }
+  },
+  \\"module\\": {
+    \\"EksModule\\": {
+      \\"cluster_name\\": \\"my_cluster_name\\",
+      \\"source\\": \\"terraform-aws-modules/eks/aws\\",
+      \\"version\\": \\"7.0.1\\",
+      \\"//\\": {
+        \\"metadata\\": {
+          \\"path\\": \\"MyStack/EksModule\\",
+          \\"uniqueId\\": \\"EksModule\\"
+        }
+      }
+    }
+  },
+  \\"output\\": {
+    \\"eks_version\\": {
+      \\"value\\": \\"7.0.1\\"
+    }
+  },
+  \\"terraform\\": {
+    \\"backend\\": {
+      \\"remote\\": {
+        \\"organization\\": \\"test\\",
+        \\"workspaces\\": {
+          \\"name\\": \\"test\\"
+        }
+      }
+    }
+  }
+}"
+`;


### PR DESCRIPTION
Fixes #248 

Just add `stack.useConstructIdsAsNames()` and all constructs will use their `id` as a name instead of generating one from their path and a hash.

This should make it much easier to convert existing Terraform stacks when a destroy/rebuild isn't feasible.