### PR TITLE
fix(cli): Make sure output parses only relevant parts 

### DIFF
--- a/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
@@ -62,7 +62,7 @@ const parseOutput = (str: string): DeployingResource[] => {
         applyState = DeployingResourceApplyState.DESTROYED
         break;
       default:
-        applyState = DeployingResourceApplyState.WAITING
+        return
     }
 
     if (resourceMatch && resourceMatch.length >= 0 && resourceMatch[1] != "Warning") {

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -1,7 +1,7 @@
 // set a generous global timeout for beforeAll hooks as jest does run the tests anyway even
 // if the hook timeout out. This produces weird errors that are hard to trace down
 // for reference: https://github.com/facebook/jest/issues/9527
-const DEFAULT_TIMEOUT = 300000;
+const DEFAULT_TIMEOUT = 500000;
 let originalBeforeAll = global.beforeAll;
 global.beforeAll = function beforeAllWithDefaultTimeout(setup, timeout = DEFAULT_TIMEOUT) {
     return originalBeforeAll(setup, timeout);


### PR DESCRIPTION
I think this should have been the default case in the first place. This
surfaced due to output changes in 0.15.4 - similar to this #739 but now
for cdktf destroy.

In general I think we'll switch the entire output processing over
to this https://www.terraform.io/docs/internals/machine-readable-ui.html

Here's an example of the `terraform destroy` output with `0.15.4` - so there are lots of false positive matches for the resource regex. With the change in this PR, these false positives aren't actually processed anymore:

<details>

```
aws_iam_role.lambda-exec: Refreshing state... [id=learn-cdktf-lambda-hello-world]
aws_s3_bucket.bucket: Refreshing state... [id=learn-cdktf-lambda-hello-world20210604185509492100000001]
aws_iam_role_policy_attachment.lambda-managed-policy: Refreshing state... [id=learn-cdktf-lambda-hello-world-20210604185512028400000002]
aws_s3_bucket_object.lambda-archive: Refreshing state... [id=v0.0.2/archive.zip]
aws_lambda_function.learn-cdktf-lambda: Refreshing state... [id=learn-cdktf-lambda-hello-world]
aws_apigatewayv2_api.api-gw: Refreshing state... [id=gefjfspov9]
aws_lambda_permission.apigw-lambda: Refreshing state... [id=terraform-20210604185538182500000003]

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # aws_lambda_function.learn-cdktf-lambda has been changed
  ~ resource "aws_lambda_function" "learn-cdktf-lambda" {
        id                             = "learn-cdktf-lambda-hello-world"
      ~ last_modified                  = "2021-06-04T18:55:25.634+0000" -> "2021-06-04T18:55:39.011+0000"
      + layers                         = []
      + tags                           = {}
        # (18 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }
  # aws_s3_bucket.bucket has been changed
  ~ resource "aws_s3_bucket" "bucket" {
        id                          = "learn-cdktf-lambda-hello-world20210604185509492100000001"
      + tags                        = {}
        # (11 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }
  # aws_s3_bucket_object.lambda-archive has been changed
  ~ resource "aws_s3_bucket_object" "lambda-archive" {
        id                 = "v0.0.2/archive.zip"
      + metadata           = {}
      + tags               = {}
        # (10 unchanged attributes hidden)
    }
  # aws_apigatewayv2_api.api-gw has been changed
  ~ resource "aws_apigatewayv2_api" "api-gw" {
        id                           = "gefjfspov9"
        name                         = "lambda-hello-world"
      + tags                         = {}
        # (9 unchanged attributes hidden)
    }
  # aws_iam_role.lambda-exec has been changed
  ~ resource "aws_iam_role" "lambda-exec" {
        id                    = "learn-cdktf-lambda-hello-world"
      ~ managed_policy_arns   = [
          + "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
        ]
        name                  = "learn-cdktf-lambda-hello-world"
      + tags                  = {}
        # (8 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to undo or respond to these changes.

───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # aws_apigatewayv2_api.api-gw will be destroyed
  - resource "aws_apigatewayv2_api" "api-gw" {
      - api_endpoint                 = "https://gefjfspov9.execute-api.us-west-2.amazonaws.com" -> null
      - api_key_selection_expression = "$request.header.x-api-key" -> null
      - arn                          = "arn:aws:apigateway:us-west-2::/apis/gefjfspov9" -> null
      - disable_execute_api_endpoint = false -> null
      - execution_arn                = "arn:aws:execute-api:us-west-2:732198772205:gefjfspov9" -> null
      - id                           = "gefjfspov9" -> null
      - name                         = "lambda-hello-world" -> null
      - protocol_type                = "HTTP" -> null
      - route_selection_expression   = "$request.method $request.path" -> null
      - tags                         = {} -> null
      - tags_all                     = {} -> null
      - target                       = "arn:aws:lambda:us-west-2:732198772205:function:learn-cdktf-lambda-hello-world" -> null
    }

  # aws_iam_role.lambda-exec will be destroyed
  - resource "aws_iam_role" "lambda-exec" {
      - arn                   = "arn:aws:iam::732198772205:role/learn-cdktf-lambda-hello-world" -> null
      - assume_role_policy    = jsonencode(
            {
              - Statement = [
                  - {
                      - Action    = "sts:AssumeRole"
                      - Effect    = "Allow"
                      - Principal = {
                          - Service = "lambda.amazonaws.com"
                        }
                      - Sid       = ""
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
      - create_date           = "2021-06-04T18:55:10Z" -> null
      - force_detach_policies = false -> null
      - id                    = "learn-cdktf-lambda-hello-world" -> null
      - managed_policy_arns   = [
          - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
        ] -> null
      - max_session_duration  = 3600 -> null
      - name                  = "learn-cdktf-lambda-hello-world" -> null
      - path                  = "/" -> null
      - tags                  = {} -> null
      - tags_all              = {} -> null
      - unique_id             = "AROA2U6TSTXW34URXWSWD" -> null

      - inline_policy {}
    }

  # aws_iam_role_policy_attachment.lambda-managed-policy will be destroyed
  - resource "aws_iam_role_policy_attachment" "lambda-managed-policy" {
      - id         = "learn-cdktf-lambda-hello-world-20210604185512028400000002" -> null
      - policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole" -> null
      - role       = "learn-cdktf-lambda-hello-world" -> null
    }

  # aws_lambda_function.learn-cdktf-lambda will be destroyed
  - resource "aws_lambda_function" "learn-cdktf-lambda" {
      - arn                            = "arn:aws:lambda:us-west-2:732198772205:function:learn-cdktf-lambda-hello-world" -> null
      - function_name                  = "learn-cdktf-lambda-hello-world" -> null
      - handler                        = "index.handler" -> null
      - id                             = "learn-cdktf-lambda-hello-world" -> null
      - invoke_arn                     = "arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:732198772205:function:learn-cdktf-lambda-hello-world/invocations" -> null
      - last_modified                  = "2021-06-04T18:55:39.011+0000" -> null
      - layers                         = [] -> null
      - memory_size                    = 128 -> null
      - package_type                   = "Zip" -> null
      - publish                        = false -> null
      - qualified_arn                  = "arn:aws:lambda:us-west-2:732198772205:function:learn-cdktf-lambda-hello-world:$LATEST" -> null
      - reserved_concurrent_executions = -1 -> null
      - role                           = "arn:aws:iam::732198772205:role/learn-cdktf-lambda-hello-world" -> null
      - runtime                        = "nodejs10.x" -> null
      - s3_bucket                      = "learn-cdktf-lambda-hello-world20210604185509492100000001" -> null
      - s3_key                         = "v0.0.2/archive.zip" -> null
      - source_code_hash               = "3c7zhbXob5fqCHnKyL9MPF9qaO6ol4BInZYQ8YY1hM0=" -> null
      - source_code_size               = 1587 -> null
      - tags                           = {} -> null
      - tags_all                       = {} -> null
      - timeout                        = 3 -> null
      - version                        = "$LATEST" -> null

      - tracing_config {
          - mode = "PassThrough" -> null
        }
    }

  # aws_lambda_permission.apigw-lambda will be destroyed
  - resource "aws_lambda_permission" "apigw-lambda" {
      - action        = "lambda:InvokeFunction" -> null
      - function_name = "learn-cdktf-lambda-hello-world" -> null
      - id            = "terraform-20210604185538182500000003" -> null
      - principal     = "apigateway.amazonaws.com" -> null
      - source_arn    = "arn:aws:execute-api:us-west-2:732198772205:gefjfspov9/*/*" -> null
      - statement_id  = "terraform-20210604185538182500000003" -> null
    }

  # aws_s3_bucket.bucket will be destroyed
  - resource "aws_s3_bucket" "bucket" {
      - acl                         = "private" -> null
      - arn                         = "arn:aws:s3:::learn-cdktf-lambda-hello-world20210604185509492100000001" -> null
      - bucket                      = "learn-cdktf-lambda-hello-world20210604185509492100000001" -> null
      - bucket_domain_name          = "learn-cdktf-lambda-hello-world20210604185509492100000001.s3.amazonaws.com" -> null
      - bucket_prefix               = "learn-cdktf-lambda-hello-world" -> null
      - bucket_regional_domain_name = "learn-cdktf-lambda-hello-world20210604185509492100000001.s3.us-west-2.amazonaws.com" -> null
      - force_destroy               = false -> null
      - hosted_zone_id              = "Z3BJ6K6RIION7M" -> null
      - id                          = "learn-cdktf-lambda-hello-world20210604185509492100000001" -> null
      - region                      = "us-west-2" -> null
      - request_payer               = "BucketOwner" -> null
      - tags                        = {} -> null
      - tags_all                    = {} -> null

      - versioning {
          - enabled    = false -> null
          - mfa_delete = false -> null
        }
    }

  # aws_s3_bucket_object.lambda-archive will be destroyed
  - resource "aws_s3_bucket_object" "lambda-archive" {
      - acl                = "private" -> null
      - bucket             = "learn-cdktf-lambda-hello-world20210604185509492100000001" -> null
      - bucket_key_enabled = false -> null
      - content_type       = "binary/octet-stream" -> null
      - etag               = "9cde18011592de0680af74f4a164cda7" -> null
      - force_destroy      = false -> null
      - id                 = "v0.0.2/archive.zip" -> null
      - key                = "v0.0.2/archive.zip" -> null
      - metadata           = {} -> null
      - source             = "assets/lambda-asset/archive.zip" -> null
      - storage_class      = "STANDARD" -> null
      - tags               = {} -> null
      - tags_all           = {} -> null
    }

Plan: 0 to add, 0 to change, 7 to destroy.

Changes to Outputs:
  - url = "https://gefjfspov9.execute-api.us-west-2.amazonaws.com" -> null
aws_iam_role_policy_attachment.lambda-managed-policy: Destroying... [id=learn-cdktf-lambda-hello-world-20210604185512028400000002]
aws_lambda_permission.apigw-lambda: Destroying... [id=terraform-20210604185538182500000003]
aws_iam_role_policy_attachment.lambda-managed-policy: Destruction complete after 0s
aws_lambda_permission.apigw-lambda: Destruction complete after 6s
aws_apigatewayv2_api.api-gw: Destroying... [id=gefjfspov9]
aws_apigatewayv2_api.api-gw: Destruction complete after 4s
aws_lambda_function.learn-cdktf-lambda: Destroying... [id=learn-cdktf-lambda-hello-world]
aws_lambda_function.learn-cdktf-lambda: Destruction complete after 1s
aws_s3_bucket_object.lambda-archive: Destroying... [id=v0.0.2/archive.zip]
aws_iam_role.lambda-exec: Destroying... [id=learn-cdktf-lambda-hello-world]
aws_s3_bucket_object.lambda-archive: Destruction complete after 1s
aws_s3_bucket.bucket: Destroying... [id=learn-cdktf-lambda-hello-world20210604185509492100000001]
aws_s3_bucket.bucket: Destruction complete after 1s
aws_iam_role.lambda-exec: Destruction complete after 2s

Destroy complete! Resources: 7 destroyed.
```

</details>