### PR TITLE
fix(cli): Adapt to changed output format in Terraform 0.15.4

### DIFF
--- a/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
@@ -36,7 +36,7 @@ const parseOutput = (str: string): DeployingResource[] => {
     if (/^Outputs:/.test(line)) { return }
     if (/^data\..*/.test(line)) { return }
 
-    const resourceMatch = line.match(/^([a-zA-Z_][a-zA-Z\d_\-.]*):/)
+    const resourceMatch = line.match(/^([a-zA-Z_][a-zA-Z\d_-]+\.[a-zA-Z\d_-]+):/)
     let applyState: DeployingResourceApplyState;
 
     switch (true) {


### PR DESCRIPTION
`Plan:` was matched by accident. This changes the regex to require
something like `abc.foo` to match.

### Terraform 0.15.4

```
null_resource.test: Refreshing state... [id=2265159398281528182]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # null_resource.test will be destroyed
  - resource "null_resource" "test" {
      - id = "2265159398281528182" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.
null_resource.test: Destroying... [id=2265159398281528182]
null_resource.test: Destruction complete after 0s

Destroy complete! Resources: 1 destroyed.
```

### Terraform 0.15.0

```
null_resource.test: Refreshing state... [id=1540203300502369612]
null_resource.test: Destroying... [id=1540203300502369612]
null_resource.test: Destruction complete after 0s

Destroy complete! Resources: 1 destroyed.
```