### PR TITLE
fix(cli): dont error on init when log has been written

### DIFF
--- a/packages/cdktf-cli/bin/cmds/init.ts
+++ b/packages/cdktf-cli/bin/cmds/init.ts
@@ -12,7 +12,7 @@ import { terraformCheck } from './terraform-check';
 import { displayVersionMessage } from './version-check'
 import { FUTURE_FLAGS } from 'cdktf/lib/features';
 import { downloadFile, HttpError } from '../../lib/util';
-import { logger } from '../../lib/logging';
+import { logFileName, logger } from '../../lib/logging';
 
 const chalkColour = new chalk.Instance();
 
@@ -44,7 +44,7 @@ class Command implements yargs.CommandModule {
     await terraformCheck()
     await displayVersionMessage()
 
-    if (fs.readdirSync('.').filter(f => !f.startsWith('.')).length > 0) {
+    if (fs.readdirSync('.').filter(f => !f.startsWith('.') && f !== logFileName).length > 0) {
       console.error(chalkColour`{redBright ERROR: Cannot initialize a project in a non-empty directory}`);
       process.exit(1);
     }

--- a/packages/cdktf-cli/lib/logging.ts
+++ b/packages/cdktf-cli/lib/logging.ts
@@ -4,9 +4,10 @@ const logger = getLogger();
 
 logger.level = process.env.CDKTF_LOG_LEVEL || 'INFO';
 
+const logFileName = "cdktf.log";
 if (process.env.CDKTF_DISABLE_LOGGING === 'false') {
   configure({
-    appenders: { cdktf: { type: "file", filename: "./cdktf.log" } },
+    appenders: { cdktf: { type: "file", filename: "./" + logFileName } },
     categories: { default: { appenders: ["cdktf"], level: "debug" } }
   });
 }
@@ -18,5 +19,6 @@ const processLogger = (chunk: Buffer | string | Uint8Array) => {
 export {
   logger,
   getLogger,
-  processLogger
+  processLogger,
+  logFileName
 }


### PR DESCRIPTION
I have the `CDKTF_DISABLE_LOGGING=false` set, so every `cdktf init` fails because the first log line is written before the init command checks if the directory is empty