### PR TITLE
GitHub maven prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,20 +96,17 @@ jobs:
 
   release_maven_github:
     name: Release to GitHub Maven
-    runs-on: ubuntu-latest
     needs: build_artifact
+    runs-on: ubuntu-latest
+    container:
+      image: hashicorp/jsii-terraform
     steps:
-      - name: Setup Java
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-      - uses: actions/checkout@v2
       - name: Download dist
         uses: actions/download-artifact@v2
         with:
           name: dist
           path: dist
-      - name: Publish package
+      - name: Release
         run: npx -p jsii-release jsii-release-maven
         env:
           MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -62,3 +62,23 @@ jobs:
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+
+  release_maven_github:
+    name: Release to GitHub Maven
+    needs: build_artifact
+    runs-on: ubuntu-latest
+    container:
+      image: hashicorp/jsii-terraform
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+      - name: Release
+        run: npx -p jsii-release jsii-release-maven
+        env:
+          MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_USERNAME: ${{ github.actor }}
+          MAVEN_SERVER_ID: github
+          MAVEN_REPOSITORY_URL: "https://maven.pkg.github.com/${{ github.repository }}"


### PR DESCRIPTION
Closes #450 

While not an actual snapshot (or even using standard naming), this does match with other languages and should work with cdktf-cli@next without requiring extra builds or code changes.

Also a bit of cleanup on actual release that was missed when switching to jsii-release.