### PR TITLE
Always attempt to pull a newer version of the base image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
+          pull: true
           push: true
           tags: hashicorp/jsii-terraform:latest
           cache-from: type=local,src=/tmp/.buildx-cache


### PR DESCRIPTION
We depend on [jsii superchain ](https://github.com/aws/jsii/tree/main/superchain) as a base image for our [Dockerfile](https://github.com/hashicorp/terraform-cdk/blob/d9d65467ecfa7c74f4ce3b8a63fbeb4150918117/Dockerfile)

In order to keep up with the base image, this PR changes the [build action](https://github.com/docker/build-push-action) to always pull images when building.