### PR TITLE
chore(lib): track overrides and backend types in stack

### DIFF
--- a/packages/cdktf-cli/bin/cmds/helper/synth-stack.ts
+++ b/packages/cdktf-cli/bin/cmds/helper/synth-stack.ts
@@ -98,7 +98,6 @@ Command output on stdout:
 
     // end performance timer
     const endTime = performance.now();
-    await this.synthTelemetry(command, endTime - startTime, synthOrigin);
 
     const stacks: SynthesizedStack[] = [];
     const manifest = JSON.parse(
@@ -117,6 +116,13 @@ Command output on stdout:
         content: JSON.stringify(jsonContent, null, 2),
       });
     }
+
+    await this.synthTelemetry(
+      command,
+      endTime - startTime,
+      stacks,
+      synthOrigin
+    );
 
     if (stacks.length === 0) {
       console.error("ERROR: No Terraform code synthesized.");
@@ -137,12 +143,16 @@ Command output on stdout:
   public static async synthTelemetry(
     command: string,
     totalTime: number,
+    stacks: SynthesizedStack[],
     synthOrigin?: SynthOrigin
   ): Promise<void> {
     await sendTelemetry("synth", {
       command: command,
       totalTime: totalTime,
       synthOrigin,
+      stackMetadata: stacks.map(
+        (stack) => JSON.parse(stack.content)["//"].metadata
+      ),
     });
   }
 

--- a/packages/cdktf/lib/terraform-backend.ts
+++ b/packages/cdktf/lib/terraform-backend.ts
@@ -31,6 +31,9 @@ export abstract class TerraformBackend extends TerraformElement {
   public toMetadata(): any {
     return {
       backend: this.name,
+      ...(Object.keys(this.rawOverrides)
+        ? { overrides: { backend: this.rawOverrides } }
+        : {}),
     };
   }
 }

--- a/packages/cdktf/lib/terraform-backend.ts
+++ b/packages/cdktf/lib/terraform-backend.ts
@@ -27,4 +27,10 @@ export abstract class TerraformBackend extends TerraformElement {
       },
     };
   }
+
+  public toMetadata(): any {
+    return {
+      backendType: this.name,
+    };
+  }
 }

--- a/packages/cdktf/lib/terraform-backend.ts
+++ b/packages/cdktf/lib/terraform-backend.ts
@@ -30,7 +30,7 @@ export abstract class TerraformBackend extends TerraformElement {
 
   public toMetadata(): any {
     return {
-      backendType: this.name,
+      backend: this.name,
     };
   }
 }

--- a/packages/cdktf/lib/terraform-backend.ts
+++ b/packages/cdktf/lib/terraform-backend.ts
@@ -32,7 +32,7 @@ export abstract class TerraformBackend extends TerraformElement {
     return {
       backend: this.name,
       ...(Object.keys(this.rawOverrides)
-        ? { overrides: { backend: this.rawOverrides } }
+        ? { overrides: { backend: Object.keys(this.rawOverrides) } }
         : {}),
     };
   }

--- a/packages/cdktf/lib/terraform-backend.ts
+++ b/packages/cdktf/lib/terraform-backend.ts
@@ -31,7 +31,7 @@ export abstract class TerraformBackend extends TerraformElement {
   public toMetadata(): any {
     return {
       backend: this.name,
-      ...(Object.keys(this.rawOverrides)
+      ...(Object.keys(this.rawOverrides).length > 0
         ? { overrides: { backend: Object.keys(this.rawOverrides) } }
         : {}),
     };

--- a/packages/cdktf/lib/terraform-data-source.ts
+++ b/packages/cdktf/lib/terraform-data-source.ts
@@ -96,6 +96,17 @@ export class TerraformDataSource
       },
     };
   }
+  public toMetadata(): any {
+    if (!Object.keys(this.rawOverrides).length) {
+      return {};
+    }
+
+    return {
+      overrides: {
+        [this.terraformResourceType]: Object.keys(this.rawOverrides),
+      },
+    };
+  }
 
   public interpolationForAttribute(terraformAttribute: string) {
     return `\${data.${this.terraformResourceType}.${this.friendlyUniqueId}.${terraformAttribute}}`;

--- a/packages/cdktf/lib/terraform-element.ts
+++ b/packages/cdktf/lib/terraform-element.ts
@@ -31,6 +31,10 @@ export class TerraformElement extends Construct {
     return {};
   }
 
+  public toMetadata(): any {
+    return {};
+  }
+
   public get friendlyUniqueId() {
     if (this._logicalIdOverride) {
       return this._logicalIdOverride;

--- a/packages/cdktf/lib/terraform-local.ts
+++ b/packages/cdktf/lib/terraform-local.ts
@@ -46,4 +46,15 @@ export class TerraformLocal extends TerraformElement {
       },
     };
   }
+  public toMetadata(): any {
+    if (!Object.keys(this.rawOverrides).length) {
+      return {};
+    }
+
+    return {
+      overrides: {
+        local: Object.keys(this.rawOverrides),
+      },
+    };
+  }
 }

--- a/packages/cdktf/lib/terraform-module.ts
+++ b/packages/cdktf/lib/terraform-module.ts
@@ -95,4 +95,16 @@ export abstract class TerraformModule
       },
     };
   }
+
+  public toMetadata(): any {
+    if (!Object.keys(this.rawOverrides).length) {
+      return {};
+    }
+
+    return {
+      overrides: {
+        [`module.${this.source}`]: Object.keys(this.rawOverrides),
+      },
+    };
+  }
 }

--- a/packages/cdktf/lib/terraform-output.ts
+++ b/packages/cdktf/lib/terraform-output.ts
@@ -56,4 +56,15 @@ export class TerraformOutput extends TerraformElement {
       },
     };
   }
+  public toMetadata(): any {
+    if (!Object.keys(this.rawOverrides).length) {
+      return {};
+    }
+
+    return {
+      overrides: {
+        output: Object.keys(this.rawOverrides),
+      },
+    };
+  }
 }

--- a/packages/cdktf/lib/terraform-provider.ts
+++ b/packages/cdktf/lib/terraform-provider.ts
@@ -71,4 +71,15 @@ export abstract class TerraformProvider extends TerraformElement {
       },
     };
   }
+  public toMetadata(): any {
+    if (!Object.keys(this.rawOverrides).length) {
+      return {};
+    }
+
+    return {
+      overrides: {
+        [this.terraformResourceType]: Object.keys(this.rawOverrides),
+      },
+    };
+  }
 }

--- a/packages/cdktf/lib/terraform-remote-state.ts
+++ b/packages/cdktf/lib/terraform-remote-state.ts
@@ -71,4 +71,15 @@ export abstract class TerraformRemoteState extends TerraformElement {
       },
     };
   }
+  public toMetadata(): any {
+    if (!Object.keys(this.rawOverrides).length) {
+      return {};
+    }
+
+    return {
+      overrides: {
+        terraform_remote_state: Object.keys(this.rawOverrides),
+      },
+    };
+  }
 }

--- a/packages/cdktf/lib/terraform-resource.ts
+++ b/packages/cdktf/lib/terraform-resource.ts
@@ -127,6 +127,18 @@ export class TerraformResource
     };
   }
 
+  public toMetadata(): any {
+    if (!Object.keys(this.rawOverrides).length) {
+      return {};
+    }
+
+    return {
+      overrides: {
+        [this.terraformResourceType]: Object.keys(this.rawOverrides),
+      },
+    };
+  }
+
   public interpolationForAttribute(terraformAttribute: string) {
     return `\${${this.terraformResourceType}.${this.friendlyUniqueId}.${terraformAttribute}}`;
   }

