### PR TITLE
fix: Fix EC2 Instance creation example

### DIFF
--- a/docs/getting-started/typescript.md
+++ b/docs/getting-started/typescript.md
@@ -71,7 +71,7 @@ Let's take a simple TypeScript application that uses the CDK for Terraform packa
 ```typescript
 import { Construct } from "constructs";
 import { App, TerraformStack } from "cdktf";
-import { AwsProvider, Instance } from "./.gen/providers/aws";
+import { AwsProvider, EC2 } from "./.gen/providers/aws";
 
 class MyStack extends TerraformStack {
   constructor(scope: Construct, id: string) {
@@ -81,7 +81,7 @@ class MyStack extends TerraformStack {
       region: "us-east-1",
     });
 
-    new Instance(this, "Hello", {
+    new EC2.Instance(this, "Hello", {
       ami: "ami-2757f631",
       instanceType: "t2.micro",
     });


### PR DESCRIPTION
Looks like `Instance` is no longer directly exported

https://github.com/hashicorp/terraform-cdk/blob/main/examples/typescript/aws-multiple-stacks/main.ts