### PR TITLE
Fix TerraformProvider alias definition

### DIFF
--- a/packages/cdktf/lib/terraform-provider.ts
+++ b/packages/cdktf/lib/terraform-provider.ts
@@ -14,7 +14,6 @@ export abstract class TerraformProvider extends TerraformElement {
   public readonly terraformResourceType: string;
   public readonly terraformGeneratorMetadata?: TerraformGeneratorMetadata;
   public readonly terraformProviderSource?: string;
-  public alias?: string;
 
   constructor(scope: Construct, id: string, config: TerraformProviderConfig) {
     super(scope, id);
@@ -22,6 +21,15 @@ export abstract class TerraformProvider extends TerraformElement {
     this.terraformResourceType = config.terraformResourceType;
     this.terraformGeneratorMetadata = config.terraformGeneratorMetadata;
     this.terraformProviderSource = config.terraformProviderSource;
+  }
+
+  public get alias(): string | undefined {
+    // This is always* being overriden currently
+    return undefined;
+  }
+
+  public set alias(_value: string | undefined) {
+    // This is always* being overriden currently
   }
 
   public get fqn(): string {

--- a/packages/cdktf/test/helper/provider.ts
+++ b/packages/cdktf/test/helper/provider.ts
@@ -11,7 +11,6 @@ export enum TestProviderMetadata {
 }
 
 export class TestProvider extends TerraformProvider {
-  public alias?: string;
   public accessKey: string;
 
   constructor(scope: Construct, id: string, config: TestProviderConfig) {
@@ -21,6 +20,14 @@ export class TestProvider extends TerraformProvider {
 
     this.alias = config.alias
     this.accessKey = config.accessKey
+  }
+
+  private _alias?: string;
+  public get alias() {
+    return this._alias;
+  }
+  public set alias(value: string | undefined) {
+    this._alias = value;
   }
 
   protected synthesizeAttributes(): { [name: string]: any } {


### PR DESCRIPTION
Match override behavior of generated provider schema

I'm not sure yet how this passed tests in #276, but this should fix the integration tests.

It is quite strange to me that terraform provider schema include `alias` when it is really more of a meta argument. If anyone from the terraform team could provide more context, that could make me more confident that this is the correct approach.