### PR TITLE
Easy package tasks for individual language targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "scripts": {
     "build": "lerna run --scope cdktf* build",
     "package": "lerna run package && tools/collect-dist.sh",
+    "package:python": "lerna run package:python && tools/collect-dist.sh",
+    "package:java": "lerna run package:java && tools/collect-dist.sh",
+    "package:donet": "lerna run package:donet && tools/collect-dist.sh",
+    "package:js": "lerna run package:js && tools/collect-dist.sh",
     "package-windows": "lerna run package && tools\\collect-dist.bat",
     "bootstrap-plugin-cache": "./test/run-against-dist ./tools/bootstrap-plugin-cache.sh",
     "examples:reinstall": "lerna run --parallel --scope @examples/* --ignore @examples/java* reinstall && lerna run --stream --scope @examples/java* reinstall --concurrency 1",

--- a/packages/cdktf/package.json
+++ b/packages/cdktf/package.json
@@ -7,6 +7,10 @@
     "watch": "jsii -w --silence-warnings reserved-word",
     "watch-preserve-output": "tsc -w --preserveWatchOutput",
     "package": "jsii-pacmak",
+    "package:python": "jsii-pacmak --targets python",
+    "package:java": "jsii-pacmak --targets java",
+    "package:donet": "jsii-pacmak --targets dotnet",
+    "package:js": "jsii-pacmak --targets js",
     "lint": "eslint . --ext .ts",
     "test": "jest --passWithNoTests && yarn lint",
     "dist-clean": "rm -rf dist"


### PR DESCRIPTION
Allows packaging for single language targets from project root directory. In particular useful when working with examples which are referencing these packages.