### PR TITLE
TerraformHclModule outputs need to use tokens

### DIFF
--- a/packages/cdktf/lib/terraform-hcl-module.ts
+++ b/packages/cdktf/lib/terraform-hcl-module.ts
@@ -1,5 +1,6 @@
 import { Construct } from "constructs";
 import { TerraformModuleOptions, TerraformModule } from "./terraform-module";
+import { Token } from "./tokens";
 
 export interface TerraformHclModuleOptions extends TerraformModuleOptions {
     readonly variables?: {[key: string]: any};
@@ -26,23 +27,23 @@ export class TerraformHclModule extends TerraformModule {
     }
 
     public get(output: string): any {
-        return this.interpolationForOutput(output);
+        return Token.asAny(this.interpolationForOutput(output));
     }
 
     public getString(output: string): string {
-        return this.get(output);
+        return Token.asString(this.interpolationForOutput(output));
     }
 
     public getNumber(output: string): number {
-        return this.get(output);
+        return Token.asNumber(this.interpolationForOutput(output));
     }
 
     public getBoolean(output: string): boolean {
-        return this.get(output);
+        return Token.asString(this.interpolationForOutput(output)) as any as boolean;
     }
 
     public getList(output: string): string[] {
-        return this.get(output);
+        return Token.asList(this.interpolationForOutput(output));
     }
 
     protected synthesizeAttributes(): { [name: string]: any } {

--- a/packages/cdktf/test/__snapshots__/terraform-hcl-module.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/terraform-hcl-module.test.js.snap
@@ -282,6 +282,42 @@ exports[`reference module 1`] = `
 }"
 `;
 
+exports[`reference module list 1`] = `
+"{
+  \\"//\\": {
+    \\"metadata\\": {
+      \\"version\\": \\"stubbed\\",
+      \\"stackName\\": \\"test\\"
+    }
+  },
+  \\"module\\": {
+    \\"test\\": {
+      \\"source\\": \\"./foo\\",
+      \\"//\\": {
+        \\"metadata\\": {
+          \\"path\\": \\"test/test\\",
+          \\"uniqueId\\": \\"test\\"
+        }
+      }
+    }
+  },
+  \\"resource\\": {
+    \\"test_resource\\": {
+      \\"resource\\": {
+        \\"name\\": \\"test\\",
+        \\"names\\": \\"\${module.test.names}\\",
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"test/resource\\",
+            \\"uniqueId\\": \\"resource\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
 exports[`set variable 1`] = `
 "{
   \\"//\\": {

--- a/packages/cdktf/test/terraform-hcl-module.test.ts
+++ b/packages/cdktf/test/terraform-hcl-module.test.ts
@@ -104,6 +104,22 @@ test('reference module', () => {
     expect(Testing.synth(stack)).toMatchSnapshot();
 });
 
+test('reference module list', () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, 'test');
+
+    const module = new TerraformHclModule(stack, 'test', {
+        source: './foo'
+    });
+
+    const resource = new TestResource(stack, 'resource', {
+        name: 'test'
+    });
+    resource.names = module.getList('names');
+
+    expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
 test('set variable', () => {
     const app = Testing.app();
     const stack = new TerraformStack(app, 'test');


### PR DESCRIPTION
Changing output reference to use tokens similar to data sources, variables, etc., since the cast from any was causing exceptions at runtime for non-string types.