### PR TITLE
chore(docs): Move examples up in sidebar, list out tutorials

### DIFF
--- a/website/docs/cdktf/examples.html.md
+++ b/website/docs/cdktf/examples.html.md
@@ -15,15 +15,14 @@ This page contains links to tutorials, example projects in every supported langu
 
 Follow these hands-on tutorials from HashiCorp Learn:
 
-| Tutorial | Description |
-|---------| -------------|
-|[Install CDKTF and Run a Quick Start Demo](https://learn.hashicorp.com/tutorials/terraform/cdktf-install?in=terraform/cdktf) | Write TypeScript code that will provision an NGINX server using Docker on Mac, Windows, or Linux. |
-| [Build AWS Infrastructure with TypeScript](https://learn.hashicorp.com/tutorials/terraform/cdktf-build?in=terraform/cdktf) | Provision an EC2 instance on AWS using TypeScript. |
-| [Build AWS Infrastructure with Python](https://learn.hashicorp.com/tutorials/terraform/cdktf-build-python?in=terraform/cdktf) | Provision an EC2 instance on AWS using Python. |
-|[Build AWS Infrastructure with Go](https://learn.hashicorp.com/tutorials/terraform/cdktf-build-go?in=terraform/cdktf) | Provision an EC2 instance on AWS using Go. |
+| Tutorial                                                                                                                                          | Description                                                                                                           |
+| ------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| [Install CDKTF and Run a Quick Start Demo](https://learn.hashicorp.com/tutorials/terraform/cdktf-install?in=terraform/cdktf)                      | Write TypeScript code that will provision an NGINX server using Docker on Mac, Windows, or Linux.                     |
+| [Build AWS Infrastructure with TypeScript](https://learn.hashicorp.com/tutorials/terraform/cdktf-build?in=terraform/cdktf)                        | Provision an EC2 instance on AWS using TypeScript.                                                                    |
+| [Build AWS Infrastructure with Python](https://learn.hashicorp.com/tutorials/terraform/cdktf-build-python?in=terraform/cdktf)                     | Provision an EC2 instance on AWS using Python.                                                                        |
+| [Build AWS Infrastructure with Go](https://learn.hashicorp.com/tutorials/terraform/cdktf-build-go?in=terraform/cdktf)                             | Provision an EC2 instance on AWS using Go.                                                                            |
 | [Deploy Multiple Lambda Functions with TypeScript](https://learn.hashicorp.com/tutorials/terraform/cdktf-assets-stacks-lambda?in=terraform/cdktf) | Deploy a CDKTF application made up of two stacks, each containing a simple AWS Lambda function written in TypeScript. |
-|[Deploy Applications with CDK for Terraform](https://learn.hashicorp.com/tutorials/terraform/cdktf-applications?in=terraform/cdktf) | Use CDKTF to deploy an application on Kubernetes.
-
+| [Deploy Applications with CDK for Terraform](https://learn.hashicorp.com/tutorials/terraform/cdktf-applications?in=terraform/cdktf)               | Use CDKTF to deploy an application on Kubernetes.                                                                     |
 
 ## Example Projects
 

--- a/website/docs/cdktf/examples.html.md
+++ b/website/docs/cdktf/examples.html.md
@@ -1,6 +1,6 @@
 ---
 layout: "cdktf"
-page_title: "CDKTF Examples"
+page_title: "CDKTF Examples and Guides"
 sidebar_current: "cdktf"
 description: "Resources to help you learn CDK for Terraform, including example projects in Typescript, Java, Python C Sharp, and Go."
 ---
@@ -13,7 +13,17 @@ This page contains links to tutorials, example projects in every supported langu
 
 ## Tutorials
 
-Follow these hands-on tutorials from HashiCorp Learn: [Write CDK for Terraform Configurations](https://learn.hashicorp.com/collections/terraform/cdktf)
+Follow these hands-on tutorials from HashiCorp Learn:
+
+| Tutorial | Description |
+|---------| -------------|
+|[Install CDKTF and Run a Quick Start Demo](https://learn.hashicorp.com/tutorials/terraform/cdktf-install?in=terraform/cdktf) | Write TypeScript code that will provision an NGINX server using Docker on Mac, Windows, or Linux. |
+| [Build AWS Infrastructure with TypeScript](https://learn.hashicorp.com/tutorials/terraform/cdktf-build?in=terraform/cdktf) | Provision an EC2 instance on AWS using TypeScript. |
+| [Build AWS Infrastructure with Python](https://learn.hashicorp.com/tutorials/terraform/cdktf-build-python?in=terraform/cdktf) | Provision an EC2 instance on AWS using Python. |
+|[Build AWS Infrastructure with Go](https://learn.hashicorp.com/tutorials/terraform/cdktf-build-go?in=terraform/cdktf) | Provision an EC2 instance on AWS using Go. |
+| [Deploy Multiple Lambda Functions with TypeScript](https://learn.hashicorp.com/tutorials/terraform/cdktf-assets-stacks-lambda?in=terraform/cdktf) | Deploy a CDKTF application made up of two stacks, each containing a simple AWS Lambda function written in TypeScript. |
+|[Deploy Applications with CDK for Terraform](https://learn.hashicorp.com/tutorials/terraform/cdktf-applications?in=terraform/cdktf) | Use CDKTF to deploy an application on Kubernetes.
+
 
 ## Example Projects
 

--- a/website/layouts/cdktf.erb
+++ b/website/layouts/cdktf.erb
@@ -61,7 +61,7 @@
           </li>
           <li>
             <a href="/docs/cdktf/concepts/stacks.html">Stacks</a>
-          </li> 
+          </li>
           <li>
             <a href="/docs/cdktf/concepts/aspects.html">Aspects</a>
           </li>
@@ -95,6 +95,10 @@
       </li>
 
       <li>
+        <a href="/docs/cdktf/examples.html">Examples and Guides</a>
+      </li>
+
+      <li>
         <a href="#">Test</a>
         <ul class="nav">
           <li><a href="/docs/cdktf/test/unit-tests.html">Unit Tests</a></li>
@@ -113,10 +117,6 @@
             <a href="/docs/cdktf/cli-reference/commands.html">Commands</a>
           </li>
         </ul>
-      </li>
-
-      <li>
-        <a href="/docs/cdktf/examples.html">Examples</a>
       </li>
 
       <li>


### PR DESCRIPTION
Per a conversation with @schersh, users have been asking for "How To" guides for CDKTF. We do have those on Learn, so our hypothesis is that it's not clear to some users what's available for them. This PR aims to address this issue by:
- Renaming "Examples" to "Examples and Guides". We think users may be looking for keywords like "How To" or "Guide", which are sections in other popular documentation sets. 
- Moving the Examples and Guides page up higher in the sidebar - it now sits underneath "Create and Deploy." This is one of the most-visited pages according to Google Analytics, so it's obviously information that users want and need. Moving it up in the hierarchy will hopefully help emphasize it a bit more.
- Listing out the available tutorials on Learn inside the Examples and Guides page. It's not always clear what's available from the name of the "Get Started" collection, so we think listing out the available tutorials and helping users understand what they will teach them to do will be helpful.