### PR TITLE
Provide accessors to nested computed attributes

### DIFF
--- a/packages/cdktf-cli/lib/get/generator/emitter/struct-emitter.ts
+++ b/packages/cdktf-cli/lib/get/generator/emitter/struct-emitter.ts
@@ -27,7 +27,7 @@ export class StructEmitter {
       this.code.openBlock(`export interface ${struct.name}${struct.extends}`);
     }
 
-    for (const att of struct.assignableAttributes) {
+    for (const att of struct.accessibleAttributes) {
       if (att.description) {
         this.code.line(`/** ${att.description} */`);
       }
@@ -56,7 +56,7 @@ export class StructEmitter {
     this.code.openBlock(`function ${downcaseFirst(struct.name)}ToTerraform(struct?: ${struct.name}): any`);
     this.code.line(`if (!cdktf.canInspect(struct)) { return struct; }`);
     this.code.openBlock('return');
-    for (const att of struct.isClass ? struct.attributes : struct.assignableAttributes) {
+    for (const att of struct.assignableAttributes) {
       this.attributesEmitter.emitToTerraform(att, true);
     }
     this.code.closeBlock(';');

--- a/packages/cdktf-cli/lib/get/generator/emitter/struct-emitter.ts
+++ b/packages/cdktf-cli/lib/get/generator/emitter/struct-emitter.ts
@@ -27,7 +27,7 @@ export class StructEmitter {
       this.code.openBlock(`export interface ${struct.name}${struct.extends}`);
     }
 
-    for (const att of struct.accessibleAttributes) {
+    for (const att of struct.isComputed ? struct.nonAssignableAttributes : struct.assignableAttributes) {
       if (att.description) {
         this.code.line(`/** ${att.description} */`);
       }
@@ -36,7 +36,7 @@ export class StructEmitter {
     }
     this.code.closeBlock();
 
-    if (!(struct instanceof ConfigStruct)) {
+    if (!(struct instanceof ConfigStruct) && !struct.isComputed) {
       this.emitToTerraformFuction(struct);
     }
   }

--- a/packages/cdktf-cli/lib/get/generator/models/attribute-model.ts
+++ b/packages/cdktf-cli/lib/get/generator/models/attribute-model.ts
@@ -40,7 +40,7 @@ export class AttributeModel {
   }
 
   public get typeDefinition() {
-    const optional = this.required ? '' : '?';
+    const optional = this.optional ? '?' : '';
     return `${this.name}${optional}: ${this.type.name}`;
   }
 

--- a/packages/cdktf-cli/lib/get/generator/models/attribute-model.ts
+++ b/packages/cdktf-cli/lib/get/generator/models/attribute-model.ts
@@ -40,7 +40,7 @@ export class AttributeModel {
   }
 
   public get typeDefinition() {
-    const optional = this.optional ? '?' : '';
+    const optional = this.required ? '' : '?';
     return `${this.name}${optional}: ${this.type.name}`;
   }
 

--- a/packages/cdktf-cli/lib/get/generator/models/struct.ts
+++ b/packages/cdktf-cli/lib/get/generator/models/struct.ts
@@ -4,6 +4,11 @@ export class Struct {
   constructor(public readonly name: string, public readonly attributes: AttributeModel[], public readonly isClass = false, public readonly isAnonymous = false) {}
 
   public get assignableAttributes(): AttributeModel[] {
+    const attributes = this.attributes.filter(attribute => attribute.isAssignable)
+    return this.filterIgnoredAttributes(attributes)
+  }
+
+  public get accessibleAttributes(): AttributeModel[] {
     const attributes = this.isAnonymous ? this.attributes : this.attributes.filter(attribute => attribute.isAssignable)
     return this.filterIgnoredAttributes(attributes)
   }

--- a/packages/cdktf-cli/lib/get/generator/models/struct.ts
+++ b/packages/cdktf-cli/lib/get/generator/models/struct.ts
@@ -1,16 +1,20 @@
 import { AttributeModel } from './attribute-model';
 
 export class Struct {
-  constructor(public readonly name: string, public readonly attributes: AttributeModel[], public readonly isClass = false, public readonly isAnonymous = false) {}
+  constructor(public readonly name: string, public readonly attributes: AttributeModel[], public readonly isClass = false, public readonly isComputed = false) {}
 
   public get assignableAttributes(): AttributeModel[] {
     const attributes = this.attributes.filter(attribute => attribute.isAssignable)
     return this.filterIgnoredAttributes(attributes)
   }
 
-  public get accessibleAttributes(): AttributeModel[] {
-    const attributes = this.isAnonymous ? this.attributes : this.attributes.filter(attribute => attribute.isAssignable)
+  public get nonAssignableAttributes(): AttributeModel[] {
+    const attributes = this.attributes.filter(attribute => !attribute.isAssignable)
     return this.filterIgnoredAttributes(attributes)
+  }
+
+  public get accessibleAttributes(): AttributeModel[] {
+    return this.filterIgnoredAttributes(this.attributes)
   }
 
   public get optionalAttributes(): AttributeModel[] {
@@ -30,7 +34,7 @@ export class Struct {
   }
 
   public get extends(): string {
-    return '';
+    return this.isComputed ? ` extends ${this.name.replace('Computed', '')}` : '';
   }
 }
 

--- a/packages/cdktf-cli/lib/get/generator/resource-parser.ts
+++ b/packages/cdktf-cli/lib/get/generator/resource-parser.ts
@@ -117,7 +117,6 @@ class Parser {
     const attributes = new Array<AttributeModel>();
 
     for (const [ terraformAttributeName, att ] of Object.entries(block.attributes || { })) {
-      if (parentType.inBlockType && att.computed && !!att.optional === false) continue ;
       const type = this.renderAttributeType([ parentType, new Scope({name: terraformAttributeName, parent: parentType, isProvider: parentType.isProvider, isComputed: !!att.computed, isOptional: !!att.optional, isRequired: !!att.required})], att.type);
       const name = toCamelCase(terraformAttributeName);
 

--- a/packages/cdktf-cli/lib/get/generator/resource-parser.ts
+++ b/packages/cdktf-cli/lib/get/generator/resource-parser.ts
@@ -228,14 +228,24 @@ class Parser {
     const name = uniqueClassName(toPascalCase(scope.map(x => toSnakeCase(x.name)).join('_')))
     const parent = scope[scope.length - 1]
     const isClass = parent.isComputed && !parent.isOptional
-    const isAnonymous = true
     const s = new Struct(
       name,
       attributes,
       isClass,
-      isAnonymous
+      false
     )
     this.structs.push(s);
+
+    if (!isClass && attributes.some(at => at.computed && !at.isOptional && !at.isRequired)) {
+      const computedStruct = new Struct(
+        `${name}Computed`,
+        attributes,
+        isClass,
+        true
+      )
+      this.structs.push(computedStruct);
+    }
+
     return s;
   }
 }

--- a/packages/cdktf-cli/test/get/generator/__snapshots__/types.test.ts.snap
+++ b/packages/cdktf-cli/test/get/generator/__snapshots__/types.test.ts.snap
@@ -371,10 +371,7 @@ export class BlockTypeNestedComputedListInputsStartingPositionConfiguration exte
   }
 }
 export interface BlockTypeNestedComputedListInputs {
-  readonly id?: string;
   readonly namePrefix: string;
-  readonly startingPositionConfiguration?: BlockTypeNestedComputedListInputsStartingPositionConfiguration;
-  readonly streamNames?: string[];
 }
 
 function blockTypeNestedComputedListInputsToTerraform(struct?: BlockTypeNestedComputedListInputs): any {
@@ -384,6 +381,11 @@ function blockTypeNestedComputedListInputsToTerraform(struct?: BlockTypeNestedCo
   }
 }
 
+export interface BlockTypeNestedComputedListInputsComputed extends BlockTypeNestedListInputsComputed {
+  readonly id: string;
+  readonly startingPositionConfiguration: BlockTypeNestedComputedListInputsStartingPositionConfiguration;
+  readonly streamNames: string[];
+}
 
 // Resource
 

--- a/packages/cdktf-cli/test/get/generator/__snapshots__/types.test.ts.snap
+++ b/packages/cdktf-cli/test/get/generator/__snapshots__/types.test.ts.snap
@@ -363,8 +363,18 @@ export interface BlockTypeNestedComputedListConfig extends cdktf.TerraformMetaAr
   /** inputs block */
   readonly inputs?: BlockTypeNestedComputedListInputs[];
 }
+export class BlockTypeNestedComputedListInputsStartingPositionConfiguration extends cdktf.ComplexComputedList {
+
+  // starting_position - computed: true, optional: false, required: false
+  public get startingPosition() {
+    return this.getStringAttribute('starting_position');
+  }
+}
 export interface BlockTypeNestedComputedListInputs {
+  readonly id?: string;
   readonly namePrefix: string;
+  readonly startingPositionConfiguration?: BlockTypeNestedComputedListInputsStartingPositionConfiguration;
+  readonly streamNames?: string[];
 }
 
 function blockTypeNestedComputedListInputsToTerraform(struct?: BlockTypeNestedComputedListInputs): any {


### PR DESCRIPTION
Fixes #172 

This will make sure structs have all attributes available. Some won't actually be settable. Currently only enforced by terraform, but could easily add a check.