### PR TITLE
Improve C# init behaviour for Github Package Registry

### DIFF
--- a/packages/cdktf-cli/templates/csharp/.hooks.sscaff.js
+++ b/packages/cdktf-cli/templates/csharp/.hooks.sscaff.js
@@ -42,12 +42,25 @@ exports.post = options => {
         <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
       </packageSources>
     </configuration>`, 'utf-8');
+  } else {
+    writeFileSync('./NuGet.Config', `<?xml version="1.0" encoding="utf-8"?>
+    <configuration>
+        <packageSources>
+            <add key="github" value="https://nuget.pkg.github.com/hashicorp/index.json" />
+        </packageSources>
+        <packageSourceCredentials>
+            <github>
+                <add key="Username" value="%GITHUB_USER%" />
+                <add key="ClearTextPassword" value="%GITHUB_TOKEN%" />
+            </github>
+        </packageSourceCredentials>
+    </configuration>`, 'utf-8');
   }
 
-  execSync(`dotnet restore`, { stdio: 'inherit' });
+  // execSync(`dotnet restore`, { stdio: 'inherit' });
 
   execSync(`\"${process.execPath}\" ${cli} get`, { stdio: 'inherit' });
-  execSync(`\"${process.execPath}\" ${cli} synth`, { stdio: 'inherit' });
+  // execSync(`\"${process.execPath}\" ${cli} synth`, { stdio: 'inherit' });
 
   console.log(readFileSync('./help', 'utf-8'));
 };
@@ -59,4 +72,4 @@ function terraformCloudConfig(baseName, organizationName, workspaceName) {
 new RemoteBackend(stack, new RemoteBackendProps { Hostname = "app.terraform.io", Organization = "${organizationName}", Workspaces = new NamedRemoteWorkspace("${workspaceName}") });`);
 
   writeFileSync('./Main.cs', result, 'utf-8');
-} 
+}

--- a/packages/cdktf-cli/templates/csharp/help
+++ b/packages/cdktf-cli/templates/csharp/help
@@ -20,3 +20,12 @@
     cdktf destroy         Destroy the given stack
 
 ========================================================================================================
+
+Important:
+
+Please make sure to sign in to the Github Package registry and set your credentials in the Nuget.Config file which was generated.
+You can find more info about setting up the Github Package registry here: https://cdk.tf/github-nuget
+
+Then run "dotnet restore" to install the dependencies.
+
+This is a temporary solution. We'll be publishing to the official nuget.org registry soon.

--- a/test/test-csharp-app/test.js
+++ b/test/test-csharp-app/test.js
@@ -16,6 +16,8 @@ process.chdir(folder);
 // initialize an empty project
 execSync(`cdktf init --template csharp --project-name="csharp-test" --project-description="csharp test app" --local`, { stdio: 'inherit', env });
 
+execSync(`dotnet restore`)
+
 // put some code in it
 fs.copyFileSync(path.join(scriptdir, 'Main.cs'), 'Main.cs');
 fs.copyFileSync(path.join(scriptdir, 'cdktf.json'), 'cdktf.json');


### PR DESCRIPTION
This avoids init behaviour as seen here (which is due to the requirement of having to authenticate for the Github Package registry):

![Screenshot 2021-01-15 at 14 27 10](https://user-images.githubusercontent.com/136789/104776633-aa511800-577a-11eb-85a3-3af265acb1a3.png)

This PR makes sure the `init` isn't erroring out and provides guidance to the user how to authenticate to the Github Package registry. We can revert back to the original behaviour once we got the official nuget.org registry distribution.

Note: We'll do a follow up for the Java template which has similar issues.