### PR TITLE
Terraform hcl module

### DIFF
--- a/docs/working-with-cdk-for-terraform/using-providers-and-modules.md
+++ b/docs/working-with-cdk-for-terraform/using-providers-and-modules.md
@@ -216,3 +216,28 @@ When using the `cdktf` cli commands, it'll automatically set the process env `TF
 Last but not least, when approaching multiple stacks wihtin oen application (not yet implemented), provider caching is a basic prerequisite.
 
 This behaviour can be disabled by setting `CDKTF_DISABLE_PLUGIN_CACHE_ENV` to non null value, e.g. `CDKTF_DISABLE_PLUGIN_CACHE_ENV=1`. This might be desired, when a different cache directory is configured via a `.terraformrc` configuration file.
+
+## Using Modules
+For using modules on the terraform registry, see [cdktf.json](./cdktf.json).
+
+For using modules from other sources (local, github, etc), you can make use of `TerraformHclModule`. This doesn't have type safe inputs/outputs, but allows for creating any terraform module.
+
+Typescirpt example:
+```typescript
+    const provider = new TestProvider(stack, 'provider', {
+        accessKey: 'key',
+        alias: 'provider1'
+    });
+
+    const module = new TerraformHclModule(stack, 'test', {
+        source: './foo',
+        variables: {
+          param1: 'value1'
+        },
+        providers: [provider]
+    });
+
+    new TestResource(stack, 'resource', {
+        name: module.getString('name')
+    });
+```

--- a/packages/cdktf/lib/index.ts
+++ b/packages/cdktf/lib/index.ts
@@ -14,3 +14,4 @@ export * from './terraform-backend';
 export * from './backends';
 export * from './terraform-remote-state';
 export * from './terraform-local';
+export * from './terraform-hcl-module';

--- a/packages/cdktf/lib/terraform-hcl-module.ts
+++ b/packages/cdktf/lib/terraform-hcl-module.ts
@@ -1,25 +1,16 @@
 import { Construct } from "constructs";
 import { TerraformModuleOptions, TerraformModule } from "./terraform-module";
-import { TerraformProvider } from "./terraform-provider";
 
 export interface TerraformHclModuleOptions extends TerraformModuleOptions {
-    readonly providers?: (TerraformProvider | TerraformModuleProvider)[];
     readonly variables?: {[key: string]: any};
 }
 
-export interface TerraformModuleProvider {
-    readonly provider: TerraformProvider;
-    readonly moduleAlias: string;
-}
-
 export class TerraformHclModule extends TerraformModule {
-    private _providers?: (TerraformProvider | TerraformModuleProvider)[];
     private _variables?: {[key: string]: any};
 
     constructor(scope: Construct, id: string, options: TerraformHclModuleOptions) {
         super(scope, id, options);
 
-        this._providers = options.providers;
         this._variables = options.variables;
     }
 
@@ -32,17 +23,6 @@ export class TerraformHclModule extends TerraformModule {
             this._variables = {};
         }
         this._variables[variable] = value;
-    }
-
-    public get providers() {
-        return this._providers;
-    }
-
-    public addProvider(provider: TerraformProvider | TerraformModuleProvider) {
-        if (!this._providers) {
-            this._providers = [];
-        }
-        this._providers.push(provider);
     }
 
     public get(output: string): any {
@@ -66,16 +46,6 @@ export class TerraformHclModule extends TerraformModule {
     }
 
     protected synthesizeAttributes(): { [name: string]: any } {
-        return {
-            providers: this.providers?.map(p => {
-                if (p instanceof TerraformProvider) {
-                    return { [p.terraformResourceType]: p.fqn };
-                }
-                else {
-                    return { [`${p.provider.terraformResourceType}.${p.moduleAlias}`]: p.provider.fqn };
-                }
-            }),
-            ...this.variables
-        };
+        return { ...this.variables };
     }
 }

