### PR TITLE
Fixing aws eks example

### DIFF
--- a/examples/python/aws-eks/Pipfile
+++ b/examples/python/aws-eks/Pipfile
@@ -4,8 +4,8 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [requires]
-python_version = "3.7"
+python_version = "3.8"
 
 [packages]
 constructs = "~=3.0.0"
-cdktf = {path = "./../../../dist/python/cdktf-0.0.0-py3-none-any.whl"}
+cdktf = "*"

--- a/examples/python/aws-eks/Pipfile
+++ b/examples/python/aws-eks/Pipfile
@@ -8,4 +8,4 @@ python_version = "3.8"
 
 [packages]
 constructs = "~=3.0.0"
-cdktf = "*"
+cdktf = {path = "./../../../dist/python/cdktf-0.0.0-py3-none-any.whl"}

--- a/examples/python/aws-eks/Pipfile.lock
+++ b/examples/python/aws-eks/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "56861fea7f1c2b0565d332c1145931bbf32717e89ff61c151780bfaafc5f1154"
+            "sha256": "ac85689be79ad21bd2a5dc3e384e01cce323a1bf16b8eee626a6a369d7d13a56"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.8"
         },
         "sources": [
             {
@@ -18,39 +18,43 @@
     "default": {
         "attrs": {
             "hashes": [
-                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
-                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+                "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
+                "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
             ],
-            "version": "==19.3.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.3.0"
         },
         "cattrs": {
             "hashes": [
-                "sha256:616972ae3dfa6e623a40ad3cb845420e64942989152774ab055e5c2b2f89f997",
-                "sha256:b7ab5cf8ad127c42eefd01410c1c6e28569a45a255ea80ed968511873c433c7a"
+                "sha256:12688f56fbb7f54cf647d031669840e1ab0b9a198bf374a217fcb5be821855df",
+                "sha256:f92ca39ccb7373289f9cccf71b86849a29a2d75370bc983e7bf579ce95bfccd8"
             ],
-            "version": "==1.0.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==1.3.0"
         },
         "cdktf": {
             "hashes": [
-                "sha256:5f29fc46fc225f0bca711d9f380d4780d6ab9ad77713600c356e614c812fbb65"
+                "sha256:a883aff03dd6753b9e90715ca712158aabbe6d1aac3cd45ef718c72e1459b8b6",
+                "sha256:b3df8a341fb78cf735341e74e5e48720e15250ef968bd1f961bf9530fddf54ce"
             ],
-            "path": "./../../../dist/python/cdktf-0.0.0-py3-none-any.whl",
-            "version": "==0.0.0"
+            "index": "pypi",
+            "version": "==0.2.0"
         },
         "constructs": {
             "hashes": [
-                "sha256:9740f25c67d19f3c710c85f298ebfd1d109f9fd54d0ec0b869a87b4c1554da3e",
-                "sha256:edb1a78e8780f24046f8945a6f0101406f5b2106f9d93d833e61ca34dc8b980d"
+                "sha256:0649c67ab87c990edb01c3472f07b1b6e52a0cc63b44f776812b2d59d0341fbd",
+                "sha256:f6ffb8434bac4a6fcb37a49d7d84fd86213f6f2908891c9b60d851f705d1d242"
             ],
             "index": "pypi",
-            "version": "==3.0.4"
+            "version": "==3.0.29"
         },
         "jsii": {
             "hashes": [
-                "sha256:c7618ad78d7047fdc03d1813d261af335385cf955cc8bc5e366ad567bc03c349",
-                "sha256:de2c9931ae941de38a9bff6ae76c799865bf9995a9651e5d55fc43a0e6e6c063"
+                "sha256:594bf95bfb6823373aa860892933d23717d7b5b8c3ace7077b41ee5135fee061",
+                "sha256:9a6e46d9c2914f32d6231e38df0069b7035a7ad85041c0cf901262041c4be6ff"
             ],
-            "version": "==1.11.0"
+            "markers": "python_version ~= '3.6'",
+            "version": "==1.25.0"
         },
         "publication": {
             "hashes": [
@@ -64,6 +68,7 @@
                 "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
                 "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.1"
         },
         "six": {
@@ -71,15 +76,16 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:6e95524d8a547a91e08f404ae485bbb71962de46967e1b71a0cb89af24e761c5",
-                "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae",
-                "sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392"
+                "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918",
+                "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
+                "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
             ],
-            "version": "==3.7.4.2"
+            "version": "==3.7.4.3"
         }
     },
     "develop": {}

--- a/examples/python/aws-eks/main.py
+++ b/examples/python/aws-eks/main.py
@@ -8,8 +8,8 @@ from cdktf import App, TerraformStack, TerraformOutput, Token
 from imports.aws import AwsProvider, DataAwsCallerIdentity
 
 # for terraform module
-from imports.terraform_aws_modules.vpc.aws import TerraformAwsModulesVpcAws
-from imports.terraform_aws_modules.eks.aws import TerraformAwsModulesEksAws
+from imports.vpc import Vpc
+from imports.eks import Eks
 
 class MyStack(TerraformStack):
     def __init__(self, scope: Construct, ns: str):
@@ -17,7 +17,7 @@ class MyStack(TerraformStack):
 
         AwsProvider(self, 'Aws', region='us-west-2')
 
-        my_vpc = TerraformAwsModulesVpcAws(self, 'MyVpc',
+        my_vpc = Vpc(self, 'MyVpc',
             name='my-vpc',
             cidr='10.0.0.0/16',
             azs=['us-west-2a', 'us-west-2b', 'us-west-2c'],
@@ -26,11 +26,12 @@ class MyStack(TerraformStack):
             enable_nat_gateway=True
         )
 
-        my_eks= TerraformAwsModulesEksAws(self, 'MyEks',
+        my_eks= Eks(self, 'MyEks',
             cluster_name='my-eks',
             subnets=Token().as_list(my_vpc.private_subnets_output),
             vpc_id=Token().as_string(my_vpc.vpc_id_output),
-            manage_aws_auth='false'
+            manage_aws_auth=False,
+            cluster_version='1.17'
         )
 
         TerraformOutput(self, 'cluster_endpoint',


### PR DESCRIPTION
The following changes were broken on the example:

- Inside the imports folder, with the same cdktf.json, the subfolders created were: aws, vpc and eks instead of terraform_aws_modules.vpc and terraform_aws_modules.eks

- The constructor of the Eks and Vpc objects had their names updated from TerraformAwsModulesEksAws 
and TerraformAwsModulesVpcAws respectively

- The Eks constructor has the cluster_version parameter as obrigatory