### PR TITLE
chore(docs): - Add azure python example on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Choose a language:
 
 * [aws](./examples/python/aws)
 * [aws-eks](./examples/python/aws-eks)
+* [azure](./examples/python/azure)
 * [docker](./examples/python/docker)
 * [kubernetes](./examples/python/kubernetes)
 


### PR DESCRIPTION
There was a missing link of azure example in python on the README.md file. So, this pull request is to add that missing link into the file.