### PR TITLE
Remove jfrog references

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Dev Container Definition - Terraform CDK",
-  "image": "hashicorp.jfrog.io/docker/hashicorp/jsii-terraform",
+  "image": "docker.mirror.hashicorp.services/hashicorp/jsii-terraform",
   "postCreateCommand": "yarn build",
   "extensions": ["dbaeumer.vscode-eslint@2.1.5"]
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         terraform: ["0.12.29", "0.13.4", "0.14.0"]
     container:
-      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
+      image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     env:
       CHECKPOINT_DISABLE: "1"
 
@@ -48,7 +48,7 @@ jobs:
         terraform: ["0.12.29", "0.13.4", "0.14.0"]
         target: ["typescript", "python", "java", "csharp"]
     container:
-      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
+      image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     needs: build
     env:
       CHECKPOINT_DISABLE: "1"

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -13,7 +13,7 @@ jobs:
         terraform: ["0.14.0"]
         target: ["python", "csharp", "java", "typescript"]
     container:
-      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
+      image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     env:
       TF_PLUGIN_CACHE_DIR: "/root/.terraform.d/plugin-cache"
       CHECKPOINT_DISABLE: "1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'hashicorp/terraform-cdk'
     runs-on: ubuntu-latest
     container:
-      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
+      image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     env:
       CHECKPOINT_DISABLE: "1"
 
@@ -49,7 +49,7 @@ jobs:
     needs: build_artifact
     runs-on: ubuntu-latest
     container:
-      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
+      image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v1
@@ -65,7 +65,7 @@ jobs:
     needs: build_artifact
     runs-on: ubuntu-latest
     container:
-      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
+      image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v1
@@ -82,7 +82,7 @@ jobs:
     needs: build_artifact
     runs-on: ubuntu-latest
     container:
-      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
+      image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v1
@@ -103,7 +103,7 @@ jobs:
     needs: build_artifact
     runs-on: ubuntu-latest
     container:
-      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
+      image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     steps:
       - name: Download dist
         uses: actions/download-artifact@v2

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'hashicorp/terraform-cdk'
     runs-on: ubuntu-latest
     container:
-      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
+      image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     env:
       CHECKPOINT_DISABLE: "1"
     steps:
@@ -37,7 +37,7 @@ jobs:
     needs: build_artifact
     runs-on: ubuntu-latest
     container:
-      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
+      image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v1
@@ -54,7 +54,7 @@ jobs:
     needs: build_artifact
     runs-on: ubuntu-latest
     container:
-      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
+      image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v1
@@ -71,7 +71,7 @@ jobs:
     needs: build_artifact
     runs-on: ubuntu-latest
     container:
-      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
+      image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     steps:
       - name: Download dist
         uses: actions/download-artifact@v2
@@ -92,7 +92,7 @@ jobs:
     needs: build_artifact
     runs-on: ubuntu-latest
     container:
-      image: hashicorp.jfrog.io/docker/hashicorp/jsii-terraform
+      image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     steps:
       - name: Download dist
         uses: actions/download-artifact@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp.jfrog.io/docker/jsii/superchain
+FROM docker.mirror.hashicorp.services/jsii/superchain
 
 RUN yum install -y unzip jq && curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python3
 


### PR DESCRIPTION
This removes all references to `hashicorp.jfrog.io` which has been replaced with a self-hosted registry, `docker.mirror.hashicorp.services`
