### PR TITLE
chore(deps): use nodejs v14 version of aws jsii/superchain image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.mirror.hashicorp.services/jsii/superchain
+FROM docker.mirror.hashicorp.services/jsii/superchain:node14
 
 RUN yum install -y unzip jq && curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python3
 


### PR DESCRIPTION
This is mainly to test whether everything would still build and compile with this version.

We require Nodejs version 12 in our installation instructions but currently use the default jsii/superchain Docker image for builds which contains Nodejs v10. Unfortunately there is no Docker container with Nodejs v12 readily available for the jsii/superchain image.
The reason for this test is that the graphql-server, which is used in #801, needs Nodejs v12.