### PR TITLE
Don't treat warning lines as resources

### DIFF
--- a/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
@@ -65,7 +65,7 @@ const parseOutput = (str: string): DeployingResource[] => {
         applyState = DeployingResourceApplyState.WAITING
     }
 
-    if (resourceMatch && resourceMatch.length >= 0) {
+    if (resourceMatch && resourceMatch.length >= 0 && resourceMatch[1] != "Warning") {
       return {
         id: resourceMatch[1],
         action: PlannedResourceAction.CREATE,


### PR DESCRIPTION
Fixes #582 

Currently any warning that is emitted by terraform during deployment or destruction will be interpreted as a resource which will cause a crash.

The check is added is certainly simplistic, but I'm not sure of a better way to definitely determine if an output line is referring to a resource.