### PR TITLE
fix(release): Release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.4.1 (June 7, 2021)
+
+**Fixed Bugs**
+
+- Fix `cdktf destroy` - Make sure output parses only relevant parts [\#761](https://github.com/hashicorp/terraform-cdk/pull/761)
+- Dont error on init when log has been written [\#759](https://github.com/hashicorp/terraform-cdk/pull/759)
+
 ## 0.4.0 (May 27, 2021)
 
 **Implemented enhancements**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "scripts": {
     "build": "lerna run --scope cdktf* --scope @cdktf/* build",


### PR DESCRIPTION
## 0.4.1 (June 7, 2021)

**Fixed Bugs**

- Fix `cdktf destroy` - Make sure output parses only relevant parts [\#761](https://github.com/hashicorp/terraform-cdk/pull/761)
- Dont error on init when log has been written [\#759](https://github.com/hashicorp/terraform-cdk/pull/759)