### PR TITLE
Add Release Workflow for Nuget.org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,24 +114,6 @@ jobs:
           MAVEN_SERVER_ID: github
           MAVEN_REPOSITORY_URL: "https://maven.pkg.github.com/${{ github.repository }}"
 
-  release_nuget_github:
-    name: Release to GitHub NuGet
-    needs: build_artifact
-    runs-on: ubuntu-latest
-    container:
-      image: hashicorp/jsii-terraform
-    steps:
-      - name: Download dist
-        uses: actions/download-artifact@v2
-        with:
-          name: dist
-          path: dist
-      - name: Release
-        run: npx -p jsii-release jsii-release-nuget
-        env:
-          NUGET_API_KEY: ${{ secrets.GITHUB_TOKEN }}
-          NUGET_SERVER: "https://nuget.pkg.github.com/${{ github.repository_owner }}"
-
   release_nuget:
     name: Release to NuGet
     needs: build_artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,23 @@ jobs:
           NUGET_API_KEY: ${{ secrets.GITHUB_TOKEN }}
           NUGET_SERVER: "https://nuget.pkg.github.com/${{ github.repository_owner }}"
 
+  release_nuget:
+    name: Release to NuGet
+    needs: build_artifact
+    runs-on: ubuntu-latest
+    container:
+      image: hashicorp/jsii-terraform
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+      - name: Release
+        run: npx -p jsii-release jsii-release-nuget
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+
   release_homebrew:
     name: Release to Homebrew
     # The branch or tag ref that triggered the workflow run.

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -83,8 +83,8 @@ jobs:
           MAVEN_SERVER_ID: github
           MAVEN_REPOSITORY_URL: "https://maven.pkg.github.com/${{ github.repository }}"
 
-  release_nuget_github:
-    name: Release to GitHub NuGet
+  release_nuget:
+    name: Release to NuGet
     needs: build_artifact
     runs-on: ubuntu-latest
     container:
@@ -98,5 +98,4 @@ jobs:
       - name: Release
         run: npx -p jsii-release jsii-release-nuget
         env:
