### PR TITLE
feat(cli): Add python-poetry CLI template

### DIFF
--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -126,7 +126,8 @@ Options:
   --log-level                 Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL
                                                                                                            [string]
   --template                  The template to be used to create a new project. Either URL to zip file or one of the
-                              built-in templates: ["csharp", "go", "java", "python", "python-pip", "typescript"]
+                              built-in templates: ["csharp", "go", "java", "python", "python-pip", "python-poetry",
+                              "typescript"]
                                                                                                            [string]
   --project-name              The name of the project.                                                     [string]
   --project-description       The description of the project.                                              [string]

--- a/docs/getting-started/python.md
+++ b/docs/getting-started/python.md
@@ -31,11 +31,13 @@ mkdir hello-terraform
 cd hello-terraform
 ```
 
-There are two Python templates available that you can choose from.
-The `python` template uses `Pipenv` for package management wheras the
-`python-pip` template just uses `pip` with a simple `requirements.txt` file.
+There are three Python templates available that you can choose from:
 
-Here's how to choose between the two
+- `python` template uses `Pipenv` for package management
+- `python-pip` template uses `pip` with a simple `requirements.txt` file
+- `python-poetry` template uses `Poetry` for package management
+
+Here's how to choose between the three
 
 ### pipenv
 
@@ -43,6 +45,14 @@ Note: Make sure [Pipenv](https://pipenv.pypa.io/en/latest/install/#installing-pi
 
 ```bash
 cdktf init --template="python" --local
+```
+
+### poetry
+
+Note: Make sure [Poetry](https://pipenv.pypa.io/en/latest/install/#installing-pipenv/) is installed.
+
+```bash
+cdktf init --template="python-poetry" --local
 ```
 
 ### pip

--- a/packages/cdktf-cli/templates/python-poetry/.hooks.sscaff.js
+++ b/packages/cdktf-cli/templates/python-poetry/.hooks.sscaff.js
@@ -1,0 +1,55 @@
+const { execSync } = require('child_process');
+const { chmodSync } = require('fs');
+const { readFileSync, writeFileSync } = require('fs');
+const os = require('os');
+
+const cli = require.resolve('../../bin/cdktf');
+
+exports.pre = () => {
+  try {
+    if (os.platform() === 'win32') {
+      execSync('where poetry')
+    }
+    else {
+      execSync('which poetry')
+    }
+  } catch {
+    console.error(`Unable to find "poetry". Install from https://python-poetry.org/docs/#installation`)
+    process.exit(1);
+  }
+};
+
+exports.post = options => {
+  // Terraform Cloud configuration settings if the organization name and workspace is set.
+  if (options.OrganizationName != '') {
+    console.log(`\nGenerating Terraform Cloud configuration for '${options.OrganizationName}' organization and '${options.WorkspaceName}' workspace.....`)
+    terraformCloudConfig(options.$base, options.OrganizationName, options.WorkspaceName)
+  }
+
+  const pypi_cdktf = options.pypi_cdktf;
+  if (!pypi_cdktf) {
+    throw new Error(`missing context "pypi_cdktf"`);
+  }
+
+  execSync('poetry install', { stdio: 'inherit' });
+  execSync(`poetry add ${pypi_cdktf}`, { stdio: 'inherit' });
+  chmodSync('main.py', '700');
+
+  console.log(readFileSync('./help', 'utf-8'));
+};
+
+function terraformCloudConfig(baseName, organizationName, workspaceName) {
+  template = readFileSync('./main.py', 'utf-8');
+
+  const templateWithImports = template.replace(`from cdktf import App, TerraformStack`,
+    `from cdktf import App, TerraformStack, RemoteBackend, NamedRemoteWorkspace`)
+
+  const result = templateWithImports.replace(`MyStack(app, "${baseName}")`, `stack = MyStack(app, "${baseName}")
+RemoteBackend(stack,
+  hostname='app.terraform.io',
+  organization='${organizationName}',
+  workspaces=NamedRemoteWorkspace('${workspaceName}')
+)`);
+
+  writeFileSync('./main.py', result, 'utf-8');
+}

--- a/packages/cdktf-cli/templates/python-poetry/cdktf.json
+++ b/packages/cdktf-cli/templates/python-poetry/cdktf.json
@@ -1,0 +1,10 @@
+{
+  "language": "python",
+  "app": "poetry run python main.py",
+  "terraformProviders": [],
+  "terraformModules": [],
+  "codeMakerOutput": "imports",
+  "context": {
+    {{futureFlags}}
+  }
+}

--- a/packages/cdktf-cli/templates/python-poetry/help
+++ b/packages/cdktf-cli/templates/python-poetry/help
@@ -1,0 +1,24 @@
+========================================================================================================
+
+  Your cdktf Python project is ready!
+
+  cat help                Prints this message
+
+  Compile:
+    poetry run ./main.py  Compile and run the python code.
+
+  Synthesize:
+    cdktf synth [stack]   Synthesize Terraform resources to cdktf.out/
+
+  Diff:
+    cdktf diff [stack]    Perform a diff (terraform plan) for the given stack
+
+  Deploy:
+    cdktf deploy [stack]  Deploy the given stack
+
+  Destroy:
+    cdktf destroy [stack] Destroy the given stack
+
+  Learn more about using modules and providers https://cdk.tf/modules-and-providers
+
+========================================================================================================

--- a/packages/cdktf-cli/templates/python-poetry/main.py
+++ b/packages/cdktf-cli/templates/python-poetry/main.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+from constructs import Construct
+from cdktf import App, TerraformStack
+
+
+class MyStack(TerraformStack):
+    def __init__(self, scope: Construct, ns: str):
+        super().__init__(scope, ns)
+
+        # define resources here
+
+
+app = App()
+MyStack(app, "{{ $base }}")
+
+app.synth()

--- a/packages/cdktf-cli/templates/python-poetry/pyproject.toml
+++ b/packages/cdktf-cli/templates/python-poetry/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.poetry]
+name = "{{ $base }}"
+version = "1.0.0"
+description = ""
+authors = []
+
+[tool.poetry.dependencies]
+python = "^3.6"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/packages/cdktf-cli/templates/python-poetry/{{}}.gitignore
+++ b/packages/cdktf-cli/templates/python-poetry/{{}}.gitignore
@@ -1,0 +1,7 @@
+dist/
+imports/*
+!imports/__init__.py
+.terraform
+cdktf.out
+cdktf.log
+*terraform.*.tfstate*


### PR DESCRIPTION
Adds CLI template for Poetry, a popular alternative dependency and package manager for Python.

See: https://python-poetry.org/

I tested this locally by running the following in a sibling directory of `terraform-cdk` and it worked well!

```console
node ../terraform-cdk/packages/cdktf-cli/bin/cdktf.js init --template="python-poetry" --local --cdktf-version 0.5.0
```