### PR TITLE
fix: fix github workflow for releasing cdktf go package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,7 @@ jobs:
         run: npx -p jsii-release jsii-release-golang
         env:
           GITHUB_TOKEN: ${{ secrets.TERRAFORM_CDK_GO_REPO_GITHUB_TOKEN }}
+          GIT_USER_NAME: "CDK for Terraform Team"
 
   release_homebrew:
     name: Release to Homebrew

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -120,3 +120,4 @@ jobs:
         run: npx -p jsii-release jsii-release-golang
         env:
           GITHUB_TOKEN: ${{ secrets.TERRAFORM_CDK_GO_REPO_GITHUB_TOKEN }}
+          GIT_USER_NAME: "CDK for Terraform Team"


### PR DESCRIPTION
Related Workflow failure: https://github.com/hashicorp/terraform-cdk/runs/2685171282?check_suite_focus=true