### PR TITLE
Define global timeout for integration tests

### DIFF
--- a/test/csharp/synth-app/test.ts
+++ b/test/csharp/synth-app/test.ts
@@ -16,5 +16,5 @@ describe("csharp full integration test synth", () => {
   test("synth generates JSON", async () => {
     await driver.synth()
     expect(driver.synthesizedStack('csharp-simple')).toMatchSnapshot()
-  }, 180_000);
+  });
 })

--- a/test/java/synth-app/test.ts
+++ b/test/java/synth-app/test.ts
@@ -7,7 +7,6 @@ import { TestDriver } from "../../test-helper";
 
 describe("java full integration", () => {
   let driver: TestDriver;
-  jest.setTimeout(240_000);
 
   beforeAll(async () => {
     driver = new TestDriver(__dirname)

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -10,5 +10,6 @@ module.exports = {
     "js",
     "ts"
   ],
-  runner: "groups"
+  runner: "groups",
+  testTimeout: 300000
 }

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -6,3 +6,5 @@ let originalBeforeAll = global.beforeAll;
 global.beforeAll = function beforeAllWithDefaultTimeout(setup, timeout = DEFAULT_TIMEOUT) {
     return originalBeforeAll(setup, timeout);
 };
+
+global.setTimeout(DEFAULT_TIMEOUT)

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -6,5 +6,3 @@ let originalBeforeAll = global.beforeAll;
 global.beforeAll = function beforeAllWithDefaultTimeout(setup, timeout = DEFAULT_TIMEOUT) {
     return originalBeforeAll(setup, timeout);
 };
-
-global.setTimeout(DEFAULT_TIMEOUT)

--- a/test/python/multiple-stacks/test.ts
+++ b/test/python/multiple-stacks/test.ts
@@ -17,5 +17,5 @@ describe("python full integration test synth", () => {
     await driver.synth()
     expect(driver.synthesizedStack('python-simple-one')).toMatchSnapshot()
     expect(driver.synthesizedStack('python-simple-two')).toMatchSnapshot()
-  }, 240_000)
+  })
 })

--- a/test/python/synth-app/test.ts
+++ b/test/python/synth-app/test.ts
@@ -16,5 +16,5 @@ describe("python full integration test synth", () => {
   test("synth generates JSON", async () => {
     await driver.synth()
     expect(driver.synthesizedStack('python-simple')).toMatchSnapshot()
-  }, 240_000);
+  });
 })

--- a/test/python/third-party-provider/test.ts
+++ b/test/python/third-party-provider/test.ts
@@ -16,5 +16,5 @@ describe("python full integration 3rd party", () => {
   test("synth generates JSON", async () => {
     await driver.synth()
     expect(driver.synthesizedStack('python-third-party-provider')).toMatchSnapshot()
-  }, 30_000)
+  })
 })

--- a/test/typescript/feature-flags/test.ts
+++ b/test/typescript/feature-flags/test.ts
@@ -31,19 +31,19 @@ describe("full integration test", () => {
     writeConfig(driver.workingDirectory, jsonWithContext({ excludeStackIdFromLogicalIds: "true" }))
     await driver.synth()
     expect(loadStackJson(driver.workingDirectory, 'hello-deploy')).toMatchSnapshot();
-  }, 60_000);
+  });
 
   test("with allowSepCharsInLogicalIds feature", async () => {
     writeConfig(driver.workingDirectory, jsonWithContext({ allowSepCharsInLogicalIds: "true" }))
     await driver.synth()
     expect(loadStackJson(driver.workingDirectory, 'hello-deploy')).toMatchSnapshot();
-  }, 60_000);
+  });
 
   test("without features", async () => {
     writeConfig(driver.workingDirectory, cdktfJSON)
     await driver.synth()
     expect(loadStackJson(driver.workingDirectory, 'hello-deploy')).toMatchSnapshot();
-  }, 60_000);
+  });
 
   const jsonWithContext = (context) => {
     return Object.assign({}, cdktfJSON, { context })

--- a/test/typescript/init-remote-template/test.ts
+++ b/test/typescript/init-remote-template/test.ts
@@ -8,22 +8,22 @@ import { TestDriver } from "../../test-helper";
 const fs = require('fs').promises;
 
 describe("remote templates", () => {
-  
+
   test("can init", async () => {
     const driver = new TestDriver(__dirname)
     await driver.setupRemoteTemplateProject();
     const files = await fs.readdir(driver.workingDirectory);
     expect(files).toEqual(['.gen', '.gitignore', '.npmrc', 'cdktf.json', 'help', 'main.ts', 'package.json', 'tsconfig.json']);
-  }, 120_000)
+  })
 
   test("handles invalid url", async () => {
     const driver = new TestDriver(__dirname)
-    
+
     try {
       await driver.setupRemoteTemplateProject('invalid_url');
       fail('Expected init to throw an error');
     } catch (e) {
       expect(e.stderr).toContain('Could not download template: the supplied url is invalid');
     }
-  }, 120_000)
+  })
 })

