### PR TITLE
fix(lib): Add in new optional AWS route attributes

### DIFF
--- a/packages/cdktf-cli/lib/get/generator/custom-defaults.ts
+++ b/packages/cdktf-cli/lib/get/generator/custom-defaults.ts
@@ -28,6 +28,7 @@ export const CUSTOM_DEFAULTS: { [fullName: string]: any } = {
   "aws.default_route_table.route.transit_gateway_id": null,
   "aws.default_route_table.route.vpc_endpoint_id": null,
   "aws.default_route_table.route.vpc_peering_connection_id": null,
+  "aws.default_route_table.route.destination_prefix_list_id": null,
 
   "aws.emr_cluster.step.action_on_failure": null,
   "aws.emr_cluster.step.hadoop_jar_step": null,
@@ -67,6 +68,8 @@ export const CUSTOM_DEFAULTS: { [fullName: string]: any } = {
   "aws.route_table.route.transit_gateway_id": null,
   "aws.route_table.route.vpc_endpoint_id": null,
   "aws.route_table.route.vpc_peering_connection_id": null,
+  "aws.route_table.route.destination_prefix_list_id": null,
+  "aws.route_table.route.carrier_gateway_id": null,
 
   "aws.default_security_group.ingress.cidr_blocks": null,
   "aws.default_security_group.ingress.description": null,


### PR DESCRIPTION
Fixes #813 

This just adds in the reported missing defaults.

Would be nice if Terraform were modified to either not work this way when using json or to provide the information in the json schema.