### PR TITLE
feat(lib): Print a hint when the app has been passed to a backend instead of the stack

### DIFF
--- a/packages/cdktf/lib/terraform-stack.ts
+++ b/packages/cdktf/lib/terraform-stack.ts
@@ -14,6 +14,8 @@ import { StackSynthesizer } from "./synthesize/synthesizer";
 
 const STACK_SYMBOL = Symbol.for("cdktf/TerraformStack");
 import { ValidateProviderPresence } from "./validations";
+import { App } from "./app";
+import { TerraformBackend } from "./terraform-backend";
 
 export interface TerraformStackMetadata {
   readonly stackName: string;
@@ -53,8 +55,20 @@ export class TerraformStack extends Construct {
       const node = c.node;
 
       if (!node.scope) {
+        let hint = "";
+        if (
+          construct.node.scope === c &&
+          c instanceof App &&
+          construct instanceof TerraformBackend
+        ) {
+          // the scope of the originally passed construct equals the construct c
+          // which has no scope (i.e. has no parent construct) and c is an App
+          // and our construct is a Backend
+          hint = `. You seem to have passed your root App as scope to a TerraformBackend construct. Pass a stack as scope to your backend instead.`;
+        }
+
         throw new Error(
-          `No stack could be identified for the construct at path '${construct.node.path}'`
+          `No stack could be identified for the construct at path '${construct.node.path}'${hint}`
         );
       }
 

--- a/packages/cdktf/test/stack.test.ts
+++ b/packages/cdktf/test/stack.test.ts
@@ -4,6 +4,7 @@ import {
   App,
   Testing,
   TerraformOutput,
+  LocalBackend,
 } from "cdktf/lib";
 import { TerraformModule } from "cdktf/lib/terraform-module";
 import { TestProvider } from "./helper";
@@ -111,6 +112,15 @@ test("stack validation returns no error when provider is not set", () => {
 
   const errors = stack.node.validate();
   expect(errors).toEqual([]);
+});
+
+test("getting Stack for TerraformBackend which was added to root app returns friendly error", () => {
+  const app = Testing.stubVersion(new App({ stackTraces: false }));
+  new TerraformStack(app, "MyStack");
+
+  expect(() => new LocalBackend(app, {})).toThrowErrorMatchingInlineSnapshot(
+    `"No stack could be identified for the construct at path 'backend'. You seem to have passed your root App as scope to a TerraformBackend construct. Pass a stack as scope to your backend instead."`
+  );
 });
 
 class MyModule extends TerraformModule {


### PR DESCRIPTION
Relates to reported issue #944