### PR TITLE
fix(tests): fix onWindows helper skipping on windows

### DIFF
--- a/test/typescript/modules/__snapshots__/test.ts.snap
+++ b/test/typescript/modules/__snapshots__/test.ts.snap
@@ -53,7 +53,7 @@ exports[`full integration test build modules windows 1`] = `
   },
   \\"module\\": {
     \\"localmodule\\": {
-      \\"source\\": \\"..\\\\local-module\\",
+      \\"source\\": \\"..\\\\\\\\local-module\\",
       \\"//\\": {
         \\"metadata\\": {
           \\"path\\": \\"hello-modules/local-module\\",

--- a/test/typescript/modules/test.ts
+++ b/test/typescript/modules/test.ts
@@ -8,7 +8,7 @@ import { TestDriver } from "../../test-helper";
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
-const onWindows = process.platform === 'win32' ? it.skip : it.skip
+const onWindows = process.platform === 'win32' ? it : it.skip
 const onPosix = process.platform !== 'win32' ? it : it.skip
 
 describe("full integration test", () => {


### PR DESCRIPTION
It skipped in both cases, but shouldn't.