### PR TITLE
Remap 'equals' to 'equalTo' to work around jsii limitation

### DIFF
--- a/packages/cdktf-cli/lib/get/generator/models/attribute-model.ts
+++ b/packages/cdktf-cli/lib/get/generator/models/attribute-model.ts
@@ -69,6 +69,8 @@ export class AttributeModel {
     if (this._name === 'self' || this._name === 'build') return `${this._name}Attribute`;
     // jsii can't handle `getFoo` properties, since it's incompatible with Java
     if (this._name.match(/^get[A-Z]+/)) return this._name.replace('get', 'fetch');
+    // `equals` is a prohibited name in jsii
+    if (this._name === 'equals') return 'equalTo';
     return this._name
   }
 


### PR DESCRIPTION
Fixes #393 

This just adds to the existing renaming block in order to handle the `equals` attribute used by `aws_guardduty_filter`.
Long term this will hopefully be handled in jsii, but that is proving to be a bigger project than expected, so work around to unblock aws provider v3.