### PR TITLE
Drop obsolete json-stable-stringify package

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,10 +47,6 @@
       "test",
       ".yalc/*",
       ".yalc/@*/*"
-    ],
-    "nohoist": [
-      "cdktf/json-stable-stringify",
-      "cdktf/json-stable-stringify/**"
     ]
   },
   "devDependencies": {

--- a/packages/cdktf/package.json
+++ b/packages/cdktf/package.json
@@ -74,7 +74,6 @@
   "license": "MPL-2.0",
   "devDependencies": {
     "@types/jest": "^25.1.2",
-    "@types/json-stable-stringify": "^1.0.32",
     "@types/node": "^14.0.26",
     "@typescript-eslint/eslint-plugin": "^2.20.0",
     "@typescript-eslint/parser": "^2.20.0",
@@ -91,12 +90,6 @@
     "moduleFileExtensions": [
       "js"
     ]
-  },
-  "bundledDependencies": [
-    "json-stable-stringify"
-  ],
-  "dependencies": {
-    "json-stable-stringify": "^1.0.1"
   },
   "stability": "experimental",
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1600,11 +1600,6 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
   integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
-"@types/json-stable-stringify@^1.0.32":
-  version "1.0.32"
-  resolved "https://registry.yarnpkg.com/@types/json-stable-stringify/-/json-stable-stringify-1.0.32.tgz#121f6917c4389db3923640b2e68de5fa64dda88e"
-  integrity sha512-q9Q6+eUEGwQkv4Sbst3J4PNgDOvpuVuKj79Hl/qnmBMEIPzB5QoFRUtjcgcg2xNUZyYUGXBk5wYIBKHt0A+Mxw==
-
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -5677,13 +5672,6 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json-stable-stringify@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
-  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
-  dependencies:
-    jsonify "~0.0.0"
-
 json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -5711,11 +5699,6 @@ jsonfile@^6.0.1:
     universalify "^1.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
-
-jsonify@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
-  integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
 jsonparse@^1.2.0:
   version "1.3.1"


### PR DESCRIPTION
This looks like a relict from the initial import of the code more than a year ago.
Couldn't find any traces of this being used in the code. Since it popped up
as an error https://github.com/hashicorp/terraform-cdk/issues/704 this simply
removes the dependency