### PR TITLE
chore(#644): Upgrade python templates to use RemoteBackend class

### DIFF
--- a/packages/cdktf-cli/templates/python-pip/.hooks.sscaff.js
+++ b/packages/cdktf-cli/templates/python-pip/.hooks.sscaff.js
@@ -41,16 +41,15 @@ exports.post = options => {
 function terraformCloudConfig(baseName, organizationName, workspaceName) {
   template = readFileSync('./main.py', 'utf-8');
 
-  const result = template.replace(`MyStack(app, "${baseName}")`, `stack = MyStack(app, "${baseName}")
-stack.add_override('terraform.backend', {
-  'remote': {
-    'hostname': 'app.terraform.io',
-    'organization': '${organizationName}',
-    'workspaces': {
-      'name': '${workspaceName}'
-    }
-  }
-})`);
+  const templateWithImports = template.replace(`from cdktf import App, TerraformStack`,
+    `from cdktf import App, TerraformStack, RemoteBackend, NamedRemoteWorkspace`)
+
+  const result = templateWithImports.replace(`MyStack(app, "${baseName}")`, `stack = MyStack(app, "${baseName}")
+RemoteBackend(stack,
+  hostname='app.terraform.io',
+  organization='${organizationName}',
+  workspaces=NamedRemoteWorkspace('${workspaceName}')
+)`);
 
   writeFileSync('./main.py', result, 'utf-8');
 }

--- a/packages/cdktf-cli/templates/python/.hooks.sscaff.js
+++ b/packages/cdktf-cli/templates/python/.hooks.sscaff.js
@@ -41,16 +41,15 @@ exports.post = options => {
 function terraformCloudConfig(baseName, organizationName, workspaceName) {
   template = readFileSync('./main.py', 'utf-8');
 
-  const result = template.replace(`MyStack(app, "${baseName}")`, `stack = MyStack(app, "${baseName}")
-stack.add_override('terraform.backend', {
-  'remote': {
-    'hostname': 'app.terraform.io',
-    'organization': '${organizationName}',
-    'workspaces': {
-      'name': '${workspaceName}'
-    }
-  }
-})`);
+  const templateWithImports = template.replace(`from cdktf import App, TerraformStack`,
+    `from cdktf import App, TerraformStack, RemoteBackend, NamedRemoteWorkspace`)
+
+  const result = templateWithImports.replace(`MyStack(app, "${baseName}")`, `stack = MyStack(app, "${baseName}")
+RemoteBackend(stack,
+  hostname='app.terraform.io',
+  organization='${organizationName}',
+  workspaces=NamedRemoteWorkspace('${workspaceName}')
+)`);
 
   writeFileSync('./main.py', result, 'utf-8');
 }


### PR DESCRIPTION
Addresses issue #644 

Tested locally by initializing the python template project and successfully generating the cdk.tf.json output:
```
{
  "//": {
    "metadata": {
      "version": "0.0.0",
      "stackName": "python-example"
    }
  },
  "terraform": {
    "backend": {
      "remote": {
        "organization": "bradseiler-test",
        "workspaces": {
          "name": "python"
        },
        "hostname": "app.terraform.io"
      }
    }
  }
}
```