### PR TITLE
add cdktf.log to .gitignore of built-in templates

### DIFF
--- a/packages/cdktf-cli/templates/csharp/{{}}.gitignore
+++ b/packages/cdktf-cli/templates/csharp/{{}}.gitignore
@@ -2,6 +2,7 @@
 # cdktf and terraform ignores
 .terraform
 cdktf.out
+cdktf.log
 terraform.tfstate*
 
 # Created by https://www.gitignore.io/api/csharp

--- a/packages/cdktf-cli/templates/java/{{}}.gitignore
+++ b/packages/cdktf-cli/templates/java/{{}}.gitignore
@@ -1,5 +1,6 @@
 .terraform
 cdktf.out
+cdktf.log
 terraform.tfstate*
 
 .classpath

--- a/packages/cdktf-cli/templates/python-pip/{{}}.gitignore
+++ b/packages/cdktf-cli/templates/python-pip/{{}}.gitignore
@@ -3,4 +3,5 @@ imports/*
 !imports/__init__.py
 .terraform
 cdktf.out
+cdktf.log
 terraform.tfstate*

--- a/packages/cdktf-cli/templates/python/{{}}.gitignore
+++ b/packages/cdktf-cli/templates/python/{{}}.gitignore
@@ -3,4 +3,5 @@ imports/*
 !imports/__init__.py
 .terraform
 cdktf.out
+cdktf.log
 terraform.tfstate*

--- a/packages/cdktf-cli/templates/typescript/{{}}.gitignore
+++ b/packages/cdktf-cli/templates/typescript/{{}}.gitignore
@@ -2,6 +2,7 @@
 *.js
 node_modules
 cdktf.out
+cdktf.log
 terraform.tfstate*
 .gen
 .terraform


### PR DESCRIPTION
I noticed that the `cdktf.log` was not yet ignored. I think it should be.