### PR TITLE
Don't run Github Actions for doc changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,11 @@
 name: Build
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: Build
 on:
   pull_request:
-    branches:
-      - main
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,9 @@ name: docker
 on:
   push:
     branches: main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 jobs:
   build-docker-image:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,5 +1,11 @@
 name: Examples Integration
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 jobs:
   build:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,8 +1,6 @@
 name: Examples Integration
 on:
   pull_request:
-    branches:
-      - main
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 jobs:
   build_artifact:

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 jobs:
   build_artifact:


### PR DESCRIPTION
Since Markdown files and everything in [./docs](/docs) is unrelated to Github Actions we can safely skip running Actions if the diff contains only changes to these files. The [paths-ignore](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths) config in Github Actions is doing the heavy lifting here.