### PR TITLE
Fix pre release

### DIFF
--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -18,7 +18,7 @@ jobs:
       - name: installing dependencies
         run: |
           yarn install
-      - run: tools/align-version.sh "-pre.${{ github.sha }}"
+      - run: tools/align-version.sh "-pre.${{ env.GITHUB_RUN_NUMBER }}"
       - run: yarn build
       - run: yarn test
       - run: yarn package


### PR DESCRIPTION
With the upgrade of jsii to 1.14 a [new version mapping](https://github.com/aws/jsii/commit/1338fc2492295f683381d00a04fb88517f3c4d55#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3) for pre releases got introduced.
This broke our current schema based on git shas. 

This PR switches to `GITHUB_RUN_NUMBER`, which is an incrementing number and stable for retries of the same workflow run (see https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables)