### PR TITLE
Improve activity indicator performance

### DIFF
--- a/packages/cdktf-cli/bin/cmds/ui/components/activity-indicator.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/components/activity-indicator.tsx
@@ -1,0 +1,83 @@
+import React, {useEffect, useState} from "react";
+import {Text} from "ink";
+import spinners from 'cli-spinners';
+
+interface Props {
+    readonly color?: string;
+}
+
+const DEFAULT_INDICATOR_COLOR = "green";
+
+type Unsubscribe = () => void;
+type Subscription = () => void;
+
+class SpinnerClock {
+
+    private subscriptions: Subscription[] = [];
+    private interval?: NodeJS.Timeout;
+
+    constructor(private spinRate: number = 1000) {
+    }
+
+    subscribe(subscription: Subscription): Unsubscribe {
+
+        this.subscriptions.push(subscription);
+
+        this.start();
+
+        return () => {
+            this.removeSubscription(subscription);
+        };
+    }
+
+    private start() {
+        if (!this.interval) {
+            this.interval = setInterval(() => {
+                this.notify();
+            }, this.spinRate);
+        }
+    }
+
+    private stop() {
+        if (this.interval) {
+            clearInterval(this.interval);
+            this.interval = undefined;
+        }
+    }
+
+    private notify() {
+        for (const subscription of this.subscriptions) {
+            subscription()
+        }
+    }
+
+    private removeSubscription(subscription: Subscription) {
+        this.subscriptions = this.subscriptions.filter((sub) => sub !== subscription);
+
+        if (this.subscriptions.length === 0) {
+            this.stop();
+        }
+    }
+}
+
+const sharedSpinnerClock = new SpinnerClock();
+
+const Spinner = () => {
+    const [frame, setFrame] = useState(0);
+    const spinner = spinners["circleQuarters"];
+
+    useEffect(() => {
+        return sharedSpinnerClock.subscribe(() => {
+            setFrame(previousFrame => {
+                const isLastFrame = previousFrame === spinner.frames.length - 1;
+                return isLastFrame ? 0 : previousFrame + 1;
+            });
+        });
+    }, [spinner]);
+
+    return <Text>{spinner.frames[frame]}</Text>;
+};
+
+export const ActivityIndicator: React.FC<Props> = React.memo((props) => {
+    return <Text color={props.color || DEFAULT_INDICATOR_COLOR}><Spinner/>{props.children}</Text>
+});

--- a/packages/cdktf-cli/bin/cmds/ui/components/deploying-element.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/components/deploying-element.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Text, Box } from 'ink'
-import Spinner from 'ink-spinner';
 import { DeployingResourceApplyState, DeployingResource } from "../models/terraform"
 import { ResourceName } from './resource-name'
