### PR TITLE
chore(cli): Make sure Python dependencies are working locally

### DIFF
--- a/packages/cdktf-cli/bin/cmds/helper/init.ts
+++ b/packages/cdktf-cli/bin/cmds/helper/init.ts
@@ -178,11 +178,7 @@ async function determineDeps(
     const ret = {
       npm_cdktf: path.resolve(dist, "js", `cdktf@${version}.jsii.tgz`),
       npm_cdktf_cli: path.resolve(dist, "js", `cdktf-cli-${version}.tgz`),
-      pypi_cdktf: path.resolve(
-        dist,
-        "python",
-        `cdktf-${pythonVersion}-py3-none-any.whl`
-      ),
+      pypi_cdktf: path.resolve(dist, "python", `cdktf-${pythonVersion}.tar.gz`),
       mvn_cdktf: path.resolve(
         dist,
         "java",


### PR DESCRIPTION
When setting up a project from `CDKTF_DIST` with locally built
packages, the wheel file had weird dependencies installed. Rather
than installing constructs v10, it was installing v3

Haven't really looked into this thoroughly. However, changing the
package file fixed that issue.