### PR TITLE
test(lib): ensure assets dont redeploy without FS changes

### DIFF
--- a/test/typescript/asset/__snapshots__/test.ts.snap
+++ b/test/typescript/asset/__snapshots__/test.ts.snap
@@ -13,7 +13,7 @@ exports[`full integration test synth 1`] = `
   \\"//\\": {
     \\"metadata\\": {
       \\"version\\": \\"stubbed\\",
-      \\"stackName\\": \\"stack\\",
+      \\"stackName\\": \\"fixed\\",
       \\"backend\\": \\"local\\"
     }
   },

--- a/test/typescript/asset/test.ts
+++ b/test/typescript/asset/test.ts
@@ -13,16 +13,16 @@ describe("full integration test", () => {
   });
 
   test("synth", async () => {
-    await driver.synth();
-    expect(driver.synthesizedStack("stack")).toMatchSnapshot();
+    await driver.synth("fixed");
+    expect(driver.synthesizedStack("fixed")).toMatchSnapshot();
   });
 
   test("file asset copied", async () => {
-    await driver.synth();
+    await driver.synth("fixed");
     expect(
       fs.readFileSync(
         path.resolve(
-          driver.stackDirectory("stack"),
+          driver.stackDirectory("fixed"),
           "assets/localasset/hash/local-asset.txt"
         ),
         "utf-8"
@@ -31,11 +31,11 @@ describe("full integration test", () => {
   });
 
   test("folder asset copied", async () => {
-    await driver.synth();
+    await driver.synth("fixed");
     expect(
       fs.readFileSync(
         path.resolve(
-          driver.stackDirectory("stack"),
+          driver.stackDirectory("fixed"),
           "assets/fixtures/hash/a.txt"
         ),
         "utf-8"
@@ -44,7 +44,7 @@ describe("full integration test", () => {
     expect(
       fs.readFileSync(
         path.resolve(
-          driver.stackDirectory("stack"),
+          driver.stackDirectory("fixed"),
           "assets/fixtures/hash/b.txt"
         ),
         "utf-8"
@@ -53,7 +53,7 @@ describe("full integration test", () => {
     expect(
       fs.readFileSync(
         path.resolve(
-          driver.stackDirectory("stack"),
+          driver.stackDirectory("fixed"),
           "assets/fixtures/hash/foo/bar/c.txt"
         ),
         "utf-8"
@@ -62,14 +62,24 @@ describe("full integration test", () => {
   });
 
   test("zip file created", async () => {
-    await driver.synth();
+    await driver.synth("fixed");
 
     const stat = fs.statSync(
       path.resolve(
-        driver.stackDirectory("stack"),
+        driver.stackDirectory("fixed"),
         "assets/zippedfixtures/hash/archive.zip"
       )
     );
     expect(stat.isFile()).toBe(true);
+  });
+
+  test("without asset changes there should be no redeployment", async () => {
+    expect(await driver.diff("normal")).toContain(
+      "1 to create, 0 to update, 0 to delete"
+    );
+    await driver.deploy("normal");
+    expect(await driver.diff("normal")).toContain(
+      "0 to create, 0 to update, 0 to delete"
+    );
   });
 });


### PR DESCRIPTION
Closes #883 

As this is just adding tests and passing I would guess there were FS changes in #883, maybe we should add some filtering logic to exclude files that are not interesting from an asset