### PR TITLE
feat(lib): Expand Output value types

### DIFF
--- a/packages/cdktf/lib/index.ts
+++ b/packages/cdktf/lib/index.ts
@@ -29,3 +29,4 @@ export * from "./annotations";
 export * from "./aspect";
 export * from "./terraform-functions";
 export * from "./tfExpression";
+export * from "./terraform-addressable";

--- a/packages/cdktf/lib/terraform-addressable.ts
+++ b/packages/cdktf/lib/terraform-addressable.ts
@@ -1,0 +1,3 @@
+export interface ITerraformAddressable {
+  readonly fqn: string;
+}

--- a/packages/cdktf/lib/terraform-dependable.ts
+++ b/packages/cdktf/lib/terraform-dependable.ts
@@ -1,3 +1,3 @@
-export interface ITerraformDependable {
-  readonly fqn: string;
-}
+import { ITerraformAddressable } from "./terraform-addressable";
+
+export interface ITerraformDependable extends ITerraformAddressable {}

--- a/packages/cdktf/lib/terraform-local.ts
+++ b/packages/cdktf/lib/terraform-local.ts
@@ -3,8 +3,12 @@ import { TerraformElement } from "./terraform-element";
 import { Token } from "./tokens";
 import { ref } from "./tfExpression";
 import { IResolvable } from "./tokens/resolvable";
+import { ITerraformAddressable } from "./terraform-addressable";
 
