### PR TITLE
chore(deps): add gcc and gcc-c++ to Dockerfile required for node-gyp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.mirror.hashicorp.services/jsii/superchain:node14
 
-RUN yum install -y unzip jq && curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python3
+RUN yum install -y unzip jq gcc gcc-c++ && curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python3
 
 ENV DEFAULT_TERRAFORM_VERSION=0.15.4                                \
     TF_PLUGIN_CACHE_DIR="/root/.terraform.d/plugin-cache"           \

--- a/test/test-helper.ts
+++ b/test/test-helper.ts
@@ -77,12 +77,12 @@ export class TestDriver {
 
   copyFiles = (...fileNames) => {
     for (const fileName of fileNames) {
-      fs.copyFileSync(path.join(this.rootDir, fileName), fileName);
+      fse.copySync(path.join(this.rootDir, fileName), fileName);
     }
   };
 
   copyFile = (source, dest) => {
-    fs.copyFileSync(path.join(this.rootDir, source), dest);
+    fse.copySync(path.join(this.rootDir, source), dest);
   };
 
   stackDirectory = (stackName: string) => {


### PR DESCRIPTION
node-gyp is used by node-pty which is going to be used to test the interactive cdktf watch command