### PR TITLE
Laura add descriptions example drafts

### DIFF
--- a/website/docs/cdktf/examples.html.md
+++ b/website/docs/cdktf/examples.html.md
@@ -32,11 +32,14 @@ Follow these hands-on tutorials from HashiCorp Learn: [Write CDK for Terraform C
 |[vault](./examples/typescript/vault) | TBD - one line about what the app does. |
 
 #### Backends
+Each CDK for Terraform project can specify a [backend](https://www.terraform.io/docs/language/settings/backends/index.html) that defines where and how Terraform operations are performed, where Terraform [state snapshots](https://www.terraform.io/docs/language/state/index.html) are stored, etc.
 
-- [azurerm](./examples/typescript/backends/azurerm)
-- [gcs](./examples/typescript/backends/gcs)
-- [remote](./examples/typescript/backends/remote)
-- [s3](./examples/typescript/backends/s3)
+|Example | Description |
+| -------| -----------|
+|[azurerm](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/backends/azurerm)| A simple application that specifies Azure Resource Manager ([azurerm](https://www.terraform.io/docs/language/settings/backends/azurerm.html)) as the backend. |
+|[gcs](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/backends/gcs)| A simple application that specifies Google Cloud Storage ([gcs](https://www.terraform.io/docs/language/settings/backends/gcs.html)) as the backend. |
+|[remote](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/backends/remote) | A simple application that specifies a [remote](https://www.terraform.io/docs/language/settings/backends/remote.html) backend. You can use remote backends to run operations in Terraform Cloud.|
+|[s3](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/backends/s3) | A simple application that specifies Amazon S3 ([s3](https://www.terraform.io/docs/language/settings/backends/s3.html)) as the backend.
 
 ### Python
 

--- a/website/docs/cdktf/examples.html.md
+++ b/website/docs/cdktf/examples.html.md
@@ -13,6 +13,8 @@ Follow these hands-on tutorials from HashiCorp Learn: [Write CDK for Terraform C
 
 ## Example Projects
 
+-> **Note**: You can find more information about all of the providers in the examples below on the [Terraform Registry](https://registry.terraform.io/).
+
 ### Typescript
 
 |Example | Description |
@@ -76,10 +78,12 @@ Each CDK for Terraform project can specify a [backend](https://www.terraform.io/
 
 > Please note: Support for Golang is at an experimental state. In the CDK for Terraform and in the [upstream library JSII](https://aws.github.io/jsii/user-guides/lib-author/configuration/targets/go/) which powers the support for the supported languages.
 
-- [docker](./examples/go/docker)
-- [aws](./examples/go/aws) ⚠️ _High memory usage: the provider generation currently needs ~6 GB of memory. Hence the maximum for Node.js is [currently set to 8GB](https://github.com/hashicorp/terraform-cdk/blob/11d2e783d1fe94e50abd116ba73689c02590a391/packages/cdktf-cli/lib/get/constructs-maker.ts#L279)_
-- [google cloud kubernetes engine + kubernetes](./examples/go/google)
-- [ucloud](./examples/go/ucloud)
+|Example | Description |
+| ------ | ----------- |
+|[docker](https://github.com/hashicorp/terraform-cdk/tree/main/examples/go/docker) | Starts a Docker container with an NGINX server. |
+|[aws](https://github.com/hashicorp/terraform-cdk/tree/main/examples/go/aws) | Provisions an EKS cluster on an AWS Virtual Private Cloud. **High memory usage:** The provider generation currently needs ~6 GB of memory, so the maximum for Node.js is [currently set to 8GB](https://github.com/hashicorp/terraform-cdk/blob/11d2e783d1fe94e50abd116ba73689c02590a391/packages/cdktf-cli/lib/get/constructs-maker.ts#L279). |
+|[google cloud kubernetes engine + kubernetes](https://github.com/hashicorp/terraform-cdk/tree/main/examples/go/google) | TBD - A line about what the app does. |
+|[ucloud](https://github.com/hashicorp/terraform-cdk/tree/main/examples/go/ucloud) | Provisions a Linux base image on UCloud. |
 
 ## Youtube Playlist
 

--- a/website/docs/cdktf/examples.html.md
+++ b/website/docs/cdktf/examples.html.md
@@ -17,14 +17,14 @@ Follow these hands-on tutorials from HashiCorp Learn: [Write CDK for Terraform C
 
 |Example | Description |
 | ------------| -----------|
-|[aws-ecs-docker-and-static-frontend](https://github.com/hashicorp/docker-on-aws-ecs-with-terraform-cdk-using-typescript) | A backend service in a Docker container with a static frontend running on AWS. Walk through AWS setup and configuring the backend to run against a Postgres Database.|
-|[aws-lambda-end-to-end](https://github.com/hashicorp/cdktf-integration-serverless-example) | An end-to-end example  for a serverless web application hosted on AWS. |
-| [aws-prebuilt](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/aws-prebuilt) | An application that uses the prebuilt AWS provider to create a DynamoDB table. |
-|[aws-multiple-stacks](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/aws-multiple-stacks) | An application that uses Stacks to pass different settings into the development, staging, and production environments. |
+|[aws-ecs-docker-and-static-frontend](https://github.com/hashicorp/docker-on-aws-ecs-with-terraform-cdk-using-typescript) | Uses a backend service in a Docker container with a static frontend running in Amazon Web Services (AWS). Walk through AWS setup and configuring the backend to run against a Postgres Database.|
+|[aws-lambda-end-to-end](https://github.com/hashicorp/cdktf-integration-serverless-example) | An end-to-end example for a serverless web application hosted on AWS.|
+| [aws-prebuilt](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/aws-prebuilt) | Uses the prebuilt AWS provider to create a DynamoDB table. |
+|[aws-multiple-stacks](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/aws-multiple-stacks) | Uses Stacks to pass different settings into the development, staging, and production environments. |
 |[aws-cloudfront-proxy](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/aws-cloudfront-proxy) | TBD - one line about what the app does. |
-|[azure](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/azure) | An application to provision a Virtual Network with the Azure provider. |
+|[azure](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/azure) | Provisions a Virtual Network on Microsoft Azure. |
 |[azure-app-service](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/azure-app-service) | TBD - one line about what the app does. |
-| [docker](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/docker) | An application that starts a Docker container with an Nginx server. |
+| [docker](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/docker) | Starts a Docker container with an NGINX server. |
 |[google](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/google) | TBD - one line about what the app does. |
 |[google-cloudrun](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/google-cloudrun) | TBD - one line about what the app does.|
 |[kubernetes](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/kubernetes) | TBD - one line about what the app does. |
@@ -36,19 +36,21 @@ Each CDK for Terraform project can specify a [backend](https://www.terraform.io/
 
 |Example | Description |
 | -------| -----------|
-|[azurerm](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/backends/azurerm)| A simple application that specifies Azure Resource Manager ([azurerm](https://www.terraform.io/docs/language/settings/backends/azurerm.html)) as the backend. |
-|[gcs](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/backends/gcs)| A simple application that specifies Google Cloud Storage ([gcs](https://www.terraform.io/docs/language/settings/backends/gcs.html)) as the backend. |
-|[remote](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/backends/remote) | A simple application that specifies a [remote](https://www.terraform.io/docs/language/settings/backends/remote.html) backend. You can use remote backends to run operations in Terraform Cloud.|
-|[s3](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/backends/s3) | A simple application that specifies Amazon S3 ([s3](https://www.terraform.io/docs/language/settings/backends/s3.html)) as the backend.
+|[azurerm](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/backends/azurerm)| Specifies Azure Resource Manager ([azurerm](https://www.terraform.io/docs/language/settings/backends/azurerm.html)) as the backend. |
+|[gcs](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/backends/gcs)| Specifies Google Cloud Storage ([gcs](https://www.terraform.io/docs/language/settings/backends/gcs.html)) as the backend. |
+|[remote](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/backends/remote) | Specifies a [remote](https://www.terraform.io/docs/language/settings/backends/remote.html) backend. You can use remote backends to run operations in Terraform Cloud.|
+|[s3](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/backends/s3) | Specifies Amazon S3 ([s3](https://www.terraform.io/docs/language/settings/backends/s3.html)) as the backend.
 
 ### Python
 
-- [aws](./examples/python/aws)
-- [aws-eks](./examples/python/aws-eks)
-- [azure](./examples/python/azure)
-- [docker](./examples/python/docker)
-- [kubernetes](./examples/python/kubernetes)
-- [ucloud](./examples/python/ucloud)
+|Example | Description |
+| ------| ----------- |
+| [aws](https://github.com/hashicorp/terraform-cdk/tree/main/examples/python/aws) | Provisions an AWS Virtual Private Cloud (VPC).
+|[aws-eks](https://github.com/hashicorp/terraform-cdk/tree/main/examples/python/aws-eks) | Provisions an EKS cluster on an AWS Virtual Private Cloud. |
+|[azure](https://github.com/hashicorp/terraform-cdk/tree/main/examples/python/azure) | Provisions a Virtual Network on Microsoft Azure. |
+| [docker](https://github.com/hashicorp/terraform-cdk/tree/main/examples/python/docker) | Starts a Docker container with an NGINX server. |
+| [kubernetes](https://github.com/hashicorp/terraform-cdk/tree/main/examples/python/kubernetes) | Schedules and exposes a NGINX deployment on a Kubernetes cluster. |
+|[ucloud](https://github.com/hashicorp/terraform-cdk/tree/main/examples/python/ucloud) | Provisions a Linux base image on UCloud. |
 
 ### Java
 

--- a/website/docs/cdktf/examples.html.md
+++ b/website/docs/cdktf/examples.html.md
@@ -19,7 +19,7 @@ Follow these hands-on tutorials from HashiCorp Learn: [Write CDK for Terraform C
 | ------------| -----------|
 |[aws-ecs-docker-and-static-frontend](https://github.com/hashicorp/docker-on-aws-ecs-with-terraform-cdk-using-typescript) | Uses a backend service in a Docker container with a static frontend running in Amazon Web Services (AWS). Walk through AWS setup and configuring the backend to run against a Postgres Database.|
 |[aws-lambda-end-to-end](https://github.com/hashicorp/cdktf-integration-serverless-example) | An end-to-end example for a serverless web application hosted on AWS.|
-| [aws-prebuilt](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/aws-prebuilt) | Uses the prebuilt AWS provider to create a DynamoDB table. |
+| [aws-prebuilt](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/aws-prebuilt) | Provisions a DynamoDB table on the prebuilt AWS provider. |
 |[aws-multiple-stacks](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/aws-multiple-stacks) | Uses Stacks to pass different settings into the development, staging, and production environments. |
 |[aws-cloudfront-proxy](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/aws-cloudfront-proxy) | TBD - one line about what the app does. |
 |[azure](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/azure) | Provisions a Virtual Network on Microsoft Azure. |
@@ -28,8 +28,8 @@ Follow these hands-on tutorials from HashiCorp Learn: [Write CDK for Terraform C
 |[google](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/google) | TBD - one line about what the app does. |
 |[google-cloudrun](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/google-cloudrun) | TBD - one line about what the app does.|
 |[kubernetes](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/kubernetes) | TBD - one line about what the app does. |
-|[ucloud](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/ucloud) | TBD - one line about what the app does. |
-|[vault](./examples/typescript/vault) | TBD - one line about what the app does. |
+|[ucloud](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/ucloud) | Provisions a Linux base image on UCloud. |
+|[vault](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/vault) | TBD - one line about what the app does. |
 
 #### Backends
 Each CDK for Terraform project can specify a [backend](https://www.terraform.io/docs/language/settings/backends/index.html) that defines where and how Terraform operations are performed, where Terraform [state snapshots](https://www.terraform.io/docs/language/state/index.html) are stored, etc.
@@ -50,23 +50,27 @@ Each CDK for Terraform project can specify a [backend](https://www.terraform.io/
 |[azure](https://github.com/hashicorp/terraform-cdk/tree/main/examples/python/azure) | Provisions a Virtual Network on Microsoft Azure. |
 | [docker](https://github.com/hashicorp/terraform-cdk/tree/main/examples/python/docker) | Starts a Docker container with an NGINX server. |
 | [kubernetes](https://github.com/hashicorp/terraform-cdk/tree/main/examples/python/kubernetes) | Schedules and exposes a NGINX deployment on a Kubernetes cluster. |
-|[ucloud](https://github.com/hashicorp/terraform-cdk/tree/main/examples/python/ucloud) | Provisions a Linux base image on UCloud. |
+|[ucloud](https://github.com/hashicorp/terraform-cdk/tree/main/examples/python/ucloud) | Provisions a Linux base image on UCloud.|
 
 ### Java
 
-- [aws](./examples/java/aws)
-- [azure](./examples/java/azure)
-- [google](./examples/java/google)
-- [gradle-shared-module](./examples/java/gradle-shared-module)
-- [kubernetes](./examples/java/kubernetes)
-- [ucloud](./examples/java/ucloud)
+|Example | Description |
+| ------| ------------|
+|[aws](https://github.com/hashicorp/terraform-cdk/tree/main/examples/java/aws) | Provisions a DynamoDB table on the AWS provider. |
+|[azure](https://github.com/hashicorp/terraform-cdk/tree/main/examples/java/azure) | Provisions a Virtual Network on Microsoft Azure. |
+|[google](https://github.com/hashicorp/terraform-cdk/tree/main/examples/java/google) | TBD - one line about what the app does. |
+|[gradle-shared-module](https://github.com/hashicorp/terraform-cdk/tree/main/examples/java/gradle-shared-module) | Uses gradle to build and share two AWS modules. [Modules](./concepts/fundamentals/modules.html) are distinct configurations that you can package and reuse across projects and teams.|
+|[kubernetes](https://github.com/hashicorp/terraform-cdk/tree/main/examples/java/kubernetes) | Schedules and exposes a NGINX deployment on a Kubernetes cluster. **Please check me for accuracy**
+|[ucloud](https://github.com/hashicorp/terraform-cdk/tree/main/examples/java/ucloud) | Provisions a Linux base image on UCloud. |
 
 ### C Sharp
 
-- [aws](./examples/csharp/aws)
-- [azure](./examples/csharp/azure)
-- [google](./examples/csharp/google)
-- [ucloud](./examples/csharp/ucloud)
+|Example | Description |
+| -------| ------------|
+|[aws](https://github.com/hashicorp/terraform-cdk/tree/main/examples/csharp/aws) | Provisions a DynamoDB table on the AWS provider. |
+|[azure](https://github.com/hashicorp/terraform-cdk/tree/main/examples/csharp/azure) | Provisions a Virtual Network on Microsoft Azure. |
+|[google](https://github.com/hashicorp/terraform-cdk/tree/main/examples/csharp/google) | TBD - A line about what the app does.
+|[ucloud](https://github.com/hashicorp/terraform-cdk/tree/main/examples/csharp/ucloud) | Provisions a Linux base image on UCloud. |
 
 ### Go
 

--- a/website/docs/cdktf/examples.html.md
+++ b/website/docs/cdktf/examples.html.md
@@ -15,19 +15,21 @@ Follow these hands-on tutorials from HashiCorp Learn: [Write CDK for Terraform C
 
 ### Typescript
 
-- [aws-ecs-docker-and-static-frontend](https://github.com/hashicorp/docker-on-aws-ecs-with-terraform-cdk-using-typescript)
-- [aws-lambda-end-to-end](./docs/full-guide/serverless-application-typescript.md)
-- [aws-prebuilt](./examples/typescript/aws-prebuilt)
-- [aws-multiple-stacks](./examples/typescript/aws-multiple-stacks)
-- [aws-cloudfront-proxy](./examples/typescript/aws-cloudfront-proxy)
-- [azure](./examples/typescript/azure)
-- [azure-app-service](./examples/typescript/azure-app-service)
-- [docker](./examples/typescript/docker)
-- [google](./examples/typescript/google)
-- [google-cloudrun](./examples/typescript/google-cloudrun)
-- [kubernetes](./examples/typescript/kubernetes)
-- [ucloud](./examples/typescript/ucloud)
-- [vault](./examples/typescript/vault)
+|Example | Description |
+| ------------| -----------|
+|[aws-ecs-docker-and-static-frontend](https://github.com/hashicorp/docker-on-aws-ecs-with-terraform-cdk-using-typescript) | A backend service in a Docker container with a static frontend running on AWS. Walk through AWS setup and configuring the backend to run against a Postgres Database.|
+|[aws-lambda-end-to-end](https://github.com/hashicorp/cdktf-integration-serverless-example) | An end-to-end example  for a serverless web application hosted on AWS. |
+| [aws-prebuilt](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/aws-prebuilt) | An application that uses the prebuilt AWS provider to create a DynamoDB table. |
+|[aws-multiple-stacks](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/aws-multiple-stacks) | An application that uses Stacks to pass different settings into the development, staging, and production environments. |
+|[aws-cloudfront-proxy](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/aws-cloudfront-proxy) | TBD - one line about what the app does. |
+|[azure](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/azure) | An application to provision a Virtual Network with the Azure provider. |
+|[azure-app-service](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/azure-app-service) | TBD - one line about what the app does. |
+| [docker](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/docker) | An application that starts a Docker container with an Nginx server. |
+|[google](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/google) | TBD - one line about what the app does. |
+|[google-cloudrun](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/google-cloudrun) | TBD - one line about what the app does.|
+|[kubernetes](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/kubernetes) | TBD - one line about what the app does. |
+|[ucloud](https://github.com/hashicorp/terraform-cdk/tree/main/examples/typescript/ucloud) | TBD - one line about what the app does. |
+|[vault](./examples/typescript/vault) | TBD - one line about what the app does. |
 
 #### Backends
 


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-cdk/issues/967.

As promised, I took a stab at building out descriptions for the Examples we provide for various languages. In this PR I:
- Created tables for the examples for each language so that we could have a link to the example + a tiny description of what the app in the example does. 
- Updated all of the example link paths so that they're no longer relative links but full-on links to our github examples. 
- Took a pass at drafting descriptions of examples where I could. Please check these for accuracy - I'm still new to infrastructure, and I'm not familiar with all of these providers. The description should be 1-2 lines maximum - the goal is to 1) help users understand what the application is going to do/show them before they click it and 2) briefly explain any jargon that users will need to know in order to understand the value of the example (e.g. what a module is). Where appropriate, I've added in-text links to other areas of our docs for users who may need more information about a particular concept. 

@danieldreier Could you please just review for accuracy and leave me comments with any missing descriptions? Thank you :-)   @schersh Always value your feedback - let me know what you think/if you have any ideas to make this even more helpful for our users. 