### PR TITLE
Add missing handling for resource status lines

### DIFF
--- a/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
@@ -41,6 +41,7 @@ const parseOutput = (str: string): DeployingResource[] => {
 
     switch (true) {
       case /Creating.../.test(line):
+      case /Still creating.../.test(line):
         applyState = DeployingResourceApplyState.CREATING
         break;
       case /Creation complete/.test(line):
@@ -53,6 +54,7 @@ const parseOutput = (str: string): DeployingResource[] => {
         applyState = DeployingResourceApplyState.UPDATED
         break;
       case /Destroying.../.test(line):
+      case /Still destroying.../.test(line):
         applyState = DeployingResourceApplyState.DESTROYING
         break;
       case /Destruction complete/.test(line):


### PR DESCRIPTION
Still creating... and Still destroying... were not handled. If resource took long enough time to create or destroy it went from "Creating" state to "Waiting" state.

Probably cause of https://github.com/hashicorp/terraform-cdk/issues/403