### PR TITLE
chore(cli): lint tsx files and clean up React Hooks code

### DIFF
--- a/BUGPROCESS.md
+++ b/BUGPROCESS.md
@@ -4,15 +4,15 @@ New issues are labeled with `new`. Bugs and feature requests filed by other engi
 
 ## [Bugs](https://github.com/hashicorp/terraform-cdk/issues?q=is%3Aissue+is%3Aopen+label%3Abug+label%3Anew)
 
-* Try to reproduce bugs. If they can readily be reproduced, label them `confirmed`. If they can't, ask for information and label them `needs-reproduction` and `waiting-on-answer`.
-* For bugs that seem serious and urgent, label them `priority/important-soon` or `priority/critical-urgent` if a key workflow is completely broken. Pull them into the current or next release. Self-assign if you plan to do them, or drop a comment in the team slack channel to coordinate who 
-* If it's not really a bug, try to explain to the user what to do, consider filing a documentation issue, and close the issue.
-* Remove the `new` label
+- Try to reproduce bugs. If they can readily be reproduced, label them `confirmed`. If they can't, ask for information and label them `needs-reproduction` and `waiting-on-answer`.
+- For bugs that seem serious and urgent, label them `priority/important-soon` or `priority/critical-urgent` if a key workflow is completely broken. Pull them into the current or next release. Self-assign if you plan to do them, or drop a comment in the team slack channel to coordinate who
+- If it's not really a bug, try to explain to the user what to do, consider filing a documentation issue, and close the issue.
+- Remove the `new` label
 
 ## [Enhancement requests](https://github.com/hashicorp/terraform-cdk/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement+label%3Anew+)
 
-* Categorize issues, e.g. `documentation`
-* Read and try to understand the request. If it's unclear what the user wants, or why, ask for clarification.
-* Remove the `new` label, and try to (subjectively) prioritize using the `priority/` labels. If it's not obvious, label it `needs-priority`.
+- Categorize issues, e.g. `documentation`
+- Read and try to understand the request. If it's unclear what the user wants, or why, ask for clarification.
+- Remove the `new` label, and try to (subjectively) prioritize using the `priority/` labels. If it's not obvious, label it `needs-priority`.
 
 If an issue requires discussion with the user to get it out of this initial state, leave "new" on there and label it `waiting-on-answer` until this phase of triage is done.

