### PR TITLE
Increase Maven max memory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM jsii/superchain
 
-RUN yum install -y unzip jq && curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
+RUN yum install -y unzip jq && curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python3
 
 ENV DEFAULT_TERRAFORM_VERSION=0.13.0                                \
     TF_PLUGIN_CACHE_DIR="/root/.terraform.d/plugin-cache"           \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM jsii/superchain
 
 RUN yum install -y unzip jq && curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
 
-ENV DEFAULT_TERRAFORM_VERSION=0.13.0
-ENV TF_PLUGIN_CACHE_DIR="/root/.terraform.d/plugin-cache"
+ENV DEFAULT_TERRAFORM_VERSION=0.13.0                                \
+    TF_PLUGIN_CACHE_DIR="/root/.terraform.d/plugin-cache"           \
+    MAVEN_OPTS="-Xms256m -Xmx3G"
 
 # Install Terraform
 RUN AVAILABLE_TERRAFORM_VERSIONS="0.12.29 0.13.0-rc1 ${DEFAULT_TERRAFORM_VERSION}" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN yum install -y unzip jq && curl https://raw.githubusercontent.com/pypa/pipen
 
 ENV DEFAULT_TERRAFORM_VERSION=0.13.0                                \
     TF_PLUGIN_CACHE_DIR="/root/.terraform.d/plugin-cache"           \
+# MAVEN_OPTS is set in jsii/superchain with -Xmx512m. This isn't enough memory for provider generation.
     MAVEN_OPTS="-Xms256m -Xmx3G"
 
 # Install Terraform


### PR DESCRIPTION
The jsii/superchain image sets `MAVEN_OPTS` with a max heap size that is too small for generating some of the larger providers. I've worked around it in #360, but for https://github.com/terraform-cdk-providers/cdktf-provider-project/pull/14 it will be easier to just have the value increased.