### PR TITLE
chore(docs): Link Python Poetry community template

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ Choose a language:
 - [google cloud kubernetes engine + kubernetes](./examples/go/google)
 - [ucloud](./examples/go/ucloud)
 
+## Community Templates (for `cdktf init`)
+
+> The following [remote templates](./docs/working-with-cdk-for-terraform/remote-templates.md) are maintained by the community and can be used to setup a CDK for Terraform project instead of the built-in ones.
+
+- [python-poetry](https://github.com/johnfraney/cdktf-remote-template-python-poetry) (by [@johnfraney](https://github.com/johnfraney))
+
 ## Documentation
 
 - Install and run a quick start tutorial at [HashiCorp Learn](https://learn.hashicorp.com/terraform/cdktf/cdktf-install)

--- a/docs/getting-started/python.md
+++ b/docs/getting-started/python.md
@@ -31,7 +31,7 @@ mkdir hello-terraform
 cd hello-terraform
 ```
 
-There are two Python templates available that you can choose from.
+There are two built-in Python templates available that you can choose from.
 The `python` template uses `Pipenv` for package management wheras the
 `python-pip` template just uses `pip` with a simple `requirements.txt` file.
 


### PR DESCRIPTION
Link a first community maintained remote template for using Python with Python Poetry as a package manager. Related to #905 