### PR TITLE
feat(lib): use jest asymetric matchers & nicer error messages

### DIFF
--- a/docs/working-with-cdk-for-terraform/testing.md
+++ b/docs/working-with-cdk-for-terraform/testing.md
@@ -46,6 +46,20 @@ In the example above we use `Testing.synthScope` to test a part of the applicati
 - `toHaveDataSource`: Checks if a certain data source exists
 - `toHaveDataSourceWithProperties`: Checks if a certain data source exists with all properties passed
 
+Since we are using jest you can also use asymetric matchers like [`expect.anything()`](https://jestjs.io/docs/expect#expectanything), [`expect.arrayContaining([...])`](https://jestjs.io/docs/expect#expectarraycontainingarray), and [`expect.objectContaining({...})`](https://jestjs.io/docs/expect#expectobjectcontainingobject):
+
+```ts
+expect(synthesized).toHaveResourceWithProperties(aws.S3Bucket, {
+  bucketPrefix: `sls-example-frontend-test`,
+  website: [
+    expect.objectContaining({
+      indexDocument: "index.html",
+      errorDocument: "index.html",
+    }),
+  ],
+});
+```
+
 ### Snapshot Testing
 
 Snapshot tests are a very useful tool whenever you want to make sure your infrastructure does not change unexpectedly. You can read more about them in the [Jest docs](https://jestjs.io/docs/snapshot-testing).

--- a/packages/cdktf/lib/testing/adapters/__tests__/jest.test.ts
+++ b/packages/cdktf/lib/testing/adapters/__tests__/jest.test.ts
@@ -1,4 +1,7 @@
 import { setupJest } from "../jest";
+import { Testing } from "../../index";
+import { TestDataSource } from "../../../../test/helper/data-source";
+import { TestResource } from "../../../../test/helper/resource";
 
 describe("jest-adapter", () => {
   beforeAll(() => {
@@ -8,5 +11,34 @@ describe("jest-adapter", () => {
   it("should add extra matchers", () => {
     expect(expect(true).toHaveResource).toBeDefined();
     expect(expect(true).toHaveResourceWithProperties).toBeDefined();
+  });
+
+  describe("jestPassEvaluation", () => {
+    it("fails with jest error message", () => {
+      expect(() =>
+        expect(
+          Testing.synthScope((stack) => {
+            new TestDataSource(stack, "test-data-source", {
+              name: "foo",
+            });
+
+            new TestResource(stack, "test-resource", {
+              name: "bar",
+            });
+          })
+        ).toHaveResourceWithProperties(TestResource, {
+          name: "bazs",
+          foo: expect.arrayContaining([expect.anything()]),
+        })
+      ).toThrowErrorMatchingInlineSnapshot(`
+        "Expected test_resource with properties {\\"name\\":\\"bazs\\",\\"foo\\":\\"expect.ArrayContaining\\"} to be present in synthesised stack.
+        Found 1 test_resource resources instead:
+        [
+          {
+            \\"name\\": \\"bar\\"
+          }
+        ]"
+      `);
+    });
   });
 });


### PR DESCRIPTION

- Allows Jest users to write assertions using asymetric matchers (e.g. `expect.arrayContaining` or `expect.stringContaining`) making the assertions easier to write
- Adds more context to a failed test by showing the resources found of the given type
- Changes the semantic of `toHaveResourceWithProperties` and `toHaveDataSourceWithProperties` from object equality to deep equality

Closes #1047