### PR TITLE
Use docker mirror

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jsii/superchain
+FROM hashicorp.jfrog.io/docker/jsii/superchain
 
 RUN yum install -y unzip jq && curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python3
 


### PR DESCRIPTION
CHANGELOG: no impact

Dockerhub is going to rate limit unauthenticated pulls on November 1st. IPs from CI machines will be near their limit all the time. We're moving projects to use a public un-rate-limited Mirror of these images instead. Let me know if you have any q's, otherwise feel free to merge when you can! 
