### PR TITLE
fix(lib): Also separate Token Map and symbols for interoperability with AWS CDK Tokens

### DIFF
--- a/packages/cdktf/lib/tokens/private/token-map.ts
+++ b/packages/cdktf/lib/tokens/private/token-map.ts
@@ -14,9 +14,9 @@ import {
 
 const glob = global as any;
 
-const STRING_SYMBOL = Symbol.for("@aws-cdk/core.TokenMap.STRING");
-const LIST_SYMBOL = Symbol.for("@aws-cdk/core.TokenMap.LIST");
-const NUMBER_SYMBOL = Symbol.for("@aws-cdk/core.TokenMap.NUMBER");
+const STRING_SYMBOL = Symbol.for("@cdktf/core.TokenMap.STRING");
+const LIST_SYMBOL = Symbol.for("@cdktf/core.TokenMap.LIST");
+const NUMBER_SYMBOL = Symbol.for("@cdktf/core.TokenMap.NUMBER");
 
 /**
  * Central place where we keep a mapping from Tokens to their String representation
@@ -32,10 +32,10 @@ export class TokenMap {
    * Singleton instance of the token string map
    */
   public static instance(): TokenMap {
-    if (!glob.__cdkTokenMap) {
-      glob.__cdkTokenMap = new TokenMap();
+    if (!glob.__cdktfTokenMap) {
+      glob.__cdktfTokenMap = new TokenMap();
     }
-    return glob.__cdkTokenMap;
+    return glob.__cdktfTokenMap;
   }
 
   private readonly stringTokenMap = new Map<string, IResolvable>();


### PR DESCRIPTION
This missed the way the TokenMap was instantiated as a singleton which caused
the two token systems to still be connected causing weird errors.

For example AWS CDK Tokens were encoded as `TfToken` causing more issues
further down the chain in the AWS Adapter (see `@cdktf/aws-cdk` package).