### PR TITLE
Default to NPM in templates

### DIFF
--- a/docs/getting-started/typescript.md
+++ b/docs/getting-started/typescript.md
@@ -4,7 +4,7 @@
 
 - [Terraform](https://www.terraform.io/downloads.html) >= v0.12
 - [Node.js](https://nodejs.org) >= v12.16
-- [Yarn](https://yarnpkg.com/en/docs/install) >= v1.21 (optional - NPM will work as well)
+- [Yarn](https://yarnpkg.com/en/docs/install) >= v1.21 (optional - NPM will work as an alternative)
 
 **Install CDK for Terraform CLI**
 

--- a/docs/getting-started/typescript.md
+++ b/docs/getting-started/typescript.md
@@ -4,7 +4,7 @@
 
 - [Terraform](https://www.terraform.io/downloads.html) >= v0.12
 - [Node.js](https://nodejs.org) >= v12.16
-- [Yarn](https://yarnpkg.com/en/docs/install) >= v1.21
+- [Yarn](https://yarnpkg.com/en/docs/install) >= v1.21 (optional - NPM will work as well)
 
 **Install CDK for Terraform CLI**
 

--- a/packages/cdktf-cli/templates/typescript-minimal/help
+++ b/packages/cdktf-cli/templates/typescript-minimal/help
@@ -5,7 +5,7 @@
   cat help              Print this message
 
   Compile:
-    npm run compile     Compile typescript code to javascript (or "yarn watch")
+    npm run compile     Compile typescript code to javascript (or "npm run watch")
     npm run watch       Watch for changes and compile typescript in the background
     npm run build       Compile typescript
 

--- a/packages/cdktf-cli/templates/typescript/help
+++ b/packages/cdktf-cli/templates/typescript/help
@@ -5,7 +5,7 @@
   cat help              Print this message
 
   Compile:
-    npm run compile     Compile typescript code to javascript (or "yarn watch")
+    npm run compile     Compile typescript code to javascript (or "npm run watch")
     npm run watch       Watch for changes and compile typescript in the background
     npm run build       cdktf get and compile typescript
 

--- a/packages/cdktf-cli/templates/typescript/package.json
+++ b/packages/cdktf-cli/templates/typescript/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "scripts": {
     "get": "cdktf get",
-    "build": "yarn get && tsc",
+    "build": "cdktf get && tsc",
     "synth": "cdktf synth",
     "compile": "tsc --pretty",
     "watch": "tsc -w",


### PR DESCRIPTION
Since yarn isn't required for regular usage, this changes the Typescript template to use NPM.