### PR TITLE
Publish to Maven Central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
     needs: build_artifact
     runs-on: ubuntu-latest
     container:
-      image: jsii/superchain
+      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v1
@@ -102,7 +102,7 @@ jobs:
     needs: build_artifact
     runs-on: ubuntu-latest
     container:
-      image: hashicorp/jsii-terraform
+      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
     steps:
       - name: Download dist
         uses: actions/download-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,14 +81,14 @@ jobs:
     name: Release to Maven
     needs: build_artifact
     runs-on: ubuntu-latest
-    if: false # Disable until maven credentials are setup
     container:
-      image: jsii/superchain
+      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v1
         with:
           name: dist
+          path: dist
       - name: Release
         run: npx -p jsii-release jsii-release-maven
         env:
@@ -96,26 +96,6 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
           MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           MAVEN_STAGING_PROFILE_ID: ${{ secrets.MAVEN_STAGING_PROFILE_ID }}
-
-  release_maven_github:
-    name: Release to GitHub Maven
-    needs: build_artifact
-    runs-on: ubuntu-latest
-    container:
-      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
-    steps:
-      - name: Download dist
-        uses: actions/download-artifact@v2
-        with:
-          name: dist
-          path: dist
-      - name: Release
-        run: npx -p jsii-release jsii-release-maven
-        env:
-          MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          MAVEN_USERNAME: ${{ github.actor }}
-          MAVEN_SERVER_ID: github
-          MAVEN_REPOSITORY_URL: "https://maven.pkg.github.com/${{ github.repository }}"
 
   release_nuget:
     name: Release to NuGet

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -66,8 +66,8 @@ jobs:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
 
-  release_maven_github:
-    name: Release to GitHub Maven
+  release_maven:
+    name: Release to Maven
     needs: build_artifact
     runs-on: ubuntu-latest
     container:
@@ -81,10 +81,10 @@ jobs:
       - name: Release
         run: npx -p jsii-release jsii-release-maven
         env:
-          MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          MAVEN_USERNAME: ${{ github.actor }}
-          MAVEN_SERVER_ID: github
-          MAVEN_REPOSITORY_URL: "https://maven.pkg.github.com/${{ github.repository }}"
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          MAVEN_STAGING_PROFILE_ID: ${{ secrets.MAVEN_STAGING_PROFILE_ID }}
 
   release_nuget:
     name: Release to NuGet

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -91,7 +91,7 @@ jobs:
     needs: build_artifact
     runs-on: ubuntu-latest
     container:
-      image: hashicorp/jsii-terraform
+      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
     steps:
       - name: Download dist
         uses: actions/download-artifact@v2


### PR DESCRIPTION
This PR switches the release process from Github Packages to Maven Central. 

Fixes: #523 