### PR TITLE
fix(tests): adjust terraform provider name to match imports used in main.go

### DIFF
--- a/test/go/synth-app/cdktf.json
+++ b/test/go/synth-app/cdktf.json
@@ -1,7 +1,7 @@
 {
   "language": "go",
   "app": "go run main.go",
-  "terraformProviders": ["random@~> 3.1.0"],
+  "terraformProviders": ["hashicorp/random@~> 3.1.0"],
   "codeMakerOutput": "generated",
   "context": {
     "excludeStackIdFromLogicalIds": "true"


### PR DESCRIPTION
The tests `main.go` uses generated provider bindings that are within a namespace. And although Terraform defaults to `hashicorp` if no namespace is set, our code apparently doesn't do that yet.

I'm going to create a follow-up issue to address this.