### PR TITLE
fix(hcl2cdk): only run get conditionally

### DIFF
--- a/packages/@cdktf/hcl2cdk/lib/index.ts
+++ b/packages/@cdktf/hcl2cdk/lib/index.ts
@@ -332,7 +332,7 @@ export async function convertProject(
 
   return {
     code: prettier.format(outputMainFile, { parser: "babel" }),
-    cdktfJson: prettier.format(JSON.stringify(cdktfJson), { parser: "json" }),
+    cdktfJson,
     stats,
   };
 }

--- a/packages/@cdktf/hcl2cdk/lib/index.ts
+++ b/packages/@cdktf/hcl2cdk/lib/index.ts
@@ -301,10 +301,14 @@ export function getTerraformConfigFromDir(importPath: string) {
   return fileContents.join("\n");
 }
 
+type CdktfJson = Record<string, unknown> & {
+  terraformProviders: any[];
+  terraformModules: any[];
+};
 export async function convertProject(
   combinedHcl: string,
   inputMainFile: string,
-  inputCdktfJson: Record<string, unknown>,
+  inputCdktfJson: CdktfJson,
   { language }: ConvertOptions
 ) {
   if (language !== "typescript") {

--- a/packages/@cdktf/hcl2cdk/test/convertProject.test.ts
+++ b/packages/@cdktf/hcl2cdk/test/convertProject.test.ts
@@ -206,7 +206,11 @@ describe("convertProject", () => {
     );
 
     fs.writeFileSync(path.resolve(targetPath, "main.ts"), code, "utf8");
-    fs.writeFileSync(path.resolve(targetPath, "cdktf.json"), cdktfJson, "utf8");
+    fs.writeFileSync(
+      path.resolve(targetPath, "cdktf.json"),
+      JSON.stringify(cdktfJson),
+      "utf8"
+    );
 
     const currentPlan = getCdkPlan(targetPath);
 

--- a/packages/cdktf-cli/bin/cmds/helper/init.ts
+++ b/packages/cdktf-cli/bin/cmds/helper/init.ts
@@ -159,7 +159,7 @@ This means that your Terraform state file will be stored locally on disk in a fi
       }
     } else {
       console.error(
-        `The --from-terraform-project flag is only support with the typescript template. The command will continue and ignore the flag.`
+        `The --from-terraform-project flag is only supported with the typescript template. The command will continue and ignore the flag.`
       );
     }
   }

--- a/packages/cdktf-cli/bin/cmds/helper/init.ts
+++ b/packages/cdktf-cli/bin/cmds/helper/init.ts
@@ -145,10 +145,7 @@ This means that your Terraform state file will be stored locally on disk in a fi
           "utf8"
         );
 
-        const { terraformModules, terraformProviders } = cdktfJson as {
-          terraformModules: string[];
-          terraformProviders: string[];
-        };
+        const { terraformModules, terraformProviders } = cdktfJson;
         if (terraformModules.length + terraformProviders.length > 0) {
           execSync("npm run get", { cwd: destination });
         }

--- a/packages/cdktf-cli/bin/cmds/helper/init.ts
+++ b/packages/cdktf-cli/bin/cmds/helper/init.ts
@@ -141,15 +141,22 @@ This means that your Terraform state file will be stored locally on disk in a fi
         fs.writeFileSync(path.resolve(destination, "main.ts"), code, "utf8");
         fs.writeFileSync(
           path.resolve(destination, "cdktf.json"),
-          cdktfJson,
+          JSON.stringify(cdktfJson, null, 2),
           "utf8"
         );
+
+        const { terraformModules, terraformProviders } = cdktfJson as {
+          terraformModules: string[];
+          terraformProviders: string[];
+        };
+        if (terraformModules.length + terraformProviders.length > 0) {
+          execSync("npm run get", { cwd: destination });
+        }
 
         telemetryData.conversionStats = stats;
       } catch (err) {
         throw Errors.Internal("init", err, { fromTerraformProject: true });
       }
-      execSync("npm run get", { cwd: destination });
     } else {
       console.error(
         `The --from-terraform-project flag is only support with the typescript template. The command will continue and ignore the flag.`


### PR DESCRIPTION
Should fix running get if there are no modules and providers added to the cdktf.json