-export class TerraformLocal extends TerraformElement {
+export class TerraformLocal
+  extends TerraformElement
+  implements ITerraformAddressable
+{
   private _expression: any;
 
   constructor(scope: Construct, id: string, expression: any) {
@@ -38,6 +42,10 @@ export class TerraformLocal extends TerraformElement {
   }
 
   private interpolation(): any {
+    return `local.${this.friendlyUniqueId}`;
+  }
+
+  public get fqn() {
     return `local.${this.friendlyUniqueId}`;
   }
 

--- a/packages/cdktf/lib/terraform-output.ts
+++ b/packages/cdktf/lib/terraform-output.ts
@@ -4,6 +4,7 @@ import { keysToSnakeCase, deepMerge } from "./util";
 import { ITerraformDependable } from "./terraform-dependable";
 import { Expression, ref } from ".";
 import { isArray } from "util";
+import { ITerraformAddressable } from "./terraform-addressable";
 
 export interface TerraformOutputConfig {
   readonly value: Expression | ITerraformDependable;
@@ -20,7 +21,7 @@ export interface TerraformOutputConfig {
 }
 
 export class TerraformOutput extends TerraformElement {
-  public value: Expression | ITerraformDependable;
+  public value: Expression | ITerraformAddressable;
   public description?: string;
   public sensitive?: boolean;
   public dependsOn?: ITerraformDependable[];
@@ -44,7 +45,9 @@ export class TerraformOutput extends TerraformElement {
     return this.friendlyUniqueId === this.node.id;
   }
 
-  private isITerraformDependable(object: any): object is ITerraformDependable {
+  private isITerraformAddressable(
+    object: any
+  ): object is ITerraformAddressable {
     return (
       object &&
       typeof object === "object" &&
@@ -55,7 +58,7 @@ export class TerraformOutput extends TerraformElement {
 
   protected synthesizeAttributes(): { [key: string]: any } {
     return {
-      value: this.isITerraformDependable(this.value)
+      value: this.isITerraformAddressable(this.value)
         ? ref(this.value.fqn)
         : this.value,
       description: this.description,

--- a/packages/cdktf/lib/terraform-output.ts
+++ b/packages/cdktf/lib/terraform-output.ts
@@ -3,6 +3,7 @@ import { TerraformElement } from "./terraform-element";
 import { keysToSnakeCase, deepMerge } from "./util";
 import { ITerraformDependable } from "./terraform-dependable";
 import { Expression, ref } from ".";
+import { isArray } from "util";
 
 export interface TerraformOutputConfig {
   readonly value: Expression | ITerraformDependable;
@@ -44,7 +45,12 @@ export class TerraformOutput extends TerraformElement {
   }
 
   private isITerraformDependable(object: any): object is ITerraformDependable {
-    return "fqn" in object;
+    return (
+      object &&
+      typeof object === "object" &&
+      !isArray(object) &&
+      "fqn" in object
+    );
   }
 
   protected synthesizeAttributes(): { [key: string]: any } {

--- a/packages/cdktf/lib/terraform-remote-state.ts
+++ b/packages/cdktf/lib/terraform-remote-state.ts
@@ -4,13 +4,17 @@ import { Token } from "./tokens";
 import { deepMerge, keysToSnakeCase } from "./util";
 import { ref } from "./tfExpression";
 import { IResolvable } from "./tokens/resolvable";
+import { ITerraformAddressable } from "./terraform-addressable";
 
 export interface DataTerraformRemoteStateConfig {
   readonly workspace?: string;
   readonly defaults?: { [key: string]: any };
 }
 
-export abstract class TerraformRemoteState extends TerraformElement {
+export abstract class TerraformRemoteState
+  extends TerraformElement
+  implements ITerraformAddressable
+{
   constructor(
     scope: Construct,
     id: string,
@@ -46,6 +50,10 @@ export abstract class TerraformRemoteState extends TerraformElement {
     return ref(
       `data.terraform_remote_state.${this.friendlyUniqueId}.outputs.${terraformAttribute}`
     );
+  }
+
+  public get fqn() {
+    return `data.terraform_remote_state.${this.friendlyUniqueId}`;
   }
 
   private extractConfig(): { [name: string]: any } {

--- a/packages/cdktf/lib/terraform-variable.ts
+++ b/packages/cdktf/lib/terraform-variable.ts
@@ -4,6 +4,7 @@ import { keysToSnakeCase, deepMerge } from "./util";
 import { Token } from "./tokens";
 import { ref } from "./tfExpression";
 import { IResolvable } from "./tokens/resolvable";
+import { ITerraformAddressable } from "./terraform-addressable";
 
 export abstract class VariableType {
   public static readonly STRING = "string";
@@ -82,7 +83,10 @@ export interface TerraformVariableConfig {
   readonly sensitive?: boolean;
 }
 
-export class TerraformVariable extends TerraformElement {
+export class TerraformVariable
+  extends TerraformElement
+  implements ITerraformAddressable
+{
   public readonly default?: any;
   public readonly description?: string;
   public readonly type?: string;
@@ -119,6 +123,10 @@ export class TerraformVariable extends TerraformElement {
 
   private interpolation(): IResolvable {
     return ref(`var.${this.friendlyUniqueId}`);
+  }
+
+  public get fqn() {
+    return `var.${this.friendlyUniqueId}`;
   }
 
   public synthesizeAttributes(): { [key: string]: any } {

--- a/packages/cdktf/lib/tfExpression.ts
+++ b/packages/cdktf/lib/tfExpression.ts
@@ -350,4 +350,8 @@ export type Expression =
   | string[]
   | number
   | boolean
-  | IResolvable;
+  | IResolvable
+  | { [key: string]: any }
+  | null
+  | any // ultimately any valid Terraform type can be used as an expression
+  | any[];

--- a/packages/cdktf/test/__snapshots__/output.test.ts.snap
+++ b/packages/cdktf/test/__snapshots__/output.test.ts.snap
@@ -146,6 +146,73 @@ exports[`number output 1`] = `
 }"
 `;
 
+exports[`resource map output 1`] = `
+"{
+  \\"output\\": {
+    \\"test-output\\": {
+      \\"value\\": {
+        \\"myResource\\": \\"\${test_resource.foo}\\",
+        \\"something\\": \\"else\\"
+      }
+    }
+  },
+  \\"provider\\": {
+    \\"test\\": [
+      {}
+    ]
+  },
+  \\"resource\\": {
+    \\"test_resource\\": {
+      \\"foo\\": {
+        \\"name\\": \\"foo\\"
+      }
+    }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"test\\": {
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
+  }
+}"
+`;
+
+exports[`resource[] output 1`] = `
+"{
+  \\"output\\": {
+    \\"test-output\\": {
+      \\"value\\": [
+        \\"\${test_resource.foo1}\\",
+        \\"\${test_resource.foo2}\\"
+      ]
+    }
+  },
+  \\"provider\\": {
+    \\"test\\": [
+      {}
+    ]
+  },
+  \\"resource\\": {
+    \\"test_resource\\": {
+      \\"foo1\\": {
+        \\"name\\": \\"foo1\\"
+      },
+      \\"foo2\\": {
+        \\"name\\": \\"foo2\\"
+      }
+    }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"test\\": {
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
+  }
+}"
+`;
+
 exports[`sensitive output 1`] = `
 "{
   \\"output\\": {

--- a/packages/cdktf/test/__snapshots__/output.test.ts.snap
+++ b/packages/cdktf/test/__snapshots__/output.test.ts.snap
@@ -53,6 +53,35 @@ exports[`description output 1`] = `
 }"
 `;
 
+exports[`full resource output 1`] = `
+"{
+  \\"output\\": {
+    \\"test-output\\": {
+      \\"value\\": \\"\${test_resource.foo}\\"
+    }
+  },
+  \\"provider\\": {
+    \\"test\\": [
+      {}
+    ]
+  },
+  \\"resource\\": {
+    \\"test_resource\\": {
+      \\"foo\\": {
+        \\"name\\": \\"foo\\"
+      }
+    }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"test\\": {
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
+  }
+}"
+`;
+
 exports[`list output 1`] = `
 "{
   \\"output\\": {

--- a/packages/cdktf/test/__snapshots__/output.test.ts.snap
+++ b/packages/cdktf/test/__snapshots__/output.test.ts.snap
@@ -53,6 +53,35 @@ exports[`description output 1`] = `
 }"
 `;
 
+exports[`expression output 1`] = `
+"{
+  \\"output\\": {
+    \\"test-output\\": {
+      \\"value\\": \\"\${upper(\\\\\\"foo\\\\\\")}\\"
+    }
+  },
+  \\"provider\\": {
+    \\"test\\": [
+      {}
+    ]
+  },
+  \\"resource\\": {
+    \\"test_resource\\": {
+      \\"foo\\": {
+        \\"name\\": \\"foo\\"
+      }
+    }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"test\\": {
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
+  }
+}"
+`;
+
 exports[`full resource output 1`] = `
 "{
   \\"output\\": {

--- a/packages/cdktf/test/output.test.ts
+++ b/packages/cdktf/test/output.test.ts
@@ -136,3 +136,19 @@ test("static output id (without feature flags enabled)", () => {
 
   expect(Testing.synth(stack)).toMatchSnapshot();
 });
+
+test("full resource output", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+
+  new TestProvider(stack, "provider", {});
+  const resource = new TestResource(stack, "foo", {
+    name: "foo",
+  });
+
+  new TerraformOutput(stack, "test-output", {
+    value: resource,
+  });
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});

--- a/packages/cdktf/test/output.test.ts
+++ b/packages/cdktf/test/output.test.ts
@@ -169,3 +169,40 @@ test("expression output", () => {
 
   expect(Testing.synth(stack)).toMatchSnapshot();
 });
+
+test("resource[] output", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+
+  new TestProvider(stack, "provider", {});
+  const resource1 = new TestResource(stack, "foo1", {
+    name: "foo1",
+  });
+  const resource2 = new TestResource(stack, "foo2", {
+    name: "foo2",
+  });
+
+  new TerraformOutput(stack, "test-output", {
+    value: [resource1, resource2],
+  });
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test("resource map output", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+
+  new TestProvider(stack, "provider", {});
+  const resource = new TestResource(stack, "foo", {
+    name: "foo",
+  });
+  new TerraformOutput(stack, "test-output", {
+    value: {
+      myResource: resource,
+      something: "else",
+    },
+  });
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});

--- a/packages/cdktf/test/output.test.ts
+++ b/packages/cdktf/test/output.test.ts
@@ -4,6 +4,7 @@ import {
   TerraformOutput,
   TerraformElement,
   App,
+  Fn,
 } from "../lib";
 import fs = require("fs");
 import path = require("path");
@@ -148,6 +149,22 @@ test("full resource output", () => {
 
   new TerraformOutput(stack, "test-output", {
     value: resource,
+  });
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test("expression output", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+
+  new TestProvider(stack, "provider", {});
+  const resource = new TestResource(stack, "foo", {
+    name: "foo",
+  });
+
+  new TerraformOutput(stack, "test-output", {
+    value: Fn.upper(resource.name),
   });
 
   expect(Testing.synth(stack)).toMatchSnapshot();

--- a/packages/cdktf/test/tfExpression.test.ts
+++ b/packages/cdktf/test/tfExpression.test.ts
@@ -170,3 +170,15 @@ test("functions escape string markers", () => {
     resolveExpression(call("length", [rawString(`"`)]))
   ).toMatchInlineSnapshot(`"\${length(\\"\\\\\\"\\")}"`);
 });
+
+test("string index expression argument renders correctly", () => {
+  expect(
+    resolve(null as any, orOperation(true, { a: "foo", b: "bar " }))
+  ).toMatchInlineSnapshot(`"\${(true || {a = \\"foo\\", b = \\"bar \\"})}"`);
+});
+
+test("null expression argument renders correctly", () => {
+  expect(resolve(null as any, orOperation(true, null))).toMatchInlineSnapshot(
+    `"\${(true || undefined)}"`
+  );
+});


### PR DESCRIPTION
Fixes #1088 

Terraform output values can be assigned any expression according to https://www.terraform.io/docs/language/values/outputs.html#declaring-an-output-value.

Since we have started having a type to represent expressions, I thought it would make sense to start using it. I added a few things in so that we wouldn't reduce what could be passed to an output. We don't yet have a complete list; however, we do have `any` which can help cover missing cases.

I also added in `ITerraformDependable` to just output values to cover outputting an entire resource or module. I assume data sources can also be used that way, but if not, we can easily narrow it. I'm not sure if these can be used in general expressions, but if so, can move to there.

Draft because no new tests yet.