### PR TITLE
fix(docs): rename `aws` to `aws-multiple-stacks` and add `aws-prebuilt` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Choose a language:
 
 ### Typescript
 
+* [aws-prebuilt](./examples/typescript/aws-prebuilt)
+* [aws-multiple-stacks](./examples/typescript/aws-multiple-stacks)
 * [aws-cloudfront-proxy](./examples/typescript/aws-cloudfront-proxy)
 * [azure](./examples/typescript/azure)
 * [azure-app-service](./examples/typescript/azure-app-service)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Choose a language:
 
 ### Typescript
 
-* [aws](./examples/typescript/aws)
 * [aws-cloudfront-proxy](./examples/typescript/aws-cloudfront-proxy)
 * [azure](./examples/typescript/azure)
 * [azure-app-service](./examples/typescript/azure-app-service)


### PR DESCRIPTION
fix(docs): remove readme not exist path
- Typescript
   -  aws
![截圖 2021-05-03 上午10 35 32](https://user-images.githubusercontent.com/46012524/116837010-50764000-abfb-11eb-88a1-0005f618dd88.png)
