### PR TITLE
fix(tests): make less assumptions about environment in config.test.ts

### DIFF
--- a/packages/cdktf-cli/test/config.test.ts
+++ b/packages/cdktf-cli/test/config.test.ts
@@ -133,7 +133,7 @@ describe("parseConfig", () => {
       };
       const parsed: any = parseConfig(JSON.stringify(input));
       expect(parsed.terraformModules[0].localSource).toMatch(
-        "terraform-cdk/packages/cdktf-cli/foo"
+        "/packages/cdktf-cli/foo"
       );
     });
 


### PR DESCRIPTION
Don't require the terraform-cdk to be checked out into a directory with exactly that name for this test case to succeed. Reported by @yufeiminds in https://github.com/hashicorp/terraform-cdk/pull/790\#issuecomment-879046497