### PR TITLE
chore: fix config for dependabot

### DIFF
--- a/.github/.dependabot.yml
+++ b/.github/.dependabot.yml
@@ -5,6 +5,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit_message:
+      prefix: "chore"
+      include_scope: true
     ignore:
       - dependency-name: jsii
       - dependency-name: "@jsii/*"


### PR DESCRIPTION
Dependabot created commits / PRs with a bad prefix (`build(deps)`). After this change it'll be `chore(deps)`.