### PR TITLE
Ignore GitHub Maven duplicate publish failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      - uses: actions/checkout@v2
       - name: Download dist
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
           name: dist
           path: dist
       - name: Publish package
-        run: cd "$(dirname "$(find dist/java/ -type f -name *.pom | head -1)")" && mvn deploy -f "$(find . -type f -name *.pom | head -1)" -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/${{github.repository}}
+        run: yarn release-github-maven
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "integration": "test/run-against-dist test/test-all.sh",
     "integration-windows": "test\\run-against-dist.bat test\\test-all.bat",
     "release-github": "tools/release-github.sh",
+    "release-github-maven": "tools/release-github-maven.sh",
     "build-docker-jsii": "docker build -t hashicorp/jsii-terraform .",
     "push-docker-jsii": "docker push hashicorp/jsii-terraform"
   },

--- a/tools/release-github-maven.sh
+++ b/tools/release-github-maven.sh
@@ -7,7 +7,7 @@ pom="$(find . -type f -name *.pom | head -1)"
 cd "$(dirname ${pom})" 
 
 release_output="${workdir}/release-output.txt"
-mvn deploy -f ${pom} -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/hashicorp/terraform-cdk | tee ${release_output}
+mvn deploy -f "$(basename ${pom})" -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/hashicorp/terraform-cdk | tee ${release_output}
 
 # If release failed, check if this was caused because we are trying to publish
 # the same version again, which is not an error. The magic string "409 Conflict"

--- a/tools/release-github-maven.sh
+++ b/tools/release-github-maven.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -eu # we don't want "pipefail" to implement idempotency
+
+workdir=$(mktemp -d)
+
+pom="$(find . -type f -name *.pom | head -1)"
+cd "$(dirname ${pom})" 
+
+release_output="${workdir}/release-output.txt"
+mvn deploy -f ${pom} -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/hashicorp/terraform-cdk | tee ${release_output}
+
+# If release failed, check if this was caused because we are trying to publish
+# the same version again, which is not an error. The magic string "409 Conflict"
+# indicates that we are trying to
+# override an existing version. Otherwise, fail!
+if [ ${PIPESTATUS[0]} -ne 0 ]; then
+    if cat ${release_output} | grep -q "409 Conflict"; then
+        echo "⚠️ Artifact already published. Skipping"
+    else
+        echo "❌ Release failed"
+        exit 1
+    fi
+fi


### PR DESCRIPTION
Fixes #404 
This matches the behavior of jsii-release which will hopefully support GitHub packages in the future.

Duplicate testing: https://github.com/jsteinich/terraform-cdk/runs/1217459704?check_suite_focus=true
New version testing: https://github.com/jsteinich/terraform-cdk/runs/1217491032?check_suite_focus=true