### PR TITLE
Make sure tokens resolved before converting to json

### DIFF
--- a/packages/cdktf/test/remote-state.test.ts
+++ b/packages/cdktf/test/remote-state.test.ts
@@ -295,7 +295,7 @@ test('s3 reference', () => {
     });
 
     new TestResource(stack, 'test_resource', {
-        name: remoteState.getString('name')
+        name: remoteState.get('name')
     });
 
     expect(Testing.synth(stack)).toMatchSnapshot();

--- a/packages/cdktf/test/variable.test.ts
+++ b/packages/cdktf/test/variable.test.ts
@@ -121,7 +121,7 @@ test('reference', () => {
     });
 
     new TestResource(stack, 'test-resource', {
-        name: variable.stringValue
+        name: variable.value
     });
     expect(Testing.synth(stack)).toMatchSnapshot();
 });


### PR DESCRIPTION
Fixes #433.
Fixes #437.
Fixes #256.

Need to resolve tokens before converting to terraform json to prevent the Intrinsic's creation stack from being included. This matches the behavior of the AWS CDK.

I also updated a couple tests to check this behavior and to match the documentation for the associated features.