### PR TITLE
Update UI state on deploy / destroy

### DIFF
--- a/packages/cdktf-cli/bin/cmds/ui/models/terraform-cloud.ts
+++ b/packages/cdktf-cli/bin/cmds/ui/models/terraform-cloud.ts
@@ -142,16 +142,16 @@ export class TerraformCloud implements Terraform {
     const workspace = await this.workspace()
     const workspaceUrl = `https://app.terraform.io/app/${this.organizationName}/workspaces/${this.workspaceName}`
 
-    if (workspace.attributes.locked && (workspace as any).relationships?.lockedBy?.data?.type === "users") {
+    if (workspace.attributes.locked && workspace.relationships?.lockedBy?.data?.type === "users") {
       throw new Error(`Can not plan, the workspace ${this.organizationName}/${this.workspaceName} is locked by a user. You can find more information at ${workspaceUrl}`)
     }
 
-    if (workspace.attributes.locked && (workspace as any).relationships?.lockedBy?.data?.type === "runs") {
+    if (workspace.attributes.locked && workspace.relationships?.lockedBy?.data?.type === "runs") {
       throw new Error(`Can not plan, the workspace ${this.organizationName}/${this.workspaceName} is locked by a previous run, please wait until it's done. You can find more information at ${workspaceUrl}`)
     }
 
     if (workspace.attributes.locked) {
-      throw new Error(`Can not plan, the workspace ${this.organizationName}/${this.workspaceName} is locked for an unknown reason: ${JSON.stringify((workspace as any).relationships?.lockedBy)}. You can find more information at ${workspaceUrl}`)
+      throw new Error(`Can not plan, the workspace ${this.organizationName}/${this.workspaceName} is locked for an unknown reason: ${JSON.stringify(workspace.relationships?.lockedBy)}. You can find more information at ${workspaceUrl}`)
     }
 
     let result = await this.client.Runs.create({

--- a/packages/cdktf-cli/bin/cmds/ui/models/terraform-cloud.ts
+++ b/packages/cdktf-cli/bin/cmds/ui/models/terraform-cloud.ts
@@ -169,10 +169,13 @@ export class TerraformCloud implements Terraform {
       await wait(1000);
     }
 
+    const url = `https://app.terraform.io/app/${this.organizationName}/workspaces/${this.workspaceName}/runs/${result.id}`
+    if (result.attributes.status === 'errored') {
+      throw new Error(`Error planning the run, please take a look at ${url}`)
+    }
 
     const plan = await this.client.Plans.jsonOutput(result.relationships.plan.data.id)
     this.run = result
-    const url = `https://app.terraform.io/app/${this.organizationName}/workspaces/${this.workspaceName}/runs/${result.id}`
     return new TerraformCloudPlan('terraform-cloud', plan as unknown as any, url)
   }
 

--- a/packages/cdktf-cli/bin/cmds/ui/models/terraform-cloud.ts
+++ b/packages/cdktf-cli/bin/cmds/ui/models/terraform-cloud.ts
@@ -164,13 +164,9 @@ export class TerraformCloud implements Terraform {
     })
 
     const pendingStates = ['pending', 'plan_queued', 'planning']
-
-    if (pendingStates.includes(result.attributes.status)) {
+    while (pendingStates.includes(result.attributes.status)) {
       result = await this.client.Runs.show(result.id)
-      while (pendingStates.includes(result.attributes.status)) {
-        result = await this.client.Runs.show(result.id)
-        await wait(1000);
-      }
+      await wait(1000);
     }
 
 

--- a/packages/cdktf-cli/bin/cmds/ui/models/terraform-cloud.ts
+++ b/packages/cdktf-cli/bin/cmds/ui/models/terraform-cloud.ts
@@ -188,16 +188,18 @@ export class TerraformCloud implements Terraform {
     await this.client.Runs.action('apply', runId)
     let result = await this.client.Runs.show(runId)
 
-    if (deployingStates.includes(result.attributes.status)) {
-      result = await this.client.Runs.show(runId)
-      while (deployingStates.includes(result.attributes.status)) {
-        result = await this.client.Runs.show(runId)
-        await wait(1000);
-      }
+    async function update(client: TerraformCloudClient.TerraformCloud) {
+      const res = await client.Runs.show(runId);
+
+      // fetch logs and update UI in the background
+      client.Applies.logs(result.relationships.apply.data.id).then(({ data }) => stdout(Buffer.from(data, 'utf8')));
+      return res;
     }
 
-    const logs = await this.client.Applies.logs(result.relationships.apply.data.id)
-    stdout(Buffer.from(logs.data, 'utf8'))
+    while (deployingStates.includes(result.attributes.status)) {
+      result = await update(this.client)
+      await wait(1000);
+    }
 
     switch (result.attributes.status) {
       case 'applied': break;
@@ -214,16 +216,18 @@ export class TerraformCloud implements Terraform {
     await this.client.Runs.action('apply', runId)
     let result = await this.client.Runs.show(runId)
 
-    if (destroyingStates.includes(result.attributes.status)) {
-      result = await this.client.Runs.show(runId)
-      while (destroyingStates.includes(result.attributes.status)) {
-        result = await this.client.Runs.show(runId)
-        await wait(1000);
-      }
+    async function update(client: TerraformCloudClient.TerraformCloud) {
+      const res = await client.Runs.show(runId);
+
+      // fetch logs and update UI in the background
+      client.Applies.logs(result.relationships.apply.data.id).then(({ data }) => stdout(Buffer.from(data, 'utf8')));
+      return res;
     }
 
-    const logs = await this.client.Applies.logs(result.relationships.apply.data.id)
-    stdout(Buffer.from(logs.data, 'utf8'))
+    while (destroyingStates.includes(result.attributes.status)) {
+      result = await update(this.client)
+      await wait(1000);
+    }
 
     switch (result.attributes.status) {
       case 'applied': break;

--- a/packages/cdktf-cli/package.json
+++ b/packages/cdktf-cli/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@cdktf/hcl2json": "0.0.0",
     "@skorfmann/ink-confirm-input": "^3.0.0",
-    "@skorfmann/terraform-cloud": "^1.10.0",
+    "@skorfmann/terraform-cloud": "^1.10.1",
     "@types/node": "^14.0.26",
     "archiver": "^5.1.0",
     "cdktf": "0.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,10 +1406,10 @@
     prop-types "^15.5.10"
     yn "^3.1.1"
 
-"@skorfmann/terraform-cloud@^1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@skorfmann/terraform-cloud/-/terraform-cloud-1.10.0.tgz#cba669213dacf92aa1a80c8e8d112f0b5e422cc9"
-  integrity sha512-Yd5WWmmUjFYBpQpsAnAntwQMerilNRpHILNPA7x0EkwHhf+5KTSKYZwzYL/bOY1QfGJX6DTnOSHXIRStHZDUgg==
+"@skorfmann/terraform-cloud@^1.10.1":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@skorfmann/terraform-cloud/-/terraform-cloud-1.10.1.tgz#a09c9fb3a582b04c39b97a16e53424172db2feb1"
+  integrity sha512-yQpxfH1VbwIcsyRQ8eN8qLJ76pZ4CQ1Ck1SmFtiKE7J790KFwC8o2r1dlTU130M/bv1eb/8gdPY1T3DLj40D8w==
   dependencies:
     axios "^0.21.1"
     camelcase-keys "^6.2.2"


### PR DESCRIPTION
## Summary

- Throws prefixed errors in case of terraform cloud API errors so that there is more context
- Throws a new error when the plan errored
- Poll logs from terraform cloud to see updates inbetween
- Throws a new error when the workspace is locked

