### PR TITLE
Silence jsii warnings for reserved words

### DIFF
--- a/packages/cdktf/package.json
+++ b/packages/cdktf/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "description": "Cloud Development Kit for Terraform",
   "scripts": {
-    "build": "jsii",
-    "watch": "jsii -w",
+    "build": "jsii --silence-warnings reserved-word",
+    "watch": "jsii -w --silence-warnings reserved-word",
     "watch-preserve-output": "tsc -w --preserveWatchOutput",
     "package": "jsii-pacmak",
     "lint": "eslint . --ext .ts",


### PR DESCRIPTION
These silences the current warnings we have:

```
lib/app.ts:5:14 - message TS9999: JSII: Ignoring VariableDeclaration node (it cannot be represented in the jsii type model)

5 export const CONTEXT_ENV = 'CDKTF_CONTEXT_JSON';
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lib/terraform-variable.ts:50:14 - warning TS9999: JSII: 'default' is a reserved word in C#, Java. Using this name may cause problems when generating language bindings. Consider using a different name.

50     readonly default?: any;
                ~~~~~~~
lib/backends/etcdv3-backend.ts:27:14 - warning TS9999: JSII: 'lock' is a reserved word in C#. Using this name may cause problems when generating language bindings. Consider using a different name.

27     readonly lock?: boolean;
                ~~~~
lib/backends/consul-backend.ts:30:14 - warning TS9999: JSII: 'lock' is a reserved word in C#. Using this name may cause problems when generating language bindings. Consider using a different name.

30     readonly lock?: boolean;
                ~~~~
lib/terraform-variable.ts:44:19 - warning TS9999: JSII: 'object' is a reserved word in C#. Using this name may cause problems when generating language bindings. Consider using a different name.

44     public static object(attributes: { [key: string]: string}) {
                     ~~~~~~
lib/terraform-variable.ts:80:21 - warning TS9999: JSII: 'default' is a reserved word in C#, Java. Using this name may cause problems when generating language bindings. Consider using a different name.

80     public readonly default?: any;
```

After:

```
lib/app.ts:5:14 - message TS9999: JSII: Ignoring VariableDeclaration node (it cannot be represented in the jsii type model)

5 export const CONTEXT_ENV = 'CDKTF_CONTEXT_JSON';
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

In general, we should fix these warnings. However, I'd be leaning towards an explicit check for these warnings, rather than polluting the output always with these warnings, while they aren't really relevant at the moment.