### PR TITLE
chore(docs): remove roadmap link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ CDK for Terraform is an early experimental project and the development team woul
 - Ask a question on the HashiCorp [Discuss](https://discuss.hashicorp.com/) using the [terraform-cdk](https://discuss.hashicorp.com/c/terraform-core/cdk-for-terraform/) category.
 - Report a [bug](https://github.com/hashicorp/terraform-cdk/issues/new?assignees=&labels=bug&template=bug-report.md&title=) or request a new [feature](https://github.com/hashicorp/terraform-cdk/issues/new?assignees=&labels=enhancement&template=feature-request.md&title=).
 - Browse all [open issues](https://github.com/hashicorp/terraform-cdk/issues).
-- [Roadmap](https://github.com/orgs/hashicorp/projects/77).
 
 ## Building
 


### PR DESCRIPTION
I think it's confusing to have a roadmap link that isn't a roadmap we maintain