### PR TITLE
support rendering map and list outputs

### DIFF
--- a/packages/cdktf-cli/bin/cmds/ui/deploy.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/deploy.tsx
@@ -45,7 +45,11 @@ export const Output = ({ output }: OutputConfig): React.ReactElement => {
     <Box flexDirection="column">
       {Object.keys(output).map((key) => (
         <Box key={key}>
-          <Text>{key} = {output[key].value}</Text>
+          <Text>{key} = {
+            typeof output[key].value === 'object' ?
+              JSON.stringify(output[key].value, null, 2) :
+              output[key].value
+          }</Text>
         </Box>
       ))}
     </Box>

--- a/packages/cdktf-cli/bin/cmds/ui/models/terraform.ts
+++ b/packages/cdktf-cli/bin/cmds/ui/models/terraform.ts
@@ -46,7 +46,7 @@ export interface ResourceChanges {
 export interface TerraformOutput {
   sensitive: boolean;
   type: string;
-  value: string;
+  value: string | object;
 }
 
 export interface TerraformPlan {

--- a/packages/cdktf-cli/test/ui/deploy.test.tsx
+++ b/packages/cdktf-cli/test/ui/deploy.test.tsx
@@ -37,11 +37,32 @@ test("Output", async () => {
       sensitive: false,
       type: "bar",
       value: "baz"
+    },
+    map: {
+      sensitive: false,
+      type: "map",
+      value: { keyA: "valueA", keyB: "valueB" }
+    },
+    list: {
+      sensitive: false,
+      type: "list",
+      value: ["A", "B", "C"]
     }
   };
 
   const { lastFrame } = render(<Output output={output} />);
-  expect(stripAnsi(lastFrame())).toMatchInlineSnapshot(`"foo = baz"`);
+  expect(stripAnsi(lastFrame())).toMatchInlineSnapshot(`
+    "foo = baz
+    map = {
+      \\"keyA\\": \\"valueA\\",
+      \\"keyB\\": \\"valueB\\"
+    }
+    list = [
+      \\"A\\",
+      \\"B\\",
+      \\"C\\"
+    ]"
+  `);
 });
 
 test("Apply", async () => {


### PR DESCRIPTION
Fixes 695 by using JSON.stringify to print the value of an output if it is not a primitive data type.