### PR TITLE
rename instance variable to a more specific name to avoid name collisions

### DIFF
--- a/packages/cdktf-cli/test/get/generator/module-generator.test.ts
+++ b/packages/cdktf-cli/test/get/generator/module-generator.test.ts
@@ -6,7 +6,7 @@ import { TerraformModuleConstraint  } from '../../../lib/config'
 import { expectModuleToMatchSnapshot } from '../util';
 
 test('generate some modules', async () => {
-  jest.setTimeout(20000)
+  jest.setTimeout(60000)
 
   const workdir = fs.mkdtempSync(path.join(os.tmpdir(), 'module-generator.test'));
   const constraint = new TerraformModuleConstraint('terraform-aws-modules/eks/aws@7.0.1')

--- a/packages/cdktf-cli/test/get/read-schema.test.ts
+++ b/packages/cdktf-cli/test/get/read-schema.test.ts
@@ -4,7 +4,7 @@ import { TerraformModuleConstraint, TerraformProviderConstraint } from "../../li
 
 describe("readSchema", () => {
   beforeAll(() => {
-    jest.setTimeout(30000)
+    jest.setTimeout(40000)
   })
 
   it("generates a single provider schema", async () => {

--- a/packages/cdktf/lib/complex-computed-list.ts
+++ b/packages/cdktf/lib/complex-computed-list.ts
@@ -48,11 +48,11 @@ export class BooleanMap {
 }
 
 export class ComplexComputedList extends ComplexComputedAttribute {
-  constructor(protected terraformResource: ITerraformResource, protected terraformAttribute: string, protected index: string) {
+  constructor(protected terraformResource: ITerraformResource, protected terraformAttribute: string, protected complexComputedListIndex: string) {
     super(terraformResource, terraformAttribute)
   }
 
   protected interpolationForAttribute(property: string) {
-    return this.terraformResource.interpolationForAttribute(`${this.terraformAttribute}.${this.index}.${property}`);
+    return this.terraformResource.interpolationForAttribute(`${this.terraformAttribute}.${this.complexComputedListIndex}.${property}`);
   }
 }


### PR DESCRIPTION
Resolves #634 which was caused by a Terraform data source which had an attribute containing a list of items which each have a key `index` which collided with its base class `ComplexComputedList`.