### PR TITLE
chore(cdktf-cli): enable eslint rule no-sequences

### DIFF
--- a/packages/cdktf-cli/package.json
+++ b/packages/cdktf-cli/package.json
@@ -68,7 +68,8 @@
     "rules": {
       "@typescript-eslint/no-explicit-any": 0,
       "@typescript-eslint/explicit-function-return-type": 0,
-      "@typescript-eslint/no-use-before-define": 0
+      "@typescript-eslint/no-use-before-define": 0,
+      "no-sequences": "error"
     },
     "ignorePatterns": [
       "node_modules",

--- a/packages/cdktf/package.json
+++ b/packages/cdktf/package.json
@@ -68,7 +68,8 @@
       "@typescript-eslint/explicit-function-return-type": 0,
       "@typescript-eslint/no-use-before-define": 0,
       "@typescript-eslint/interface-name-prefix": 0,
-      "@typescript-eslint/no-empty-interface": 0
+      "@typescript-eslint/no-empty-interface": 0,
+      "no-sequences": "error"
     },
     "ignorePatterns": [
       "node_modules",


### PR DESCRIPTION
We previously had a switch statement which had a case like `case a,b:` which at first looked like handling both a and b but in JS/TS it doesn't. It resolves to just b. To catch something like this, we enable this eslint rule and disallow sequences anywhere.

This is how it is going to look with this commit
<img width="633" alt="Screenshot 2021-05-26 at 12 26 35" src="https://user-images.githubusercontent.com/1112056/119645812-bdf24680-be1e-11eb-8beb-97dca622e279.png">

For reference, this is what that code meant to say
<img width="305" alt="Screenshot 2021-05-26 at 12 27 03" src="https://user-images.githubusercontent.com/1112056/119645938-da8e7e80-be1e-11eb-9b46-85869b78883e.png">
