### PR TITLE
fix(hcl2cdk): suffix variables and locals

### DIFF
--- a/packages/@cdktf/hcl2cdk/lib/expressions.ts
+++ b/packages/@cdktf/hcl2cdk/lib/expressions.ts
@@ -184,9 +184,7 @@ export function referenceToVariableName(ref: Reference): string {
 
 export function variableName(resource: string, name: string): string {
   const proposedName = camelCase(
-    ["var", "local", "module"].includes(resource)
-      ? name
-      : [resource, name].join("_")
+    resource === "module" ? name : [resource, name].join("_")
   );
 
   if (!Number.isNaN(parseInt(proposedName[0], 10))) {

--- a/packages/@cdktf/hcl2cdk/lib/expressions.ts
+++ b/packages/@cdktf/hcl2cdk/lib/expressions.ts
@@ -1,6 +1,6 @@
 import * as t from "@babel/types";
 import { camelCase, pascalCase } from "./utils";
-import { TerraformResourceBlock } from "./types";
+import { TerraformResourceBlock, Scope } from "./types";
 import isValidDomain from "is-valid-domain";
 
 export type Reference = {
@@ -175,23 +175,46 @@ export function extractReferencesFromExpression(
   }, [] as Reference[]);
 }
 
-export function referenceToVariableName(ref: Reference): string {
+export function referenceToVariableName(scope: Scope, ref: Reference): string {
   const parts = ref.referencee.full.split(".");
   const resource = parts[0] === "data" ? `${parts[0]}.${parts[1]}` : parts[0];
   const name = parts[0] === "data" ? parts[2] : parts[1];
-  return variableName(resource, name);
+  return variableName(scope, resource, name);
 }
 
-export function variableName(resource: string, name: string): string {
-  const proposedName = camelCase(
-    resource === "module" ? name : [resource, name].join("_")
-  );
+function validVarName(name: string) {
+  if (!Number.isNaN(parseInt(name[0], 10))) {
+    return `d${name}`;
+  } else {
+    return name;
+  }
+}
 
-  if (!Number.isNaN(parseInt(proposedName[0], 10))) {
-    return `d${proposedName}`;
+export function variableName(
+  scope: Scope,
+  resource: string,
+  name: string
+): string {
+  // name collision, we need to prefix the name
+  if (scope.variables[name]) {
+    if (resource === scope.variables[name].resource) {
+      return scope.variables[name].variableName;
+    }
+
+    // we only cache one per name
+    return validVarName(camelCase([resource, name].join("_")));
   }
 
-  return proposedName;
+  const variableName = validVarName(
+    camelCase(
+      ["var", "local", "module"].includes(resource)
+        ? name
+        : [resource, name].join("_")
+    )
+  );
+
+  scope.variables[name] = { variableName, resource };
+  return variableName;
 }
 
 export function constructAst(type: string, isModuleImport: boolean) {
@@ -219,11 +242,11 @@ export function constructAst(type: string, isModuleImport: boolean) {
   return t.identifier(pascalCase(type));
 }
 
-export function referenceToAst(ref: Reference) {
+export function referenceToAst(scope: Scope, ref: Reference) {
   const [resource, _name, ...selector] = ref.referencee.full.split(".");
 
   const variableReference = t.identifier(
-    camelCase(referenceToVariableName(ref))
+    camelCase(referenceToVariableName(scope, ref))
   );
 
   if (resource === "data") {
@@ -254,6 +277,7 @@ export function referenceToAst(ref: Reference) {
 }
 
 export function referencesToAst(
+  scope: Scope,
   input: string,
   refs: Reference[],
   scopedIds: readonly string[] = [] // dynamics introduce new scoped variables that are not the globally accessible ids
@@ -265,7 +289,7 @@ export function referencesToAst(
   const refAsts = refs
     .sort((a, b) => a.start - b.start)
     .filter((ref) => !scopedIds.includes(ref.referencee.id))
-    .map((ref) => ({ ref, ast: referenceToAst(ref) }));
+    .map((ref) => ({ ref, ast: referenceToAst(scope, ref) }));
 
   if (
     refAsts.length === 1 &&

--- a/packages/@cdktf/hcl2cdk/lib/expressions.ts
+++ b/packages/@cdktf/hcl2cdk/lib/expressions.ts
@@ -1,4 +1,5 @@
 import * as t from "@babel/types";
+import reservedWords from "reserved-words";
 import { camelCase, pascalCase } from "./utils";
 import { TerraformResourceBlock, Scope } from "./types";
 import isValidDomain from "is-valid-domain";
@@ -183,11 +184,15 @@ export function referenceToVariableName(scope: Scope, ref: Reference): string {
 }
 
 function validVarName(name: string) {
+  if (reservedWords.check(name)) {
+    return `${name}Var`;
+  }
+
   if (!Number.isNaN(parseInt(name[0], 10))) {
     return `d${name}`;
-  } else {
-    return name;
   }
+
+  return name;
 }
 
 export function variableName(

--- a/packages/@cdktf/hcl2cdk/lib/index.ts
+++ b/packages/@cdktf/hcl2cdk/lib/index.ts
@@ -104,7 +104,7 @@ ${JSON.stringify((err as z.ZodError).errors)}`);
   // We recursively inspect each resource value to find references to other values
   // We add these to a dependency graph so that the programming code has the right order
   function addGlobalEdges(
-    _scopeIdentifiers: Scope,
+    _scope: Scope,
     _key: string,
     id: string,
     value: TerraformResourceBlock
@@ -112,7 +112,7 @@ ${JSON.stringify((err as z.ZodError).errors)}`);
     addEdges(id, value);
   }
   function addProviderEdges(
-    _scopeIdentifiers: Scope,
+    _scope: Scope,
     key: string,
     _id: string,
     value: TerraformResourceBlock
@@ -120,7 +120,7 @@ ${JSON.stringify((err as z.ZodError).errors)}`);
     addEdges(key, value);
   }
   function addNamespacedEdges(
-    _scopeIdentifiers: Scope,
+    _scope: Scope,
     _type: string,
     _key: string,
     id: string,

--- a/packages/@cdktf/hcl2cdk/lib/iteration.ts
+++ b/packages/@cdktf/hcl2cdk/lib/iteration.ts
@@ -3,22 +3,37 @@ import { providers as telemetryAllowedProviders } from "./telemetryAllowList.jso
 
 // locals, variables, and outputs are global key value maps
 export function forEachGlobal<T, R>(
+  scopeIdentifiers: Set<string>,
   prefix: string,
   record: Record<string, T> | undefined,
-  iterator: (key: string, id: string, value: T, graph: DirectedGraph) => R
+  iterator: (
+    scopeIdentifiers: Set<string>,
+    key: string,
+    id: string,
+    value: T,
+    graph: DirectedGraph
+  ) => R
 ): Record<string, (graph: DirectedGraph) => R> {
   return Object.entries(record || {}).reduce((carry, [key, item]) => {
     const id = `${prefix}.${key}`;
     return {
       ...carry,
-      [id]: (graph: DirectedGraph) => iterator(key, id, item, graph),
+      [id]: (graph: DirectedGraph) =>
+        iterator(scopeIdentifiers, key, id, item, graph),
     };
   }, {});
 }
 
 export function forEachProvider<T, R>(
+  scopeIdentifiers: Set<string>,
   record: Record<string, T[]> | undefined,
-  iterator: (key: string, id: string, value: T, graph: DirectedGraph) => R
+  iterator: (
+    scopeIdentifiers: Set<string>,
+    key: string,
+    id: string,
+    value: T,
+    graph: DirectedGraph
+  ) => R
 ): Record<string, (graph: DirectedGraph) => R> {
   return Object.entries(record || {}).reduce((carry, [key, items]) => {
     return {
@@ -27,7 +42,8 @@ export function forEachProvider<T, R>(
         const id = item.alias ? `${key}.${item.alias}` : `${key}`;
         return {
           ...innerCarry,
-          [id]: (graph: DirectedGraph) => iterator(key, id, item, graph),
+          [id]: (graph: DirectedGraph) =>
+            iterator(scopeIdentifiers, key, id, item, graph),
         };
       }, {}),
     };
@@ -36,8 +52,10 @@ export function forEachProvider<T, R>(
 
 // data and resource are namespaced key value maps
 export function forEachNamespaced<T, R>(
+  scopeIdentifiers: Set<string>,
   record: Record<string, Record<string, T>> | undefined,
   iterator: (
+    scopeIdentifiers: Set<string>,
     type: string,
     key: string,
     id: string,
@@ -55,7 +73,7 @@ export function forEachNamespaced<T, R>(
         return {
           ...innerCarry,
           [id]: (graph: DirectedGraph) =>
-            iterator(prefixedType, key, id, item, graph),
+            iterator(scopeIdentifiers, prefixedType, key, id, item, graph),
         };
       }, {} as Record<string, (graph: DirectedGraph) => R>),
     }),

--- a/packages/@cdktf/hcl2cdk/lib/iteration.ts
+++ b/packages/@cdktf/hcl2cdk/lib/iteration.ts
@@ -1,13 +1,14 @@
 import { DirectedGraph } from "graphology";
 import { providers as telemetryAllowedProviders } from "./telemetryAllowList.json";
+import { Scope } from "./types";
 
 // locals, variables, and outputs are global key value maps
 export function forEachGlobal<T, R>(
-  scopeIdentifiers: Set<string>,
+  scope: Scope,
   prefix: string,
   record: Record<string, T> | undefined,
   iterator: (
-    scopeIdentifiers: Set<string>,
+    scope: Scope,
     key: string,
     id: string,
     value: T,
@@ -18,17 +19,16 @@ export function forEachGlobal<T, R>(
     const id = `${prefix}.${key}`;
     return {
       ...carry,
-      [id]: (graph: DirectedGraph) =>
-        iterator(scopeIdentifiers, key, id, item, graph),
+      [id]: (graph: DirectedGraph) => iterator(scope, key, id, item, graph),
     };
   }, {});
 }
 
 export function forEachProvider<T, R>(
-  scopeIdentifiers: Set<string>,
+  scope: Scope,
   record: Record<string, T[]> | undefined,
   iterator: (
-    scopeIdentifiers: Set<string>,
+    scope: Scope,
     key: string,
     id: string,
     value: T,
@@ -42,8 +42,7 @@ export function forEachProvider<T, R>(
         const id = item.alias ? `${key}.${item.alias}` : `${key}`;
         return {
           ...innerCarry,
-          [id]: (graph: DirectedGraph) =>
-            iterator(scopeIdentifiers, key, id, item, graph),
+          [id]: (graph: DirectedGraph) => iterator(scope, key, id, item, graph),
         };
       }, {}),
     };
@@ -52,10 +51,10 @@ export function forEachProvider<T, R>(
 
 // data and resource are namespaced key value maps
 export function forEachNamespaced<T, R>(
-  scopeIdentifiers: Set<string>,
+  scope: Scope,
   record: Record<string, Record<string, T>> | undefined,
   iterator: (
-    scopeIdentifiers: Set<string>,
+    scope: Scope,
     type: string,
     key: string,
     id: string,
@@ -73,7 +72,7 @@ export function forEachNamespaced<T, R>(
         return {
           ...innerCarry,
           [id]: (graph: DirectedGraph) =>
-            iterator(scopeIdentifiers, prefixedType, key, id, item, graph),
+            iterator(scope, prefixedType, key, id, item, graph),
         };
       }, {} as Record<string, (graph: DirectedGraph) => R>),
     }),

--- a/packages/@cdktf/hcl2cdk/lib/types.ts
+++ b/packages/@cdktf/hcl2cdk/lib/types.ts
@@ -1,2 +1,5 @@
 export type TerraformResourceBlock = unknown;
-export type Scope = { constructs: Set<string>; variables: Set<string> };
+export type Scope = {
+  constructs: Set<string>;
+  variables: Record<string, { resource: string; variableName: string }>;
+};

--- a/packages/@cdktf/hcl2cdk/lib/types.ts
+++ b/packages/@cdktf/hcl2cdk/lib/types.ts
@@ -1,1 +1,2 @@
 export type TerraformResourceBlock = unknown;
+export type Scope = { constructs: Set<string>; variables: Set<string> };

--- a/packages/@cdktf/hcl2cdk/lib/utils.ts
+++ b/packages/@cdktf/hcl2cdk/lib/utils.ts
@@ -3,3 +3,11 @@ import camelcase from "camelcase";
 export const camelCase = (str: string) => camelcase(str.replace(/[-/]/g, "_"));
 export const pascalCase = (str: string) =>
   camelcase(str.replace(/[-/]/g, "_"), { pascalCase: true });
+
+export function uniqueId(set: Set<string>, key: string): string {
+  if (set.has(key)) {
+    return uniqueId(set, `${key}_${set.size}`);
+  }
+  set.add(key);
+  return key;
+}

--- a/packages/@cdktf/hcl2cdk/package.json
+++ b/packages/@cdktf/hcl2cdk/package.json
@@ -38,12 +38,14 @@
     "is-valid-domain": "^0.1.2",
     "jsii-rosetta": "^1.30.0",
     "prettier": "^2.3.1",
+    "reserved-words": "^0.1.2",
     "zod": "^1.11.7"
   },
   "devDependencies": {
     "@types/glob": "^7.1.4",
     "@types/jest": "^26.0.20",
     "@types/node": "^14.0.0",
+    "@types/reserved-words": "^0.1.0",
     "jest": "^26.6.3",
     "typescript": "^4.2.2"
   }

--- a/packages/@cdktf/hcl2cdk/test/__snapshots__/hcl2cdk.test.ts.snap
+++ b/packages/@cdktf/hcl2cdk/test/__snapshots__/hcl2cdk.test.ts.snap
@@ -41,10 +41,10 @@ new cdktf.TerraformHclModule(this, \\"vpc\\", {
 
 exports[`convert arithmetics configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
-const varAdmins = new cdktf.TerraformVariable(this, \\"admins\\", {});
-const varMembers = new cdktf.TerraformVariable(this, \\"members\\", {});
+const admins = new cdktf.TerraformVariable(this, \\"admins\\", {});
+const members = new cdktf.TerraformVariable(this, \\"members\\", {});
 new cdktf.TerraformOutput(this, \\"arithmetics\\", {
-  value: \`\\\\\${\${varMembers.value} + \${varAdmins.value}}\`,
+  value: \`\\\\\${\${members.value} + \${admins.value}}\`,
 });
 "
 `;
@@ -267,9 +267,9 @@ new aws.S3BucketObject(this, \\"examplebucket_object\\", {
 exports[`convert count loops configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as aws from \\"./.gen/providers/aws\\";
-const varUsers = new cdktf.TerraformVariable(this, \\"users\\", {});
+const users = new cdktf.TerraformVariable(this, \\"users\\", {});
 const awsIamUserLb = new aws.IamUser(this, \\"lb\\", {
-  name: \`\\\\\${element(\${varUsers.value}, count.index)}\`,
+  name: \`\\\\\${element(\${users.value}, count.index)}\`,
   path: \\"/system/\\",
   tags: {
     tagKey: \\"tag-value\\",
@@ -280,7 +280,7 @@ const awsIamUserLb = new aws.IamUser(this, \\"lb\\", {
 not inside of the Terraform context. If you are looping over something external, e.g. a variable or a file input
 you should consider using a for loop. If you are looping over something only known to Terraform, e.g. a result of a data source
 you need to keep this like it is.*/
-awsIamUserLb.addOverride(\\"count\\", \`\\\\\${length(\${varUsers.value})}\`);
+awsIamUserLb.addOverride(\\"count\\", \`\\\\\${length(\${users.value})}\`);
 "
 `;
 
@@ -295,7 +295,7 @@ new local.DataLocalFile(this, \\"_01_please_verify\\", {
 exports[`convert data references configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as aws from \\"./.gen/providers/aws\\";
-const varBucketName = new cdktf.TerraformVariable(this, \\"bucket_name\\", {
+const bucketName = new cdktf.TerraformVariable(this, \\"bucket_name\\", {
   default: \\"demo\\",
 });
 const dataAwsS3BucketExamplebucket = new aws.DataAwsS3Bucket(
@@ -303,7 +303,7 @@ const dataAwsS3BucketExamplebucket = new aws.DataAwsS3Bucket(
   \\"examplebucket\\",
   {
     acl: \\"private\\",
-    bucket: varBucketName.value,
+    bucket: bucketName.value,
   }
 );
 new aws.S3BucketObject(this, \\"examplebucket_object\\", {
@@ -317,14 +317,14 @@ new aws.S3BucketObject(this, \\"examplebucket_object\\", {
 exports[`convert double references configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as aws from \\"./.gen/providers/aws\\";
-const varBucketName = new cdktf.TerraformVariable(this, \\"bucket_name\\", {
+const bucketName = new cdktf.TerraformVariable(this, \\"bucket_name\\", {
   default: \\"demo\\",
 });
 new aws.S3Bucket(this, \\"examplebucket\\", {
   acl: \\"private\\",
-  bucket: varBucketName.value,
+  bucket: bucketName.value,
   tags: {
-    tagKey: varBucketName.value,
+    tagKey: bucketName.value,
   },
 });
 "
@@ -333,8 +333,8 @@ new aws.S3Bucket(this, \\"examplebucket\\", {
 exports[`convert dynamic blocks configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as aws from \\"./.gen/providers/aws\\";
-const varNamespace = new cdktf.TerraformVariable(this, \\"namespace\\", {});
-const varSettings = new cdktf.TerraformVariable(this, \\"settings\\", {});
+const namespace = new cdktf.TerraformVariable(this, \\"namespace\\", {});
+const settings = new cdktf.TerraformVariable(this, \\"settings\\", {});
 const awsElasticBeanstalkEnvironmentTfenvtest =
   new aws.ElasticBeanstalkEnvironment(this, \\"tfenvtest\\", {
     application: \\"best-app\\",
@@ -348,11 +348,11 @@ not inside of the Terraform context. If you are looping over something external,
 you should consider using a for loop. If you are looping over something only known to Terraform, e.g. a result of a data source
 you need to keep this like it is.*/
 awsElasticBeanstalkEnvironmentTfenvtest.addOverride(\\"setting\\", {
-  for_each: varSettings.value,
+  for_each: settings.value,
   content: [
     {
       name: '\${setting.value[\\"name\\"]}',
-      namespace: varNamespace.value,
+      namespace: namespace.value,
       value: '\${setting.value[\\"value\\"]}',
     },
   ],
@@ -369,7 +369,7 @@ new docker.DockerProvider(this, \\"docker\\", {});
 exports[`convert for each on list using splat configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as aws from \\"./.gen/providers/aws\\";
-const varBuckets = new cdktf.TerraformVariable(this, \\"buckets\\", {});
+const buckets = new cdktf.TerraformVariable(this, \\"buckets\\", {});
 const awsKmsKeyExamplekms = new aws.KmsKey(this, \\"examplekms\\", {
   deletionWindowInDays: 7,
   description: \\"KMS key 1\\",
@@ -385,7 +385,7 @@ you should consider using a for loop. If you are looping over something only kno
 you need to keep this like it is.*/
 awsS3BucketExamplebucket.addOverride(
   \\"for_each\\",
-  \`\\\\\${toset(\${varBuckets.value}.*)}\`
+  \`\\\\\${toset(\${buckets.value}.*)}\`
 );
 const awsS3BucketObjectExamplebucketObject = new aws.S3BucketObject(
   this,
@@ -411,29 +411,29 @@ awsS3BucketObjectExamplebucketObject.addOverride(
 
 exports[`convert for expression 1 configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
-const varUsers = new cdktf.TerraformVariable(this, \\"users\\", {});
-const localAdminUsers = \`\\\\\${{
-            for name, user in \${varUsers.value} : name => user
+const users = new cdktf.TerraformVariable(this, \\"users\\", {});
+const adminUsers = \`\\\\\${{
+            for name, user in \${users.value} : name => user
             if user.is_admin
           }}\`;
-const localRegularUsers = \`\\\\\${{
-            for name, user in \${varUsers.value} : name => user
+const regularUsers = \`\\\\\${{
+            for name, user in \${users.value} : name => user
             if !user.is_admin
           }}\`;
 new cdktf.TerraformOutput(this, \\"combined-so-it-does-not-get-removed\\", {
-  value: \`\\\\\${\${localAdminUsers}},\\\\\${\${localRegularUsers}}\`,
+  value: \`\\\\\${\${adminUsers}},\\\\\${\${regularUsers}}\`,
 });
 "
 `;
 
 exports[`convert for expression 2 configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
-const varUsers = new cdktf.TerraformVariable(this, \\"users\\", {});
-const localUsersByRole = \`\\\\\${{
-            for name, user in \${varUsers.value} : user.role => name...
+const users = new cdktf.TerraformVariable(this, \\"users\\", {});
+const usersByRole = \`\\\\\${{
+            for name, user in \${users.value} : user.role => name...
           }}\`;
 new cdktf.TerraformOutput(this, \\"so-it-does-not-get-removed\\", {
-  value: localUsersByRole,
+  value: usersByRole,
 });
 "
 `;
@@ -441,10 +441,10 @@ new cdktf.TerraformOutput(this, \\"so-it-does-not-get-removed\\", {
 exports[`convert for expression 3 configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as datadog from \\"./.gen/providers/datadog\\";
-const varUsers = new cdktf.TerraformVariable(this, \\"users\\", {});
+const users = new cdktf.TerraformVariable(this, \\"users\\", {});
 new datadog.Monitor(this, \\"hard_query\\", {
   name: \\"queries are hard\\",
-  query: \`\\\\\${join(\\" && \\", [for o in \${varUsers.value} : \\"!(!\\\\\${o.id})\\"])}\`,
+  query: \`\\\\\${join(\\" && \\", [for o in \${users.value} : \\"!(!\\\\\${o.id})\\"])}\`,
 });
 "
 `;
@@ -452,7 +452,7 @@ new datadog.Monitor(this, \\"hard_query\\", {
 exports[`convert for_each loops configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as aws from \\"./.gen/providers/aws\\";
-const varUsers = new cdktf.TerraformVariable(this, \\"users\\", {});
+const users = new cdktf.TerraformVariable(this, \\"users\\", {});
 const awsIamUserLb = new aws.IamUser(this, \\"lb\\", {
   name: \\"\${each.key}\\",
   path: \\"/system/\\",
@@ -465,24 +465,24 @@ const awsIamUserLb = new aws.IamUser(this, \\"lb\\", {
 not inside of the Terraform context. If you are looping over something external, e.g. a variable or a file input
 you should consider using a for loop. If you are looping over something only known to Terraform, e.g. a result of a data source
 you need to keep this like it is.*/
-awsIamUserLb.addOverride(\\"for_each\\", varUsers.value);
+awsIamUserLb.addOverride(\\"for_each\\", users.value);
 "
 `;
 
 exports[`convert for_each with var usage configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as azuread from \\"./.gen/providers/azuread\\";
-const varAzureAdDomainName = new cdktf.TerraformVariable(
+const azureAdDomainName = new cdktf.TerraformVariable(
   this,
   \\"azure_ad_domain_name\\",
   {
     description: \\"domain\\",
   }
 );
-const varOneSetOfUsers = new cdktf.TerraformVariable(this, \\"one_set_of_users\\", {
+const oneSetOfUsers = new cdktf.TerraformVariable(this, \\"one_set_of_users\\", {
   description: \\"users\\",
 });
-const varOtherSetOfUsers = new cdktf.TerraformVariable(
+const otherSetOfUsers = new cdktf.TerraformVariable(
   this,
   \\"other_set_of_users\\",
   {
@@ -491,7 +491,7 @@ const varOtherSetOfUsers = new cdktf.TerraformVariable(
 );
 const azureadUserAzureUsers = new azuread.User(this, \\"azure_users\\", {
   displayName: \\"\${each.key}\\",
-  userPrincipalName: \`\\\\\${each.value}\\\\\${\${varAzureAdDomainName.value}}\`,
+  userPrincipalName: \`\\\\\${each.value}\\\\\${\${azureAdDomainName.value}}\`,
 });
 
 /*In most cases loops should be handled in the programming language context and 
@@ -501,8 +501,8 @@ you need to keep this like it is.*/
 azureadUserAzureUsers.addOverride(
   \\"for_each\\",
   \`\\\\\${merge(
-          \${varOneSetOfUsers.value},
-          \${varOtherSetOfUsers.value},
+          \${oneSetOfUsers.value},
+          \${otherSetOfUsers.value},
         )}\`
 );
 "
@@ -511,10 +511,10 @@ azureadUserAzureUsers.addOverride(
 exports[`convert list access through [] configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as aws from \\"./.gen/providers/aws\\";
-const varSettings = new cdktf.TerraformVariable(this, \\"settings\\", {});
+const settings = new cdktf.TerraformVariable(this, \\"settings\\", {});
 new aws.S3Bucket(this, \\"examplebucket\\", {
   acl: \\"private\\",
-  bucket: \`\\\\\${\${varSettings.value}[0][\\"bucket_name\\"]}\`,
+  bucket: \`\\\\\${\${settings.value}[0][\\"bucket_name\\"]}\`,
 });
 "
 `;
@@ -537,22 +537,22 @@ new cdktf.TerraformHclModule(this, \\"aws_vpc\\", {
 
 exports[`convert locals configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
-const localHowMany = 42;
-const localIsItGreat = true;
-const localOwner = \\"Community Team\\";
-const localServiceName = \\"forum\\";
+const howMany = 42;
+const isItGreat = true;
+const owner = \\"Community Team\\";
+const serviceName = \\"forum\\";
 new cdktf.TerraformOutput(this, \\"combined-so-it-does-not-get-removed\\", {
-  value: \`\\\\\${\${localServiceName}},\\\\\${\${localOwner}},\\\\\${\${localIsItGreat}},\\\\\${\${localHowMany}}\`,
+  value: \`\\\\\${\${serviceName}},\\\\\${\${owner}},\\\\\${\${isItGreat}},\\\\\${\${howMany}}\`,
 });
 "
 `;
 
 exports[`convert locals references configuration 1`] = `
 "import * as aws from \\"./.gen/providers/aws\\";
-const localBucketName = \\"foo\\";
+const bucketName = \\"foo\\";
 new aws.S3Bucket(this, \\"examplebucket\\", {
   acl: \\"private\\",
-  bucket: localBucketName,
+  bucket: bucketName,
 });
 "
 `;
@@ -617,12 +617,12 @@ new aws.SecurityGroup(this, \\"allow_tls\\", {
 
 exports[`convert multiple locals blocks configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
-const localOwner = \\"Community Team\\";
-const localServiceName = \\"forum\\";
-const localHowMany = 42;
-const localIsItGreat = true;
+const owner = \\"Community Team\\";
+const serviceName = \\"forum\\";
+const howMany = 42;
+const isItGreat = true;
 new cdktf.TerraformOutput(this, \\"combined-so-it-does-not-get-removed\\", {
-  value: \`\\\\\${\${localServiceName}},\\\\\${\${localOwner}},\\\\\${\${localIsItGreat}},\\\\\${\${localHowMany}}\`,
+  value: \`\\\\\${\${serviceName}},\\\\\${\${owner}},\\\\\${\${isItGreat}},\\\\\${\${howMany}}\`,
 });
 "
 `;
@@ -691,10 +691,10 @@ new cdktf.TerraformOutput(this, \\"cidr_out\\", {
 exports[`convert property access through [] configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as aws from \\"./.gen/providers/aws\\";
-const varSettings = new cdktf.TerraformVariable(this, \\"settings\\", {});
+const settings = new cdktf.TerraformVariable(this, \\"settings\\", {});
 new aws.S3Bucket(this, \\"examplebucket\\", {
   acl: \\"private\\",
-  bucket: \`\\\\\${\${varSettings.value}[\\"bucket_name\\"]}\`,
+  bucket: \`\\\\\${\${settings.value}[\\"bucket_name\\"]}\`,
 });
 "
 `;
@@ -742,11 +742,11 @@ new aws.AwsProvider(this, \\"aws\\", {
 exports[`convert provider with var reference configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as auth0 from \\"./.gen/providers/auth0\\";
-const varDomain = new cdktf.TerraformVariable(this, \\"domain\\", {
+const domain = new cdktf.TerraformVariable(this, \\"domain\\", {
   description: \\"A domain\\",
 });
 new auth0.Auth0Provider(this, \\"auth0\\", {
-  domain: varDomain.value,
+  domain: domain.value,
 });
 "
 `;
@@ -795,11 +795,11 @@ new cdktf.RemoteBackend(this, {
 exports[`convert required namespaced provider configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as auth0 from \\"./.gen/providers/auth0\\";
-const varDomain = new cdktf.TerraformVariable(this, \\"domain\\", {
+const domain = new cdktf.TerraformVariable(this, \\"domain\\", {
   description: \\"A domain\\",
 });
 new auth0.Auth0Provider(this, \\"auth0\\", {
-  domain: varDomain.value,
+  domain: domain.value,
 });
 "
 `;
@@ -844,8 +844,8 @@ new aws.S3BucketObject(this, \\"examplebucket_object\\", {
 
 exports[`convert same name local, var, out configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
-const varTest = new cdktf.TerraformVariable(this, \\"test\\", {});
-const localTest = \`\\\\\${\${varTest.value}} + 1\`;
+const test = new cdktf.TerraformVariable(this, \\"test\\", {});
+const localTest = \`\\\\\${\${test.value}} + 1\`;
 new cdktf.TerraformOutput(this, \\"test_1\\", {
   value: localTest,
 });
@@ -889,12 +889,12 @@ new cdktf.TerraformHclModule(this, \\"example\\", {
 exports[`convert variable references configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as aws from \\"./.gen/providers/aws\\";
-const varBucketName = new cdktf.TerraformVariable(this, \\"bucket_name\\", {
+const bucketName = new cdktf.TerraformVariable(this, \\"bucket_name\\", {
   default: \\"demo\\",
 });
 new aws.S3Bucket(this, \\"examplebucket\\", {
   acl: \\"private\\",
-  bucket: varBucketName.value,
+  bucket: bucketName.value,
 });
 "
 `;

--- a/packages/@cdktf/hcl2cdk/test/__snapshots__/hcl2cdk.test.ts.snap
+++ b/packages/@cdktf/hcl2cdk/test/__snapshots__/hcl2cdk.test.ts.snap
@@ -41,10 +41,10 @@ new cdktf.TerraformHclModule(this, \\"vpc\\", {
 
 exports[`convert arithmetics configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
-const admins = new cdktf.TerraformVariable(this, \\"admins\\", {});
-const members = new cdktf.TerraformVariable(this, \\"members\\", {});
+const varAdmins = new cdktf.TerraformVariable(this, \\"admins\\", {});
+const varMembers = new cdktf.TerraformVariable(this, \\"members\\", {});
 new cdktf.TerraformOutput(this, \\"arithmetics\\", {
-  value: \`\\\\\${\${members.value} + \${admins.value}}\`,
+  value: \`\\\\\${\${varMembers.value} + \${varAdmins.value}}\`,
 });
 "
 `;
@@ -76,11 +76,15 @@ const awsAcmCertificateExample = new aws.AcmCertificate(this, \\"example\\", {
   domainName: \\"example.com\\",
   validationMethod: \\"DNS\\",
 });
-const dataAwsRoute53ZoneExample = new aws.DataAwsRoute53Zone(this, \\"example\\", {
-  name: \\"example.com\\",
-  privateZone: false,
-});
-const awsRoute53RecordExample = new aws.Route53Record(this, \\"example\\", {
+const dataAwsRoute53ZoneExample = new aws.DataAwsRoute53Zone(
+  this,
+  \\"example_1\\",
+  {
+    name: \\"example.com\\",
+    privateZone: false,
+  }
+);
+const awsRoute53RecordExample = new aws.Route53Record(this, \\"example_2\\", {
   allowOverwrite: true,
   name: \\"\${each.value.name}\\",
   records: [\\"\${each.value.record}\\"],
@@ -105,13 +109,13 @@ awsRoute53RecordExample.addOverride(
 );
 const awsAcmCertificateValidationExample = new aws.AcmCertificateValidation(
   this,
-  \\"example\\",
+  \\"example_3\\",
   {
     certificateArn: awsAcmCertificateExample.arn,
     validationRecordFqdns: \`\\\\\${[for record in \${awsRoute53RecordExample.fqn} : record.fqdn]}\`,
   }
 );
-new aws.LbListener(this, \\"example\\", {
+new aws.LbListener(this, \\"example_4\\", {
   certificateArn: awsAcmCertificateValidationExample.certificateArn,
 });
 "
@@ -263,9 +267,9 @@ new aws.S3BucketObject(this, \\"examplebucket_object\\", {
 exports[`convert count loops configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as aws from \\"./.gen/providers/aws\\";
-const users = new cdktf.TerraformVariable(this, \\"users\\", {});
+const varUsers = new cdktf.TerraformVariable(this, \\"users\\", {});
 const awsIamUserLb = new aws.IamUser(this, \\"lb\\", {
-  name: \`\\\\\${element(\${users.value}, count.index)}\`,
+  name: \`\\\\\${element(\${varUsers.value}, count.index)}\`,
   path: \\"/system/\\",
   tags: {
     tagKey: \\"tag-value\\",
@@ -276,7 +280,7 @@ const awsIamUserLb = new aws.IamUser(this, \\"lb\\", {
 not inside of the Terraform context. If you are looping over something external, e.g. a variable or a file input
 you should consider using a for loop. If you are looping over something only known to Terraform, e.g. a result of a data source
 you need to keep this like it is.*/
-awsIamUserLb.addOverride(\\"count\\", \`\\\\\${length(\${users.value})}\`);
+awsIamUserLb.addOverride(\\"count\\", \`\\\\\${length(\${varUsers.value})}\`);
 "
 `;
 
@@ -291,7 +295,7 @@ new local.DataLocalFile(this, \\"_01_please_verify\\", {
 exports[`convert data references configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as aws from \\"./.gen/providers/aws\\";
-const bucketName = new cdktf.TerraformVariable(this, \\"bucket_name\\", {
+const varBucketName = new cdktf.TerraformVariable(this, \\"bucket_name\\", {
   default: \\"demo\\",
 });
 const dataAwsS3BucketExamplebucket = new aws.DataAwsS3Bucket(
@@ -299,7 +303,7 @@ const dataAwsS3BucketExamplebucket = new aws.DataAwsS3Bucket(
   \\"examplebucket\\",
   {
     acl: \\"private\\",
-    bucket: bucketName.value,
+    bucket: varBucketName.value,
   }
 );
 new aws.S3BucketObject(this, \\"examplebucket_object\\", {
@@ -313,14 +317,14 @@ new aws.S3BucketObject(this, \\"examplebucket_object\\", {
 exports[`convert double references configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as aws from \\"./.gen/providers/aws\\";
-const bucketName = new cdktf.TerraformVariable(this, \\"bucket_name\\", {
+const varBucketName = new cdktf.TerraformVariable(this, \\"bucket_name\\", {
   default: \\"demo\\",
 });
 new aws.S3Bucket(this, \\"examplebucket\\", {
   acl: \\"private\\",
-  bucket: bucketName.value,
+  bucket: varBucketName.value,
   tags: {
-    tagKey: bucketName.value,
+    tagKey: varBucketName.value,
   },
 });
 "
@@ -329,8 +333,8 @@ new aws.S3Bucket(this, \\"examplebucket\\", {
 exports[`convert dynamic blocks configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as aws from \\"./.gen/providers/aws\\";
-const namespace = new cdktf.TerraformVariable(this, \\"namespace\\", {});
-const settings = new cdktf.TerraformVariable(this, \\"settings\\", {});
+const varNamespace = new cdktf.TerraformVariable(this, \\"namespace\\", {});
+const varSettings = new cdktf.TerraformVariable(this, \\"settings\\", {});
 const awsElasticBeanstalkEnvironmentTfenvtest =
   new aws.ElasticBeanstalkEnvironment(this, \\"tfenvtest\\", {
     application: \\"best-app\\",
@@ -344,11 +348,11 @@ not inside of the Terraform context. If you are looping over something external,
 you should consider using a for loop. If you are looping over something only known to Terraform, e.g. a result of a data source
 you need to keep this like it is.*/
 awsElasticBeanstalkEnvironmentTfenvtest.addOverride(\\"setting\\", {
-  for_each: settings.value,
+  for_each: varSettings.value,
   content: [
     {
       name: '\${setting.value[\\"name\\"]}',
-      namespace: namespace.value,
+      namespace: varNamespace.value,
       value: '\${setting.value[\\"value\\"]}',
     },
   ],
@@ -365,7 +369,7 @@ new docker.DockerProvider(this, \\"docker\\", {});
 exports[`convert for each on list using splat configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as aws from \\"./.gen/providers/aws\\";
-const buckets = new cdktf.TerraformVariable(this, \\"buckets\\", {});
+const varBuckets = new cdktf.TerraformVariable(this, \\"buckets\\", {});
 const awsKmsKeyExamplekms = new aws.KmsKey(this, \\"examplekms\\", {
   deletionWindowInDays: 7,
   description: \\"KMS key 1\\",
@@ -381,7 +385,7 @@ you should consider using a for loop. If you are looping over something only kno
 you need to keep this like it is.*/
 awsS3BucketExamplebucket.addOverride(
   \\"for_each\\",
-  \`\\\\\${toset(\${buckets.value}.*)}\`
+  \`\\\\\${toset(\${varBuckets.value}.*)}\`
 );
 const awsS3BucketObjectExamplebucketObject = new aws.S3BucketObject(
   this,
@@ -407,29 +411,29 @@ awsS3BucketObjectExamplebucketObject.addOverride(
 
 exports[`convert for expression 1 configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
-const users = new cdktf.TerraformVariable(this, \\"users\\", {});
-const adminUsers = \`\\\\\${{
-            for name, user in \${users.value} : name => user
+const varUsers = new cdktf.TerraformVariable(this, \\"users\\", {});
+const localAdminUsers = \`\\\\\${{
+            for name, user in \${varUsers.value} : name => user
             if user.is_admin
           }}\`;
-const regularUsers = \`\\\\\${{
-            for name, user in \${users.value} : name => user
+const localRegularUsers = \`\\\\\${{
+            for name, user in \${varUsers.value} : name => user
             if !user.is_admin
           }}\`;
 new cdktf.TerraformOutput(this, \\"combined-so-it-does-not-get-removed\\", {
-  value: \`\\\\\${\${adminUsers}},\\\\\${\${regularUsers}}\`,
+  value: \`\\\\\${\${localAdminUsers}},\\\\\${\${localRegularUsers}}\`,
 });
 "
 `;
 
 exports[`convert for expression 2 configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
-const users = new cdktf.TerraformVariable(this, \\"users\\", {});
-const usersByRole = \`\\\\\${{
-            for name, user in \${users.value} : user.role => name...
+const varUsers = new cdktf.TerraformVariable(this, \\"users\\", {});
+const localUsersByRole = \`\\\\\${{
+            for name, user in \${varUsers.value} : user.role => name...
           }}\`;
 new cdktf.TerraformOutput(this, \\"so-it-does-not-get-removed\\", {
-  value: usersByRole,
+  value: localUsersByRole,
 });
 "
 `;
@@ -437,10 +441,10 @@ new cdktf.TerraformOutput(this, \\"so-it-does-not-get-removed\\", {
 exports[`convert for expression 3 configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as datadog from \\"./.gen/providers/datadog\\";
-const users = new cdktf.TerraformVariable(this, \\"users\\", {});
+const varUsers = new cdktf.TerraformVariable(this, \\"users\\", {});
 new datadog.Monitor(this, \\"hard_query\\", {
   name: \\"queries are hard\\",
-  query: \`\\\\\${join(\\" && \\", [for o in \${users.value} : \\"!(!\\\\\${o.id})\\"])}\`,
+  query: \`\\\\\${join(\\" && \\", [for o in \${varUsers.value} : \\"!(!\\\\\${o.id})\\"])}\`,
 });
 "
 `;
@@ -448,7 +452,7 @@ new datadog.Monitor(this, \\"hard_query\\", {
 exports[`convert for_each loops configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as aws from \\"./.gen/providers/aws\\";
-const users = new cdktf.TerraformVariable(this, \\"users\\", {});
+const varUsers = new cdktf.TerraformVariable(this, \\"users\\", {});
 const awsIamUserLb = new aws.IamUser(this, \\"lb\\", {
   name: \\"\${each.key}\\",
   path: \\"/system/\\",
@@ -461,24 +465,24 @@ const awsIamUserLb = new aws.IamUser(this, \\"lb\\", {
 not inside of the Terraform context. If you are looping over something external, e.g. a variable or a file input
 you should consider using a for loop. If you are looping over something only known to Terraform, e.g. a result of a data source
 you need to keep this like it is.*/
-awsIamUserLb.addOverride(\\"for_each\\", users.value);
+awsIamUserLb.addOverride(\\"for_each\\", varUsers.value);
 "
 `;
 
 exports[`convert for_each with var usage configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as azuread from \\"./.gen/providers/azuread\\";
-const azureAdDomainName = new cdktf.TerraformVariable(
+const varAzureAdDomainName = new cdktf.TerraformVariable(
   this,
   \\"azure_ad_domain_name\\",
   {
     description: \\"domain\\",
   }
 );
-const oneSetOfUsers = new cdktf.TerraformVariable(this, \\"one_set_of_users\\", {
+const varOneSetOfUsers = new cdktf.TerraformVariable(this, \\"one_set_of_users\\", {
   description: \\"users\\",
 });
-const otherSetOfUsers = new cdktf.TerraformVariable(
+const varOtherSetOfUsers = new cdktf.TerraformVariable(
   this,
   \\"other_set_of_users\\",
   {
@@ -487,7 +491,7 @@ const otherSetOfUsers = new cdktf.TerraformVariable(
 );
 const azureadUserAzureUsers = new azuread.User(this, \\"azure_users\\", {
   displayName: \\"\${each.key}\\",
-  userPrincipalName: \`\\\\\${each.value}\\\\\${\${azureAdDomainName.value}}\`,
+  userPrincipalName: \`\\\\\${each.value}\\\\\${\${varAzureAdDomainName.value}}\`,
 });
 
 /*In most cases loops should be handled in the programming language context and 
@@ -497,8 +501,8 @@ you need to keep this like it is.*/
 azureadUserAzureUsers.addOverride(
   \\"for_each\\",
   \`\\\\\${merge(
-          \${oneSetOfUsers.value},
-          \${otherSetOfUsers.value},
+          \${varOneSetOfUsers.value},
+          \${varOtherSetOfUsers.value},
         )}\`
 );
 "
@@ -507,10 +511,10 @@ azureadUserAzureUsers.addOverride(
 exports[`convert list access through [] configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as aws from \\"./.gen/providers/aws\\";
-const settings = new cdktf.TerraformVariable(this, \\"settings\\", {});
+const varSettings = new cdktf.TerraformVariable(this, \\"settings\\", {});
 new aws.S3Bucket(this, \\"examplebucket\\", {
   acl: \\"private\\",
-  bucket: \`\\\\\${\${settings.value}[0][\\"bucket_name\\"]}\`,
+  bucket: \`\\\\\${\${varSettings.value}[0][\\"bucket_name\\"]}\`,
 });
 "
 `;
@@ -533,22 +537,22 @@ new cdktf.TerraformHclModule(this, \\"aws_vpc\\", {
 
 exports[`convert locals configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
-const howMany = 42;
-const isItGreat = true;
-const owner = \\"Community Team\\";
-const serviceName = \\"forum\\";
+const localHowMany = 42;
+const localIsItGreat = true;
+const localOwner = \\"Community Team\\";
+const localServiceName = \\"forum\\";
 new cdktf.TerraformOutput(this, \\"combined-so-it-does-not-get-removed\\", {
-  value: \`\\\\\${\${serviceName}},\\\\\${\${owner}},\\\\\${\${isItGreat}},\\\\\${\${howMany}}\`,
+  value: \`\\\\\${\${localServiceName}},\\\\\${\${localOwner}},\\\\\${\${localIsItGreat}},\\\\\${\${localHowMany}}\`,
 });
 "
 `;
 
 exports[`convert locals references configuration 1`] = `
 "import * as aws from \\"./.gen/providers/aws\\";
-const bucketName = \\"foo\\";
+const localBucketName = \\"foo\\";
 new aws.S3Bucket(this, \\"examplebucket\\", {
   acl: \\"private\\",
-  bucket: bucketName,
+  bucket: localBucketName,
 });
 "
 `;
@@ -613,12 +617,12 @@ new aws.SecurityGroup(this, \\"allow_tls\\", {
 
 exports[`convert multiple locals blocks configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
-const owner = \\"Community Team\\";
-const serviceName = \\"forum\\";
-const howMany = 42;
-const isItGreat = true;
+const localOwner = \\"Community Team\\";
+const localServiceName = \\"forum\\";
+const localHowMany = 42;
+const localIsItGreat = true;
 new cdktf.TerraformOutput(this, \\"combined-so-it-does-not-get-removed\\", {
-  value: \`\\\\\${\${serviceName}},\\\\\${\${owner}},\\\\\${\${isItGreat}},\\\\\${\${howMany}}\`,
+  value: \`\\\\\${\${localServiceName}},\\\\\${\${localOwner}},\\\\\${\${localIsItGreat}},\\\\\${\${localHowMany}}\`,
 });
 "
 `;
@@ -687,10 +691,10 @@ new cdktf.TerraformOutput(this, \\"cidr_out\\", {
 exports[`convert property access through [] configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as aws from \\"./.gen/providers/aws\\";
-const settings = new cdktf.TerraformVariable(this, \\"settings\\", {});
+const varSettings = new cdktf.TerraformVariable(this, \\"settings\\", {});
 new aws.S3Bucket(this, \\"examplebucket\\", {
   acl: \\"private\\",
-  bucket: \`\\\\\${\${settings.value}[\\"bucket_name\\"]}\`,
+  bucket: \`\\\\\${\${varSettings.value}[\\"bucket_name\\"]}\`,
 });
 "
 `;
@@ -701,7 +705,7 @@ import * as TerraformAwsModulesVpcAws from \\"./.gen/modules/terraform-aws-modul
 new aws.AwsProvider(this, \\"aws\\", {
   region: \\"us-east-1\\",
 });
-new aws.AwsProvider(this, \\"aws\\", {
+new aws.AwsProvider(this, \\"aws_1\\", {
   alias: \\"west\\",
   region: \\"us-west-2\\",
 });
@@ -738,11 +742,11 @@ new aws.AwsProvider(this, \\"aws\\", {
 exports[`convert provider with var reference configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as auth0 from \\"./.gen/providers/auth0\\";
-const domain = new cdktf.TerraformVariable(this, \\"domain\\", {
+const varDomain = new cdktf.TerraformVariable(this, \\"domain\\", {
   description: \\"A domain\\",
 });
 new auth0.Auth0Provider(this, \\"auth0\\", {
-  domain: domain.value,
+  domain: varDomain.value,
 });
 "
 `;
@@ -791,11 +795,11 @@ new cdktf.RemoteBackend(this, {
 exports[`convert required namespaced provider configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as auth0 from \\"./.gen/providers/auth0\\";
-const domain = new cdktf.TerraformVariable(this, \\"domain\\", {
+const varDomain = new cdktf.TerraformVariable(this, \\"domain\\", {
   description: \\"A domain\\",
 });
 new auth0.Auth0Provider(this, \\"auth0\\", {
-  domain: domain.value,
+  domain: varDomain.value,
 });
 "
 `;
@@ -838,6 +842,16 @@ new aws.S3BucketObject(this, \\"examplebucket_object\\", {
 "
 `;
 
+exports[`convert same name local, var, out configuration 1`] = `
+"import * as cdktf from \\"cdktf\\";
+const varTest = new cdktf.TerraformVariable(this, \\"test\\", {});
+const localTest = \`\\\\\${\${varTest.value}} + 1\`;
+new cdktf.TerraformOutput(this, \\"test_1\\", {
+  value: localTest,
+});
+"
+`;
+
 exports[`convert sensitive output configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 new cdktf.TerraformOutput(this, \\"cidr_out\\", {
@@ -875,12 +889,12 @@ new cdktf.TerraformHclModule(this, \\"example\\", {
 exports[`convert variable references configuration 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as aws from \\"./.gen/providers/aws\\";
-const bucketName = new cdktf.TerraformVariable(this, \\"bucket_name\\", {
+const varBucketName = new cdktf.TerraformVariable(this, \\"bucket_name\\", {
   default: \\"demo\\",
 });
 new aws.S3Bucket(this, \\"examplebucket\\", {
   acl: \\"private\\",
-  bucket: bucketName.value,
+  bucket: varBucketName.value,
 });
 "
 `;

--- a/packages/@cdktf/hcl2cdk/test/expressions.test.ts
+++ b/packages/@cdktf/hcl2cdk/test/expressions.test.ts
@@ -1,6 +1,7 @@
 import generate from "@babel/generator";
 import * as t from "@babel/types";
 import { referencesToAst } from "../lib/expressions";
+import { Scope } from "../lib/types";
 import {
   extractReferencesFromExpression,
   referenceToAst,
@@ -392,11 +393,12 @@ describe("expressions", () => {
 
   describe("#referenceToAst", () => {
     it("property access", () => {
+      const scope: Scope = { constructs: new Set<string>(), variables: {} };
       expect(
         generate(
           t.program([
             t.expressionStatement(
-              referenceToAst({
+              referenceToAst(scope, {
                 start: 0,
                 end: 0,
                 useFqn: false,
@@ -415,12 +417,14 @@ describe("expressions", () => {
 
   describe("#referencesToAst", () => {
     it("nested terraform expressions without space", () => {
+      const scope: Scope = { constructs: new Set<string>(), variables: {} };
       const expr = `\${\${each.value}\${var.azure_ad_domain_name}}"`;
       expect(
         generate(
           t.program([
             t.expressionStatement(
               referencesToAst(
+                scope,
                 expr,
                 extractReferencesFromExpression(expr, [
                   "var.azure_ad_domain_name",

--- a/packages/@cdktf/hcl2cdk/test/hcl2cdk.test.ts
+++ b/packages/@cdktf/hcl2cdk/test/hcl2cdk.test.ts
@@ -857,6 +857,20 @@ describe("convert", () => {
       }
       `,
     ],
+    [
+      "same name local, var, out",
+      `
+      variable "test" {
+        type    = string
+      }
+      locals {
+        test = "\${var.test} + 1"
+      }
+      output "test" {
+        value = "\${local.test}"
+      }
+      `,
+    ],
   ])("%s configuration", async (_name, hcl) => {
     const { all } = await convert(hcl, {
       language: "typescript",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2069,6 +2069,11 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/reserved-words@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@types/reserved-words/-/reserved-words-0.1.0.tgz#a9d5318bb4ac4466862b93fc702542b75d2cd3ac"
+  integrity sha512-ls6lSkkhEFm8XSVQjHj47pJoCL9sVK91mwIONw0Iwjqkmy98ForMFYa5+/vb6sytTaK0HSwkzKKYzREPTUhhhg==
+
 "@types/semver@^7.1.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.2.0.tgz#0d72066965e910531e1db4621c15d0ca36b8d83b"
@@ -8757,6 +8762,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+reserved-words@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/reserved-words/-/reserved-words-0.1.2.tgz#00a0940f98cd501aeaaac316411d9adc52b31ab1"
+  integrity sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=
 
 resolve-cwd@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
### Input

```hcl
variable "test" {
  type = string
}

locals {
  test = "${var.test} + 1"
}

output "test" {
  value = "${local.test}"
}
```

### Output Before PR

```ts
import * as cdktf from "cdktf";
const test = new cdktf.TerraformVariable(this, "test", {});
const test = `\${${test.value}} + 1`;
new cdktf.TerraformOutput(this, "test", {
  value: test,
});
```

### Output After PR

```ts
import * as cdktf from "cdktf";
const testVar = new cdktf.TerraformVariable(this, "test", {});
const testLocal = `\${${testVar.value}} + 1`;
new cdktf.TerraformOutput(this, "test", {
  value: testLocal,
});
```