--- a/packages/cdktf/lib/terraform-hcl-module.ts
+++ b/packages/cdktf/lib/terraform-hcl-module.ts
@@ -1,0 +1,81 @@
+import { Construct } from "constructs";
+import { TerraformModuleOptions, TerraformModule } from "./terraform-module";
+import { TerraformProvider } from "./terraform-provider";
+
+export interface TerraformHclModuleOptions extends TerraformModuleOptions {
+    readonly providers?: (TerraformProvider | TerraformModuleProvider)[];
+    readonly variables?: {[key: string]: any};
+}
+
+export interface TerraformModuleProvider {
+    readonly provider: TerraformProvider;
+    readonly moduleAlias: string;
+}
+
+export class TerraformHclModule extends TerraformModule {
+    private _providers?: (TerraformProvider | TerraformModuleProvider)[];
+    private _variables?: {[key: string]: any};
+
+    constructor(scope: Construct, id: string, options: TerraformHclModuleOptions) {
+        super(scope, id, options);
+
+        this._providers = options.providers;
+        this._variables = options.variables;
+    }
+
+    public get variables() {
+        return this._variables;
+    }
+
+    public set(variable: string, value: any) {
+        if (!this._variables) {
+            this._variables = {};
+        }
+        this._variables[variable] = value;
+    }
+
+    public get providers() {
+        return this._providers;
+    }
+
+    public addProvider(provider: TerraformProvider | TerraformModuleProvider) {
+        if (!this._providers) {
+            this._providers = [];
+        }
+        this._providers.push(provider);
+    }
+
+    public get(output: string): any {
+        return this.interpolationForOutput(output);
+    }
+
+    public getString(output: string): string {
+        return this.get(output);
+    }
+
+    public getNumber(output: string): number {
+        return this.get(output);
+    }
+
+    public getBoolean(output: string): boolean {
+        return this.get(output);
+    }
+
+    public getList(output: string): string[] {
+        return this.get(output);
+    }
+
+    protected synthesizeAttributes(): { [name: string]: any } {
+        return {
+            providers: this.providers?.map(p => {
+                if (p instanceof TerraformProvider) {
+                    return { [p.terraformResourceType]: p.fqn };
+                }
+                else {
+                    return { [`${p.provider.terraformResourceType}.${p.moduleAlias}`]: p.provider.fqn };
+                }
+            }),
+            ...this.variables
+        };
+    }
+}

--- a/packages/cdktf/lib/terraform-module.ts
+++ b/packages/cdktf/lib/terraform-module.ts
@@ -1,22 +1,31 @@
 import { Construct } from "constructs";
 import { TerraformElement } from "./terraform-element";
