### PR TITLE
chore(deps): relax jsii dependencies

### DIFF
--- a/packages/@cdktf/provider-generator/lib/get/constructs-maker.ts
+++ b/packages/@cdktf/provider-generator/lib/get/constructs-maker.ts
@@ -2,7 +2,7 @@ import * as fs from "fs-extra";
 import * as path from "path";
 import { CodeMaker } from "codemaker";
 import { mkdtemp } from "../util";
-import * as srcmak from "@skorfmann/jsii-srcmak";
+import * as srcmak from "jsii-srcmak";
 import {
   TerraformModuleConstraint,
   TerraformDependencyConstraint,

--- a/packages/@cdktf/provider-generator/package.json
+++ b/packages/@cdktf/provider-generator/package.json
@@ -27,7 +27,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "@skorfmann/jsii-srcmak": "^0.1.272",
+    "jsii-srcmak": "^0.1.272",
     "cdktf": "0.0.0",
     "codemaker": "^0.22.0",
     "fs-extra": "^8.1.0",

--- a/packages/cdktf-cli/package.json
+++ b/packages/cdktf-cli/package.json
@@ -36,7 +36,7 @@
     "@graphql-tools/load": "^6.2.8",
     "@npmcli/ci-detect": "^1.3.0",
     "@skorfmann/ink-confirm-input": "^3.0.0",
-    "@skorfmann/jsii-srcmak": "^0.1.272",
+    "jsii-srcmak": "^0.1.272",
     "@skorfmann/terraform-cloud": "^1.10.1",
     "@types/node": "^14.0.26",
     "apollo-server-core": "^3.0.2",

--- a/packages/cdktf/package.json
+++ b/packages/cdktf/package.json
@@ -86,8 +86,8 @@
     "constructs": "^10.0.0",
     "eslint": "^7.29.0",
     "jest": "^26.6.3",
-    "jsii": "1.37.0",
-    "jsii-pacmak": "1.37.0",
+    "jsii": "^1.37.0",
+    "jsii-pacmak": "^1.37.0",
     "ts-jest": "^26.4.4",
     "typescript": "^3.9.7"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -903,14 +903,6 @@
   resolved "https://registry.yarnpkg.com/@josephg/resolvable/-/resolvable-1.0.1.tgz#69bc4db754d79e1a2f17a650d3466e038d94a5eb"
   integrity sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg==
 
-"@jsii/check-node@1.37.0":
-  version "1.37.0"
-  resolved "https://registry.yarnpkg.com/@jsii/check-node/-/check-node-1.37.0.tgz#33fe8f590bd93c18048ce973aa07cd4bd4cc2028"
-  integrity sha512-s0jhnq/1X1IQQpKcAoUAd3KZ6X58nEjIi+vL4aC0iyDW6v2pmt8J5G/ilUZSbvplyJ2GdTMYi7NOCz2f3QAGZA==
-  dependencies:
-    chalk "^4.1.2"
-    semver "^7.3.5"
-
 "@jsii/check-node@1.43.0":
   version "1.43.0"
   resolved "https://registry.yarnpkg.com/@jsii/check-node/-/check-node-1.43.0.tgz#e0b07fb57da48a1eb6f844730e816af8c7295c95"
@@ -919,7 +911,7 @@
     chalk "^4.1.2"
     semver "^7.3.5"
 
-"@jsii/spec@^1.37.0", "@jsii/spec@^1.43.0":
+"@jsii/spec@^1.43.0":
   version "1.43.0"
   resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-1.43.0.tgz#78b7f21235b29dbbf31c9bc83afdf51cbe5f26a2"
   integrity sha512-4FZmzdBdVO64VEq1dQ6vXvBIWWHnUjP8bz7jAIjwSTE6iyJnSz2XT32tJpNg57RpBHRDdUuZGCgYa+xl06iGcA==
@@ -1872,17 +1864,6 @@
     ink-text-input "^4.0.1"
     prop-types "^15.5.10"
     yn "^3.1.1"
-
-"@skorfmann/jsii-srcmak@^0.1.272":
-  version "0.1.374"
-  resolved "https://registry.yarnpkg.com/@skorfmann/jsii-srcmak/-/jsii-srcmak-0.1.374.tgz#36921f695afa07d998eb5864aa7266f5b366bbad"
-  integrity sha512-laXjQBxKD/592o4GXQVpGwR66Hdi0o4jn5lOl3ff3Mk3NnTQmeMYWeQYfk+CI5fJPkipy/brnqtxk3IoFjr2TA==
-  dependencies:
-    fs-extra "^9.1.0"
-    jsii "1.37.0"
-    jsii-pacmak "1.37.0"
-    ncp "^2.0.0"
-    yargs "^15.4.1"
 
 "@skorfmann/terraform-cloud@^1.10.1":
   version "1.10.1"
@@ -3519,7 +3500,7 @@ codemaker@^0.22.0:
     decamelize "^1.2.0"
     fs-extra "^8.1.0"
 
-codemaker@^1.37.0:
+codemaker@^1.43.0:
   version "1.43.0"
   resolved "https://registry.yarnpkg.com/codemaker/-/codemaker-1.43.0.tgz#4c6c52cadd295c4fe3682faecd74427dcb7dcc26"
   integrity sha512-6FA4syN+22H9V0Dfadk9xbQ894kkeIhOH6HleiLRL0lU6Ts3nMB4lM01cHtnY/5YhLBr+XrHboV5Bi5xVFf4sg==
@@ -7153,26 +7134,26 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
-jsii-pacmak@1.37.0:
-  version "1.37.0"
-  resolved "https://registry.yarnpkg.com/jsii-pacmak/-/jsii-pacmak-1.37.0.tgz#2c0d4584375a3debc6862a13060dff769ba36909"
-  integrity sha512-cXLXAOyCqd/QNBy+OfcmMgj8UdNVbJJsKoM/C3SvRgdi+fpQlxh1iDTOcKUwd3/QgMuDMDLvKCCpLmq/YRjreA==
+jsii-pacmak@^1.37.0, jsii-pacmak@^1.43.0:
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/jsii-pacmak/-/jsii-pacmak-1.43.0.tgz#ff048a98a1b05256630e0bc6f538f9025e42ae97"
+  integrity sha512-GrvEz/Rbiwu+O3HWNiDybXV+homhzSZH0DgBkfCvmPvPUJPmSn1u3cU586F77gESGTOy9bOXJOkGfXpq9PZO4Q==
   dependencies:
-    "@jsii/check-node" "1.37.0"
-    "@jsii/spec" "^1.37.0"
+    "@jsii/check-node" "1.43.0"
+    "@jsii/spec" "^1.43.0"
     clone "^2.1.2"
-    codemaker "^1.37.0"
+    codemaker "^1.43.0"
     commonmark "^0.30.0"
     escape-string-regexp "^4.0.0"
     fs-extra "^9.1.0"
-    jsii-reflect "^1.37.0"
-    jsii-rosetta "^1.37.0"
+    jsii-reflect "^1.43.0"
+    jsii-rosetta "^1.43.0"
     semver "^7.3.5"
     spdx-license-list "^6.4.0"
     xmlbuilder "^15.1.1"
     yargs "^16.2.0"
 
-jsii-reflect@^1.37.0:
+jsii-reflect@^1.43.0:
   version "1.43.0"
   resolved "https://registry.yarnpkg.com/jsii-reflect/-/jsii-reflect-1.43.0.tgz#ff697abd367f82aa4a093b270406fefd9f76d8a9"
   integrity sha512-UoEK0c2CO0LPvb53TkedFFyAKBXbrb35vs65HJhfBzBqyZBcPQ3+mm6lFA38oTtsDFNBJe0Eyg0cuFaWzWDllg==
@@ -7184,7 +7165,7 @@ jsii-reflect@^1.37.0:
     oo-ascii-tree "^1.43.0"
     yargs "^16.2.0"
 
-jsii-rosetta@^1.37.0, jsii-rosetta@^1.39.0:
+jsii-rosetta@^1.39.0, jsii-rosetta@^1.43.0:
   version "1.43.0"
   resolved "https://registry.yarnpkg.com/jsii-rosetta/-/jsii-rosetta-1.43.0.tgz#12f396b23e86b88a1158a9a8df8c41a32310adfe"
   integrity sha512-AjJ0tlrnBatJB7OJ/cn9sFaLpM4Ra7fSkxLlHNWsVE1KFAUnCLIcDloXaytaDmBXY/emxi3/XbWwGUIqbjbCIw==
@@ -7199,13 +7180,24 @@ jsii-rosetta@^1.37.0, jsii-rosetta@^1.39.0:
     workerpool "^6.1.5"
     yargs "^16.2.0"
 
-jsii@1.37.0:
-  version "1.37.0"
-  resolved "https://registry.yarnpkg.com/jsii/-/jsii-1.37.0.tgz#96f7045df058725a872110c52d6252b5e44ee038"
-  integrity sha512-M+opnlcNb1Ne5igms/OJn/e2ZyQgcCwmqqljuOsHXBMFm7vMOVLSjEUcBYcW7ifJeM1+XYg8+wfuAoZhqY1zCg==
+jsii-srcmak@^0.1.272:
+  version "0.1.395"
+  resolved "https://registry.yarnpkg.com/jsii-srcmak/-/jsii-srcmak-0.1.395.tgz#f1e4f548211301401188a5ca8a0dab56918d44aa"
+  integrity sha512-bes1vFd0qC/R7Ef/iuLdQgJ9yNVASh3HFPhfGHubJ1urDOBZN3XcNdE6cBuRradItVBrzBWovHabfW1DiEvz+g==
   dependencies:
-    "@jsii/check-node" "1.37.0"
-    "@jsii/spec" "^1.37.0"
+    fs-extra "^9.1.0"
+    jsii "^1.43.0"
+    jsii-pacmak "^1.43.0"
+    ncp "^2.0.0"
+    yargs "^15.4.1"
+
+jsii@^1.37.0, jsii@^1.43.0:
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/jsii/-/jsii-1.43.0.tgz#661f09aeb8b1ba12267268d2a62b8b162c5951c8"
+  integrity sha512-2GsSiwbX++/f6BE/fnT9s0iBQtT+MSsnFBZdpyw4sV50gEg9gbD1rPO/ewSLuUh83mrztPtdiurxsBpYGj17Nw==
+  dependencies:
+    "@jsii/check-node" "1.43.0"
+    "@jsii/spec" "^1.43.0"
     case "^1.6.3"
     colors "^1.4.0"
     deep-equal "^2.0.5"


### PR DESCRIPTION
With the 0.7 release we fixed jsii to `1.37.0` because of https://github.com/hashicorp/terraform-cdk/issues/1152 and https://github.com/aws/jsii/issues/3078

This pull request aims to relax that restriction again. I'm not exactly sure if our changes to the namespacing fixed the issues already or if we have to push for https://github.com/aws/jsii/issues/3078 - Tests will tell :) 