### PR TITLE
Fix complex map attribute data source reference

### DIFF
--- a/packages/cdktf/lib/complex-computed-list.ts
+++ b/packages/cdktf/lib/complex-computed-list.ts
@@ -27,7 +27,7 @@ export class StringMap {
   constructor(protected terraformResource: ITerraformResource, protected terraformAttribute: string) {}
 
   public lookup(key: string): string {
-    return Token.asString(`\${${this.terraformResource.terraformResourceType}.${this.terraformResource.friendlyUniqueId}.${this.terraformAttribute}["${key}"]}`)
+    return Token.asString(this.terraformResource.interpolationForAttribute(`${this.terraformAttribute}["${key}"]`))
   }
 }
 
@@ -35,7 +35,7 @@ export class NumberMap {
   constructor(protected terraformResource: ITerraformResource, protected terraformAttribute: string) {}
 
   public lookup(key: string): number {
-    return Token.asNumber(`\${${this.terraformResource.terraformResourceType}.${this.terraformResource.friendlyUniqueId}.${this.terraformAttribute}["${key}"]`)
+    return Token.asNumber(this.terraformResource.interpolationForAttribute(`${this.terraformAttribute}["${key}"]`))
   }
 }
 
@@ -43,7 +43,7 @@ export class BooleanMap {
   constructor(protected terraformResource: ITerraformResource, protected terraformAttribute: string) {}
 
   public lookup(key: string): boolean {
-    return Token.asString(`\${${this.terraformResource.terraformResourceType}.${this.terraformResource.friendlyUniqueId}.${this.terraformAttribute}["${key}"]`) as any as boolean
+    return Token.asString(this.terraformResource.interpolationForAttribute(`${this.terraformAttribute}["${key}"]`)) as any as boolean
   }
 }
 

--- a/packages/cdktf/test/__snapshots__/data-source.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/data-source.test.js.snap
@@ -23,6 +23,42 @@ exports[`minimal configuration 1`] = `
 }"
 `;
 
+exports[`with boolean map 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test-data-source\\"
+    }
+  },
+  \\"data\\": {
+    \\"test_data_source\\": {
+      \\"test\\": {
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test-data-source/test\\",
+            \\"uniqueId\\": \\"test\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"test_resource\\": {
+      \\"test-resource\\": {
+        \\"name\\": \\"\${data.test_data_source.test.boolean_map[\\\\\\"id\\\\\\"]}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test-data-source/test-resource\\",
+            \\"uniqueId\\": \\"test-resource\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
 exports[`with complex computed list 1`] = `
 "{
   \\"//\\": {
@@ -47,6 +83,78 @@ exports[`with complex computed list 1`] = `
     \\"test_resource\\": {
       \\"test-resource\\": {
         \\"name\\": \\"\${data.test_data_source.test.complex_computed_list.0.id}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test-data-source/test-resource\\",
+            \\"uniqueId\\": \\"test-resource\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`with number map 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test-data-source\\"
+    }
+  },
+  \\"data\\": {
+    \\"test_data_source\\": {
+      \\"test\\": {
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test-data-source/test\\",
+            \\"uniqueId\\": \\"test\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"test_resource\\": {
+      \\"test-resource\\": {
+        \\"name\\": \\"\${data.test_data_source.test.number_map[\\\\\\"id\\\\\\"]}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test-data-source/test-resource\\",
+            \\"uniqueId\\": \\"test-resource\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`with string map 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test-data-source\\"
+    }
+  },
+  \\"data\\": {
+    \\"test_data_source\\": {
+      \\"test\\": {
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test-data-source/test\\",
+            \\"uniqueId\\": \\"test\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"test_resource\\": {
+      \\"test-resource\\": {
+        \\"name\\": \\"\${data.test_data_source.test.string_map[\\\\\\"id\\\\\\"]}\\",
         \\"//\\": {
           \\"metadata\\": {
             \\"path\\": \\"test-data-source/test-resource\\",

--- a/packages/cdktf/test/data-source.test.ts
+++ b/packages/cdktf/test/data-source.test.ts
@@ -1,4 +1,4 @@
-import { TerraformStack, Testing } from '../lib';
+import { TerraformStack, Testing, Token } from '../lib';
 import { TestResource } from './helper';
 import { TestDataSource } from './helper/data-source';
 
@@ -26,3 +26,44 @@ test('with complex computed list', () => {
   expect(Testing.synth(stack)).toMatchSnapshot();
 });
 
+test('with string map', () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, 'test-data-source');
+
+  const dataSource = new TestDataSource(stack, 'test', {
+    name: 'foo'
+  });
+  new TestResource(stack, 'test-resource', {
+    name: dataSource.stringMap('id'),
+  })
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test('with number map', () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, 'test-data-source');
+
+  const dataSource = new TestDataSource(stack, 'test', {
+    name: 'foo'
+  });
+  new TestResource(stack, 'test-resource', {
+    name: Token.asString(dataSource.numberMap('id')),
+  })
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test('with boolean map', () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, 'test-data-source');
+
+  const dataSource = new TestDataSource(stack, 'test', {
+    name: 'foo'
+  });
+  new TestResource(stack, 'test-resource', {
+    name: dataSource.booleanMap('id').toString(),
+  })
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});

--- a/packages/cdktf/test/helper/data-source.ts
+++ b/packages/cdktf/test/helper/data-source.ts
@@ -1,5 +1,5 @@
 import { Construct } from 'constructs';
-import { ComplexComputedList, TerraformDataSource, TerraformMetaArguments } from '../../lib';
+import { ComplexComputedList, TerraformDataSource, TerraformMetaArguments, StringMap, NumberMap, BooleanMap } from '../../lib';
 import { TestProviderMetadata } from './provider';
 
 export interface TestDataSourceConfig extends TerraformMetaArguments {
@@ -24,6 +24,18 @@ export class TestDataSource extends TerraformDataSource {
 
   public complexComputedList(index: string) {
     return new TestComplexComputedList(this, 'complex_computed_list', index);
+  }
+
+  public stringMap(key: string) {
+    return new StringMap(this, 'string_map').lookup(key);
+  }
+
+  public numberMap(key: string) {
+    return new NumberMap(this, 'number_map').lookup(key);
+  }
+
+  public booleanMap(key: string) {
+    return new BooleanMap(this, 'boolean_map').lookup(key);
   }
 
   protected synthesizeAttributes(): { [p: string]: any } {


### PR DESCRIPTION
Fixes #372 

Use same pattern as `ComplexComputeList` interpolation for `StringMap`, `NumberMap`, and `BooleanMap`.