--- a/test/typescript/init-with-colors/test.ts
+++ b/test/typescript/init-with-colors/test.ts
@@ -18,5 +18,5 @@ describe("test with colors", () => {
     driver = new TestDriver(__dirname, { FORCE_COLOR: '1' })
     driver.switchToTempDir()
     await driver.init('typescript')
-  }, 120_000)
+  })
 })

--- a/test/typescript/modules/test.ts
+++ b/test/typescript/modules/test.ts
@@ -26,10 +26,10 @@ describe("full integration test", () => {
   onPosix("build modules posix", async () => {
     await driver.synth()
     expect(driver.synthesizedStack('hello-modules')).toMatchSnapshot()
-  }, 120_000)
+  })
 
   onWindows("build modules windows", async () => {
     await driver.synth()
     expect(driver.synthesizedStack('hello-modules')).toMatchSnapshot()
-  }, 120_000)
+  })
 })

--- a/test/typescript/synth-app-error/test.ts
+++ b/test/typescript/synth-app-error/test.ts
@@ -25,5 +25,5 @@ describe("full integration test synth", () => {
 Synth command: npm run --silent compile && node thisFileDoesNotExist.js
 Error:         non-zero exit code 1`);
     }
-  }, 120_000)
+  })
 })

--- a/test/typescript/synth-app/test.ts
+++ b/test/typescript/synth-app/test.ts
@@ -8,7 +8,6 @@ import { TestDriver } from "../../test-helper";
 
 describe("full integration test synth", () => {
   let driver: TestDriver;
-  jest.setTimeout(120_000);
 
   beforeAll(async () => {
     driver = new TestDriver(__dirname)

--- a/test/typescript/terraform-cloud/test.ts
+++ b/test/typescript/terraform-cloud/test.ts
@@ -15,10 +15,6 @@ if (withAuth == it.skip) {
   console.log('TERRAFORM_CLOUD_TOKEN is undefined, skipping authed tests')
 }
 
-const delay = (ms: number) => {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
 describe("full integration test", () => {
   let driver: TestDriver;
   let workspaceName: string;

--- a/test/typescript/terraform-cloud/test.ts
+++ b/test/typescript/terraform-cloud/test.ts
@@ -25,7 +25,6 @@ describe("full integration test", () => {
   const orgName = 'cdktf'
 
   beforeAll(async () => {
-    jest.setTimeout(240_000);
     workspaceName = `${GITHUB_RUN_NUMBER}-${crypto.randomBytes(10).toString('hex')}`
     driver = new TestDriver(__dirname, {
       TERRAFORM_CLOUD_WORKSPACE_NAME: workspaceName,
@@ -33,10 +32,6 @@ describe("full integration test", () => {
     });
     await driver.setupTypescriptProject()
   });
-
-  afterAll(() => {
-    jest.setTimeout(5000); // default
-  })
 
   withAuth("deploy in Terraform Cloud", async () => {
     const client = new TerraformCloud(TERRAFORM_CLOUD_TOKEN)


### PR DESCRIPTION
Addressing integration test timeouts globally, so we don't have to think about this individually for each test.