### PR TITLE
fix(examples): temporarily set fixed AWS provider version for Java

### DIFF
--- a/examples/java/aws/cdktf.json
+++ b/examples/java/aws/cdktf.json
@@ -1,5 +1,5 @@
 {
   "language": "java",
   "app": "mvn -e -q compile exec:java",
-  "terraformProviders": ["aws@~> 3.0"]
+  "terraformProviders": ["aws@= 3.63.0"]
 }


### PR DESCRIPTION
allows our builds to work until #1260 is resolved
