### PR TITLE
fix(lib): escape newlines in terraform functions

### DIFF
--- a/packages/cdktf/lib/terraform-functions.ts
+++ b/packages/cdktf/lib/terraform-functions.ts
@@ -13,9 +13,7 @@ type TFValueValidator = (value: any) => TFValue;
 type ExecutableTfFunction = (...args: any[]) => IResolvable;
 
 function hasUnescapedDoubleQuotes(str: string) {
-  const ret = /\\([\s\S])|(")/.test(str);
-  console.log("hasUnescapedDoubleQuotes", str, ret);
-  return ret;
+  return /\\([\s\S])|(")/.test(str);
 }
 
 // Validators

--- a/packages/cdktf/lib/tfExpression.ts
+++ b/packages/cdktf/lib/tfExpression.ts
@@ -17,7 +17,9 @@ class TFExpression extends Intrinsic implements IResolvable {
     }
 
     if (Array.isArray(resolvedArg)) {
-      return `[${resolvedArg.join(", ")}]`;
+      return `[${resolvedArg
+        .map((_, index) => this.resolveArg(context, arg[index]))
+        .join(", ")}]`;
     }
 
     if (typeof resolvedArg === "object") {

--- a/packages/cdktf/lib/tfExpression.ts
+++ b/packages/cdktf/lib/tfExpression.ts
@@ -86,7 +86,8 @@ class RawString extends TFExpression {
   }
 
   public resolve() {
-    return `"${this.escapeString(this.str).replace(/\"/g, '\\"')}"`; // eslint-disable-line no-useless-escape
+    const qts = this.isInnerTerraformExpression ? `"` : ``;
+    return `${qts}${this.escapeString(this.str).replace(/\"/g, '\\"')}${qts}`; // eslint-disable-line no-useless-escape
   }
 
   public toString() {

--- a/packages/cdktf/test/functions.test.ts
+++ b/packages/cdktf/test/functions.test.ts
@@ -357,6 +357,34 @@ test("quoted primitives, unquoted functions", () => {
   `);
 });
 
+test("nested objects and arrays as args", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+
+  new TerraformOutput(stack, "test-output", {
+    value: Fn.jsonencode({
+      Statement: [
+        {
+          Action: "sts:AssumeRole",
+          Effect: "Allow",
+          Principal: { Service: "lambda.amazonaws.com" },
+        },
+      ],
+      Version: "2012-10-17",
+    }),
+  });
+
+  expect(Testing.synth(stack)).toMatchInlineSnapshot(`
+    "{
+      \\"output\\": {
+        \\"test-output\\": {
+          \\"value\\": \\"\${jsonencode({Statement = [{Action = \\\\\\"sts:AssumeRole\\\\\\", Effect = \\\\\\"Allow\\\\\\", Principal = {Service = \\\\\\"lambda.amazonaws.com\\\\\\"}}], Version = \\\\\\"2012-10-17\\\\\\"})}\\"
+        }
+      }
+    }"
+  `);
+});
+
 test("terraform local", () => {
   const app = Testing.app();
   const stack = new TerraformStack(app, "test");

--- a/packages/cdktf/test/tfExpression.test.ts
+++ b/packages/cdktf/test/tfExpression.test.ts
@@ -1,3 +1,4 @@
+import { Token } from "../lib";
 import {
   addOperation,
   andOperation,
@@ -16,9 +17,12 @@ import {
   orOperation,
   propertyAccess,
   ref,
+  call,
   subOperation,
+  Expression,
 } from "../lib/tfExpression";
 import { resolve } from "../lib/_tokens";
+const resolveExpression = (expr: Expression) => resolve(null as any, expr);
 
 test("can render reference", () => {
   expect(
@@ -28,8 +32,7 @@ test("can render reference", () => {
 
 test("propertyAccess renders correctly", () => {
   expect(
-    resolve(
-      null as any,
+    resolveExpression(
       propertyAccess(ref("some_resource.my_resource.some_attribute_array"), [
         0,
         "name",
@@ -41,83 +44,122 @@ test("propertyAccess renders correctly", () => {
 });
 
 test("conditional renders correctly", () => {
-  expect(resolve(null as any, conditional(true, 1, 0))).toMatchInlineSnapshot(
+  expect(resolveExpression(conditional(true, 1, 0))).toMatchInlineSnapshot(
     `"\${true ? 1 : 0}"`
   );
 });
 
 test("notOperation renders correctly", () => {
-  expect(resolve(null as any, notOperation(true))).toMatchInlineSnapshot(
+  expect(resolveExpression(notOperation(true))).toMatchInlineSnapshot(
     `"\${!true}"`
   );
 });
 test("negateOperation renders correctly", () => {
-  expect(resolve(null as any, negateOperation(1))).toMatchInlineSnapshot(
+  expect(resolveExpression(negateOperation(1))).toMatchInlineSnapshot(
     `"\${-1}"`
   );
 });
 test("mulOperation renders correctly", () => {
-  expect(resolve(null as any, mulOperation(2, 3))).toMatchInlineSnapshot(
+  expect(resolveExpression(mulOperation(2, 3))).toMatchInlineSnapshot(
     `"\${(2 * 3)}"`
   );
 });
 test("divOperation renders correctly", () => {
-  expect(resolve(null as any, divOperation(4, 2))).toMatchInlineSnapshot(
+  expect(resolveExpression(divOperation(4, 2))).toMatchInlineSnapshot(
     `"\${(4 / 2)}"`
   );
 });
 test("modOperation renders correctly", () => {
-  expect(resolve(null as any, modOperation(5, 3))).toMatchInlineSnapshot(
+  expect(resolveExpression(modOperation(5, 3))).toMatchInlineSnapshot(
     `"\${(5 % 3)}"`
   );
 });
 test("addOperation renders correctly", () => {
-  expect(resolve(null as any, addOperation(1, 1))).toMatchInlineSnapshot(
+  expect(resolveExpression(addOperation(1, 1))).toMatchInlineSnapshot(
     `"\${(1 + 1)}"`
   );
 });
 test("subOperation renders correctly", () => {
-  expect(resolve(null as any, subOperation(1, 2))).toMatchInlineSnapshot(
+  expect(resolveExpression(subOperation(1, 2))).toMatchInlineSnapshot(
     `"\${(1 - 2)}"`
   );
 });
 test("gtOperation renders correctly", () => {
-  expect(resolve(null as any, gtOperation(1, 2))).toMatchInlineSnapshot(
+  expect(resolveExpression(gtOperation(1, 2))).toMatchInlineSnapshot(
     `"\${(1 > 2)}"`
   );
 });
 test("gteOperation renders correctly", () => {
-  expect(resolve(null as any, gteOperation(1, 2))).toMatchInlineSnapshot(
+  expect(resolveExpression(gteOperation(1, 2))).toMatchInlineSnapshot(
     `"\${(1 >= 2)}"`
   );
 });
 test("ltOperation renders correctly", () => {
-  expect(resolve(null as any, ltOperation(1, 2))).toMatchInlineSnapshot(
+  expect(resolveExpression(ltOperation(1, 2))).toMatchInlineSnapshot(
     `"\${(1 < 2)}"`
   );
 });
 test("lteOperation renders correctly", () => {
-  expect(resolve(null as any, lteOperation(1, 2))).toMatchInlineSnapshot(
+  expect(resolveExpression(lteOperation(1, 2))).toMatchInlineSnapshot(
     `"\${(1 <= 2)}"`
   );
 });
 test("eqOperation renders correctly", () => {
-  expect(resolve(null as any, eqOperation(1, 1))).toMatchInlineSnapshot(
+  expect(resolveExpression(eqOperation(1, 1))).toMatchInlineSnapshot(
     `"\${(1 == 1)}"`
   );
 });
 test("neqOperation renders correctly", () => {
-  expect(resolve(null as any, neqOperation(1, 2))).toMatchInlineSnapshot(
+  expect(resolveExpression(neqOperation(1, 2))).toMatchInlineSnapshot(
     `"\${(1 != 2)}"`
   );
 });
 test("andOperation renders correctly", () => {
-  expect(resolve(null as any, andOperation(true, true))).toMatchInlineSnapshot(
+  expect(resolveExpression(andOperation(true, true))).toMatchInlineSnapshot(
     `"\${(true && true)}"`
   );
 });
 test("orOperation renders correctly", () => {
-  expect(resolve(null as any, orOperation(true, true))).toMatchInlineSnapshot(
+  expect(resolveExpression(orOperation(true, true))).toMatchInlineSnapshot(
     `"\${(true || true)}"`
   );
+});
+
+test("functions escape newlines", () => {
+  expect(
+    resolveExpression(
+      call("length", [
+        `
+This
+is
+a
+multi
+line
+string
+  `,
+      ])
+    )
+  ).toMatchInlineSnapshot(
+    `"\${length(\\"\\\\nThis\\\\nis\\\\na\\\\nmulti\\\\nline\\\\nstring\\\\n  \\")}"`
+  );
+});
+
+test("functions escape terraform reference like strings", () => {
+  expect(resolveExpression(call("length", [`\${}`]))).toMatchInlineSnapshot(
+    `"\${length(\\"$\${}\\")}"`
+  );
+});
+
+test("functions don't escape terraform references", () => {
+  expect(
+    resolveExpression(call("length", [ref("docker_container.foo.bar")]))
+  ).toMatchInlineSnapshot(`"\${length(docker_container.foo.bar)}"`);
+});
+
+test("functions don't escape terraform references that have been tokenized", () => {
+  expect(
+    resolveExpression(
+      call("length", [Token.asString(ref("docker_container.foo.bar"))])
+    )
+  ).toMatchInlineSnapshot(`"\${length(docker_container.foo.bar)}"`);
 });

--- a/packages/cdktf/test/tfExpression.test.ts
+++ b/packages/cdktf/test/tfExpression.test.ts
@@ -20,6 +20,7 @@ import {
   call,
   subOperation,
   Expression,
+  rawString,
 } from "../lib/tfExpression";
 import { resolve } from "../lib/_tokens";
 const resolveExpression = (expr: Expression) => resolve(null as any, expr);
@@ -162,4 +163,10 @@ test("functions don't escape terraform references that have been tokenized", () 
       call("length", [Token.asString(ref("docker_container.foo.bar"))])
     )
   ).toMatchInlineSnapshot(`"\${length(docker_container.foo.bar)}"`);
+});
+
+test("functions escape string markers", () => {
+  expect(
+    resolveExpression(call("length", [rawString(`"`)]))
+  ).toMatchInlineSnapshot(`"\${length(\\"\\\\\\"\\")}"`);
 });


### PR DESCRIPTION
Previously newlines were added to the synthesised JSON, which JSON only accepts if escaped
This PR also escapes ${} into $${}

Closes #1165