### PR TITLE
Python-pip template fix/improvements

### DIFF
--- a/packages/cdktf-cli/templates/python-pip/.hooks.sscaff.js
+++ b/packages/cdktf-cli/templates/python-pip/.hooks.sscaff.js
@@ -1,6 +1,7 @@
 const { execSync } = require('child_process');
 const { chmodSync } = require('fs');
 const { readFileSync, writeFileSync } = require('fs');
+const os = require('os');
 
 const cli = require.resolve('../../bin/cdktf');
 

--- a/packages/cdktf-cli/templates/python-pip/.hooks.sscaff.js
+++ b/packages/cdktf-cli/templates/python-pip/.hooks.sscaff.js
@@ -8,13 +8,13 @@ const cli = require.resolve('../../bin/cdktf');
 exports.pre = () => {
   try {
     if (os.platform() === 'win32') {
-      execSync('where pip')
+      execSync('where pip3')
     }
     else {
-      execSync('which pip')
+      execSync('which pip3')
     }
   } catch {
-    console.error(`Unable to find "pip".`)
+    console.error(`Unable to find "pip3".`)
     process.exit(1);
   }
 };
@@ -32,7 +32,7 @@ exports.post = options => {
   }
 
   writeFileSync('requirements.txt', pypi_cdktf, 'utf-8');
-  execSync('pip install --user -r requirements.txt', { stdio: 'inherit' });
+  execSync('pip3 install --user -r requirements.txt', { stdio: 'inherit' });
   chmodSync('main.py', '700');
 
   execSync(`\"${process.execPath}\" \"${cli}\" get`, { stdio: 'inherit' });

--- a/packages/cdktf-cli/templates/python-pip/.hooks.sscaff.js
+++ b/packages/cdktf-cli/templates/python-pip/.hooks.sscaff.js
@@ -32,7 +32,7 @@ exports.post = options => {
   }
 
   writeFileSync('requirements.txt', pypi_cdktf, 'utf-8');
-  execSync('pip install -r requirements.txt', { stdio: 'inherit' });
+  execSync('pip install --user -r requirements.txt', { stdio: 'inherit' });
   chmodSync('main.py', '700');
 
   execSync(`\"${process.execPath}\" \"${cli}\" get`, { stdio: 'inherit' });


### PR DESCRIPTION
Accidentally broke it when trying to fix for Windows.

Also adding some improvements.

- Don't require admin for install
- Explicitly use pip3 in case user has pip pointing to a different version. Fixes #532 

`pip` ends up just being an alias to `pip2` or `pip3` (unless you have python 1). Since we require python 3, pip3 will be installed.