### PR TITLE
fix(lib): remove undefined and null values from terraform function lists

### DIFF
--- a/packages/cdktf/lib/terraform-functions.ts
+++ b/packages/cdktf/lib/terraform-functions.ts
@@ -45,33 +45,35 @@ function listOf(type: TFValueValidator): TFValueValidator {
       return value;
     }
 
-    return value.map((item, i) => {
-      if (Tokenization.isResolvable(item)) {
-        return item;
-      }
-
-      if (TokenString.forListToken(item).test()) {
-        return item;
-      }
-
-      if (typeof item === "string") {
-        const tokenList = Tokenization.reverseString(item);
-        const numberOfTokens =
-          tokenList.tokens.length + tokenList.intrinsic.length;
-        if (numberOfTokens === 1 && tokenList.literals.length === 0) {
+    return value
+      .filter((item) => item !== undefined && item !== null)
+      .map((item, i) => {
+        if (Tokenization.isResolvable(item)) {
           return item;
         }
-      }
 
-      try {
-        type(item);
-        return typeof item === "string" ? `"${item}"` : item;
-      } catch (error) {
-        throw new Error(
-          `Element in list ${value} at position ${i} is not of the right type: ${error}`
-        );
-      }
-    });
+        if (TokenString.forListToken(item).test()) {
+          return item;
+        }
+
+        if (typeof item === "string") {
+          const tokenList = Tokenization.reverseString(item);
+          const numberOfTokens =
+            tokenList.tokens.length + tokenList.intrinsic.length;
+          if (numberOfTokens === 1 && tokenList.literals.length === 0) {
+            return item;
+          }
+        }
+
+        try {
+          type(item);
+          return typeof item === "string" ? `"${item}"` : item;
+        } catch (error) {
+          throw new Error(
+            `Element in list ${value} at position ${i} is not of the right type: ${error}`
+          );
+        }
+      });
   };
 }
 

--- a/packages/cdktf/test/functions.test.ts
+++ b/packages/cdktf/test/functions.test.ts
@@ -383,3 +383,27 @@ test("terraform local", () => {
     }"
   `);
 });
+
+test("undefined and null", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+
+  const local = new TerraformLocal(stack, "value", "hello world");
+
+  new TerraformOutput(stack, "test-output", {
+    value: Fn.coalesce([null, local.asString, undefined, 42, false]),
+  });
+
+  expect(Testing.synth(stack)).toMatchInlineSnapshot(`
+    "{
+      \\"locals\\": {
+        \\"value\\": \\"hello world\\"
+      },
+      \\"output\\": {
+        \\"test-output\\": {
+          \\"value\\": \\"\${coalesce(local.value, 42, false)}\\"
+        }
+      }
+    }"
+  `);
+});


### PR DESCRIPTION
Passing undefined and null into arrays in terraform functions leads to errors / invalid terraform configuration. We strip them out for that reason