### PR TITLE
feat(lib): throw error when a token is used in a construct name

### DIFF
--- a/packages/cdktf/lib/terraform-element.ts
+++ b/packages/cdktf/lib/terraform-element.ts
@@ -1,5 +1,5 @@
 import { Construct } from "constructs";
-import { Tokenization } from ".";
+import { Token } from ".";
 import { TerraformStack } from "./terraform-stack";
 
 export interface TerraformElementMetadata {
@@ -20,7 +20,7 @@ export class TerraformElement extends Construct {
   constructor(scope: Construct, id: string) {
     super(scope, id);
 
-    if (Tokenization.containsToken(id)) {
+    if (Token.isUnresolved(id)) {
       throw new Error(
         "You cannot use a Token (e.g. a reference to an attribute) as the id of a construct"
       );

--- a/packages/cdktf/lib/tokens/token.ts
+++ b/packages/cdktf/lib/tokens/token.ts
@@ -115,10 +115,6 @@ export class Tokenization {
     return [];
   }
 
-  public static containsToken(x: any): boolean {
-    return Tokenization.reverse(x).length > 0;
-  }
-
   /**
    * Un-encode a string potentially containing encoded tokens
    */


### PR DESCRIPTION
Closes #1068

This should help folks with a better error message than the current one