--- a/packages/cdktf/lib/terraform-stack.ts
+++ b/packages/cdktf/lib/terraform-stack.ts
@@ -147,6 +147,9 @@ export class TerraformStack extends Construct {
       version: this.cdktfVersion,
       stackName: Node.of(this).id,
       backend: "local", // overwritten by backend implementations if used
+      ...(Object.keys(this.rawOverrides)
+        ? { overrides: { stack: this.rawOverrides } }
+        : {}),
     };
 
     const elements = terraformElements(this);

--- a/packages/cdktf/lib/terraform-stack.ts
+++ b/packages/cdktf/lib/terraform-stack.ts
@@ -17,7 +17,7 @@ const STACK_SYMBOL = Symbol.for("ckdtf/TerraformStack");
 export interface TerraformStackMetadata {
   readonly stackName: string;
   readonly version: string;
-  readonly backendType: string;
+  readonly backend: string;
 }
 
 export class TerraformStack extends Construct {
@@ -146,17 +146,10 @@ export class TerraformStack extends Construct {
     const metadata: TerraformStackMetadata = {
       version: this.cdktfVersion,
       stackName: Node.of(this).id,
-      backendType: "local", // overwritten by backend implementations if used
+      backend: "local", // overwritten by backend implementations if used
     };
 
     const elements = terraformElements(this);
-    const fragments = elements.map((e) => resolve(this, e.toTerraform()));
-
-    for (const fragment of fragments) {
-      deepMerge(tf, fragment);
-    }
-
-    deepMerge(tf, this.rawOverrides);
 
     const metadatas = elements.map((e) => resolve(this, e.toMetadata()));
     for (const meta of metadatas) {
@@ -164,6 +157,13 @@ export class TerraformStack extends Construct {
     }
 
     (tf as any)["//"] = { metadata };
+
+    const fragments = elements.map((e) => resolve(this, e.toTerraform()));
+    for (const fragment of fragments) {
+      deepMerge(tf, fragment);
+    }
+
+    deepMerge(tf, this.rawOverrides);
 
     return resolve(this, tf);
   }

--- a/packages/cdktf/lib/terraform-stack.ts
+++ b/packages/cdktf/lib/terraform-stack.ts
@@ -147,8 +147,8 @@ export class TerraformStack extends Construct {
       version: this.cdktfVersion,
       stackName: Node.of(this).id,
       backend: "local", // overwritten by backend implementations if used
-      ...(Object.keys(this.rawOverrides)
-        ? { overrides: { stack: this.rawOverrides } }
+      ...(Object.keys(this.rawOverrides).length > 0
+        ? { overrides: { stack: Object.keys(this.rawOverrides) } }
         : {}),
     };
 

--- a/packages/cdktf/test/__snapshots__/backend.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/backend.test.js.snap
@@ -6,7 +6,10 @@ exports[`artifactory backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"artifactory\\"
+      \\"backend\\": \\"artifactory\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"terraform\\": {
@@ -29,7 +32,10 @@ exports[`azurerm backend access key 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"azurerm\\"
+      \\"backend\\": \\"azurerm\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"terraform\\": {
@@ -51,7 +57,10 @@ exports[`azurerm backend cli/sp 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"azurerm\\"
+      \\"backend\\": \\"azurerm\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"terraform\\": {
@@ -77,7 +86,10 @@ exports[`azurerm backend msi 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"azurerm\\"
+      \\"backend\\": \\"azurerm\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"terraform\\": {
@@ -102,7 +114,10 @@ exports[`azurerm backend sas 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"azurerm\\"
+      \\"backend\\": \\"azurerm\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"terraform\\": {
@@ -124,7 +139,10 @@ exports[`consul backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"consul\\"
+      \\"backend\\": \\"consul\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"terraform\\": {
@@ -153,7 +171,10 @@ exports[`cos backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"cos\\"
+      \\"backend\\": \\"cos\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"terraform\\": {
@@ -179,7 +200,10 @@ exports[`etcd backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"etcd\\"
+      \\"backend\\": \\"etcd\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"terraform\\": {
@@ -201,7 +225,10 @@ exports[`etcdv3 backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"etcdv3\\"
+      \\"backend\\": \\"etcdv3\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"terraform\\": {
@@ -231,7 +258,10 @@ exports[`gcs backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"gcs\\"
+      \\"backend\\": \\"gcs\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"terraform\\": {
@@ -254,7 +284,10 @@ exports[`http backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"http\\"
+      \\"backend\\": \\"http\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"terraform\\": {
@@ -284,7 +317,13 @@ exports[`local backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {},
+        \\"backend\\": {
+          \\"workspace_dir\\": \\"local_workspace\\"
+        }
+      }
     }
   },
   \\"terraform\\": {
@@ -304,7 +343,10 @@ exports[`manta backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"manta\\"
+      \\"backend\\": \\"manta\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"terraform\\": {
@@ -330,7 +372,10 @@ exports[`oss backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"oss\\"
+      \\"backend\\": \\"oss\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"terraform\\": {
@@ -369,7 +414,10 @@ exports[`pg backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"pg\\"
+      \\"backend\\": \\"pg\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"terraform\\": {
@@ -390,7 +438,10 @@ exports[`remote backend multi ws 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"remote\\"
+      \\"backend\\": \\"remote\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"terraform\\": {
@@ -414,7 +465,10 @@ exports[`remote backend single ws 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"remote\\"
+      \\"backend\\": \\"remote\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"terraform\\": {
@@ -437,7 +491,10 @@ exports[`s3 backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"s3\\"
+      \\"backend\\": \\"s3\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"terraform\\": {
@@ -481,7 +538,10 @@ exports[`swift backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"swift\\"
+      \\"backend\\": \\"swift\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"terraform\\": {

--- a/packages/cdktf/test/__snapshots__/backend.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/backend.test.js.snap
@@ -5,7 +5,8 @@ exports[`artifactory backend 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"artifactory\\"
     }
   },
   \\"terraform\\": {
@@ -27,7 +28,8 @@ exports[`azurerm backend access key 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"azurerm\\"
     }
   },
   \\"terraform\\": {
@@ -48,7 +50,8 @@ exports[`azurerm backend cli/sp 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"azurerm\\"
     }
   },
   \\"terraform\\": {
@@ -73,7 +76,8 @@ exports[`azurerm backend msi 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"azurerm\\"
     }
   },
   \\"terraform\\": {
@@ -97,7 +101,8 @@ exports[`azurerm backend sas 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"azurerm\\"
     }
   },
   \\"terraform\\": {
@@ -118,7 +123,8 @@ exports[`consul backend 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"consul\\"
     }
   },
   \\"terraform\\": {
@@ -146,7 +152,8 @@ exports[`cos backend 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"cos\\"
     }
   },
   \\"terraform\\": {
@@ -171,7 +178,8 @@ exports[`etcd backend 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"etcd\\"
     }
   },
   \\"terraform\\": {
@@ -192,7 +200,8 @@ exports[`etcdv3 backend 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"etcdv3\\"
     }
   },
   \\"terraform\\": {
@@ -221,7 +230,8 @@ exports[`gcs backend 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"gcs\\"
     }
   },
   \\"terraform\\": {
@@ -243,7 +253,8 @@ exports[`http backend 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"http\\"
     }
   },
   \\"terraform\\": {
@@ -272,7 +283,8 @@ exports[`local backend 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"terraform\\": {
@@ -291,7 +303,8 @@ exports[`manta backend 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"manta\\"
     }
   },
   \\"terraform\\": {
@@ -316,7 +329,8 @@ exports[`oss backend 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"oss\\"
     }
   },
   \\"terraform\\": {
@@ -354,7 +368,8 @@ exports[`pg backend 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"pg\\"
     }
   },
   \\"terraform\\": {
@@ -374,7 +389,8 @@ exports[`remote backend multi ws 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"remote\\"
     }
   },
   \\"terraform\\": {
@@ -397,7 +413,8 @@ exports[`remote backend single ws 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"remote\\"
     }
   },
   \\"terraform\\": {
@@ -419,7 +436,8 @@ exports[`s3 backend 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"s3\\"
     }
   },
   \\"terraform\\": {
@@ -462,7 +480,8 @@ exports[`swift backend 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"swift\\"
     }
   },
   \\"terraform\\": {

--- a/packages/cdktf/test/__snapshots__/backend.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/backend.test.js.snap
@@ -286,9 +286,9 @@ exports[`local backend 1`] = `
       \\"stackName\\": \\"test\\",
       \\"backend\\": \\"local\\",
       \\"overrides\\": {
-        \\"backend\\": {
-          \\"workspace_dir\\": \\"local_workspace\\"
-        }
+        \\"backend\\": [
+          \\"workspace_dir\\"
+        ]
       }
     }
   },

--- a/packages/cdktf/test/__snapshots__/backend.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/backend.test.js.snap
@@ -6,10 +6,7 @@ exports[`artifactory backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"artifactory\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"artifactory\\"
     }
   },
   \\"terraform\\": {
@@ -32,10 +29,7 @@ exports[`azurerm backend access key 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"azurerm\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"azurerm\\"
     }
   },
   \\"terraform\\": {
@@ -57,10 +51,7 @@ exports[`azurerm backend cli/sp 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"azurerm\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"azurerm\\"
     }
   },
   \\"terraform\\": {
@@ -86,10 +77,7 @@ exports[`azurerm backend msi 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"azurerm\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"azurerm\\"
     }
   },
   \\"terraform\\": {
@@ -114,10 +102,7 @@ exports[`azurerm backend sas 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"azurerm\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"azurerm\\"
     }
   },
   \\"terraform\\": {
@@ -139,10 +124,7 @@ exports[`consul backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"consul\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"consul\\"
     }
   },
   \\"terraform\\": {
@@ -171,10 +153,7 @@ exports[`cos backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"cos\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"cos\\"
     }
   },
   \\"terraform\\": {
@@ -200,10 +179,7 @@ exports[`etcd backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"etcd\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"etcd\\"
     }
   },
   \\"terraform\\": {
@@ -225,10 +201,7 @@ exports[`etcdv3 backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"etcdv3\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"etcdv3\\"
     }
   },
   \\"terraform\\": {
@@ -258,10 +231,7 @@ exports[`gcs backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"gcs\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"gcs\\"
     }
   },
   \\"terraform\\": {
@@ -284,10 +254,7 @@ exports[`http backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"http\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"http\\"
     }
   },
   \\"terraform\\": {
@@ -319,7 +286,6 @@ exports[`local backend 1`] = `
       \\"stackName\\": \\"test\\",
       \\"backend\\": \\"local\\",
       \\"overrides\\": {
-        \\"stack\\": {},
         \\"backend\\": {
           \\"workspace_dir\\": \\"local_workspace\\"
         }
@@ -343,10 +309,7 @@ exports[`manta backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"manta\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"manta\\"
     }
   },
   \\"terraform\\": {
@@ -372,10 +335,7 @@ exports[`oss backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"oss\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"oss\\"
     }
   },
   \\"terraform\\": {
@@ -414,10 +374,7 @@ exports[`pg backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"pg\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"pg\\"
     }
   },
   \\"terraform\\": {
@@ -438,10 +395,7 @@ exports[`remote backend multi ws 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"remote\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"remote\\"
     }
   },
   \\"terraform\\": {
@@ -465,10 +419,7 @@ exports[`remote backend single ws 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"remote\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"remote\\"
     }
   },
   \\"terraform\\": {
@@ -491,10 +442,7 @@ exports[`s3 backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"s3\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"s3\\"
     }
   },
   \\"terraform\\": {
@@ -538,10 +486,7 @@ exports[`swift backend 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"swift\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"swift\\"
     }
   },
   \\"terraform\\": {

--- a/packages/cdktf/test/__snapshots__/data-source.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/data-source.test.js.snap
@@ -6,7 +6,10 @@ exports[`dependent data source 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"resource\\": {
@@ -46,7 +49,10 @@ exports[`minimal configuration 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"data\\": {
@@ -70,7 +76,10 @@ exports[`with boolean map 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test-data-source\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"data\\": {
@@ -107,7 +116,10 @@ exports[`with complex computed list 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test-data-source\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"data\\": {
@@ -144,7 +156,10 @@ exports[`with number map 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test-data-source\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"data\\": {
@@ -181,7 +196,10 @@ exports[`with string map 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test-data-source\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"data\\": {

--- a/packages/cdktf/test/__snapshots__/data-source.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/data-source.test.js.snap
@@ -5,7 +5,8 @@ exports[`dependent data source 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"resource\\": {
@@ -44,7 +45,8 @@ exports[`minimal configuration 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -67,7 +69,8 @@ exports[`with boolean map 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test-data-source\\"
+      \\"stackName\\": \\"test-data-source\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -103,7 +106,8 @@ exports[`with complex computed list 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test-data-source\\"
+      \\"stackName\\": \\"test-data-source\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -139,7 +143,8 @@ exports[`with number map 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test-data-source\\"
+      \\"stackName\\": \\"test-data-source\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -175,7 +180,8 @@ exports[`with string map 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test-data-source\\"
+      \\"stackName\\": \\"test-data-source\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {

--- a/packages/cdktf/test/__snapshots__/data-source.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/data-source.test.js.snap
@@ -6,10 +6,7 @@ exports[`dependent data source 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"resource\\": {
@@ -49,10 +46,7 @@ exports[`minimal configuration 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -76,10 +70,7 @@ exports[`with boolean map 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test-data-source\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -116,10 +107,7 @@ exports[`with complex computed list 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test-data-source\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -156,10 +144,7 @@ exports[`with number map 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test-data-source\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -196,10 +181,7 @@ exports[`with string map 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test-data-source\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {

--- a/packages/cdktf/test/__snapshots__/local.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/local.test.js.snap
@@ -6,7 +6,10 @@ exports[`function local 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"locals\\": {
@@ -21,7 +24,10 @@ exports[`local reference 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"locals\\": {
@@ -49,7 +55,10 @@ exports[`multiple locals 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"locals\\": {
@@ -65,7 +74,10 @@ exports[`object local 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"locals\\": {
@@ -83,7 +95,10 @@ exports[`string local 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"locals\\": {

--- a/packages/cdktf/test/__snapshots__/local.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/local.test.js.snap
@@ -5,7 +5,8 @@ exports[`function local 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"locals\\": {
@@ -19,7 +20,8 @@ exports[`local reference 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"locals\\": {
@@ -46,7 +48,8 @@ exports[`multiple locals 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"locals\\": {
@@ -61,7 +64,8 @@ exports[`object local 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"locals\\": {
@@ -78,7 +82,8 @@ exports[`string local 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"locals\\": {

--- a/packages/cdktf/test/__snapshots__/local.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/local.test.js.snap
@@ -6,10 +6,7 @@ exports[`function local 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"locals\\": {
@@ -24,10 +21,7 @@ exports[`local reference 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"locals\\": {
@@ -55,10 +49,7 @@ exports[`multiple locals 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"locals\\": {
@@ -74,10 +65,7 @@ exports[`object local 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"locals\\": {
@@ -95,10 +83,7 @@ exports[`string local 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"locals\\": {

--- a/packages/cdktf/test/__snapshots__/output.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/output.test.js.snap
@@ -5,7 +5,8 @@ exports[`boolean output 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"output\\": {
@@ -21,7 +22,8 @@ exports[`dependent output 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"resource\\": {
@@ -53,7 +55,8 @@ exports[`description output 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"output\\": {
@@ -70,7 +73,8 @@ exports[`list output 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"output\\": {
@@ -89,7 +93,8 @@ exports[`map output 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"output\\": {
@@ -107,7 +112,8 @@ exports[`number output 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"output\\": {
@@ -123,7 +129,8 @@ exports[`sensitive output 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"output\\": {
@@ -140,7 +147,8 @@ exports[`string output 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"output\\": {

--- a/packages/cdktf/test/__snapshots__/output.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/output.test.js.snap
@@ -6,7 +6,10 @@ exports[`boolean output 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"output\\": {
@@ -23,7 +26,10 @@ exports[`dependent output 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"resource\\": {
@@ -56,7 +62,10 @@ exports[`description output 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"output\\": {
@@ -74,7 +83,10 @@ exports[`list output 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"output\\": {
@@ -94,7 +106,10 @@ exports[`map output 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"output\\": {
@@ -113,7 +128,10 @@ exports[`number output 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"output\\": {
@@ -130,7 +148,10 @@ exports[`sensitive output 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"output\\": {
@@ -148,7 +169,10 @@ exports[`string output 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"output\\": {

--- a/packages/cdktf/test/__snapshots__/output.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/output.test.js.snap
@@ -6,10 +6,7 @@ exports[`boolean output 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"output\\": {
@@ -26,10 +23,7 @@ exports[`dependent output 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"resource\\": {
@@ -62,10 +56,7 @@ exports[`description output 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"output\\": {
@@ -83,10 +74,7 @@ exports[`list output 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"output\\": {
@@ -106,10 +94,7 @@ exports[`map output 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"output\\": {
@@ -128,10 +113,7 @@ exports[`number output 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"output\\": {
@@ -148,10 +130,7 @@ exports[`sensitive output 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"output\\": {
@@ -169,10 +148,7 @@ exports[`string output 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"output\\": {

--- a/packages/cdktf/test/__snapshots__/provider.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/provider.test.js.snap
@@ -6,7 +6,10 @@ exports[`minimal configuration 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"provider\\": {
@@ -25,7 +28,10 @@ exports[`with alias 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"provider\\": {
@@ -48,7 +54,10 @@ exports[`with generator metadata 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"terraform\\": {

--- a/packages/cdktf/test/__snapshots__/provider.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/provider.test.js.snap
@@ -5,7 +5,8 @@ exports[`minimal configuration 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"provider\\": {
@@ -23,7 +24,8 @@ exports[`with alias 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"provider\\": {
@@ -45,7 +47,8 @@ exports[`with generator metadata 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"terraform\\": {

--- a/packages/cdktf/test/__snapshots__/provider.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/provider.test.js.snap
@@ -6,10 +6,7 @@ exports[`minimal configuration 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"provider\\": {
@@ -28,10 +25,7 @@ exports[`with alias 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"provider\\": {
@@ -54,10 +48,7 @@ exports[`with generator metadata 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"terraform\\": {

--- a/packages/cdktf/test/__snapshots__/remote-state.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/remote-state.test.js.snap
@@ -6,7 +6,10 @@ exports[`artifactory 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"data\\": {
@@ -32,7 +35,10 @@ exports[`azurerm 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"data\\": {
@@ -61,7 +67,10 @@ exports[`consul 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"data\\": {
@@ -93,7 +102,10 @@ exports[`cos 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"data\\": {
@@ -122,7 +134,10 @@ exports[`etcd 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"data\\": {
@@ -147,7 +162,10 @@ exports[`etcdv3 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"data\\": {
@@ -180,7 +198,10 @@ exports[`gcs 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"data\\": {
@@ -206,7 +227,10 @@ exports[`http 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"data\\": {
@@ -239,7 +263,10 @@ exports[`local 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"data\\": {
@@ -262,7 +289,10 @@ exports[`manta 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"data\\": {
@@ -291,7 +321,10 @@ exports[`oss 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"data\\": {
@@ -333,7 +366,10 @@ exports[`pg 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"data\\": {
@@ -357,7 +393,10 @@ exports[`remote 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"data\\": {
@@ -383,7 +422,10 @@ exports[`s3 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"data\\": {
@@ -430,7 +472,10 @@ exports[`s3 reference 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"data\\": {
@@ -466,7 +511,10 @@ exports[`s3 with options 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"data\\": {
@@ -493,7 +541,10 @@ exports[`swift 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"data\\": {

--- a/packages/cdktf/test/__snapshots__/remote-state.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/remote-state.test.js.snap
@@ -5,7 +5,8 @@ exports[`artifactory 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -30,7 +31,8 @@ exports[`azurerm 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -58,7 +60,8 @@ exports[`consul 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -89,7 +92,8 @@ exports[`cos 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -117,7 +121,8 @@ exports[`etcd 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -141,7 +146,8 @@ exports[`etcdv3 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -173,7 +179,8 @@ exports[`gcs 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -198,7 +205,8 @@ exports[`http 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -230,7 +238,8 @@ exports[`local 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -252,7 +261,8 @@ exports[`manta 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -280,7 +290,8 @@ exports[`oss 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -321,7 +332,8 @@ exports[`pg 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -344,7 +356,8 @@ exports[`remote 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -369,7 +382,8 @@ exports[`s3 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -415,7 +429,8 @@ exports[`s3 reference 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -450,7 +465,8 @@ exports[`s3 with options 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -476,7 +492,8 @@ exports[`swift 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {

--- a/packages/cdktf/test/__snapshots__/remote-state.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/remote-state.test.js.snap
@@ -6,10 +6,7 @@ exports[`artifactory 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -35,10 +32,7 @@ exports[`azurerm 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -67,10 +61,7 @@ exports[`consul 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -102,10 +93,7 @@ exports[`cos 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -134,10 +122,7 @@ exports[`etcd 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -162,10 +147,7 @@ exports[`etcdv3 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -198,10 +180,7 @@ exports[`gcs 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -227,10 +206,7 @@ exports[`http 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -263,10 +239,7 @@ exports[`local 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -289,10 +262,7 @@ exports[`manta 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -321,10 +291,7 @@ exports[`oss 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -366,10 +333,7 @@ exports[`pg 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -393,10 +357,7 @@ exports[`remote 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -422,10 +383,7 @@ exports[`s3 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -472,10 +430,7 @@ exports[`s3 reference 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -511,10 +466,7 @@ exports[`s3 with options 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -541,10 +493,7 @@ exports[`swift 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {

--- a/packages/cdktf/test/__snapshots__/resource.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/resource.test.js.snap
@@ -5,7 +5,8 @@ exports[`dependent resource 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -44,7 +45,8 @@ exports[`do not change capitalization of arbritary nested types 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"tests\\"
+      \\"stackName\\": \\"tests\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"resource\\": {
@@ -71,7 +73,8 @@ exports[`do not change capitalization of tags 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"tests\\"
+      \\"stackName\\": \\"tests\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"resource\\": {
@@ -98,7 +101,8 @@ exports[`minimal configuration 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"resource\\": {
@@ -122,7 +126,8 @@ exports[`provider setter 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"provider\\": {
@@ -154,7 +159,8 @@ exports[`serialize list interpolation 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"tests\\"
+      \\"stackName\\": \\"tests\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"resource\\": {
@@ -189,7 +195,8 @@ exports[`with complex computed list 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"tests\\"
+      \\"stackName\\": \\"tests\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"resource\\": {
@@ -223,7 +230,8 @@ exports[`with provider alias 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"provider\\": {

--- a/packages/cdktf/test/__snapshots__/resource.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/resource.test.js.snap
@@ -6,7 +6,10 @@ exports[`dependent resource 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"data\\": {
@@ -46,7 +49,10 @@ exports[`do not change capitalization of arbritary nested types 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"tests\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"resource\\": {
@@ -74,7 +80,10 @@ exports[`do not change capitalization of tags 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"tests\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"resource\\": {
@@ -102,7 +111,10 @@ exports[`minimal configuration 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"resource\\": {
@@ -127,7 +139,10 @@ exports[`provider setter 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"provider\\": {
@@ -160,7 +175,10 @@ exports[`serialize list interpolation 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"tests\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"resource\\": {
@@ -196,7 +214,10 @@ exports[`with complex computed list 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"tests\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"resource\\": {
@@ -231,7 +252,10 @@ exports[`with provider alias 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"provider\\": {

--- a/packages/cdktf/test/__snapshots__/resource.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/resource.test.js.snap
@@ -6,10 +6,7 @@ exports[`dependent resource 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"data\\": {
@@ -49,10 +46,7 @@ exports[`do not change capitalization of arbritary nested types 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"tests\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"resource\\": {
@@ -80,10 +74,7 @@ exports[`do not change capitalization of tags 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"tests\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"resource\\": {
@@ -111,10 +102,7 @@ exports[`minimal configuration 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"resource\\": {
@@ -139,10 +127,7 @@ exports[`provider setter 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"provider\\": {
@@ -175,10 +160,7 @@ exports[`serialize list interpolation 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"tests\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"resource\\": {
@@ -214,10 +196,7 @@ exports[`with complex computed list 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"tests\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"resource\\": {
@@ -252,10 +231,7 @@ exports[`with provider alias 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"provider\\": {

--- a/packages/cdktf/test/__snapshots__/stack.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/stack.test.js.snap
@@ -5,7 +5,16 @@ exports[`stack synthesis merges all elements into a single output 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"MyStack\\"
+      \\"stackName\\": \\"MyStack\\",
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"aws_topic\\": [
+          \\"//\\",
+          \\"prop2\\",
+          \\"prop3\\",
+          \\"provisioner\\"
+        ]
+      }
     }
   },
   \\"provider\\": {
@@ -93,7 +102,8 @@ exports[`stack synthesis no flags 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"MyStack\\"
+      \\"stackName\\": \\"MyStack\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"provider\\": {

--- a/packages/cdktf/test/__snapshots__/stack.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/stack.test.js.snap
@@ -8,6 +8,18 @@ exports[`stack synthesis merges all elements into a single output 1`] = `
       \\"stackName\\": \\"MyStack\\",
       \\"backend\\": \\"local\\",
       \\"overrides\\": {
+        \\"stack\\": {
+          \\"terraform\\": {
+            \\"backend\\": {
+              \\"remote\\": {
+                \\"organization\\": \\"test\\",
+                \\"workspaces\\": {
+                  \\"name\\": \\"test\\"
+                }
+              }
+            }
+          }
+        },
         \\"aws_topic\\": [
           \\"//\\",
           \\"prop2\\",
@@ -103,7 +115,10 @@ exports[`stack synthesis no flags 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"MyStack\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"provider\\": {

--- a/packages/cdktf/test/__snapshots__/stack.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/stack.test.js.snap
@@ -8,18 +8,9 @@ exports[`stack synthesis merges all elements into a single output 1`] = `
       \\"stackName\\": \\"MyStack\\",
       \\"backend\\": \\"local\\",
       \\"overrides\\": {
-        \\"stack\\": {
-          \\"terraform\\": {
-            \\"backend\\": {
-              \\"remote\\": {
-                \\"organization\\": \\"test\\",
-                \\"workspaces\\": {
-                  \\"name\\": \\"test\\"
-                }
-              }
-            }
-          }
-        },
+        \\"stack\\": [
+          \\"terraform\\"
+        ],
         \\"aws_topic\\": [
           \\"//\\",
           \\"prop2\\",
@@ -115,10 +106,7 @@ exports[`stack synthesis no flags 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"MyStack\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"provider\\": {

--- a/packages/cdktf/test/__snapshots__/terraform-hcl-module.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/terraform-hcl-module.test.js.snap
@@ -5,7 +5,8 @@ exports[`add provider 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"module\\": {
@@ -40,7 +41,8 @@ exports[`complex providers 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"provider\\": {
@@ -88,7 +90,8 @@ exports[`depend on module 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"module\\": {
@@ -126,7 +129,8 @@ exports[`depend on other module 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"module\\": {
@@ -160,7 +164,8 @@ exports[`minimal configuration 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"module\\": {
@@ -182,7 +187,8 @@ exports[`multiple providers 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"provider\\": {
@@ -224,7 +230,8 @@ exports[`pass variables 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"module\\": {
@@ -252,7 +259,8 @@ exports[`reference module 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"module\\": {
@@ -287,7 +295,8 @@ exports[`reference module list 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"module\\": {
@@ -323,7 +332,8 @@ exports[`set variable 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"module\\": {
@@ -346,7 +356,8 @@ exports[`simple provider 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"provider\\": {

--- a/packages/cdktf/test/__snapshots__/terraform-hcl-module.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/terraform-hcl-module.test.js.snap
@@ -6,7 +6,10 @@ exports[`add provider 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"module\\": {
@@ -42,7 +45,10 @@ exports[`complex providers 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"provider\\": {
@@ -91,7 +97,10 @@ exports[`depend on module 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"module\\": {
@@ -130,7 +139,10 @@ exports[`depend on other module 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"module\\": {
@@ -165,7 +177,10 @@ exports[`minimal configuration 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"module\\": {
@@ -188,7 +203,10 @@ exports[`multiple providers 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"provider\\": {
@@ -231,7 +249,10 @@ exports[`pass variables 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"module\\": {
@@ -260,7 +281,10 @@ exports[`reference module 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"module\\": {
@@ -296,7 +320,10 @@ exports[`reference module list 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"module\\": {
@@ -333,7 +360,10 @@ exports[`set variable 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"module\\": {
@@ -357,7 +387,10 @@ exports[`simple provider 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"provider\\": {

--- a/packages/cdktf/test/__snapshots__/terraform-hcl-module.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/terraform-hcl-module.test.js.snap
@@ -6,10 +6,7 @@ exports[`add provider 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"module\\": {
@@ -45,10 +42,7 @@ exports[`complex providers 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"provider\\": {
@@ -97,10 +91,7 @@ exports[`depend on module 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"module\\": {
@@ -139,10 +130,7 @@ exports[`depend on other module 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"module\\": {
@@ -177,10 +165,7 @@ exports[`minimal configuration 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"module\\": {
@@ -203,10 +188,7 @@ exports[`multiple providers 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"provider\\": {
@@ -249,10 +231,7 @@ exports[`pass variables 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"module\\": {
@@ -281,10 +260,7 @@ exports[`reference module 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"module\\": {
@@ -320,10 +296,7 @@ exports[`reference module list 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"module\\": {
@@ -360,10 +333,7 @@ exports[`set variable 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"module\\": {
@@ -387,10 +357,7 @@ exports[`simple provider 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"provider\\": {

--- a/packages/cdktf/test/__snapshots__/variable.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/variable.test.js.snap
@@ -6,7 +6,10 @@ exports[`any type 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"variable\\": {
@@ -23,7 +26,10 @@ exports[`bool type 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"variable\\": {
@@ -40,7 +46,10 @@ exports[`collection type 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"variable\\": {
@@ -57,7 +66,10 @@ exports[`default value 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"variable\\": {
@@ -74,7 +86,10 @@ exports[`description 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"variable\\": {
@@ -91,7 +106,10 @@ exports[`map collection type 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"variable\\": {
@@ -108,7 +126,10 @@ exports[`number type 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"variable\\": {
@@ -125,7 +146,10 @@ exports[`object type 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"variable\\": {
@@ -146,7 +170,10 @@ exports[`reference 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"variable\\": {
@@ -176,7 +203,10 @@ exports[`sensitive variable 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"variable\\": {
@@ -194,7 +224,10 @@ exports[`set collection type 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"variable\\": {
@@ -211,7 +244,10 @@ exports[`string type 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"variable\\": {
@@ -228,7 +264,10 @@ exports[`tuple type 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"variable\\": {

--- a/packages/cdktf/test/__snapshots__/variable.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/variable.test.js.snap
@@ -5,7 +5,8 @@ exports[`any type 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -21,7 +22,8 @@ exports[`bool type 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -37,7 +39,8 @@ exports[`collection type 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -53,7 +56,8 @@ exports[`default value 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -69,7 +73,8 @@ exports[`description 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -85,7 +90,8 @@ exports[`map collection type 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -101,7 +107,8 @@ exports[`number type 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -117,7 +124,8 @@ exports[`object type 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -137,7 +145,8 @@ exports[`reference 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -166,7 +175,8 @@ exports[`sensitive variable 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -183,7 +193,8 @@ exports[`set collection type 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -199,7 +210,8 @@ exports[`string type 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -215,7 +227,8 @@ exports[`tuple type 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"test\\"
+      \\"stackName\\": \\"test\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {

--- a/packages/cdktf/test/__snapshots__/variable.test.js.snap
+++ b/packages/cdktf/test/__snapshots__/variable.test.js.snap
@@ -6,10 +6,7 @@ exports[`any type 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -26,10 +23,7 @@ exports[`bool type 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -46,10 +40,7 @@ exports[`collection type 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -66,10 +57,7 @@ exports[`default value 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -86,10 +74,7 @@ exports[`description 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -106,10 +91,7 @@ exports[`map collection type 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -126,10 +108,7 @@ exports[`number type 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -146,10 +125,7 @@ exports[`object type 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -170,10 +146,7 @@ exports[`reference 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -203,10 +176,7 @@ exports[`sensitive variable 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -224,10 +194,7 @@ exports[`set collection type 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -244,10 +211,7 @@ exports[`string type 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {
@@ -264,10 +228,7 @@ exports[`tuple type 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"test\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"variable\\": {

--- a/test/csharp/synth-app/__snapshots__/test.ts.snap
+++ b/test/csharp/synth-app/__snapshots__/test.ts.snap
@@ -5,7 +5,13 @@ exports[`csharp full integration test synth synth generates JSON 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"csharp-simple\\"
+      \\"stackName\\": \\"csharp-simple\\",
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"aws_sns_topic\\": [
+          \\"display_name\\"
+        ]
+      }
     }
   },
   \\"terraform\\": {

--- a/test/go/synth-app/__snapshots__/test.ts.snap
+++ b/test/go/synth-app/__snapshots__/test.ts.snap
@@ -6,7 +6,10 @@ exports[`Go full integration test synth synth generates JSON 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"go-simple\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"resource\\": {

--- a/test/go/synth-app/__snapshots__/test.ts.snap
+++ b/test/go/synth-app/__snapshots__/test.ts.snap
@@ -5,7 +5,8 @@ exports[`Go full integration test synth synth generates JSON 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"go-simple\\"
+      \\"stackName\\": \\"go-simple\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"resource\\": {

--- a/test/go/synth-app/__snapshots__/test.ts.snap
+++ b/test/go/synth-app/__snapshots__/test.ts.snap
@@ -6,10 +6,7 @@ exports[`Go full integration test synth synth generates JSON 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"go-simple\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"resource\\": {

--- a/test/java/synth-app/__snapshots__/test.ts.snap
+++ b/test/java/synth-app/__snapshots__/test.ts.snap
@@ -8,6 +8,7 @@ exports[`java full integration synth generates JSON 1`] = `
       \\"stackName\\": \\"java-simple\\",
       \\"backend\\": \\"local\\",
       \\"overrides\\": {
+        \\"stack\\": {},
         \\"aws_sns_topic\\": [
           \\"display_name\\"
         ]

--- a/test/java/synth-app/__snapshots__/test.ts.snap
+++ b/test/java/synth-app/__snapshots__/test.ts.snap
@@ -5,7 +5,13 @@ exports[`java full integration synth generates JSON 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"java-simple\\"
+      \\"stackName\\": \\"java-simple\\",
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"aws_sns_topic\\": [
+          \\"display_name\\"
+        ]
+      }
     }
   },
   \\"terraform\\": {

--- a/test/java/synth-app/__snapshots__/test.ts.snap
+++ b/test/java/synth-app/__snapshots__/test.ts.snap
@@ -8,7 +8,6 @@ exports[`java full integration synth generates JSON 1`] = `
       \\"stackName\\": \\"java-simple\\",
       \\"backend\\": \\"local\\",
       \\"overrides\\": {
-        \\"stack\\": {},
         \\"aws_sns_topic\\": [
           \\"display_name\\"
         ]

--- a/test/python/asset/__snapshots__/test.ts.snap
+++ b/test/python/asset/__snapshots__/test.ts.snap
@@ -6,7 +6,10 @@ exports[`python full integration test assets synth generates JSON and copies fil
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"python-assets\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"terraform\\": {

--- a/test/python/asset/__snapshots__/test.ts.snap
+++ b/test/python/asset/__snapshots__/test.ts.snap
@@ -5,7 +5,8 @@ exports[`python full integration test assets synth generates JSON and copies fil
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"python-assets\\"
+      \\"stackName\\": \\"python-assets\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"terraform\\": {

--- a/test/python/asset/__snapshots__/test.ts.snap
+++ b/test/python/asset/__snapshots__/test.ts.snap
@@ -6,10 +6,7 @@ exports[`python full integration test assets synth generates JSON and copies fil
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"python-assets\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"terraform\\": {

--- a/test/python/multiple-stacks/__snapshots__/test.ts.snap
+++ b/test/python/multiple-stacks/__snapshots__/test.ts.snap
@@ -6,7 +6,24 @@ exports[`python full integration test synth synth generates JSON for both stacks
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"python-simple-one\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {
+          \\"terraform\\": {
+            \\"backend\\": {
+              \\"remote\\": {
+                \\"organization\\": \\"test\\",
+                \\"workspaces\\": {
+                  \\"name\\": \\"test\\"
+                }
+              }
+            }
+          }
+        },
+        \\"aws_sns_topic\\": [
+          \\"display_name\\"
+        ]
+      }
     }
   },
   \\"terraform\\": {
@@ -54,7 +71,24 @@ exports[`python full integration test synth synth generates JSON for both stacks
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"python-simple-two\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {
+          \\"terraform\\": {
+            \\"backend\\": {
+              \\"remote\\": {
+                \\"organization\\": \\"test\\",
+                \\"workspaces\\": {
+                  \\"name\\": \\"test\\"
+                }
+              }
+            }
+          }
+        },
+        \\"aws_sns_topic\\": [
+          \\"display_name\\"
+        ]
+      }
     }
   },
   \\"terraform\\": {

--- a/test/python/multiple-stacks/__snapshots__/test.ts.snap
+++ b/test/python/multiple-stacks/__snapshots__/test.ts.snap
@@ -5,7 +5,8 @@ exports[`python full integration test synth synth generates JSON for both stacks
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"python-simple-one\\"
+      \\"stackName\\": \\"python-simple-one\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"terraform\\": {
@@ -52,7 +53,8 @@ exports[`python full integration test synth synth generates JSON for both stacks
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"python-simple-two\\"
+      \\"stackName\\": \\"python-simple-two\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"terraform\\": {

--- a/test/python/multiple-stacks/__snapshots__/test.ts.snap
+++ b/test/python/multiple-stacks/__snapshots__/test.ts.snap
@@ -8,18 +8,9 @@ exports[`python full integration test synth synth generates JSON for both stacks
       \\"stackName\\": \\"python-simple-one\\",
       \\"backend\\": \\"local\\",
       \\"overrides\\": {
-        \\"stack\\": {
-          \\"terraform\\": {
-            \\"backend\\": {
-              \\"remote\\": {
-                \\"organization\\": \\"test\\",
-                \\"workspaces\\": {
-                  \\"name\\": \\"test\\"
-                }
-              }
-            }
-          }
-        },
+        \\"stack\\": [
+          \\"terraform\\"
+        ],
         \\"aws_sns_topic\\": [
           \\"display_name\\"
         ]
@@ -73,18 +64,9 @@ exports[`python full integration test synth synth generates JSON for both stacks
       \\"stackName\\": \\"python-simple-two\\",
       \\"backend\\": \\"local\\",
       \\"overrides\\": {
-        \\"stack\\": {
-          \\"terraform\\": {
-            \\"backend\\": {
-              \\"remote\\": {
-                \\"organization\\": \\"test\\",
-                \\"workspaces\\": {
-                  \\"name\\": \\"test\\"
-                }
-              }
-            }
-          }
-        },
+        \\"stack\\": [
+          \\"terraform\\"
+        ],
         \\"aws_sns_topic\\": [
           \\"display_name\\"
         ]

--- a/test/python/synth-app/__snapshots__/test.ts.snap
+++ b/test/python/synth-app/__snapshots__/test.ts.snap
@@ -5,7 +5,8 @@ exports[`python full integration test synth synth generates JSON 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"python-simple\\"
+      \\"stackName\\": \\"python-simple\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"terraform\\": {

--- a/test/python/synth-app/__snapshots__/test.ts.snap
+++ b/test/python/synth-app/__snapshots__/test.ts.snap
@@ -6,7 +6,24 @@ exports[`python full integration test synth synth generates JSON 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"python-simple\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {
+          \\"terraform\\": {
+            \\"backend\\": {
+              \\"remote\\": {
+                \\"organization\\": \\"test\\",
+                \\"workspaces\\": {
+                  \\"name\\": \\"test\\"
+                }
+              }
+            }
+          }
+        },
+        \\"aws_sns_topic\\": [
+          \\"display_name\\"
+        ]
+      }
     }
   },
   \\"terraform\\": {

--- a/test/python/synth-app/__snapshots__/test.ts.snap
+++ b/test/python/synth-app/__snapshots__/test.ts.snap
@@ -8,18 +8,9 @@ exports[`python full integration test synth synth generates JSON 1`] = `
       \\"stackName\\": \\"python-simple\\",
       \\"backend\\": \\"local\\",
       \\"overrides\\": {
-        \\"stack\\": {
-          \\"terraform\\": {
-            \\"backend\\": {
-              \\"remote\\": {
-                \\"organization\\": \\"test\\",
-                \\"workspaces\\": {
-                  \\"name\\": \\"test\\"
-                }
-              }
-            }
-          }
-        },
+        \\"stack\\": [
+          \\"terraform\\"
+        ],
         \\"aws_sns_topic\\": [
           \\"display_name\\"
         ]

--- a/test/python/third-party-provider/__snapshots__/test.ts.snap
+++ b/test/python/third-party-provider/__snapshots__/test.ts.snap
@@ -5,7 +5,8 @@ exports[`python full integration 3rd party synth generates JSON 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"python-third-party-provider\\"
+      \\"stackName\\": \\"python-third-party-provider\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"terraform\\": {

--- a/test/python/third-party-provider/__snapshots__/test.ts.snap
+++ b/test/python/third-party-provider/__snapshots__/test.ts.snap
@@ -6,7 +6,10 @@ exports[`python full integration 3rd party synth generates JSON 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"python-third-party-provider\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"terraform\\": {

--- a/test/python/third-party-provider/__snapshots__/test.ts.snap
+++ b/test/python/third-party-provider/__snapshots__/test.ts.snap
@@ -6,10 +6,7 @@ exports[`python full integration 3rd party synth generates JSON 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"python-third-party-provider\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"terraform\\": {

--- a/test/typescript/asset/__snapshots__/test.ts.snap
+++ b/test/typescript/asset/__snapshots__/test.ts.snap
@@ -13,7 +13,8 @@ exports[`full integration test synth 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"stack\\"
+      \\"stackName\\": \\"stack\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"output\\": {

--- a/test/typescript/asset/__snapshots__/test.ts.snap
+++ b/test/typescript/asset/__snapshots__/test.ts.snap
@@ -14,7 +14,10 @@ exports[`full integration test synth 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"stack\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"output\\": {

--- a/test/typescript/asset/__snapshots__/test.ts.snap
+++ b/test/typescript/asset/__snapshots__/test.ts.snap
@@ -14,10 +14,7 @@ exports[`full integration test synth 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"stack\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"output\\": {

--- a/test/typescript/feature-flags/__snapshots__/test.ts.snap
+++ b/test/typescript/feature-flags/__snapshots__/test.ts.snap
@@ -6,7 +6,13 @@ exports[`full integration test with allowSepCharsInLogicalIds feature 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"hello-deploy\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {},
+        \\"null_resource\\": [
+          \\"provisioner\\"
+        ]
+      }
     }
   },
   \\"resource\\": {
@@ -37,7 +43,13 @@ exports[`full integration test with excludeStackIdFromLogicalIds feature 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"hello-deploy\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {},
+        \\"null_resource\\": [
+          \\"provisioner\\"
+        ]
+      }
     }
   },
   \\"resource\\": {
@@ -68,7 +80,13 @@ exports[`full integration test without features 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"hello-deploy\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {},
+        \\"null_resource\\": [
+          \\"provisioner\\"
+        ]
+      }
     }
   },
   \\"resource\\": {

--- a/test/typescript/feature-flags/__snapshots__/test.ts.snap
+++ b/test/typescript/feature-flags/__snapshots__/test.ts.snap
@@ -5,7 +5,8 @@ exports[`full integration test with allowSepCharsInLogicalIds feature 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"hello-deploy\\"
+      \\"stackName\\": \\"hello-deploy\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"resource\\": {
@@ -35,7 +36,8 @@ exports[`full integration test with excludeStackIdFromLogicalIds feature 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"hello-deploy\\"
+      \\"stackName\\": \\"hello-deploy\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"resource\\": {
@@ -65,7 +67,8 @@ exports[`full integration test without features 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"hello-deploy\\"
+      \\"stackName\\": \\"hello-deploy\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"resource\\": {

--- a/test/typescript/feature-flags/__snapshots__/test.ts.snap
+++ b/test/typescript/feature-flags/__snapshots__/test.ts.snap
@@ -8,7 +8,6 @@ exports[`full integration test with allowSepCharsInLogicalIds feature 1`] = `
       \\"stackName\\": \\"hello-deploy\\",
       \\"backend\\": \\"local\\",
       \\"overrides\\": {
-        \\"stack\\": {},
         \\"null_resource\\": [
           \\"provisioner\\"
         ]
@@ -45,7 +44,6 @@ exports[`full integration test with excludeStackIdFromLogicalIds feature 1`] = `
       \\"stackName\\": \\"hello-deploy\\",
       \\"backend\\": \\"local\\",
       \\"overrides\\": {
-        \\"stack\\": {},
         \\"null_resource\\": [
           \\"provisioner\\"
         ]
@@ -82,7 +80,6 @@ exports[`full integration test without features 1`] = `
       \\"stackName\\": \\"hello-deploy\\",
       \\"backend\\": \\"local\\",
       \\"overrides\\": {
-        \\"stack\\": {},
         \\"null_resource\\": [
           \\"provisioner\\"
         ]

--- a/test/typescript/modules/__snapshots__/test.ts.snap
+++ b/test/typescript/modules/__snapshots__/test.ts.snap
@@ -5,7 +5,8 @@ exports[`full integration test build modules posix 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"hello-modules\\"
+      \\"stackName\\": \\"hello-modules\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"module\\": {
@@ -48,7 +49,8 @@ exports[`full integration test build modules windows 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"hello-modules\\"
+      \\"stackName\\": \\"hello-modules\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"module\\": {

--- a/test/typescript/modules/__snapshots__/test.ts.snap
+++ b/test/typescript/modules/__snapshots__/test.ts.snap
@@ -6,7 +6,10 @@ exports[`full integration test build modules posix 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"hello-modules\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {}
+      }
     }
   },
   \\"module\\": {

--- a/test/typescript/modules/__snapshots__/test.ts.snap
+++ b/test/typescript/modules/__snapshots__/test.ts.snap
@@ -6,10 +6,7 @@ exports[`full integration test build modules posix 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"hello-modules\\",
-      \\"backend\\": \\"local\\",
-      \\"overrides\\": {
-        \\"stack\\": {}
-      }
+      \\"backend\\": \\"local\\"
     }
   },
   \\"module\\": {

--- a/test/typescript/multiple-stacks/__snapshots__/test.ts.snap
+++ b/test/typescript/multiple-stacks/__snapshots__/test.ts.snap
@@ -5,7 +5,8 @@ exports[`full integration test synth 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"first\\"
+      \\"stackName\\": \\"first\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"resource\\": {
@@ -35,7 +36,8 @@ exports[`full integration test synth 2`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"second\\"
+      \\"stackName\\": \\"second\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"resource\\": {
@@ -65,7 +67,8 @@ exports[`full integration test synth with json output 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"first\\"
+      \\"stackName\\": \\"first\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"resource\\": {

--- a/test/typescript/multiple-stacks/__snapshots__/test.ts.snap
+++ b/test/typescript/multiple-stacks/__snapshots__/test.ts.snap
@@ -6,7 +6,13 @@ exports[`full integration test synth 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"first\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {},
+        \\"null_resource\\": [
+          \\"provisioner\\"
+        ]
+      }
     }
   },
   \\"resource\\": {
@@ -37,7 +43,13 @@ exports[`full integration test synth 2`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"second\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {},
+        \\"null_resource\\": [
+          \\"provisioner\\"
+        ]
+      }
     }
   },
   \\"resource\\": {
@@ -68,7 +80,13 @@ exports[`full integration test synth with json output 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"first\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {},
+        \\"null_resource\\": [
+          \\"provisioner\\"
+        ]
+      }
     }
   },
   \\"resource\\": {

--- a/test/typescript/multiple-stacks/__snapshots__/test.ts.snap
+++ b/test/typescript/multiple-stacks/__snapshots__/test.ts.snap
@@ -8,7 +8,6 @@ exports[`full integration test synth 1`] = `
       \\"stackName\\": \\"first\\",
       \\"backend\\": \\"local\\",
       \\"overrides\\": {
-        \\"stack\\": {},
         \\"null_resource\\": [
           \\"provisioner\\"
         ]
@@ -45,7 +44,6 @@ exports[`full integration test synth 2`] = `
       \\"stackName\\": \\"second\\",
       \\"backend\\": \\"local\\",
       \\"overrides\\": {
-        \\"stack\\": {},
         \\"null_resource\\": [
           \\"provisioner\\"
         ]
@@ -82,7 +80,6 @@ exports[`full integration test synth with json output 1`] = `
       \\"stackName\\": \\"first\\",
       \\"backend\\": \\"local\\",
       \\"overrides\\": {
-        \\"stack\\": {},
         \\"null_resource\\": [
           \\"provisioner\\"
         ]

--- a/test/typescript/synth-app/__snapshots__/test.ts.snap
+++ b/test/typescript/synth-app/__snapshots__/test.ts.snap
@@ -5,7 +5,8 @@ exports[`full integration test synth synth generates JSON 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"hello-terra\\"
+      \\"stackName\\": \\"hello-terra\\",
+      \\"backend\\": \\"local\\"
     }
   },
   \\"terraform\\": {

--- a/test/typescript/synth-app/__snapshots__/test.ts.snap
+++ b/test/typescript/synth-app/__snapshots__/test.ts.snap
@@ -6,7 +6,26 @@ exports[`full integration test synth synth generates JSON 1`] = `
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
       \\"stackName\\": \\"hello-terra\\",
-      \\"backend\\": \\"local\\"
+      \\"backend\\": \\"local\\",
+      \\"overrides\\": {
+        \\"stack\\": {
+          \\"terraform\\": {
+            \\"backend\\": {
+              \\"remote\\": {
+                \\"organization\\": \\"test\\",
+                \\"workspaces\\": {
+                  \\"name\\": \\"test\\"
+                }
+              }
+            }
+          }
+        },
+        \\"aws_sns_topic\\": [
+          \\"display_name\\",
+          \\"provider\\",
+          \\"lifecycle\\"
+        ]
+      }
     }
   },
   \\"terraform\\": {

--- a/test/typescript/synth-app/__snapshots__/test.ts.snap
+++ b/test/typescript/synth-app/__snapshots__/test.ts.snap
@@ -8,18 +8,9 @@ exports[`full integration test synth synth generates JSON 1`] = `
       \\"stackName\\": \\"hello-terra\\",
       \\"backend\\": \\"local\\",
       \\"overrides\\": {
-        \\"stack\\": {
-          \\"terraform\\": {
-            \\"backend\\": {
-              \\"remote\\": {
-                \\"organization\\": \\"test\\",
-                \\"workspaces\\": {
-                  \\"name\\": \\"test\\"
-                }
-              }
-            }
-          }
-        },
+        \\"stack\\": [
+          \\"terraform\\"
+        ],
         \\"aws_sns_topic\\": [
           \\"display_name\\",
           \\"provider\\",


### PR DESCRIPTION
Telemetry like this is sent, giving us insights around backend types and overrides



```json
{
  "command": "synth",
  "product": "cdktf",
  "version": "0.0.0",
  "dateTime": "2021-07-12T17:17:06.396Z",
  "payload": {
    "command": "npm run --silent compile && node main.js",
    "totalTime": 4461.242155000567,
    "stackMetadata": [
      {
        "version": "0.0.0",
        "stackName": "demo-cdktf-ts-docker",
        "backendType": "local",
        "overrides": {
          "docker_image": [
            "build"
          ]
        }
      }
    ]
  },
  "runID": "62a8db03-d5cd-43bb-8e6e-cdbfce7049db",
  "arch": "x64",
  "os": "darwin"
}
```