### PR TITLE
HCL output: use attribute name instead of id

### DIFF
--- a/packages/cdktf-cli/bin/cmds/ui/models/terraform-cloud.ts
+++ b/packages/cdktf-cli/bin/cmds/ui/models/terraform-cloud.ts
@@ -242,7 +242,7 @@ export class TerraformCloud implements Terraform {
     if (!stateVersion.included) return {}
 
     const outputs = stateVersion.included.reduce((acc, output) => {
-      acc[output.id] = {
+      acc[output.attributes.name] = {
         sensitive: output.attributes.sensitive,
         type: output.attributes.type,
         value: output.attributes.value

--- a/test/typescript/terraform-cloud/__snapshots__/test.ts.snap
+++ b/test/typescript/terraform-cloud/__snapshots__/test.ts.snap
@@ -7,5 +7,7 @@ Resources
 
 
 Summary: 1 created, 0 updated, 0 destroyed.
+
+Output: output = constant value
 "
 `;

--- a/test/typescript/terraform-cloud/main.ts
+++ b/test/typescript/terraform-cloud/main.ts
@@ -1,5 +1,5 @@
 import { Construct } from 'constructs';
-import { App, TerraformStack, Testing  } from 'cdktf';
+import { App, TerraformStack, Testing, TerraformOutput } from 'cdktf';
 import * as NullProvider from './.gen/providers/null';
 const token = process.env.TERRAFORM_CLOUD_TOKEN;
 const name = process.env.TERRAFORM_CLOUD_WORKSPACE_NAME;
@@ -26,6 +26,10 @@ export class HelloTerra extends TerraformStack {
         token
       }
     });
+
+    new TerraformOutput(this, "output", {
+      value: "constant value"
+    })
   }
 }
 


### PR DESCRIPTION
This leaves us with predictable identifiers used