### PR TITLE
Add hyphens to resource id regexp in output parser

### DIFF
--- a/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
@@ -36,7 +36,7 @@ const parseOutput = (str: string): DeployingResource[] => {
     if (/^Outputs:/.test(line)) { return }
     if (/^data\..*/.test(line)) { return }
 
-    const resourceMatch = line.match(/^([a-zA-Z\d_.]*):/)
+    const resourceMatch = line.match(/^([a-zA-Z\d_\-.]*):/)
     let applyState: DeployingResourceApplyState;
 
     switch (true) {


### PR DESCRIPTION
According to Terraform docs hyphens are allowed in resource ids https://www.terraform.io/docs/language/syntax/configuration.html#identifiers

Current version doesn't display apply status for 80% of resources in my deployment because of this bug.