### PR TITLE
Update Terraform versions which are tested against

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        terraform: ["0.12.29", "0.13.4", "0.14.0"]
+        terraform: ["0.13.6", "0.14.7", "0.15.0-beta1"]
     container:
       image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     env:
@@ -45,7 +45,7 @@ jobs:
       - name: create bundle
         run: yarn package
       - name: Upload dist
-        if: ${{ matrix.terraform == '0.12.29' }}
+        if: ${{ matrix.terraform == '0.14.7' }}
         uses: actions/upload-artifact@v2
         with:
           name: dist
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        terraform: ["0.12.29", "0.13.4", "0.14.0"]
+        terraform: ["0.13.6", "0.14.7", "0.15.0-beta1"]
         target: ["typescript", "python", "java", "csharp"]
     container:
       image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
@@ -94,7 +94,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        terraform: ["0.12.29", "0.13.4", "0.14.0"]
+        terraform: ["0.13.6", "0.14.7", "0.15.0-beta1"]
         target: ["typescript", "python", "java", "csharp"]
     needs: build
     env:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        terraform: ["0.14.0"]
+        terraform: ["0.14.7"]
         target: ["python", "csharp", "java", "typescript"]
     container:
       image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV DEFAULT_TERRAFORM_VERSION=0.14.7                                \
     MAVEN_OPTS="-Xms256m -Xmx3G"
 
 # Install Terraform
-RUN AVAILABLE_TERRAFORM_VERSIONS="0.12.29 0.13.0 0.13.4 0.13.6 0.14.0 ${DEFAULT_TERRAFORM_VERSION} 0.15.0-beta1" && \
+RUN AVAILABLE_TERRAFORM_VERSIONS="0.13.6 ${DEFAULT_TERRAFORM_VERSION} 0.15.0-beta1" && \
     for VERSION in ${AVAILABLE_TERRAFORM_VERSIONS}; do curl -LOk https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_linux_amd64.zip && \
     mkdir -p /usr/local/bin/tf/versions/${VERSION} && \
     unzip terraform_${VERSION}_linux_amd64.zip -d /usr/local/bin/tf/versions/${VERSION} && \

--- a/packages/cdktf-cli/bin/cmds/terraform-check.ts
+++ b/packages/cdktf-cli/bin/cmds/terraform-check.ts
@@ -17,9 +17,8 @@ export const terraformCheck = async (): Promise<void> => {
       const cleanTerraformVersion = semver.clean(terraformVersionMatches[0].substring(terraformVersionMatches[0].indexOf('v')))
 
       if (cleanTerraformVersion && semver.lt(cleanTerraformVersion, MIN_SUPPORTED_VERSION)) {
-        const errorMessage = `Error: unsupported Terraform version [${cleanTerraformVersion}] - please upgrade to >=${MIN_SUPPORTED_VERSION}`
-          console.error(errorMessage)
-          process.exit(1)
+        const warningMessage = `Warning: unsupported Terraform version [${cleanTerraformVersion}] - please upgrade to >=${MIN_SUPPORTED_VERSION}`
+        console.warn(warningMessage)
       }
     }
   } catch(e) {

--- a/packages/cdktf-cli/bin/cmds/terraform-check.ts
+++ b/packages/cdktf-cli/bin/cmds/terraform-check.ts
@@ -1,7 +1,7 @@
 import { TerraformCli } from './ui/models/terraform-cli'
 import * as semver from 'semver';
 
-const MIN_SUPPORTED_VERSION = '0.12.0'
+const MIN_SUPPORTED_VERSION = '0.13.0'
 const VERSION_REGEXP = /Terraform v\d+.\d+.\d+/
 
 export const terraformCheck = async (): Promise<void> => {


### PR DESCRIPTION
This drops tests against `0.12` in favour of testing against the upcoming `0.15` version. That means with this PR being merged we're testing against `0.13`, `0.14`, and `0.15-beta`.


This depends https://github.com/hashicorp/terraform-cdk/pull/591 and will help https://github.com/hashicorp/terraform-cdk/pull/584 being merged. There are some provider schema differences with the change from `0.12` to `0.13` which don't seem worthwhile working around (I think it's purely testing related, functionality wise it's not an issue). 

I think it generally makes sense for now to track the current and prior major release of Terraform core - plus upcoming versions.