+import { TerraformProvider } from "./terraform-provider";
 import { deepMerge } from "./util";
 
 export interface TerraformModuleOptions {
   readonly source: string;
   readonly version?: string;
+  readonly providers?: (TerraformProvider | TerraformModuleProvider)[];
+}
+
+export interface TerraformModuleProvider {
+  readonly provider: TerraformProvider;
+  readonly moduleAlias: string;
 }
 
 export abstract class TerraformModule extends TerraformElement {
 
   public readonly source: string;
   public readonly version?: string;
+  private _providers?: (TerraformProvider | TerraformModuleProvider)[];
 
   constructor(scope: Construct, id: string, options: TerraformModuleOptions) {
     super(scope, id);
 
     this.source = options.source;
     this.version = options.version;
+    this._providers = options.providers;
   }
 
   // jsii can't handle abstract classes?
@@ -28,11 +37,30 @@ export abstract class TerraformModule extends TerraformElement {
     return `\${module.${this.friendlyUniqueId}.${moduleOutput}}` as any;
   }
 
+  public get providers() {
+    return this._providers;
+}
+
+public addProvider(provider: TerraformProvider | TerraformModuleProvider) {
+    if (!this._providers) {
+        this._providers = [];
+    }
+    this._providers.push(provider);
+}
+
   public toTerraform(): any {
     const attributes = deepMerge({
       ...this.synthesizeAttributes(),
       source: this.source,
-      version: this.version
+      version: this.version,
+      providers: this.providers?.map(p => {
+        if (p instanceof TerraformProvider) {
+            return { [p.terraformResourceType]: p.fqn };
+        }
+        else {
+            return { [`${p.provider.terraformResourceType}.${p.moduleAlias}`]: p.provider.fqn };
+        }
+    }),
     },
       this.rawOverrides
     )

--- a/packages/cdktf/lib/terraform-module.ts
+++ b/packages/cdktf/lib/terraform-module.ts
@@ -4,13 +4,13 @@ import { deepMerge } from "./util";
 
 export interface TerraformModuleOptions {
   readonly source: string;
-  readonly version: string;
+  readonly version?: string;
 }
 
 export abstract class TerraformModule extends TerraformElement {
 
   public readonly source: string;
-  public readonly version: string;
+  public readonly version?: string;
 
   constructor(scope: Construct, id: string, options: TerraformModuleOptions) {
     super(scope, id);

--- a/packages/cdktf/test/__snapshots__/terraform-hcl-module.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/terraform-hcl-module.test.js.snap
@@ -10,12 +10,12 @@ exports[`add provider 1`] = `
   },
   \\"module\\": {
     \\"test\\": {
+      \\"source\\": \\"./foo\\",
       \\"providers\\": [
         {
           \\"test\\": \\"test.provider1\\"
         }
       ],
-      \\"source\\": \\"./foo\\",
       \\"//\\": {
         \\"metadata\\": {
           \\"path\\": \\"test/test\\",
@@ -57,6 +57,13 @@ exports[`complex providers 1`] = `
   },
   \\"module\\": {
     \\"test\\": {
+      \\"param1\\": \\"name\\",
+      \\"param2\\": 1,
+      \\"param3\\": [
+        \\"id1\\",
+        \\"id2\\"
+      ],
+      \\"source\\": \\"./foo\\",
       \\"providers\\": [
         {
           \\"test.src\\": \\"test.provider1\\"
@@ -65,13 +72,6 @@ exports[`complex providers 1`] = `
           \\"test.dst\\": \\"test.provider2\\"
         }
       ],
-      \\"param1\\": \\"name\\",
-      \\"param2\\": 1,
-      \\"param3\\": [
-        \\"id1\\",
-        \\"id2\\"
-      ],
-      \\"source\\": \\"./foo\\",
       \\"//\\": {
         \\"metadata\\": {
           \\"path\\": \\"test/test\\",
@@ -127,6 +127,7 @@ exports[`multiple providers 1`] = `
   },
   \\"module\\": {
     \\"test\\": {
+      \\"source\\": \\"./foo\\",
       \\"providers\\": [
         {
           \\"test\\": \\"test.provider1\\"
@@ -135,7 +136,6 @@ exports[`multiple providers 1`] = `
           \\"test\\": \\"test.provider2\\"
         }
       ],
-      \\"source\\": \\"./foo\\",
       \\"//\\": {
         \\"metadata\\": {
           \\"path\\": \\"test/test\\",
@@ -251,12 +251,12 @@ exports[`simple provider 1`] = `
   },
   \\"module\\": {
     \\"test\\": {
+      \\"source\\": \\"./foo\\",
       \\"providers\\": [
         {
           \\"test\\": \\"test.provider1\\"
         }
       ],
-      \\"source\\": \\"./foo\\",
       \\"//\\": {
         \\"metadata\\": {
           \\"path\\": \\"test/test\\",

--- a/packages/cdktf/test/__snapshots__/terraform-hcl-module.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/terraform-hcl-module.test.js.snap
@@ -1,0 +1,269 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`add provider 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"module\\": {
+    \\"test_DBA94737\\": {
+      \\"providers\\": [
+        {
+          \\"test\\": \\"test.provider1\\"
+        }
+      ],
+      \\"source\\": \\"./foo\\",
+      \\"//\\": {
+        \\"metadata\\": {
+          \\"path\\": \\"test/test\\",
+          \\"uniqueId\\": \\"test_DBA94737\\"
+        }
+      }
+    }
+  },
+  \\"provider\\": {
+    \\"test\\": [
+      {
+        \\"access_key\\": \\"key\\",
+        \\"alias\\": \\"provider1\\"
+      }
+    ]
+  }
+}"
+`;
+
+exports[`complex providers 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"provider\\": {
+    \\"test\\": [
+      {
+        \\"access_key\\": \\"key\\",
+        \\"alias\\": \\"provider1\\"
+      },
+      {
+        \\"access_key\\": \\"key\\",
+        \\"alias\\": \\"provider2\\"
+      }
+    ]
+  },
+  \\"module\\": {
+    \\"test_DBA94737\\": {
+      \\"providers\\": [
+        {
+          \\"test.src\\": \\"test.provider1\\"
+        },
+        {
+          \\"test.dst\\": \\"test.provider2\\"
+        }
+      ],
+      \\"param1\\": \\"name\\",
+      \\"param2\\": 1,
+      \\"param3\\": [
+        \\"id1\\",
+        \\"id2\\"
+      ],
+      \\"source\\": \\"./foo\\",
+      \\"//\\": {
+        \\"metadata\\": {
+          \\"path\\": \\"test/test\\",
+          \\"uniqueId\\": \\"test_DBA94737\\"
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`minimal configuration 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"module\\": {
+    \\"test_DBA94737\\": {
+      \\"source\\": \\"./foo\\",
+      \\"//\\": {
+        \\"metadata\\": {
+          \\"path\\": \\"test/test\\",
+          \\"uniqueId\\": \\"test_DBA94737\\"
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`multiple providers 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"provider\\": {
+    \\"test\\": [
+      {
+        \\"access_key\\": \\"key\\",
+        \\"alias\\": \\"provider1\\"
+      },
+      {
+        \\"access_key\\": \\"key\\",
+        \\"alias\\": \\"provider2\\"
+      }
+    ]
+  },
+  \\"module\\": {
+    \\"test_DBA94737\\": {
+      \\"providers\\": [
+        {
+          \\"test\\": \\"test.provider1\\"
+        },
+        {
+          \\"test\\": \\"test.provider2\\"
+        }
+      ],
+      \\"source\\": \\"./foo\\",
+      \\"//\\": {
+        \\"metadata\\": {
+          \\"path\\": \\"test/test\\",
+          \\"uniqueId\\": \\"test_DBA94737\\"
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`pass variables 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"module\\": {
+    \\"test_DBA94737\\": {
+      \\"param1\\": \\"name\\",
+      \\"param2\\": 1,
+      \\"param3\\": [
+        \\"id1\\",
+        \\"id2\\"
+      ],
+      \\"source\\": \\"./foo\\",
+      \\"//\\": {
+        \\"metadata\\": {
+          \\"path\\": \\"test/test\\",
+          \\"uniqueId\\": \\"test_DBA94737\\"
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`reference module 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"module\\": {
+    \\"test_DBA94737\\": {
+      \\"source\\": \\"./foo\\",
+      \\"//\\": {
+        \\"metadata\\": {
+          \\"path\\": \\"test/test\\",
+          \\"uniqueId\\": \\"test_DBA94737\\"
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"test_resource\\": {
+      \\"test_resource_368FC2EC\\": {
+        \\"name\\": \\"\${module.test_DBA94737.name}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/resource\\",
+            \\"uniqueId\\": \\"test_resource_368FC2EC\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`set variable 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"module\\": {
+    \\"test_DBA94737\\": {
+      \\"param1\\": \\"value1\\",
+      \\"source\\": \\"./foo\\",
+      \\"//\\": {
+        \\"metadata\\": {
+          \\"path\\": \\"test/test\\",
+          \\"uniqueId\\": \\"test_DBA94737\\"
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`simple provider 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"provider\\": {
+    \\"test\\": [
+      {
+        \\"access_key\\": \\"key\\",
+        \\"alias\\": \\"provider1\\"
+      }
+    ]
+  },
+  \\"module\\": {
+    \\"test_DBA94737\\": {
+      \\"providers\\": [
+        {
+          \\"test\\": \\"test.provider1\\"
+        }
+      ],
+      \\"source\\": \\"./foo\\",
+      \\"//\\": {
+        \\"metadata\\": {
+          \\"path\\": \\"test/test\\",
+          \\"uniqueId\\": \\"test_DBA94737\\"
+        }
+      }
+    }
+  }
+}"
+`;

--- a/packages/cdktf/test/__snapshots__/terraform-hcl-module.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/terraform-hcl-module.test.js.snap
@@ -9,7 +9,7 @@ exports[`add provider 1`] = `
     }
   },
   \\"module\\": {
-    \\"test_DBA94737\\": {
+    \\"test\\": {
       \\"providers\\": [
         {
           \\"test\\": \\"test.provider1\\"
@@ -19,7 +19,7 @@ exports[`add provider 1`] = `
       \\"//\\": {
         \\"metadata\\": {
           \\"path\\": \\"test/test\\",
-          \\"uniqueId\\": \\"test_DBA94737\\"
+          \\"uniqueId\\": \\"test\\"
         }
       }
     }
@@ -56,7 +56,7 @@ exports[`complex providers 1`] = `
     ]
   },
   \\"module\\": {
-    \\"test_DBA94737\\": {
+    \\"test\\": {
       \\"providers\\": [
         {
           \\"test.src\\": \\"test.provider1\\"
@@ -75,7 +75,7 @@ exports[`complex providers 1`] = `
       \\"//\\": {
         \\"metadata\\": {
           \\"path\\": \\"test/test\\",
-          \\"uniqueId\\": \\"test_DBA94737\\"
+          \\"uniqueId\\": \\"test\\"
         }
       }
     }
@@ -92,12 +92,12 @@ exports[`minimal configuration 1`] = `
     }
   },
   \\"module\\": {
-    \\"test_DBA94737\\": {
+    \\"test\\": {
       \\"source\\": \\"./foo\\",
       \\"//\\": {
         \\"metadata\\": {
           \\"path\\": \\"test/test\\",
-          \\"uniqueId\\": \\"test_DBA94737\\"
+          \\"uniqueId\\": \\"test\\"
         }
       }
     }
@@ -126,7 +126,7 @@ exports[`multiple providers 1`] = `
     ]
   },
   \\"module\\": {
-    \\"test_DBA94737\\": {
+    \\"test\\": {
       \\"providers\\": [
         {
           \\"test\\": \\"test.provider1\\"
@@ -139,7 +139,7 @@ exports[`multiple providers 1`] = `
       \\"//\\": {
         \\"metadata\\": {
           \\"path\\": \\"test/test\\",
-          \\"uniqueId\\": \\"test_DBA94737\\"
+          \\"uniqueId\\": \\"test\\"
         }
       }
     }
@@ -156,7 +156,7 @@ exports[`pass variables 1`] = `
     }
   },
   \\"module\\": {
-    \\"test_DBA94737\\": {
+    \\"test\\": {
       \\"param1\\": \\"name\\",
       \\"param2\\": 1,
       \\"param3\\": [
@@ -167,7 +167,7 @@ exports[`pass variables 1`] = `
       \\"//\\": {
         \\"metadata\\": {
           \\"path\\": \\"test/test\\",
-          \\"uniqueId\\": \\"test_DBA94737\\"
+          \\"uniqueId\\": \\"test\\"
         }
       }
     }
@@ -184,24 +184,24 @@ exports[`reference module 1`] = `
     }
   },
   \\"module\\": {
-    \\"test_DBA94737\\": {
+    \\"test\\": {
       \\"source\\": \\"./foo\\",
       \\"//\\": {
         \\"metadata\\": {
           \\"path\\": \\"test/test\\",
-          \\"uniqueId\\": \\"test_DBA94737\\"
+          \\"uniqueId\\": \\"test\\"
         }
       }
     }
   },
   \\"resource\\": {
     \\"test_resource\\": {
-      \\"test_resource_368FC2EC\\": {
-        \\"name\\": \\"\${module.test_DBA94737.name}\\",
+      \\"resource\\": {
+        \\"name\\": \\"\${module.test.name}\\",
         \\"//\\": {
           \\"metadata\\": {
             \\"path\\": \\"test/resource\\",
-            \\"uniqueId\\": \\"test_resource_368FC2EC\\"
+            \\"uniqueId\\": \\"resource\\"
           }
         }
       }
@@ -219,13 +219,13 @@ exports[`set variable 1`] = `
     }
   },
   \\"module\\": {
-    \\"test_DBA94737\\": {
+    \\"test\\": {
       \\"param1\\": \\"value1\\",
       \\"source\\": \\"./foo\\",
       \\"//\\": {
         \\"metadata\\": {
           \\"path\\": \\"test/test\\",
-          \\"uniqueId\\": \\"test_DBA94737\\"
+          \\"uniqueId\\": \\"test\\"
         }
       }
     }
@@ -250,7 +250,7 @@ exports[`simple provider 1`] = `
     ]
   },
   \\"module\\": {
-    \\"test_DBA94737\\": {
+    \\"test\\": {
       \\"providers\\": [
         {
           \\"test\\": \\"test.provider1\\"
@@ -260,7 +260,7 @@ exports[`simple provider 1`] = `
       \\"//\\": {
         \\"metadata\\": {
           \\"path\\": \\"test/test\\",
-          \\"uniqueId\\": \\"test_DBA94737\\"
+          \\"uniqueId\\": \\"test\\"
         }
       }
     }

--- a/packages/cdktf/test/terraform-hcl-module.test.ts
+++ b/packages/cdktf/test/terraform-hcl-module.test.ts
@@ -1,0 +1,133 @@
+
+import { Testing, TerraformStack, TerraformHclModule } from '../lib';
+import { TestProvider, TestResource } from './helper'
+
+test('minimal configuration', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    new TerraformHclModule(stack, 'test', {
+        source: './foo'
+    });
+    expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test('pass variables', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    new TerraformHclModule(stack, 'test', {
+        source: './foo',
+        variables: {
+            param1: 'name',
+            param2: 1,
+            param3: ['id1', 'id2']
+        }
+    });
+    expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test('simple provider', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    const provider = new TestProvider(stack, 'provider', {
+        accessKey: 'key',
+        alias: 'provider1'
+    });
+
+    new TerraformHclModule(stack, 'test', {
+        source: './foo',
+        providers: [provider]
+    });
+    expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test('multiple providers', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    const provider1 = new TestProvider(stack, 'provider1', {
+        accessKey: 'key',
+        alias: 'provider1'
+    });
+
+    const provider2 = new TestProvider(stack, 'provider2', {
+        accessKey: 'key',
+        alias: 'provider2'
+    });
+
+    new TerraformHclModule(stack, 'test', {
+        source: './foo',
+        providers: [provider1, provider2]
+    });
+    expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test('complex providers', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    const provider1 = new TestProvider(stack, 'provider1', {
+        accessKey: 'key',
+        alias: 'provider1'
+    });
+
+    const provider2 = new TestProvider(stack, 'provider2', {
+        accessKey: 'key',
+        alias: 'provider2'
+    });
+
+    new TerraformHclModule(stack, 'test', {
+        source: './foo',
+        providers: [{provider: provider1, moduleAlias: 'src'}, {provider: provider2, moduleAlias: 'dst'}],
+        variables: {
+            param1: 'name',
+            param2: 1,
+            param3: ['id1', 'id2']
+        }
+    });
+    expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test('reference module', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    const module = new TerraformHclModule(stack, 'test', {
+        source: './foo'
+    });
+
+    new TestResource(stack, 'resource', {
+        name: module.getString('name')
+    });
+    expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test('set variable', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    const module = new TerraformHclModule(stack, 'test', {
+        source: './foo'
+    });
+
+    module.set('param1', 'value1');
+    expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test('add provider', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    const module = new TerraformHclModule(stack, 'test', {
+        source: './foo'
+    });
+
+    const provider = new TestProvider(stack, 'provider', {
+        accessKey: 'key',
+        alias: 'provider1'
+    });
+    module.addProvider(provider);
+    expect(Testing.synth(stack)).toMatchSnapshot();
+});


### PR DESCRIPTION
Helps with #16 

This is meant to be something a bit nicer than escape hatches for referencing non-registry modules. Eventually this may be come obsolete if code generation supports non-registry modules, but that seems like a ways off yet.

I didn't add the new Terraform 0.13 meta arguments. I think that's better suited for a follow up especially since there is a bunch of overlap between different types.