### PR TITLE
fix(lib): Increased --max-old-space-size value

### DIFF
--- a/packages/@cdktf/provider-generator/lib/get/constructs-maker.ts
+++ b/packages/@cdktf/provider-generator/lib/get/constructs-maker.ts
@@ -310,13 +310,13 @@ export class ConstructsMaker {
             !process.env.NODE_OPTIONS.includes(`--max-old-space-size`)
           ) {
             console.warn(`found NODE_OPTIONS environment variable without a setting for --max-old-space-size.
-The provider generation needs a substantial amount of memory (~6-7GB) for some providers and languages.
-So cdktf-cli sets it to NODE_OPTIONS="--max-old-space-size=10240" by default. As your environment already contains
+The provider generation needs a substantial amount of memory (~13GB) for some providers and languages.
+So cdktf-cli sets it to NODE_OPTIONS="--max-old-space-size=16384" by default. As your environment already contains
 a NODE_OPTIONS variable, we won't override it. Hence, the provider generation might fail with an out of memory error.`);
           } else {
-            // increase memory to allow generating large providers (i.e. aws for Go)
+            // increase memory to allow generating large providers (i.e. aws or azurerm for Go)
             // srcmak is going to spawn a childprocess (for jsii-pacmak) which is going to be affected by this env var
-            process.env.NODE_OPTIONS = "--max-old-space-size=10240";
+            process.env.NODE_OPTIONS = "--max-old-space-size=16384";
           }
 
           await srcmak.srcmak(staging, opts);


### PR DESCRIPTION
Azurerm provider generation for Go [fails](https://github.com/hashicorp/terraform-cdk/issues/1264) because the 'hard' limit is 10240 MB and azurerm provider needs ~13 GBs of memory to get generated.

⚠️ Note: This is just further delaying a fix of a workaround rather than a solution.