### PR TITLE
Oracle Provider Compatibility

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -10,6 +10,9 @@ jobs:
     container:
       image: hashicorp/jsii-terraform
 
+    env:
+      CHECKPOINT_DISABLE: "1"
+
     steps:
       - uses: actions/checkout@v2
       - name: installing dependencies

--- a/packages/cdktf/lib/terraform-data-source.ts
+++ b/packages/cdktf/lib/terraform-data-source.ts
@@ -73,7 +73,7 @@ export class TerraformDataSource extends TerraformElement implements ITerraformR
       this.rawOverrides
     )
 
-    attributes['//'] = this.nodeMetadata
+    attributes['//'] = this.constructNodeMetadata
 
     return {
       data: {

--- a/packages/cdktf/lib/terraform-element.ts
+++ b/packages/cdktf/lib/terraform-element.ts
@@ -56,7 +56,7 @@ export class TerraformElement extends Construct {
     curr[lastKey] = value;
   }
 
-  protected get nodeMetadata(): {[key: string]: any} {
+  protected get constructNodeMetadata(): {[key: string]: any} {
     return {
       metadata: {
         path: this.constructNode.path,

--- a/packages/cdktf/lib/terraform-module.ts
+++ b/packages/cdktf/lib/terraform-module.ts
@@ -37,7 +37,7 @@ export abstract class TerraformModule extends TerraformElement {
       this.rawOverrides
     )
 
-    attributes['//'] = this.nodeMetadata
+    attributes['//'] = this.constructNodeMetadata
 
     return {
       module: {

--- a/packages/cdktf/lib/terraform-resource.ts
+++ b/packages/cdktf/lib/terraform-resource.ts
@@ -108,7 +108,7 @@ export class TerraformResource extends TerraformElement implements ITerraformRes
       this.rawOverrides
     )
 
-    attributes['//'] = this.nodeMetadata
+    attributes['//'] = this.constructNodeMetadata
 
     return {
       resource: {

--- a/test/test-providers/cdktf.json
+++ b/test/test-providers/cdktf.json
@@ -11,6 +11,7 @@
     "vault",
     "nomad",
     "external",
-    "terraform-providers/openstack"
+    "terraform-providers/openstack",
+    "oci"
   ]
 }


### PR DESCRIPTION
There's a function in the Oracle provider which is named `nodeMetadata`. This conflicts
with function in cdktf base classes.

Hence, this PR aligins the naming with the change from `node` to `constructNode` (see #230)

Fixes #290