### PR TITLE
fix(lib): check for null on removing metadata in testing framework

### DIFF
--- a/packages/cdktf/lib/testing/index.ts
+++ b/packages/cdktf/lib/testing/index.ts
@@ -53,7 +53,7 @@ export class Testing {
     const tfConfig = stack.toTerraform();
 
     function removeMetadata(item: any): any {
-      if (typeof item === "object") {
+      if (item !== null && typeof item === "object") {
         if (Array.isArray(item)) {
           return item.map(removeMetadata);
         }


### PR DESCRIPTION
When using snapshot testing I was getting the following the error:

```
Cannot convert undefined or null to object
TypeError: Cannot convert undefined or null to object
```

Turns out this is caused by the following snippet of CDK code:

```
const securityGroup = new SecurityGroup(
      scope,
      'elasticache_security_group',
      {
        namePrefix: 'ACME',
        description: 'Managed by Terraform',
        vpcId:  '123',
        ingress: [
          {
            fromPort: 12,
            toPort: 12,
            protocol: 'tcp',
          },
        ],
        tags: config.tags,
      }
```

This should syntesize an ingress block to:

```
{
      cidr_blocks: null,
      description: null,
      from_port: 11211,
      ipv6_cidr_blocks: null,
      prefix_list_ids: null,
      protocol: 'tcp',
      security_groups: null,
      self: null,
      to_port: 11211
    }
```

The snapshot testing library however currently tries to remove metadata and does a typeof check which automaticlly assumes that the value is an object when it could be a null value.

In my local testing, doing a null check alleviates the issue.