### PR TITLE
Improve error handling if synthesizing fails

### DIFF
--- a/packages/cdktf-cli/package.json
+++ b/packages/cdktf-cli/package.json
@@ -27,9 +27,9 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
+    "@cdktf/hcl2json": "0.0.0",
     "@skorfmann/ink-confirm-input": "^3.0.0",
     "@skorfmann/terraform-cloud": "^1.9.1",
-    "@cdktf/hcl2json": "0.0.0",
     "@types/node": "^14.0.26",
     "archiver": "^5.1.0",
     "cdktf": "0.0.0",
@@ -37,6 +37,7 @@
     "codemaker": "^0.22.0",
     "constructs": "^3.0.0",
     "fs-extra": "^8.1.0",
+    "indent-string": "^4.0.0",
     "ink": "^3.0.8",
     "ink-spinner": "^4.0.1",
     "jsii-srcmak": "^0.1.223",

--- a/test/test-helper.ts
+++ b/test/test-helper.ts
@@ -43,7 +43,7 @@ export class TestDriver {
   }
 
   synth = () => {
-    execSync(`cdktf synth`, { stdio: "inherit", env: this.env });
+    execSync(`cdktf synth`, { stdio: "pipe", env: this.env });
   }
 
   diff = () => {

--- a/test/test-helper.ts
+++ b/test/test-helper.ts
@@ -11,6 +11,16 @@ export class TestDriver {
     this.env = Object.assign({CI: 1}, process.env, addToEnv);
   }
 
+  private execSync(command: string) {
+    try {
+      execSync(command, { stdio: "pipe", env: this.env });
+    } catch(e) {
+      console.log(e.stdout.toString())
+      console.error(e.stderr.toString())
+      throw e;
+    }
+  }
+
   switchToTempDir = () => {
     const pathName = path.join(os.tmpdir(), "test");
     this.workingDirectory = fs.mkdtempSync(pathName);
@@ -43,7 +53,7 @@ export class TestDriver {
   }
 
   synth = () => {
-    execSync(`cdktf synth`, { stdio: "pipe", env: this.env });
+    this.execSync(`cdktf synth`);
   }
 
   diff = () => {

--- a/test/typescript/synth-app-error/cdktf.json
+++ b/test/typescript/synth-app-error/cdktf.json
@@ -1,0 +1,10 @@
+{
+  "language": "typescript",
+  "app": "npm run --silent compile && node thisFileDoesNotExist.js",
+  "terraformProviders": [
+    "aws@~> 2.0"
+  ],
+  "context": {
+    "excludeStackIdFromLogicalIds": "true"
+  }
+}

--- a/test/typescript/synth-app-error/main.ts
+++ b/test/typescript/synth-app-error/main.ts
@@ -1,0 +1,16 @@
+import { Construct } from 'constructs';
+import { App, TerraformStack, TerraformOutput, Testing } from 'cdktf';
+
+export class HelloTerra extends TerraformStack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new TerraformOutput(this, 'dummy', {
+      value: 'nothing'
+    })
+  }
+}
+
+const app = Testing.stubVersion(new App({stackTraces: false}));
+new HelloTerra(app, 'hello-terra');
+app.synth();

--- a/test/typescript/synth-app-error/test.ts
+++ b/test/typescript/synth-app-error/test.ts
@@ -1,0 +1,29 @@
+/**
+ * Testing synthing typescript to json
+ *
+ * @group typescript
+ */
+
+import { TestDriver } from "../../test-helper";
+
+describe("full integration test synth", () => {
+  let driver: TestDriver;
+
+  beforeAll(() => {
+    driver = new TestDriver(__dirname)
+    driver.setupTypescriptProject()
+  });
+
+  test("synth prints error message on failure", async () => {
+    try {
+      driver.synth();
+      fail('Expected synth to fail but no error was thrown');
+    } catch (e) {
+      expect(e.status).toBe(1);
+      expect(e.stderr.toString()).toContain(`cdktf encountered an error while synthesizing
+
+Synth command: npm run --silent compile && node thisFileDoesNotExist.js
+Error:         non-zero exit code 1`);
+    }
+  })
+})


### PR DESCRIPTION
Resolves #533 by printing a more fitting error message including the command that was used for synth and the output that command wrote to stderr.

Before this change:
<img width="860" alt="Screenshot 2021-04-08 at 14 39 23" src="https://user-images.githubusercontent.com/1112056/114028049-52f1ae00-9878-11eb-8614-531eaeefed4c.png">

After this change:
<img width="858" alt="Screenshot 2021-04-08 at 14 29 24" src="https://user-images.githubusercontent.com/1112056/114028108-643aba80-9878-11eb-80b7-b8662ee52249.png">
(`index.js` did not exist)

And without anything on stderr:
<img width="850" alt="Screenshot 2021-04-08 at 14 30 19" src="https://user-images.githubusercontent.com/1112056/114028152-7157a980-9878-11eb-81ed-7917db5ab306.png">
