### PR TITLE
fix(cli): Workaround Terraform 0.15.4 output changes

### DIFF
--- a/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
@@ -36,7 +36,7 @@ const parseOutput = (str: string): DeployingResource[] => {
     if (/^Outputs:/.test(line)) { return }
     if (/^data\..*/.test(line)) { return }
 
-    const resourceMatch = line.match(/^([a-zA-Z_][a-zA-Z\d_-]+\.[a-zA-Z\d_-]+):/)
+    const resourceMatch = line.match(/^([a-zA-Z_][a-zA-Z\d_\-.]*):/)
     let applyState: DeployingResourceApplyState;
 
     switch (true) {

--- a/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
@@ -34,6 +34,7 @@ const parseOutput = (str: string): DeployingResource[] => {
   const resources = lines.map(line => {
 
     if (/^Outputs:/.test(line)) { return }
+    if (/^Plan:/.test(line)) { return }
     if (/^data\..*/.test(line)) { return }
 
     const resourceMatch = line.match(/^([a-zA-Z_][a-zA-Z\d_\-.]*):/)


### PR DESCRIPTION
This reverts #736 and adds an explicit workaround for `Plan:`. Not ideal, but should for now.

This is related to #738 