### PR TITLE
Go is required to run yarn build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-To build and install `terraform-cdk` locally, Node version 12.16+
+To build and install `terraform-cdk` locally, Node version 12.16+ and Go is required.
 
 ## Getting Started
 


### PR DESCRIPTION
yarn build (that runs ./build-go.sh) doesn't run without Go being installed in the system. Updating CONTRIBUTING.md to reflect that.