### PR TITLE
fix: ignore build output in prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,6 @@ packages/cdktf-cli/templates/*/cdktf.json
 *.json
 **/.jsii
 packages/*/coverage
+packages/**/.yalc
+packages/**/dist
+dist


### PR DESCRIPTION
These prettier errors only surfaced locally only as in CI `prettier --check` is run before any build.