### PR TITLE
Alter reset and input names when they conflict

### DIFF
--- a/packages/cdktf-cli/lib/get/generator/emitter/resource-emitter.ts
+++ b/packages/cdktf-cli/lib/get/generator/emitter/resource-emitter.ts
@@ -50,7 +50,9 @@ export class ResourceEmitter {
 
   private emitResourceAttributes(resource: ResourceModel) {
     for (const att of resource.attributes) {
-      this.attributesEmitter.emit(att)
+      this.attributesEmitter.emit(att, 
+        this.attributesEmitter.needsResetEscape(att, resource.attributes), 
+        this.attributesEmitter.needsInputEscape(att, resource.attributes));
     }
   }
 

--- a/packages/cdktf-cli/lib/get/generator/emitter/struct-emitter.ts
+++ b/packages/cdktf-cli/lib/get/generator/emitter/struct-emitter.ts
@@ -44,7 +44,9 @@ export class StructEmitter {
   private emitClass(struct: Struct) {
     this.code.openBlock(`export class ${struct.name} extends cdktf.ComplexComputedList`);
     for (const att of struct.attributes) {
-      this.attributesEmitter.emit(att)
+      this.attributesEmitter.emit(att, 
+        this.attributesEmitter.needsResetEscape(att, struct.attributes), 
+        this.attributesEmitter.needsInputEscape(att, struct.attributes));
     }
     this.code.closeBlock();
   }

--- a/packages/cdktf-cli/test/get/generator/__snapshots__/types.test.ts.snap
+++ b/packages/cdktf-cli/test/get/generator/__snapshots__/types.test.ts.snap
@@ -1321,12 +1321,11 @@ exports[`reset and input name conflicts 1`] = `
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
-import { TerraformResource } from 'cdktf';
-import { TerraformMetaArguments } from 'cdktf';
+import * as cdktf from 'cdktf';
 
 // Configuration
 
-export interface NameConflictConfig extends TerraformMetaArguments {
+export interface NameConflictConfig extends cdktf.TerraformMetaArguments {
   readonly values?: string;
   readonly resetValues?: string;
   readonly template?: string;
@@ -1335,7 +1334,7 @@ export interface NameConflictConfig extends TerraformMetaArguments {
 
 // Resource
 
-export class NameConflict extends TerraformResource {
+export class NameConflict extends cdktf.TerraformResource {
 
   // ===========
   // INITIALIZER
@@ -1432,10 +1431,10 @@ export class NameConflict extends TerraformResource {
 
   protected synthesizeAttributes(): { [name: string]: any } {
     return {
-      values: this._values,
-      reset_values: this._resetValues,
-      template: this._template,
-      template_input: this._templateInput,
+      values: cdktf.stringToTerraform(this._values),
+      reset_values: cdktf.stringToTerraform(this._resetValues),
+      template: cdktf.stringToTerraform(this._template),
+      template_input: cdktf.stringToTerraform(this._templateInput),
     };
   }
 }

--- a/packages/cdktf-cli/test/get/generator/__snapshots__/types.test.ts.snap
+++ b/packages/cdktf-cli/test/get/generator/__snapshots__/types.test.ts.snap
@@ -1316,6 +1316,132 @@ export class PrimitiveString extends cdktf.TerraformResource {
 "
 `;
 
+exports[`reset and input name conflicts 1`] = `
+"// https://www.terraform.io/docs/providers/aws/r/name_conflict.html
+// generated from terraform resource schema
+
+import { Construct } from 'constructs';
+import { TerraformResource } from 'cdktf';
+import { TerraformMetaArguments } from 'cdktf';
+
+// Configuration
+
+export interface NameConflictConfig extends TerraformMetaArguments {
+  readonly values?: string;
+  readonly resetValues?: string;
+  readonly template?: string;
+  readonly templateInput?: string;
+}
+
+// Resource
+
+export class NameConflict extends TerraformResource {
+
+  // ===========
+  // INITIALIZER
+  // ===========
+
+  public constructor(scope: Construct, id: string, config: NameConflictConfig = {}) {
+    super(scope, id, {
+      terraformResourceType: 'aws_name_conflict',
+      terraformGeneratorMetadata: {
+        providerName: 'aws'
+      },
+      provider: config.provider,
+      dependsOn: config.dependsOn,
+      count: config.count,
+      lifecycle: config.lifecycle
+    });
+    this._values = config.values;
+    this._resetValues = config.resetValues;
+    this._template = config.template;
+    this._templateInput = config.templateInput;
+  }
+
+  // ==========
+  // ATTRIBUTES
+  // ==========
+
+  // values - computed: false, optional: true, required: false
+  private _values?: string;
+  public get values() {
+    return this.getStringAttribute('values');
+  }
+  public set values(value: string ) {
+    this._values = value;
+  }
+  public resetTfValues() {
+    this._values = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get valuesInput() {
+    return this._values
+  }
+
+  // reset_values - computed: false, optional: true, required: false
+  private _resetValues?: string;
+  public get resetValues() {
+    return this.getStringAttribute('reset_values');
+  }
+  public set resetValues(value: string ) {
+    this._resetValues = value;
+  }
+  public resetResetValues() {
+    this._resetValues = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get resetValuesInput() {
+    return this._resetValues
+  }
+
+  // template - computed: false, optional: true, required: false
+  private _template?: string;
+  public get template() {
+    return this.getStringAttribute('template');
+  }
+  public set template(value: string ) {
+    this._template = value;
+  }
+  public resetTemplate() {
+    this._template = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get templateTfInput() {
+    return this._template
+  }
+
+  // template_input - computed: false, optional: true, required: false
+  private _templateInput?: string;
+  public get templateInput() {
+    return this.getStringAttribute('template_input');
+  }
+  public set templateInput(value: string ) {
+    this._templateInput = value;
+  }
+  public resetTemplateInput() {
+    this._templateInput = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get templateInputInput() {
+    return this._templateInput
+  }
+
+  // =========
+  // SYNTHESIS
+  // =========
+
+  protected synthesizeAttributes(): { [name: string]: any } {
+    return {
+      values: this._values,
+      reset_values: this._resetValues,
+      template: this._template,
+      template_input: this._templateInput,
+    };
+  }
+}
+"
+`;
+
 exports[`set / list block type 1`] = `
 "// https://www.terraform.io/docs/providers/aws/r/block_type_set_list.html
 // generated from terraform resource schema

--- a/packages/cdktf-cli/test/get/generator/fixtures/name-conflict.test.fixture.json
+++ b/packages/cdktf-cli/test/get/generator/fixtures/name-conflict.test.fixture.json
@@ -1,0 +1,34 @@
+{
+    "provider_schemas": {
+      "aws": {
+        "resource_schemas": {
+          "aws_name_conflict": {
+            "version": 1,
+            "block": {
+              "attributes": {
+                "values": {
+                  "type": "string",
+                  "optional": true
+                },
+                "reset_values": {
+                  "type": "string",
+                  "optional": true
+                },
+                "template": {
+                  "type": "string",
+                  "optional": true
+                },
+                "template_input": {
+                  "type": "string",
+                  "optional": true
+                }
+              }
+            },
+            "block_types": {}
+          }
+        }
+      }
+    }
+  }
+  
+  

--- a/packages/cdktf-cli/test/get/generator/types.test.ts
+++ b/packages/cdktf-cli/test/get/generator/types.test.ts
@@ -212,3 +212,14 @@ test('list of string map attribute', async () => {
   const output = fs.readFileSync(path.join(workdir, 'providers/aws/list-of-string-map.ts'), 'utf-8');
   expect(output).toMatchSnapshot();
 });
+
+test('reset and input name conflicts', async () => {
+  const code = new CodeMaker()
+  const workdir = fs.mkdtempSync(path.join(os.tmpdir(), 'name-conflict.test'));
+  const spec = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures', 'name-conflict.test.fixture.json'), 'utf-8'));
+  new TerraformGenerator(code, spec);
+  await code.save(workdir);
+
+  const output = fs.readFileSync(path.join(workdir, 'providers/aws/name-conflict.ts'), 'utf-8');
+  expect(output).toMatchSnapshot();
+});


### PR DESCRIPTION
Fixes #427 

Very rarely, the generated names for resetting optional values and accessing the input value for required or optional values conflicts with other values.
I checked nearly 400 providers and found only 3 instances of conflict with `reset` and 1 with `input`. As such, I choose to only diverge from convention when necessary rather than changing the naming overall.
`XInput` -> `XTfInput` and `resetX` -> `resetTfX`