### PR TITLE
Diagnostic: show version information on error

### DIFF
--- a/packages/cdktf-cli/bin/cdktf.ts
+++ b/packages/cdktf-cli/bin/cdktf.ts
@@ -5,6 +5,9 @@ import * as semver from 'semver';
 import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs-extra';
+import { terraformVersion } from './cmds/helper/terraform';
+import { DISPLAY_VERSION } from './cmds/version-check';
+
 
 const ensurePluginCache = (): string => {
   const pluginCachePath = process.env.TF_PLUGIN_CACHE_DIR || path.join(os.homedir(), '.terraform.d', 'plugin-cache')
@@ -41,5 +44,15 @@ yargs
       console.error(`Please run "${argv.$0} help" to get a list of commands.`)
       process.exit(1);
     }
+  })
+  .fail((_message, error) => {
+    console.error(error.stack);
+
+    terraformVersion.then(tfVersion => {
+      console.error(`
+Debug Information:
+    Terraform CDK version: ${DISPLAY_VERSION}
+    Terraform version: ${tfVersion}`)
+    });
   })
   .argv;

--- a/packages/cdktf-cli/bin/cmds/helper/terraform.ts
+++ b/packages/cdktf-cli/bin/cmds/helper/terraform.ts
@@ -1,0 +1,11 @@
+import { exec } from "../../../lib/util";
+
+export const terraformBinaryName =
+  process.env.TERRAFORM_BINARY_NAME || "terraform";
+export const terraformVersion = exec(
+  terraformBinaryName,
+  ["version", "-json"],
+  {}
+)
+  .then((versionString) => JSON.parse(versionString).terraform_version)
+  .catch((err) => `Unknown: Error loading terraform version ${err}`);

--- a/packages/cdktf-cli/bin/cmds/ui/models/terraform-cli.ts
+++ b/packages/cdktf-cli/bin/cmds/ui/models/terraform-cli.ts
@@ -2,8 +2,8 @@ import * as path from 'path';
 import { exec, readCDKTFVersion } from 'cdktf-cli/lib/util'
 import { Terraform, TerraformPlan, TerraformOutput, PlannedResourceAction, PlannedResource, ResourceChanges } from './terraform'
 import { SynthesizedStack } from '../../helper/synth-stack';
+import { terraformBinaryName } from '../../helper/terraform';
 
-const terraformBinaryName = process.env.TERRAFORM_BINARY_NAME || 'terraform'
 
 export class TerraformCliPlan implements TerraformPlan {
   constructor(public readonly planFile: string, public readonly plan: {[key: string]: any}) {}


### PR DESCRIPTION
An example error looks like this:

```
Error: ups I did it again
    at Object.handler (/Users/danielschmidt/work/terraform-cdk/packages/cdktf-cli/bin/cmds/init.js:66:19)
    at Object.runCommand (/Users/danielschmidt/work/terraform-cdk/packages/cdktf-cli/node_modules/yargs/lib/command.js:240:40)
    at Object.parseArgs [as _parseArgs] (/Users/danielschmidt/work/terraform-cdk/packages/cdktf-cli/node_modules/yargs/yargs.js:1154:41)
    at Object.get [as argv] (/Users/danielschmidt/work/terraform-cdk/packages/cdktf-cli/node_modules/yargs/yargs.js:1088:21)
    at Object.<anonymous> (/Users/danielschmidt/work/terraform-cdk/packages/cdktf-cli/bin/cdktf.js:75:5)
    at Module._compile (node:internal/modules/cjs/loader:1108:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1137:10)
    at Module.load (node:internal/modules/cjs/loader:988:32)
    at Function.Module._load (node:internal/modules/cjs/loader:828:14)
    at Module.require (node:internal/modules/cjs/loader:1012:19)

Debug Information:
    Terraform CDK version: 0.0.0
    Terraform version: 0.15.1
```