### PR TITLE
Correct depends on casing for modules

### DIFF
--- a/packages/cdktf/lib/terraform-module.ts
+++ b/packages/cdktf/lib/terraform-module.ts
@@ -72,7 +72,8 @@ public addProvider(provider: TerraformProvider | TerraformModuleProvider) {
             return { [`${p.provider.terraformResourceType}.${p.moduleAlias}`]: p.provider.fqn };
         }
       }),
-      dependsOn: this.dependsOn,
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      depends_on: this.dependsOn,
     },
       this.rawOverrides
     )

--- a/packages/cdktf/test/__snapshots__/terraform-hcl-module.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/terraform-hcl-module.test.js.snap
@@ -141,7 +141,7 @@ exports[`depend on other module 1`] = `
     },
     \\"test_2\\": {
       \\"source\\": \\"./foo\\",
-      \\"dependsOn\\": [
+      \\"depends_on\\": [
         \\"module.test_1\\"
       ],
       \\"//\\": {


### PR DESCRIPTION
Fixes #507 

I went with just changing the casing rather than using `keysToSnakeCase` because I think more explicit control is less likely to lead to issues and since `this.synthesizeAttributes` can have user values.