### PR TITLE
Handle malformed code blocks in provider schema descriptions

### DIFF
--- a/packages/cdktf-cli/lib/get/generator/models/attribute-model.ts
+++ b/packages/cdktf-cli/lib/get/generator/models/attribute-model.ts
@@ -75,7 +75,7 @@ export class AttributeModel {
   }
 
   public get description(): string | undefined {
-    return this._description?.replace(/(\*\/)/gi, `*\\/`)
+    return this._description?.replace(/(\*\/)/gi, `*\\/`).replace(/'''/gi, '```');
   }
 
   public get isConfigIgnored(): boolean {

--- a/packages/cdktf-cli/test/get/generator/__snapshots__/description-escaping.test.ts.snap
+++ b/packages/cdktf-cli/test/get/generator/__snapshots__/description-escaping.test.ts.snap
@@ -69,3 +69,69 @@ export class DescriptionEscaping extends cdktf.TerraformResource {
 }
 "
 `;
+
+exports[`malformed code blocks which break in python rst 1`] = `
+"// https://www.terraform.io/docs/providers/aws/r/code_blocks.html
+// generated from terraform resource schema
+
+import { Construct } from 'constructs';
+import * as cdktf from 'cdktf';
+
+// Configuration
+
+export interface CodeBlocksConfig extends cdktf.TerraformMetaArguments {
+  /** Here comes a code block \`\`\`foo.bar\`\`\` and here is more text. */
+  readonly withCodeBlock: boolean;
+}
+
+// Resource
+
+export class CodeBlocks extends cdktf.TerraformResource {
+
+  // ===========
+  // INITIALIZER
+  // ===========
+
+  public constructor(scope: Construct, id: string, config: CodeBlocksConfig) {
+    super(scope, id, {
+      terraformResourceType: 'code_blocks',
+      terraformGeneratorMetadata: {
+        providerName: 'aws'
+      },
+      provider: config.provider,
+      dependsOn: config.dependsOn,
+      count: config.count,
+      lifecycle: config.lifecycle
+    });
+    this._withCodeBlock = config.withCodeBlock;
+  }
+
+  // ==========
+  // ATTRIBUTES
+  // ==========
+
+  // with_code_block - computed: false, optional: false, required: true
+  private _withCodeBlock: boolean;
+  public get withCodeBlock() {
+    return this.getBooleanAttribute('with_code_block');
+  }
+  public set withCodeBlock(value: boolean) {
+    this._withCodeBlock = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get withCodeBlockInput() {
+    return this._withCodeBlock
+  }
+
+  // =========
+  // SYNTHESIS
+  // =========
+
+  protected synthesizeAttributes(): { [name: string]: any } {
+    return {
+      with_code_block: cdktf.booleanToTerraform(this._withCodeBlock),
+    };
+  }
+}
+"
+`;

--- a/packages/cdktf-cli/test/get/generator/description-escaping.test.ts
+++ b/packages/cdktf-cli/test/get/generator/description-escaping.test.ts
@@ -14,3 +14,20 @@ test('broken attribute description comments', async () => {
   const output = fs.readFileSync(path.join(workdir, 'providers/google/description-escaping.ts'), 'utf-8');
   expect(output).toMatchSnapshot();
 });
+
+// That popped up in the google-beta provider which transforms markdown fenced
+// code blocks from the actual markdown docs to the provider schema (``` => ''')
+// see
+//  - https://raw.githubusercontent.com/hashicorp/terraform-provider-google-beta/4094e3bdd530ca853a046a6d938807f8a131c7c7/website/docs/r/iam_workload_identity_pool_provider.html.markdown
+//  - https://github.com/hashicorp/terraform-provider-google-beta/blob/4094e3bdd530ca853a046a6d938807f8a131c7c7/google-beta/resource_iam_beta_workload_identity_pool_provider.go
+
+test('malformed code blocks which break in python rst', async () => {
+  const code = new CodeMaker()
+  const workdir = fs.mkdtempSync(path.join(os.tmpdir(), 'markdown-description-with-code-blocks.test'));
+  const spec = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures', 'markdown-description-with-code-blocks.test.fixture.json'), 'utf-8'));
+  new TerraformProviderGenerator(code, spec);
+  await code.save(workdir);
+
+  const output = fs.readFileSync(path.join(workdir, 'providers/aws/code-blocks.ts'), 'utf-8');
+  expect(output).toMatchSnapshot();
+});

--- a/packages/cdktf-cli/test/get/generator/fixtures/markdown-description-with-code-blocks.test.fixture.json
+++ b/packages/cdktf-cli/test/get/generator/fixtures/markdown-description-with-code-blocks.test.fixture.json
@@ -1,0 +1,21 @@
+{
+	"provider_schemas": {
+		"aws": {
+			"resource_schemas": {
+				"code_blocks": {
+					"version": 1,
+					"block": {
+						"attributes": {
+							"with_code_block": {
+                "type": "bool",
+								"description": "Here comes a code block '''foo.bar''' and here is more text.",
+                "required": true
+							}
+						}
+					},
+          "block_types": {}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
That popped up in the google-beta provider which transforms markdown fenced
code blocks from the actual markdown docs to the provider schema (``` => ''')
see
 - https://raw.githubusercontent.com/hashicorp/terraform-provider-google-beta/4094e3bdd530ca853a046a6d938807f8a131c7c7/website/docs/r/iam_workload_identity_pool_provider.html.markdown
 - https://github.com/hashicorp/terraform-provider-google-beta/blob/4094e3bdd530ca853a046a6d938807f8a131c7c7/google-beta/resource_iam_beta_workload_identity_pool_provider.go

Fixes https://github.com/hashicorp/terraform-cdk/issues/602

Relates to https://github.com/aws/jsii/issues/2727