### PR TITLE
Rename stack property to avoid conflict

### DIFF
--- a/packages/cdktf/lib/terraform-element.ts
+++ b/packages/cdktf/lib/terraform-element.ts
@@ -8,7 +8,7 @@ export interface TerraformElementMetadata {
 }
 
 export class TerraformElement extends Construct {
-  public readonly stack: TerraformStack;
+  public readonly cdktfStack: TerraformStack;
   protected readonly rawOverrides: any = {}
 
   /**
@@ -20,7 +20,7 @@ export class TerraformElement extends Construct {
     super(scope, id)
 
     this.constructNode.addMetadata('stacktrace', 'trace')
-    this.stack = TerraformStack.of(this);
+    this.cdktfStack = TerraformStack.of(this);
   }
 
   public get constructNode(): Node {
@@ -36,7 +36,7 @@ export class TerraformElement extends Construct {
       return this._logicalIdOverride;
     }
     else {
-      return this.stack.getLogicalId(this);
+      return this.cdktfStack.getLogicalId(this);
     }
   }
 

--- a/packages/cdktf/lib/terraform-stack.ts
+++ b/packages/cdktf/lib/terraform-stack.ts
@@ -90,7 +90,7 @@ export class TerraformStack extends Construct {
 
     let stackIndex;
     if (node.tryGetContext(EXCLUDE_STACK_ID_FROM_LOGICAL_IDS)) {
-      stackIndex = node.scopes.indexOf(tfElement.stack);
+      stackIndex = node.scopes.indexOf(tfElement.cdktfStack);
     }
     else {
       stackIndex = 0;


### PR DESCRIPTION
Fixes #702 

This is technically a breaking change since public API is being changed, though likely low impact.