### PR TITLE
fix(docs): typo in documentation

### DIFF
--- a/packages/cdktf/lib/terraform-functions.ts
+++ b/packages/cdktf/lib/terraform-functions.ts
@@ -1041,7 +1041,7 @@ export class Fn {
   }
 
   /**
-   * {@link https://www.terraform.io/docs/language/functions/split.html replace} searches a given string for another given substring, and replaces each occurrence with a given replacement string.
+   * {@link https://www.terraform.io/docs/language/functions/replace.html replace} searches a given string for another given substring, and replaces each occurrence with a given replacement string.
    * @param {string} value
    * @param {string} substring
    * @param {string} replacement


### PR DESCRIPTION
Hi Terraform Colleagues

Thanks a lot for your amazing work. Just found a little typo. Keep continue like this!

Regards

Geoffrey