### PR TITLE
Check for duplicate config class names

### DIFF
--- a/packages/cdktf-cli/lib/get/generator/models/resource-model.ts
+++ b/packages/cdktf-cli/lib/get/generator/models/resource-model.ts
@@ -14,6 +14,7 @@ interface ResourceModelOptions {
   provider: string;
   schema: Schema;
   terraformSchemaType: string;
+  configStructName: string;
 }
 
 export class ResourceModel {
@@ -30,6 +31,7 @@ export class ResourceModel {
   private _structs: Struct[];
   private dependencies: string[];
   private terraformSchemaType: string;
+  private configStructName: string;
 
   constructor(options: ResourceModelOptions) {
     this.terraformType = options.terraformType
@@ -41,7 +43,8 @@ export class ResourceModel {
     this.fileName = options.fileName;
     this.filePath = options.filePath;
     this._structs = options.structs;
-    this.terraformSchemaType = options.terraformSchemaType
+    this.terraformSchemaType = options.terraformSchemaType;
+    this.configStructName = options.configStructName;
     this.dependencies = [
       `import { Construct } from 'constructs';`,
       `import * as cdktf from 'cdktf';`
@@ -53,7 +56,7 @@ export class ResourceModel {
   }
 
   public get configStruct() {
-    return new ConfigStruct(`${this.className}Config`, this.attributes)
+    return new ConfigStruct(this.configStructName, this.attributes)
   }
 
   public get synthesizableAttributes(): AttributeModel[] {

--- a/packages/cdktf-cli/lib/get/generator/resource-parser.ts
+++ b/packages/cdktf-cli/lib/get/generator/resource-parser.ts
@@ -33,7 +33,7 @@ class Parser {
 
     const className = uniqueClassName(toPascalCase(baseName));
     // avoid naming collision - see https://github.com/hashicorp/terraform-cdk/issues/299
-    uniqueClassName(toPascalCase(`${baseName}Config`));
+    const configStructName = uniqueClassName(`${className}Config`);
     const fileName = baseName === 'index' ? 'index-resource.ts' : `${toSnakeCase(baseName).replace(/_/g, '-')}.ts`;
     const filePath = `providers/${toSnakeCase(provider)}/${fileName}`;
     const attributes = this.renderAttributesForBlock(new Scope({name: baseName, isProvider, parent: isProvider ? undefined : new Scope({name: provider, isProvider: true})}), schema.block)
@@ -48,7 +48,8 @@ class Parser {
       provider,
       attributes,
       terraformSchemaType,
-      structs: this.structs
+      structs: this.structs,
+      configStructName
     })
 
 

--- a/packages/cdktf-cli/test/get/provider.test.ts
+++ b/packages/cdktf-cli/test/get/provider.test.ts
@@ -7,3 +7,5 @@ const getProvider = (constraint: TerraformDependencyConstraint) =>
 getProvider(new TerraformProviderConstraint('aws@= 2.60.0'));
 
 getProvider(new TerraformProviderConstraint('phillbaker/elasticsearch@= 1.5.1'));
+
+getProvider(new TerraformProviderConstraint('oci@= 4.13.0'));


### PR DESCRIPTION
Fixes #568 
Fixes #703 

This just routes the config class through the existing duplicate name check. Using duplicated names is not a great user experience, but until #572 or similar is done, this is much better than failing to generate.