-          NUGET_API_KEY: ${{ secrets.GITHUB_TOKEN }}
-          NUGET_SERVER: "https://nuget.pkg.github.com/${{ github.repository_owner }}"
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ HashiCorp Terraform.
 ![](https://github.com/hashicorp/terraform-cdk/workflows/Release/badge.svg)
 [![npm version](https://badge.fury.io/js/cdktf.svg)](https://badge.fury.io/js/cdktf)
 [![PyPI version](https://badge.fury.io/py/cdktf.svg)](https://badge.fury.io/py/cdktf)
+[![NuGet version](https://badge.fury.io/nu/HashiCorp.Cdktf.svg)](https://badge.fury.io/nu/HashiCorp.Cdktf)
 [![homebrew](https://img.shields.io/homebrew/v/cdktf?color=brightgreen)](https://formulae.brew.sh/formula/cdktf#default)
 
 ## Overview

--- a/docs/getting-started/csharp.md
+++ b/docs/getting-started/csharp.md
@@ -6,13 +6,6 @@
 - [Node.js](https://nodejs.org) >= v12.16
 - [.NET](https://dotnet.microsoft.com/download) >= Core 3.1
 
-## Configure dotnet for GitHub Packages
-Currently cdktf is distributed only on GitHub packages. Until it is available on nuget.org, some additional configuration is needed.
-
-Specifically, add `https://nuget.pkg.github.com/hashicorp/index.json` as a package source using GitHub username and Personal Access Token for package source credentials.
-
-For more details read through [GitHub's Guide](https://docs.github.com/en/free-pro-team@latest/packages/guides/configuring-dotnet-cli-for-use-with-github-packages).
-
 ### Install CDK for Terraform CLI
 
 Install with [Homebrew](https://brew.sh):

--- a/docs/getting-started/csharp.md
+++ b/docs/getting-started/csharp.md
@@ -69,7 +69,7 @@ vim Main.c
 ```csharp
 using System;
 using Constructs;
-using Hashicorp.Cdktf;
+using HashiCorp.Cdktf;
 
 
 namespace MyCompany.MyApp
@@ -99,7 +99,7 @@ Let's take a simple .NET application that uses the CDK for Terraform package.
 ```csharp
 using System;
 using Constructs;
-using Hashicorp.Cdktf;
+using HashiCorp.Cdktf;
 
 using aws;
 

--- a/examples/csharp/aws/Main.cs
+++ b/examples/csharp/aws/Main.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using aws;
 using Constructs;
-using Hashicorp.Cdktf;
+using HashiCorp.Cdktf;
 
 
 namespace MyCompany.MyApp

--- a/examples/csharp/aws/MyTerraformStack.csproj
+++ b/examples/csharp/aws/MyTerraformStack.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hashicorp.Cdktf" Version="0.0.0" />
+    <PackageReference Include="HashiCorp.Cdktf" Version="0.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/csharp/azure/Main.cs
+++ b/examples/csharp/azure/Main.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using azurerm;
 using Constructs;
-using Hashicorp.Cdktf;
+using HashiCorp.Cdktf;
 
 
 namespace MyCompany.MyApp

--- a/examples/csharp/azure/MyTerraformStack.csproj
+++ b/examples/csharp/azure/MyTerraformStack.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hashicorp.Cdktf" Version="0.0.0" />
+    <PackageReference Include="HashiCorp.Cdktf" Version="0.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/csharp/google/Main.cs
+++ b/examples/csharp/google/Main.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Text;
 using google;
 using Constructs;
-using Hashicorp.Cdktf;
+using HashiCorp.Cdktf;
 
 
 namespace MyCompany.MyApp

--- a/examples/csharp/google/MyTerraformStack.csproj
+++ b/examples/csharp/google/MyTerraformStack.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hashicorp.Cdktf" Version="0.0.0" />
+    <PackageReference Include="HashiCorp.Cdktf" Version="0.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "package": "lerna run package && tools/collect-dist.sh",
     "package:python": "lerna run package:python && tools/collect-dist.sh",
     "package:java": "lerna run package:java && tools/collect-dist.sh",
-    "package:donet": "lerna run package:donet && tools/collect-dist.sh",
+    "package:dotnet": "lerna run package:dotnet && tools/collect-dist.sh",
     "package:js": "lerna run package:js && tools/collect-dist.sh",
     "package-windows": "lerna run package && tools\\collect-dist.bat",
     "bootstrap-plugin-cache": "./test/run-against-dist ./tools/bootstrap-plugin-cache.sh",

--- a/packages/cdktf-cli/bin/cmds/init.ts
+++ b/packages/cdktf-cli/bin/cmds/init.ts
@@ -95,7 +95,7 @@ async function determineDeps(version: string, dist?: string): Promise<Deps> {
       'npm_cdktf_cli': path.resolve(dist, 'js', `cdktf-cli-${version}.tgz`),
       'pypi_cdktf': path.resolve(dist, 'python', `cdktf-${pythonVersion}-py3-none-any.whl`),
       'mvn_cdktf': path.resolve(dist, 'java', `com/hashicorp/cdktf/${version}/cdktf-${version}.jar`),
-      'nuget_cdktf': path.resolve(dist, 'dotnet', `Hashicorp.Cdktf.${version}.nupkg`)
+      'nuget_cdktf': path.resolve(dist, 'dotnet', `HashiCorp.Cdktf.${version}.nupkg`)
     };
 
     for (const file of Object.values(ret)) {

--- a/packages/cdktf-cli/templates/csharp/.hooks.sscaff.js
+++ b/packages/cdktf-cli/templates/csharp/.hooks.sscaff.js
@@ -42,25 +42,12 @@ exports.post = options => {
         <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
       </packageSources>
     </configuration>`, 'utf-8');
-  } else {
-    writeFileSync('./NuGet.Config', `<?xml version="1.0" encoding="utf-8"?>
-    <configuration>
-        <packageSources>
-            <add key="github" value="https://nuget.pkg.github.com/hashicorp/index.json" />
-        </packageSources>
-        <packageSourceCredentials>
-            <github>
-                <add key="Username" value="%GITHUB_USER%" />
-                <add key="ClearTextPassword" value="%GITHUB_TOKEN%" />
-            </github>
-        </packageSourceCredentials>
-    </configuration>`, 'utf-8');
   }
 
-  // execSync(`dotnet restore`, { stdio: 'inherit' });
+  execSync(`dotnet restore`, { stdio: 'inherit' });
 
   execSync(`\"${process.execPath}\" ${cli} get`, { stdio: 'inherit' });
-  // execSync(`\"${process.execPath}\" ${cli} synth`, { stdio: 'inherit' });
+  execSync(`\"${process.execPath}\" ${cli} synth`, { stdio: 'inherit' });
 
   console.log(readFileSync('./help', 'utf-8'));
 };
@@ -72,4 +59,4 @@ function terraformCloudConfig(baseName, organizationName, workspaceName) {
 new RemoteBackend(stack, new RemoteBackendProps { Hostname = "app.terraform.io", Organization = "${organizationName}", Workspaces = new NamedRemoteWorkspace("${workspaceName}") });`);
 
   writeFileSync('./Main.cs', result, 'utf-8');
-}
+} 

--- a/packages/cdktf-cli/templates/csharp/Main.cs
+++ b/packages/cdktf-cli/templates/csharp/Main.cs
@@ -1,6 +1,6 @@
 using System;
 using Constructs;
-using Hashicorp.Cdktf;
+using HashiCorp.Cdktf;
 
 
 namespace MyCompany.MyApp

--- a/packages/cdktf-cli/templates/csharp/MyTerraformStack.csproj
+++ b/packages/cdktf-cli/templates/csharp/MyTerraformStack.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hashicorp.Cdktf" Version="{{ cdktf_version }}" />
+    <PackageReference Include="HashiCorp.Cdktf" Version="{{ cdktf_version }}" />
   </ItemGroup>
 
 </Project>

--- a/packages/cdktf-cli/templates/csharp/help
+++ b/packages/cdktf-cli/templates/csharp/help
@@ -20,12 +20,3 @@
     cdktf destroy         Destroy the given stack
 
 ========================================================================================================
-
-Important:
-
-Please make sure to sign in to the Github Package registry and set your credentials in the Nuget.Config file which was generated.
-You can find more info about setting up the Github Package registry here: https://cdk.tf/github-nuget
-
-Then run "dotnet restore" to install the dependencies.
-
-This is a temporary solution. We'll be publishing to the official nuget.org registry soon.

--- a/packages/cdktf/package.json
+++ b/packages/cdktf/package.json
@@ -33,8 +33,8 @@
         }
       },
       "dotnet": {
-        "packageId": "Hashicorp.Cdktf",
-        "namespace": "Hashicorp.Cdktf"
+        "packageId": "HashiCorp.Cdktf",
+        "namespace": "HashiCorp.Cdktf"
       }
     }
   },

--- a/packages/cdktf/package.json
+++ b/packages/cdktf/package.json
@@ -9,7 +9,7 @@
     "package": "jsii-pacmak",
     "package:python": "jsii-pacmak --targets python",
     "package:java": "jsii-pacmak --targets java",
-    "package:donet": "jsii-pacmak --targets dotnet",
+    "package:dotnet": "jsii-pacmak --targets dotnet",
     "package:js": "jsii-pacmak --targets js",
     "lint": "eslint . --ext .ts",
     "test": "jest --passWithNoTests && yarn lint",

--- a/test/test-csharp-app/Main.cs
+++ b/test/test-csharp-app/Main.cs
@@ -1,7 +1,7 @@
 using System;
 using aws;
 using Constructs;
-using Hashicorp.Cdktf;
+using HashiCorp.Cdktf;
 
 namespace MyCompany.MyApp
 {

--- a/test/test-csharp-app/test.js
+++ b/test/test-csharp-app/test.js
@@ -16,8 +16,6 @@ process.chdir(folder);
 // initialize an empty project
 execSync(`cdktf init --template csharp --project-name="csharp-test" --project-description="csharp test app" --local`, { stdio: 'inherit', env });
 
-execSync(`dotnet restore`)
-
 // put some code in it
 fs.copyFileSync(path.join(scriptdir, 'Main.cs'), 'Main.cs');
 fs.copyFileSync(path.join(scriptdir, 'cdktf.json'), 'cdktf.json');


### PR DESCRIPTION
This adds a Github Action workflow for releasing `cdktf` to the Nuget.org registry.

As part of this, I renamed the package from `HashiCorp.Cdktf`, which is consistent with the official company name. This is a breaking change for future packages. However since we're switching the registry anyway and the dotnet usage of `cdktf` doesn't seem to be widespread so far, I think it's ok to do it without prior warning. 

Closes #524 