### PR TITLE
Use docker proxy for builds

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Dev Container Definition - Terraform CDK",
-  "image": "hashicorp/jsii-terraform",
+  "image": "hashicorp.jfrog.io/docker/hashicorp/jsii-terraform",
   "postCreateCommand": "yarn build",
   "extensions": ["dbaeumer.vscode-eslint@2.1.5"]
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         terraform: ["0.12.29", "0.13.4", "0.14.0"]
     container:
-      image: hashicorp/jsii-terraform
+      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
     env:
       CHECKPOINT_DISABLE: "1"
 
@@ -43,7 +43,7 @@ jobs:
       matrix:
         terraform: ["0.12.29", "0.13.4", "0.14.0"]
     container:
-      image: hashicorp/jsii-terraform
+      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
     needs: build
     env:
       CHECKPOINT_DISABLE: "1"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: hashicorp/jsii-terraform:latest
+          tags: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         terraform: ["0.12.29", "0.13.4", "0.14.0"]
     container:
-      image: hashicorp/jsii-terraform
+      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
     env:
       TF_PLUGIN_CACHE_DIR: "/root/.terraform.d/plugin-cache"
       CHECKPOINT_DISABLE: "1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.repository == 'hashicorp/terraform-cdk'
     runs-on: ubuntu-latest
     container:
-      image: hashicorp/jsii-terraform
+      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
     env:
       CHECKPOINT_DISABLE: "1"
 
@@ -40,13 +40,13 @@ jobs:
         run: yarn release-github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
+
   release_npm:
     name: Release to Github Packages NPM regitry
     needs: build_artifact
     runs-on: ubuntu-latest
     container:
-      image: hashicorp/jsii-terraform
+      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v1
@@ -99,7 +99,7 @@ jobs:
     needs: build_artifact
     runs-on: ubuntu-latest
     container:
-      image: hashicorp/jsii-terraform
+      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
     steps:
       - name: Download dist
         uses: actions/download-artifact@v2
@@ -113,7 +113,7 @@ jobs:
           MAVEN_USERNAME: ${{ github.actor }}
           MAVEN_SERVER_ID: github
           MAVEN_REPOSITORY_URL: "https://maven.pkg.github.com/${{ github.repository }}"
-          
+
   release_homebrew:
     name: Release to Homebrew
     # The branch or tag ref that triggered the workflow run.

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.repository == 'hashicorp/terraform-cdk'
     runs-on: ubuntu-latest
     container:
-      image: hashicorp/jsii-terraform
+      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
     env:
       CHECKPOINT_DISABLE: "1"
     steps:
@@ -34,7 +34,7 @@ jobs:
     needs: build_artifact
     runs-on: ubuntu-latest
     container:
-      image: hashicorp/jsii-terraform
+      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v1
@@ -51,7 +51,7 @@ jobs:
     needs: build_artifact
     runs-on: ubuntu-latest
     container:
-      image: hashicorp/jsii-terraform
+      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v1
@@ -68,7 +68,7 @@ jobs:
     needs: build_artifact
     runs-on: ubuntu-latest
     container:
-      image: hashicorp/jsii-terraform
+      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
     steps:
       - name: Download dist
         uses: actions/download-artifact@v2


### PR DESCRIPTION
Avoid pulling from Docker Hub directly und use the Hashicorp proxy hashicorp.jfrog.io/docker/hashicorp/jsii-terraform