--- a/examples/typescript/google/cdktf.json
+++ b/examples/typescript/google/cdktf.json
@@ -2,6 +2,6 @@
   "language": "typescript",
   "app": "npm run --silent compile && node main.js",
   "terraformProviders": [
-    "google@~> 3.0"
+    "google@~> 3.74.0"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,6 @@
     "prettier": "^2.3.1"
   },
   "lint-staged": {
-    "*.{ts,js,css,md}": "prettier --write"
+    "*.{ts,tsx,js,css,md}": "prettier --write"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "examples:integration:java": "test/run-against-dist tools/build-examples-sequential.sh java",
     "examples:integration:csharp": "test/run-against-dist tools/build-examples.sh csharp",
     "examples:integration:python": "test/run-against-dist tools/build-examples.sh python",
-    "examples:integration:typescript": "test/run-against-dist tools/build-examples.sh typescript",
+    "examples:integration:typescript": "test/run-against-dist tools/build-examples-sequential.sh typescript",
     "examples:integration:go": "test/run-against-dist tools/build-examples-sequential.sh go",
     "pretest": "prettier --check .",
     "test": "lerna run --scope cdktf* --scope @cdktf* test",

--- a/packages/cdktf-cli/bin/cmds/ui/app.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/app.tsx
@@ -5,7 +5,7 @@ import { useTerraformState } from "./terraform-context";
 import { useApp } from "ink";
 
 interface TerraformErrorProps {
-  children: ReactNode
+  children: ReactNode;
 }
 
 export const TerraformErrors: React.FunctionComponent<TerraformErrorProps> = ({
@@ -24,7 +24,7 @@ export const TerraformErrors: React.FunctionComponent<TerraformErrorProps> = ({
 };
 
 interface AppProps {
-  children: ReactNode
+  children?: ReactNode;
 }
 export const App: React.FunctionComponent<AppProps> = ({
   children,

--- a/packages/cdktf-cli/bin/cmds/ui/app.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/app.tsx
@@ -1,12 +1,16 @@
 /* eslint-disable no-control-regex */
-import React from "react";
+import React, { ReactNode } from "react";
 import { TerraformProvider } from "./terraform-context";
 import { useTerraformState } from "./terraform-context";
 import { useApp } from "ink";
 
-export const TerraformErrors: React.FunctionComponent<{}> = ({
+interface TerraformErrorProps {
+  children: ReactNode
+}
+
+export const TerraformErrors: React.FunctionComponent<TerraformErrorProps> = ({
   children,
-}): React.ReactElement => {
+}: TerraformErrorProps): React.ReactElement => {
   const { errors } = useTerraformState();
   const { exit } = useApp();
 
@@ -19,10 +23,12 @@ export const TerraformErrors: React.FunctionComponent<{}> = ({
   return <>{children}</>;
 };
 
-// eslint-disable-next-line react/prop-types
-export const App: React.FunctionComponent<{}> = ({
+interface AppProps {
+  children: ReactNode
+}
+export const App: React.FunctionComponent<AppProps> = ({
   children,
-}): React.ReactElement => {
+}: AppProps): React.ReactElement => {
   return (
     <TerraformProvider>
       <TerraformErrors>{children}</TerraformErrors>

--- a/packages/cdktf-cli/bin/cmds/ui/components/resource-name.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/components/resource-name.tsx
@@ -9,6 +9,7 @@ export interface ResourceNameConfig {
 export const ResourceName = ({ name, stackName }: ResourceNameConfig) => {
   const prettyName = name.replace(/(_[A-F\d]{8})$/, "");
 
+  // eslint-disable-next-line prefer-const
   let [resource, resourceName] = prettyName.split(".");
   if (stackName != null && resourceName.startsWith(stackName)) {
     const [, ...path] = resourceName.split("_");

--- a/packages/cdktf-cli/bin/cmds/ui/deploy.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/deploy.tsx
@@ -9,7 +9,7 @@ import {
   TerraformOutput,
   PlannedResourceAction,
 } from "./models/terraform";
-import { useTerraform, Status, useTerraformState } from "./terraform-context";
+import { Status, useTerraformState, useRunDeploy } from "./terraform-context";
 import { Plan } from "./diff";
 
 interface DeploySummaryConfig {
@@ -182,17 +182,16 @@ export const Deploy = ({
   synthCommand,
   autoApprove,
 }: DeployConfig): React.ReactElement => {
-  const { deploy } = useTerraform({
+  const {
+    state: { status, currentStack, errors, plan },
+    confirmation,
+    isConfirmed,
+  } = useRunDeploy({
     targetDir,
     targetStack,
     synthCommand,
     autoApprove,
   });
-  const {
-    state: { status, currentStack, errors, plan },
-    confirmation,
-    isConfirmed,
-  } = deploy();
 
   const planStages = [
     Status.INITIALIZING,

--- a/packages/cdktf-cli/bin/cmds/ui/destroy.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/destroy.tsx
@@ -5,7 +5,7 @@ import Spinner from "ink-spinner";
 import ConfirmInput from "@skorfmann/ink-confirm-input";
 import { DeployingElement } from "./components";
 import { DeployingResource, PlannedResourceAction } from "./models/terraform";
-import { useTerraform, Status, useTerraformState } from "./terraform-context";
+import { Status, useTerraformState, useRunDestroy } from "./terraform-context";
 import { Plan } from "./diff";
 
 interface DeploySummaryConfig {
@@ -127,17 +127,16 @@ export const Destroy = ({
   synthCommand,
   autoApprove,
 }: DestroyConfig): React.ReactElement => {
-  const { destroy } = useTerraform({
+  const {
+    state: { status, currentStack, errors, plan },
+    confirmation,
+    isConfirmed,
+  } = useRunDestroy({
     targetDir,
     targetStack,
     synthCommand,
     autoApprove,
   });
-  const {
-    state: { status, currentStack, errors, plan },
-    confirmation,
-    isConfirmed,
-  } = destroy();
 
   const planStages = [
     Status.INITIALIZING,

--- a/packages/cdktf-cli/bin/cmds/ui/diff.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/diff.tsx
@@ -3,7 +3,7 @@ import { Text, Box, Static } from "ink";
 import Spinner from "ink-spinner";
 import { PlannedResource } from "./models/terraform";
 import { PlanElement } from "./components";
-import { useTerraform, Status, useTerraformState } from "./terraform-context";
+import { Status, useTerraformState, useRunDiff } from "./terraform-context";
 
 interface DiffConfig {
   targetDir: string;
@@ -95,14 +95,12 @@ export const Diff = ({
   targetStack,
   synthCommand,
 }: DiffConfig): React.ReactElement => {
-  const { plan } = useTerraform({
+  const { status, currentStack, errors } = useRunDiff({
     targetDir,
     targetStack,
     synthCommand,
     isSpeculative: true,
   });
-
-  const { status, currentStack, errors } = plan();
 
   const isPlanning: boolean = status != Status.PLANNED;
   const statusText =

--- a/packages/cdktf-cli/bin/cmds/ui/get.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/get.tsx
@@ -59,7 +59,8 @@ export const Get = ({
       }
     };
     get();
-  }, []); // only once
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // only once, we don't expect props to change
 
   const isGenerating: boolean = currentStatus != Status.DONE;
   const statusText = `${currentStatus}...`;

--- a/packages/cdktf-cli/bin/cmds/ui/list.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/list.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from "react";
 import { Text, Box } from "ink";
 import Spinner from "ink-spinner";
-import { useTerraform, Status } from "./terraform-context";
+import { useRunSynth, Status } from "./terraform-context";
 
 interface ListConfig {
   targetDir: string;
@@ -12,8 +12,7 @@ export const List = ({
   targetDir,
   synthCommand,
 }: ListConfig): React.ReactElement => {
-  const { synth } = useTerraform({ targetDir, synthCommand });
-  const { status, errors, stacks } = synth();
+  const { status, errors, stacks } = useRunSynth({ targetDir, synthCommand });
 
   const isSynthesizing: boolean = status != Status.SYNTHESIZED;
   const statusText = `${status}...`;

--- a/packages/cdktf-cli/bin/cmds/ui/synth.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/synth.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from "react";
 import { Text, Box } from "ink";
 import Spinner from "ink-spinner";
-import { useTerraform, Status, useTerraformState } from "./terraform-context";
+import { useRunSynth, Status, useTerraformState } from "./terraform-context";
 
 interface CommonSynthConfig {
   targetDir: string;
@@ -42,8 +42,11 @@ export const Synth = ({
   synthCommand,
   jsonOutput,
 }: SynthConfig): React.ReactElement => {
-  const { synth } = useTerraform({ targetDir, targetStack, synthCommand });
-  const { status, currentStack, errors } = synth();
+  const { status, currentStack, errors } = useRunSynth({
+    targetDir,
+    targetStack,
+    synthCommand,
+  });
 
   const isSynthesizing: boolean = status != Status.SYNTHESIZED;
   const statusText =

--- a/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-control-regex */
-import React from "react";
+import React, { ReactNode } from "react";
 import { TerraformCli } from "./models/terraform-cli";
 import { TerraformCloud, TerraformCloudPlan } from "./models/terraform-cloud";
 import {
@@ -24,8 +24,8 @@ type DefaultValue = undefined;
 type ContextValue = DefaultValue | DeployState;
 
 const TerraformContextState = React.createContext<ContextValue>(undefined);
-// eslint-disable-next-line @typescript-eslint/no-empty-function
 const TerraformContextDispatch = React.createContext(
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   (() => {}) as React.Dispatch<Action>
 );
 
@@ -290,11 +290,12 @@ function deployReducer(state: DeployState, action: Action): DeployState {
 
 interface TerraformProviderConfig {
   initialState?: DeployState;
+  children: ReactNode;
 }
 
 // eslint-disable-next-line react/prop-types
 export const TerraformProvider: React.FunctionComponent<TerraformProviderConfig> =
-  ({ children, initialState }): React.ReactElement => {
+  ({ children, initialState }: TerraformProviderConfig): React.ReactElement => {
     const initialCurrentStack: SynthesizedStack = {
       constructPath: "",
       content: "",
@@ -515,13 +516,10 @@ export const useTerraform = ({
   };
 
   const synth = () => {
-    React.useEffect(() => {
-      const invoke = async () => {
-        await execTerraformSynth(false);
-      };
-
-      invoke();
-    }, []);
+    const invoke = async () => {
+      await execTerraformSynth(false);
+    };
+    invoke();
 
     return state;
   };

--- a/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
@@ -544,23 +544,23 @@ export const useTerraform = ({
   };
 };
 
-const useRunOnce = <Fn extends (...args: any) => any>(
+const useRunOnce = <Fn extends (...args: any[]) => any>(
   fn: Fn,
   ...args: Parameters<Fn>
 ) => {
   React.useEffect(() => {
-    fn(args);
+    fn(...args);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // only run once on mount – ignore any changes to fn
 };
 
-const useRunIf = <Fn extends (...args: any) => any>(
+const useRunIf = <Fn extends (...args: any[]) => any>(
   condition: boolean,
   fn: Fn,
   ...args: Parameters<Fn>
 ) => {
   React.useEffect(() => {
-    if (condition) fn(args);
+    if (condition) fn(...args);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [condition]); // only run if condition changes
 };

--- a/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
@@ -544,7 +544,7 @@ export const useTerraform = ({
   };
 };
 
-const useRunOnce = <Fn extends (...args: any[]) => any>(
+const useRunOnce = <T, TR, Fn extends (...args: T[]) => TR>(
   fn: Fn,
   ...args: Parameters<Fn>
 ) => {

--- a/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
@@ -544,7 +544,7 @@ export const useTerraform = ({
   };
 };
 
-const useRunOnce = <T, TR, Fn extends (...args: T[]) => TR>(
+const useRunOnce = <Fn extends (...args: any[]) => any>(
   fn: Fn,
   ...args: Parameters<Fn>
 ) => {
@@ -554,7 +554,7 @@ const useRunOnce = <T, TR, Fn extends (...args: T[]) => TR>(
   }, []); // only run once on mount – ignore any changes to fn
 };
 
-const useRunIf = <Fn extends (...args: any[]) => any>(
+const useRunWhen = <Fn extends (...args: any[]) => any>(
   condition: boolean,
   fn: Fn,
   ...args: Parameters<Fn>
@@ -581,7 +581,7 @@ export const useRunInit = (options: UseRunInitOptions) => {
   const state = useTerraformState();
 
   useRunOnce(synth);
-  useRunIf(state.status === Status.SYNTHESIZED, init);
+  useRunWhen(state.status === Status.SYNTHESIZED, init);
 
   return state;
 };
@@ -592,18 +592,10 @@ export const useRunDiff = (options: UseRunDiffOptions) => {
   const state = useTerraformState();
 
   useRunOnce(synth);
-  useRunIf(state.status === Status.SYNTHESIZED, async () => {
+  useRunWhen(state.status === Status.SYNTHESIZED, async () => {
     await init();
     await diff();
   });
-  // TODO: check: old effect had reference to [terraform] aswell
-  // React.useEffect(() => {
-  //   const invoke = async () => {
-  //     await execTerraformInit();
-  //     await execTerraformPlan();
-  //   };
-  //   if (state.status === Status.SYNTHESIZED) invoke();
-  // }, [state.status, terraform]);
 
   return state;
 };
@@ -620,11 +612,11 @@ export const useRunDeploy = ({
   const [confirmed, confirmationCallback] = useConfirmation({ autoApprove });
 
   useRunOnce(synth);
-  useRunIf(state.status === Status.SYNTHESIZED, async () => {
+  useRunWhen(state.status === Status.SYNTHESIZED, async () => {
     await init();
     await diff();
   });
-  useRunIf(confirmed && state.status === Status.PLANNED, async () => {
+  useRunWhen(confirmed && state.status === Status.PLANNED, async () => {
     await deploy();
     await output();
   });
@@ -648,11 +640,11 @@ export const useRunDestroy = ({
   const [confirmed, confirmationCallback] = useConfirmation({ autoApprove });
 
   useRunOnce(synth);
-  useRunIf(state.status === Status.SYNTHESIZED, async () => {
+  useRunWhen(state.status === Status.SYNTHESIZED, async () => {
     await init();
     await diff(true); // true = plan a destroy
   });
-  useRunIf(confirmed && state.status === Status.PLANNED, async () => {
+  useRunWhen(confirmed && state.status === Status.PLANNED, async () => {
     await destroy();
   });
 

--- a/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/terraform-context.tsx
@@ -450,7 +450,7 @@ export const useTerraform = ({
     try {
       if (!terraform)
         throw new Error(
-          "Terraform is not initialized yet. Please call synth() with loadExecutor: true first"
+          "Internal error: Terraform is not initialized yet. Please call synth() with loadExecutor: true first"
         );
       dispatch({ type: "INIT" });
       await terraform.init();

--- a/packages/cdktf-cli/package.json
+++ b/packages/cdktf-cli/package.json
@@ -9,8 +9,8 @@
     "build": "tsc",
     "watch": "tsc -w",
     "watch-preserve-output": "tsc -w --preserveWatchOutput",
-    "lint": "eslint . --ext .ts",
-    "lint:fix": "eslint . --ext .ts --fix",
+    "lint": "eslint . --ext .ts,.tsx",
+    "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "test": "yarn lint && jest",
     "jest-watch": "jest --watch",
     "package": "./package.sh",
@@ -60,10 +60,17 @@
     "plugins": [
       "@typescript-eslint"
     ],
+    "settings": {
+      "react": {
+        "version": "detect"
+      }
+    },
     "extends": [
       "eslint:recommended",
       "plugin:@typescript-eslint/eslint-recommended",
       "plugin:@typescript-eslint/recommended",
+      "plugin:react/recommended",
+      "plugin:react-hooks/recommended",
       "prettier"
     ],
     "rules": {
@@ -99,6 +106,7 @@
     "eslint": "^7.29.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-react": "^7.20.0",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "ink-testing-library": "^2.0.0",
     "jest": "^26.6.3",
     "nock": "^13.0.7",

--- a/packages/cdktf-cli/package.json
+++ b/packages/cdktf-cli/package.json
@@ -79,7 +79,9 @@
       "@typescript-eslint/no-use-before-define": 0,
       "@typescript-eslint/explicit-module-boundary-types": 0,
       "@typescript-eslint/no-var-requires": 0,
-      "no-sequences": "error"
+      "react/no-unescaped-entities": 0,
+      "no-sequences": "error",
+      "no-irregular-whitespace": ["error", { "skipTemplates": true }]
     },
     "ignorePatterns": [
       "node_modules",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3733,6 +3733,11 @@ eslint-config-prettier@^8.3.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
   integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
 
+eslint-plugin-react-hooks@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
+  integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
+
 eslint-plugin-react@^7.20.0:
   version "7.20.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.20.0.tgz#f98712f0a5e57dfd3e5542ef0604b8739cd47be3"


### PR DESCRIPTION
Noticed some code smells with React Hooks.  
E.g. `synth` function [being a hook](https://reactjs.org/docs/hooks-rules.html#only-call-hooks-from-react-functions), because it called an `useEffect` hook, but not prefixed with `use` ([docs](https://reactjs.org/docs/hooks-custom.html#extracting-a-custom-hook)).