### PR TITLE
Return non-zero exit code on unknown command and allow terraform-like command names

### DIFF
--- a/packages/cdktf-cli/bin/cdktf.ts
+++ b/packages/cdktf-cli/bin/cdktf.ts
@@ -20,7 +20,7 @@ if (!process.env.CDKTF_DISABLE_PLUGIN_CACHE_ENV) {
 
 if (semver.lt(process.version, '10.12.0')) { console.error("Need at least Node v10.12 to run") ; process.exit(1) }
 
-const args = yargs
+yargs
   .commandDir('cmds')
   .recommendCommands()
   .wrap(yargs.terminalWidth())
@@ -33,8 +33,13 @@ const args = yargs
   .option('disable-plugin-cache-env', { type: 'boolean', default: false, required: false, desc: 'Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env CDKTF_DISABLE_PLUGIN_CACHE_ENV.'})
   .option('log-level', { type: 'string', required: false, desc: 'Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL'})
   .option('context-json', { required: false, hidden: true, desc: 'Used internally for env variable' })
+  .command({
+    command: '*', // catches everything not previously matched
+    handler: (argv) => {
+      const cmd = argv._[0];
+      console.error(cmd ? `Could not find command "${cmd}"` : `Please pass a command`);
+      console.error(`Please run "${argv.$0} help" to get a list of commands.`)
+      process.exit(1);
+    }
+  })
   .argv;
-
-if (args._.length === 0) {
-  yargs.showHelp();
-}

--- a/packages/cdktf-cli/bin/cmds/deploy.ts
+++ b/packages/cdktf-cli/bin/cmds/deploy.ts
@@ -10,6 +10,7 @@ const config = readConfigSync();
 class Command implements yargs.CommandModule {
   public readonly command = 'deploy [stack] [OPTIONS]';
   public readonly describe = 'Deploy the given stack';
+  public readonly aliases = ['apply'];
 
   public readonly builder = (args: yargs.Argv) => args
     .positional('stack', { desc: 'Deploy stack which matches the given id only. Required when more than one stack is present in the app', type: 'string' })

--- a/packages/cdktf-cli/bin/cmds/diff.ts
+++ b/packages/cdktf-cli/bin/cmds/diff.ts
@@ -10,6 +10,7 @@ const config = readConfigSync();
 class Command implements yargs.CommandModule {
   public readonly command = 'diff [stack] [OPTIONS]';
   public readonly describe = 'Perform a diff (terraform plan) for the given stack';
+  public readonly aliases = ['plan'];
 
   public readonly builder = (args: yargs.Argv) => args
     .positional('stack', { desc: 'Diff stack which matches the given id only. Required when more than one stack is present in the app', type: 'string' })


### PR DESCRIPTION
Fixes #675,#573

I was unsuccessful in getting `yargs.showHelp` to show the commands, I feel like this iteration is a good step forward already :)