### PR TITLE
Depends on expansion

### DIFF
--- a/packages/cdktf/lib/index.ts
+++ b/packages/cdktf/lib/index.ts
@@ -17,3 +17,4 @@ export * from './terraform-local';
 export * from './terraform-variable';
 export * from './terraform-hcl-module';
 export * from './runtime';
+export * from './terraform-dependable';

--- a/packages/cdktf/lib/terraform-data-source.ts
+++ b/packages/cdktf/lib/terraform-data-source.ts
@@ -4,8 +4,9 @@ import { TerraformElement } from "./terraform-element";
 import { TerraformProvider } from "./terraform-provider";
 import {  TerraformGeneratorMetadata, TerraformResourceConfig, TerraformResourceLifecycle, ITerraformResource } from "./terraform-resource";
 import { keysToSnakeCase, deepMerge } from "./util";
+import { ITerraformDependable } from "./terraform-dependable";
 
-export class TerraformDataSource extends TerraformElement implements ITerraformResource {
+export class TerraformDataSource extends TerraformElement implements ITerraformResource, ITerraformDependable {
   public readonly terraformResourceType: string;
   public readonly terraformGeneratorMetadata?: TerraformGeneratorMetadata;
 

--- a/packages/cdktf/lib/terraform-dependable.ts
+++ b/packages/cdktf/lib/terraform-dependable.ts
@@ -1,0 +1,3 @@
+export interface ITerraformDependable {
+    readonly fqn: string;
+}

--- a/packages/cdktf/lib/terraform-output.ts
+++ b/packages/cdktf/lib/terraform-output.ts
@@ -1,20 +1,20 @@
 import { Construct } from "constructs";
 import { TerraformElement } from "./terraform-element";
-import { TerraformResource } from "./terraform-resource"
 import { keysToSnakeCase, deepMerge } from "./util"
+import { ITerraformDependable } from "./terraform-dependable";
 
 export interface TerraformOutputConfig {
   readonly value: string | number | boolean | any[] | { [key: string]: any } | undefined;
   readonly description?: string;
   readonly sensitive?: boolean;
-  readonly dependsOn?: TerraformResource[];
+  readonly dependsOn?: ITerraformDependable[];
 }
 
 export class TerraformOutput extends TerraformElement {
   public value: string | number | boolean | any[] | { [key: string]: any } | undefined;
   public description?: string;
   public sensitive?: boolean;
-  public dependsOn?: TerraformResource[];
+  public dependsOn?: ITerraformDependable[];
 
   constructor(scope: Construct, id: string, config: TerraformOutputConfig) {
     super(scope, id);

--- a/packages/cdktf/lib/terraform-resource.ts
+++ b/packages/cdktf/lib/terraform-resource.ts
@@ -3,6 +3,7 @@ import { Token } from "./tokens"
 import { TerraformElement } from "./terraform-element";
 import { TerraformProvider } from "./terraform-provider";
 import { keysToSnakeCase, deepMerge } from "./util";
+import { ITerraformDependable } from "./terraform-dependable";
 
 export interface ITerraformResource {
   readonly terraformResourceType: string;
@@ -24,7 +25,7 @@ export interface TerraformResourceLifecycle {
 }
 
 export interface TerraformMetaArguments {
-  readonly dependsOn?: TerraformResource[];
+  readonly dependsOn?: ITerraformDependable[];
   readonly count?: number;
   readonly provider?: TerraformProvider;
   readonly lifecycle?: TerraformResourceLifecycle;
@@ -40,7 +41,7 @@ export interface TerraformResourceConfig extends TerraformMetaArguments {
   readonly terraformGeneratorMetadata?: TerraformGeneratorMetadata;
 }
 
-export class TerraformResource extends TerraformElement implements ITerraformResource {
+export class TerraformResource extends TerraformElement implements ITerraformResource, ITerraformDependable {
   public readonly terraformResourceType: string;
   public readonly terraformGeneratorMetadata?: TerraformGeneratorMetadata;
 

--- a/packages/cdktf/test/__snapshots__/data-source.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/data-source.test.js.snap
@@ -1,5 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`dependent data source 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"resource\\": {
+    \\"test_resource\\": {
+      \\"resource\\": {
+        \\"name\\": \\"foo\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/resource\\",
+            \\"uniqueId\\": \\"resource\\"
+          }
+        }
+      }
+    }
+  },
+  \\"data\\": {
+    \\"test_data_source\\": {
+      \\"data_source\\": {
+        \\"depends_on\\": [
+          \\"test_resource.resource\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/data_source\\",
+            \\"uniqueId\\": \\"data_source\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
 exports[`minimal configuration 1`] = `
 "{
   \\"//\\": {

--- a/packages/cdktf/test/__snapshots__/resource.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/resource.test.js.snap
@@ -1,5 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`dependent resource 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"data\\": {
+    \\"test_data_source\\": {
+      \\"data_source\\": {
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/data_source\\",
+            \\"uniqueId\\": \\"data_source\\"
+          }
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"test_resource\\": {
+      \\"resource\\": {
+        \\"name\\": \\"foo\\",
+        \\"depends_on\\": [
+          \\"data.test_data_source.data_source\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/resource\\",
+            \\"uniqueId\\": \\"resource\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
 exports[`do not change capitalization of arbritary nested types 1`] = `
 "{
   \\"//\\": {

--- a/packages/cdktf/test/__snapshots__/terraform-hcl-module.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/terraform-hcl-module.test.js.snap
@@ -83,6 +83,78 @@ exports[`complex providers 1`] = `
 }"
 `;
 
+exports[`depend on module 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"module\\": {
+    \\"test\\": {
+      \\"source\\": \\"./foo\\",
+      \\"//\\": {
+        \\"metadata\\": {
+          \\"path\\": \\"test/test\\",
+          \\"uniqueId\\": \\"test\\"
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"test_resource\\": {
+      \\"resource\\": {
+        \\"name\\": \\"foo\\",
+        \\"depends_on\\": [
+          \\"module.test\\"
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/resource\\",
+            \\"uniqueId\\": \\"resource\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`depend on other module 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"module\\": {
+    \\"test_1\\": {
+      \\"source\\": \\"./foo\\",
+      \\"//\\": {
+        \\"metadata\\": {
+          \\"path\\": \\"test/test_1\\",
+          \\"uniqueId\\": \\"test_1\\"
+        }
+      }
+    },
+    \\"test_2\\": {
+      \\"source\\": \\"./foo\\",
+      \\"dependsOn\\": [
+        \\"module.test_1\\"
+      ],
+      \\"//\\": {
+        \\"metadata\\": {
+          \\"path\\": \\"test/test_2\\",
+          \\"uniqueId\\": \\"test_2\\"
+        }
+      }
+    }
+  }
+}"
+`;
+
 exports[`minimal configuration 1`] = `
 "{
   \\"//\\": {

--- a/packages/cdktf/test/data-source.test.ts
+++ b/packages/cdktf/test/data-source.test.ts
@@ -67,3 +67,19 @@ test('with boolean map', () => {
 
   expect(Testing.synth(stack)).toMatchSnapshot();
 });
+
+test('dependent data source', () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, 'test');
+
+  const resource = new TestResource(stack, 'resource', {
+    name: 'foo'
+  })
+
+  new TestDataSource(stack, 'data_source', {
+    name: 'foo',
+    dependsOn: [resource]
+  })
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+}); 

--- a/packages/cdktf/test/helper/data-source.ts
+++ b/packages/cdktf/test/helper/data-source.ts
@@ -18,6 +18,9 @@ export class TestDataSource extends TerraformDataSource {
         providerVersionConstraint: '~> 2.0'
       },
       provider: config.provider,
+      dependsOn: config.dependsOn,
+      count: config.count,
+      lifecycle: config.lifecycle
     });
     this.name = config.name;
   }

--- a/packages/cdktf/test/helper/resource.ts
+++ b/packages/cdktf/test/helper/resource.ts
@@ -22,7 +22,10 @@ export class TestResource extends TerraformResource {
         providerName: TestProviderMetadata.TYPE,
         providerVersionConstraint: '~> 2.0'
       },
-      provider: config.provider
+      provider: config.provider,
+      dependsOn: config.dependsOn,
+      count: config.count,
+      lifecycle: config.lifecycle
     });
 
     this.name = config.name
@@ -48,7 +51,10 @@ export class OtherTestResource extends TerraformResource {
         providerName: TestProviderMetadata.TYPE,
         providerVersionConstraint: '~> 2.0'
       },
-      provider: config.provider
+      provider: config.provider,
+      dependsOn: config.dependsOn,
+      count: config.count,
+      lifecycle: config.lifecycle
     });
   }
 

--- a/packages/cdktf/test/resource.test.ts
+++ b/packages/cdktf/test/resource.test.ts
@@ -1,6 +1,7 @@
 
 import { Testing, TerraformStack } from '../lib';
 import { TestProvider, TestResource, OtherTestResource } from './helper'
+import { TestDataSource } from './helper/data-source';
 
 test('minimal configuration', () => {
   const app = Testing.app();
@@ -112,6 +113,22 @@ test('do not change capitalization of arbritary nested types', () => {
       "Tag": "isDowncased"
     }
   });
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test('dependent resource', () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, 'test');
+
+  const dataSource = new TestDataSource(stack, 'data_source', {
+    name: 'foo'
+  })
+
+  new TestResource(stack, 'resource', {
+    name: 'foo',
+    dependsOn: [dataSource]
+  })
 
   expect(Testing.synth(stack)).toMatchSnapshot();
 });

--- a/packages/cdktf/test/terraform-hcl-module.test.ts
+++ b/packages/cdktf/test/terraform-hcl-module.test.ts
@@ -131,3 +131,34 @@ test('add provider', () => {
     module.addProvider(provider);
     expect(Testing.synth(stack)).toMatchSnapshot();
 });
+
+test('depend on module', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    const module = new TerraformHclModule(stack, 'test', {
+        source: './foo'
+    });
+
+    new TestResource(stack, 'resource', {
+        name: 'foo',
+        dependsOn: [module]
+    });
+    expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test('depend on other module', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    const module1 = new TerraformHclModule(stack, 'test_1', {
+        source: './foo'
+    });
+
+    new TerraformHclModule(stack, 'test_2', {
+        source: './foo',
+        dependsOn: [module1]
+    });
+
+    expect(Testing.synth(stack)).toMatchSnapshot();
+});


### PR DESCRIPTION
Fixes #369 

Allows for depends on to specify resources, data sources, or modules.
Modules allowed to depend on the same.

Module dependencies were added in Terraform 0.13. We could add an error if running below that, but seems fine to just let Terraform fail.