### PR TITLE
Fixes CloudFront Proxy Example

### DIFF
--- a/examples/typescript/aws-cloudfront-proxy/main.ts
+++ b/examples/typescript/aws-cloudfront-proxy/main.ts
@@ -32,7 +32,7 @@ class MyStack extends TerraformStack {
     // })
 
     const record = new Route53Record(this, 'CertValidationRecord', {
-      name: cert.domainValidationOptions('0').domainName,
+      name: cert.domainValidationOptions('0').resourceRecordName,
       type: cert.domainValidationOptions('0').resourceRecordType,
       records: [
         cert.domainValidationOptions('0').resourceRecordValue


### PR DESCRIPTION
AcmCertificate DNS validation must use the DVO's resource_record_name