+import {ActivityIndicator} from "./activity-indicator";
 
 interface DeployingElementStatusProps {
   resource: DeployingResource;
@@ -55,7 +55,7 @@ export const DeployingElementStatus = ({resource}: DeployingElementStatusProps) 
 
   return(
     <>
-      { inProgress ? (<Text color={color}><Spinner/>&nbsp;</Text>) : (
+      { inProgress ? (<ActivityIndicator>&nbsp;</ActivityIndicator>) : (
       <Text color={color}>{ actionSymbol }&nbsp;</Text>)}
     </>
   )

--- a/packages/cdktf-cli/bin/cmds/ui/deploy.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/deploy.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable no-control-regex */
 import React, { Fragment, useState } from 'react';
 import { Text, Box } from 'ink'
-import Spinner from 'ink-spinner';
 import ConfirmInput from '@skorfmann/ink-confirm-input';
 import { DeployingElement } from './components'
 import { DeployingResource, TerraformOutput, PlannedResourceAction } from './models/terraform'
 import { useTerraform, Status, useTerraformState } from './terraform-context'
 import { Plan } from './diff'
+import {ActivityIndicator} from "./components/activity-indicator";
 
 interface DeploySummaryConfig {
   resources: DeployingResource[];
@@ -86,7 +86,7 @@ export const Apply = (): React.ReactElement => {
     <Fragment>
       <Box flexDirection="column">
         <Box>
-          {Status.DEPLOYING == status ? (<><Text color="green"><Spinner type="dots" /></Text><Box paddingLeft={1}><Text>Deploying Stack: </Text><Text bold>{stackName}</Text></Box></>) : (
+          {Status.DEPLOYING == status ? (<><ActivityIndicator /><Box paddingLeft={1}><Text>Deploying Stack: </Text><Text bold>{stackName}</Text></Box></>) : (
             <><Text>Deploying Stack: </Text><Text bold>{stackName}</Text></>
           )}
         </Box>
@@ -132,7 +132,7 @@ export const Deploy = ({ targetDir, synthCommand, autoApprove }: DeployConfig): 
     <Box>
       {isPlanning ? (
         <Fragment>
-          <Text color="green"><Spinner type="dots" /></Text><Box paddingLeft={1}><Text>{statusText}</Text></Box>
+          <ActivityIndicator /><Box paddingLeft={1}><Text>{statusText}</Text></Box>
         </Fragment>
       ) : (
           <>

--- a/packages/cdktf-cli/bin/cmds/ui/destroy.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/destroy.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable no-control-regex */
 import React, { Fragment, useState } from 'react';
 import { Text, Box } from 'ink'
-import Spinner from 'ink-spinner';
 import ConfirmInput from '@skorfmann/ink-confirm-input';
 import { DeployingElement } from './components'
 import { DeployingResource, PlannedResourceAction } from './models/terraform'
 import { useTerraform, Status, useTerraformState } from './terraform-context'
 import { Plan } from './diff'
+import {ActivityIndicator} from "./components/activity-indicator";
 
 interface DeploySummaryConfig {
   resources: DeployingResource[];
@@ -67,7 +67,7 @@ export const DestroyComponent = (): React.ReactElement => {
     <Fragment>
       <Box flexDirection="column">
         <Box>
-          {Status.DESTROYING == status ? (<><Text color="green"><Spinner type="dots" /></Text><Box paddingLeft={1}><Text>Destroying Stack: </Text><Text bold>{stackName}</Text></Box></>) : (
+          {Status.DESTROYING == status ? (<><ActivityIndicator /><Box paddingLeft={1}><Text>Destroying Stack: </Text><Text bold>{stackName}</Text></Box></>) : (
             <><Text>Destroying Stack: </Text><Text bold>{stackName}</Text></>
           )}
         </Box>
@@ -107,7 +107,7 @@ export const Destroy = ({ targetDir, synthCommand, autoApprove }: DestroyConfig)
     <Box>
       {isPlanning ? (
         <Fragment>
-          <Text color="green"><Spinner type="dots" /></Text><Box paddingLeft={1}><Text>{statusText}</Text></Box>
+          <ActivityIndicator /><Box paddingLeft={1}><Text>{statusText}</Text></Box>
         </Fragment>
       ) : (
           <>

--- a/packages/cdktf-cli/bin/cmds/ui/diff.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/diff.tsx
@@ -1,9 +1,9 @@
 import React, { Fragment } from 'react';
 import { Text, Box, Static } from 'ink'
-import Spinner from 'ink-spinner';
 import { PlannedResource } from "./models/terraform"
 import { PlanElement } from './components'
 import { useTerraform, Status, useTerraformState } from './terraform-context'
+import {ActivityIndicator} from "./components/activity-indicator";
 
 interface DiffConfig {
   targetDir: string;
@@ -83,7 +83,7 @@ export const Diff = ({ targetDir, synthCommand }: DiffConfig): React.ReactElemen
       <CloudRunInfo/>
       {isPlanning ? (
         <Fragment>
-          <Text color="green"><Spinner type="dots" /></Text><Box paddingLeft={1}><Text>{statusText}</Text></Box>
+          <ActivityIndicator /><Box paddingLeft={1}><Text>{statusText}</Text></Box>
         </Fragment>
       ) : (<Plan />)}
     </Box>

--- a/packages/cdktf-cli/bin/cmds/ui/get.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/get.tsx
@@ -1,9 +1,9 @@
 import React, { Fragment } from "react";
 import * as fs from 'fs-extra';
 import { Text, Box, useApp } from "ink";
-import Spinner from "ink-spinner";
 import { Language, ConstructsMaker, GetOptions } from '../../../lib/get/constructs-maker';
 import { TerraformDependencyConstraint } from '../../../lib/config'
+import {ActivityIndicator} from "./components/activity-indicator";
 
 enum Status {
     STARTING = "starting",
@@ -54,9 +54,7 @@ export const Get = ({ codeMakerOutput, language, constraints }: GetConfig): Reac
         <Box>
             {isGenerating ? (
                 <Fragment>
-                    <Text color="green">
-                        <Spinner type="dots" />
-                    </Text>
+                    <ActivityIndicator />
                     <Box paddingLeft={1}>
                         <Text>{statusText}</Text>
                     </Box>

--- a/packages/cdktf-cli/bin/cmds/ui/synth.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/synth.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from "react";
 import { Text, Box } from "ink";
-import Spinner from "ink-spinner";
 import { useTerraform, Status, useTerraformState } from './terraform-context'
+import {ActivityIndicator} from "./components/activity-indicator";
 
 interface CommonSynthConfig {
   targetDir: string;
@@ -36,9 +36,7 @@ export const Synth = ({ targetDir, synthCommand, jsonOutput }: SynthConfig): Rea
       <Box>
         {isSynthesizing ? (
           <Fragment>
-            <Text color="green">
-              <Spinner type="dots" />
-            </Text>
+            <ActivityIndicator />
             <Box paddingLeft={1}>
               <Text>{statusText}</Text>
             </Box>

--- a/packages/cdktf-cli/package.json
+++ b/packages/cdktf-cli/package.json
@@ -38,7 +38,7 @@
     "constructs": "^3.0.0",
     "fs-extra": "^8.1.0",
     "ink": "^3.0.8",
-    "ink-spinner": "^4.0.1",
+    "cli-spinners": "^2.6.0",
     "jsii-srcmak": "^0.1.223",
     "log4js": "^6.3.0",
     "open": "^7.0.4",
@@ -65,7 +65,9 @@
     "rules": {
       "@typescript-eslint/no-explicit-any": 0,
       "@typescript-eslint/explicit-function-return-type": 0,
-      "@typescript-eslint/no-use-before-define": 0
+      "@typescript-eslint/no-use-before-define": 0,
+      "react/prop-types": 0,
+      "react/display-name": 0
     },
     "ignorePatterns": [
       "node_modules",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2570,10 +2570,10 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
-cli-spinners@^2.3.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.5.0.tgz#12763e47251bf951cb75c201dfa58ff1bcb2d047"
-  integrity sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ==
+cli-spinners@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.6.0.tgz#36c7dc98fb6a9a76bd6238ec3f77e2425627e939"
+  integrity sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==
 
 cli-truncate@^2.1.0:
   version "2.1.0"
@@ -4496,13 +4496,6 @@ init-package-json@^1.10.3:
     semver "2.x || 3.x || 4 || 5"
     validate-npm-package-license "^3.0.1"
     validate-npm-package-name "^3.0.0"
-
-ink-spinner@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/ink-spinner/-/ink-spinner-4.0.1.tgz#f67a59ff6d4698a5d67b7bb66266ea6829a8a4e1"
-  integrity sha512-2eYtzzUPb22Z0Cn2bGvE4BteYjcqDhgrHnCzGJM81EHXXlyNU7aYfucPgZs2CZPy0LWz/5hwoecFhd0mj1hrbw==
-  dependencies:
-    cli-spinners "^2.3.0"
 
 ink-testing-library@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Current implementation based on ink-spinner consumes a lot of CPU if many indicators are displayed. 
There are few reasons for that.

1. Internally ink-spinner sets JS interval for each active spinner. This approach leads to constant re-render of spinners. These re-renders are not synced with each other and for each small update React and Ink need to do bunch of work. 
2. ink-spinner API doesn't allow us to specify spinner update rate. Default "dots" type sets update interval to 80ms. It's 12 updates per seconds for each spinner rendered in terminal.

How do I fixed it?

1. I replaced ink-spinner with custom version that sets less frequent update interval.
2. Instead of setInterval for each active spinner I use shared SpinnerClock that holds 1 interval for all active spinners. Now instead of tons of small updates we have 1 centralised update for all spinners. It's significantly reduced CPU usage.

I replaced default "dots" spinner with "circleQuarters" type. 
Example: ```◵ synthesizing ...``` 
It will rotate this clock like circle every 500ms.

I think it's good enough for terminal based activity indication.

I've tested it on list of 54 resource with activity indicator displayed next to each of them.
CPU usage dropped from 50-60% to 4-5% on my machine.

P.S.
I've disabled 2 ESLint rules related to React
react/prop-types: This rule force developer to write propType. PropTypes can be skipped for TS based projects.
react/display-name: This rule force developer to write displayName for functional components. It's helpful in large projects but I think it pretty useless in such small UI project like cdktf-cli. When was the last time when you debugger terminal UI from Google Chrome React inspector?)