### PR TITLE
fix(lib): Make sure empty single item lists in synth

### DIFF
--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/complex-computed-types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/complex-computed-types.test.ts.snap
@@ -83,9 +83,11 @@ export function acmCertificateOptionsToTerraform(struct?: AcmCertificateOptionsO
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     certificate_transparency_logging_preference: cdktf.stringToTerraform(struct!.certificateTransparencyLoggingPreference),
-  }
+
+  }];
 }
 
 export class AcmCertificateOptionsOutputReference extends cdktf.ComplexObject {
@@ -342,7 +344,7 @@ export class AcmCertificate extends cdktf.TerraformResource {
       subject_alternative_names: cdktf.listMapper(cdktf.stringToTerraform)(this._subjectAlternativeNames),
       tags: cdktf.hashMapper(cdktf.anyToTerraform)(this._tags),
       validation_method: cdktf.stringToTerraform(this._validationMethod),
-      options: [acmCertificateOptionsToTerraform(this._options)],
+      options: acmCertificateOptionsToTerraform(this._options),
     };
   }
 }

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/complex-computed-types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/complex-computed-types.test.ts.snap
@@ -342,7 +342,7 @@ export class AcmCertificate extends cdktf.TerraformResource {
       subject_alternative_names: cdktf.listMapper(cdktf.stringToTerraform)(this._subjectAlternativeNames),
       tags: cdktf.hashMapper(cdktf.anyToTerraform)(this._tags),
       validation_method: cdktf.stringToTerraform(this._validationMethod),
-      options: acmCertificateOptionsToTerraform(this._options),
+      options: [acmCertificateOptionsToTerraform(this._options)],
     };
   }
 }

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/provider.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/provider.test.ts.snap
@@ -168,12 +168,14 @@ export function awsProviderAssumeRoleToTerraform(struct?: AwsProviderAssumeRoleO
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     external_id: cdktf.stringToTerraform(struct!.externalId),
     policy: cdktf.stringToTerraform(struct!.policy),
     role_arn: cdktf.stringToTerraform(struct!.roleArn),
     session_name: cdktf.stringToTerraform(struct!.sessionName),
-  }
+
+  }];
 }
 
 export class AwsProviderAssumeRoleOutputReference extends cdktf.ComplexObject {
@@ -1227,10 +1229,12 @@ export function awsProviderIgnoreTagsToTerraform(struct?: AwsProviderIgnoreTagsO
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     key_prefixes: cdktf.listMapper(cdktf.stringToTerraform)(struct!.keyPrefixes),
     keys: cdktf.listMapper(cdktf.stringToTerraform)(struct!.keys),
-  }
+
+  }];
 }
 
 export class AwsProviderIgnoreTagsOutputReference extends cdktf.ComplexObject {
@@ -1672,9 +1676,9 @@ export class AwsProvider extends cdktf.TerraformProvider {
       skip_requesting_account_id: cdktf.booleanToTerraform(this._skipRequestingAccountId),
       token: cdktf.stringToTerraform(this._token),
       alias: cdktf.stringToTerraform(this._alias),
-      assume_role: [awsProviderAssumeRoleToTerraform(this._assumeRole)],
+      assume_role: awsProviderAssumeRoleToTerraform(this._assumeRole),
       endpoints: cdktf.listMapper(awsProviderEndpointsToTerraform)(this._endpoints),
-      ignore_tags: [awsProviderIgnoreTagsToTerraform(this._ignoreTags)],
+      ignore_tags: awsProviderIgnoreTagsToTerraform(this._ignoreTags),
     };
   }
 }

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/provider.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/provider.test.ts.snap
@@ -1672,9 +1672,9 @@ export class AwsProvider extends cdktf.TerraformProvider {
       skip_requesting_account_id: cdktf.booleanToTerraform(this._skipRequestingAccountId),
       token: cdktf.stringToTerraform(this._token),
       alias: cdktf.stringToTerraform(this._alias),
-      assume_role: awsProviderAssumeRoleToTerraform(this._assumeRole),
+      assume_role: [awsProviderAssumeRoleToTerraform(this._assumeRole)],
       endpoints: cdktf.listMapper(awsProviderEndpointsToTerraform)(this._endpoints),
-      ignore_tags: awsProviderIgnoreTagsToTerraform(this._ignoreTags),
+      ignore_tags: [awsProviderIgnoreTagsToTerraform(this._ignoreTags)],
     };
   }
 }

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/resource-types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/resource-types.test.ts.snap
@@ -200,7 +200,7 @@ export function cloudfrontDistributionCacheBehaviorForwardedValuesToTerraform(st
     headers: cdktf.listMapper(cdktf.stringToTerraform)(struct!.headers),
     query_string: cdktf.booleanToTerraform(struct!.queryString),
     query_string_cache_keys: cdktf.listMapper(cdktf.stringToTerraform)(struct!.queryStringCacheKeys),
-    cookies: cloudfrontDistributionCacheBehaviorForwardedValuesCookiesToTerraform(struct!.cookies),
+    cookies: [cloudfrontDistributionCacheBehaviorForwardedValuesCookiesToTerraform(struct!.cookies)],
   }
 }
 
@@ -381,7 +381,7 @@ export function cloudfrontDistributionCacheBehaviorToTerraform(struct?: Cloudfro
     target_origin_id: cdktf.stringToTerraform(struct!.targetOriginId),
     trusted_signers: cdktf.listMapper(cdktf.stringToTerraform)(struct!.trustedSigners),
     viewer_protocol_policy: cdktf.stringToTerraform(struct!.viewerProtocolPolicy),
-    forwarded_values: cloudfrontDistributionCacheBehaviorForwardedValuesToTerraform(struct!.forwardedValues),
+    forwarded_values: [cloudfrontDistributionCacheBehaviorForwardedValuesToTerraform(struct!.forwardedValues)],
     lambda_function_association: cdktf.listMapper(cloudfrontDistributionCacheBehaviorLambdaFunctionAssociationToTerraform)(struct!.lambdaFunctionAssociation),
   }
 }
@@ -509,7 +509,7 @@ export function cloudfrontDistributionDefaultCacheBehaviorForwardedValuesToTerra
     headers: cdktf.listMapper(cdktf.stringToTerraform)(struct!.headers),
     query_string: cdktf.booleanToTerraform(struct!.queryString),
     query_string_cache_keys: cdktf.listMapper(cdktf.stringToTerraform)(struct!.queryStringCacheKeys),
-    cookies: cloudfrontDistributionDefaultCacheBehaviorForwardedValuesCookiesToTerraform(struct!.cookies),
+    cookies: [cloudfrontDistributionDefaultCacheBehaviorForwardedValuesCookiesToTerraform(struct!.cookies)],
   }
 }
 
@@ -685,7 +685,7 @@ export function cloudfrontDistributionDefaultCacheBehaviorToTerraform(struct?: C
     target_origin_id: cdktf.stringToTerraform(struct!.targetOriginId),
     trusted_signers: cdktf.listMapper(cdktf.stringToTerraform)(struct!.trustedSigners),
     viewer_protocol_policy: cdktf.stringToTerraform(struct!.viewerProtocolPolicy),
-    forwarded_values: cloudfrontDistributionDefaultCacheBehaviorForwardedValuesToTerraform(struct!.forwardedValues),
+    forwarded_values: [cloudfrontDistributionDefaultCacheBehaviorForwardedValuesToTerraform(struct!.forwardedValues)],
     lambda_function_association: cdktf.listMapper(cloudfrontDistributionDefaultCacheBehaviorLambdaFunctionAssociationToTerraform)(struct!.lambdaFunctionAssociation),
   }
 }
@@ -1068,7 +1068,7 @@ export function cloudfrontDistributionOrderedCacheBehaviorForwardedValuesToTerra
     headers: cdktf.listMapper(cdktf.stringToTerraform)(struct!.headers),
     query_string: cdktf.booleanToTerraform(struct!.queryString),
     query_string_cache_keys: cdktf.listMapper(cdktf.stringToTerraform)(struct!.queryStringCacheKeys),
-    cookies: cloudfrontDistributionOrderedCacheBehaviorForwardedValuesCookiesToTerraform(struct!.cookies),
+    cookies: [cloudfrontDistributionOrderedCacheBehaviorForwardedValuesCookiesToTerraform(struct!.cookies)],
   }
 }
 
@@ -1249,7 +1249,7 @@ export function cloudfrontDistributionOrderedCacheBehaviorToTerraform(struct?: C
     target_origin_id: cdktf.stringToTerraform(struct!.targetOriginId),
     trusted_signers: cdktf.listMapper(cdktf.stringToTerraform)(struct!.trustedSigners),
     viewer_protocol_policy: cdktf.stringToTerraform(struct!.viewerProtocolPolicy),
-    forwarded_values: cloudfrontDistributionOrderedCacheBehaviorForwardedValuesToTerraform(struct!.forwardedValues),
+    forwarded_values: [cloudfrontDistributionOrderedCacheBehaviorForwardedValuesToTerraform(struct!.forwardedValues)],
     lambda_function_association: cdktf.listMapper(cloudfrontDistributionOrderedCacheBehaviorLambdaFunctionAssociationToTerraform)(struct!.lambdaFunctionAssociation),
   }
 }
@@ -1495,8 +1495,8 @@ export function cloudfrontDistributionOriginToTerraform(struct?: CloudfrontDistr
     origin_id: cdktf.stringToTerraform(struct!.originId),
     origin_path: cdktf.stringToTerraform(struct!.originPath),
     custom_header: cdktf.listMapper(cloudfrontDistributionOriginCustomHeaderToTerraform)(struct!.customHeader),
-    custom_origin_config: cloudfrontDistributionOriginCustomOriginConfigToTerraform(struct!.customOriginConfig),
-    s3_origin_config: cloudfrontDistributionOriginS3OriginConfigToTerraform(struct!.s3OriginConfig),
+    custom_origin_config: [cloudfrontDistributionOriginCustomOriginConfigToTerraform(struct!.customOriginConfig)],
+    s3_origin_config: [cloudfrontDistributionOriginS3OriginConfigToTerraform(struct!.s3OriginConfig)],
   }
 }
 
@@ -1584,7 +1584,7 @@ export function cloudfrontDistributionOriginGroupToTerraform(struct?: Cloudfront
   }
   return {
     origin_id: cdktf.stringToTerraform(struct!.originId),
-    failover_criteria: cloudfrontDistributionOriginGroupFailoverCriteriaToTerraform(struct!.failoverCriteria),
+    failover_criteria: [cloudfrontDistributionOriginGroupFailoverCriteriaToTerraform(struct!.failoverCriteria)],
     member: cdktf.listMapper(cloudfrontDistributionOriginGroupMemberToTerraform)(struct!.member),
   }
 }
@@ -1665,7 +1665,7 @@ export function cloudfrontDistributionRestrictionsToTerraform(struct?: Cloudfron
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
   return {
-    geo_restriction: cloudfrontDistributionRestrictionsGeoRestrictionToTerraform(struct!.geoRestriction),
+    geo_restriction: [cloudfrontDistributionRestrictionsGeoRestrictionToTerraform(struct!.geoRestriction)],
   }
 }
 
@@ -2263,13 +2263,13 @@ export class CloudfrontDistribution extends cdktf.TerraformResource {
       web_acl_id: cdktf.stringToTerraform(this._webAclId),
       cache_behavior: cdktf.listMapper(cloudfrontDistributionCacheBehaviorToTerraform)(this._cacheBehavior),
       custom_error_response: cdktf.listMapper(cloudfrontDistributionCustomErrorResponseToTerraform)(this._customErrorResponse),
-      default_cache_behavior: cloudfrontDistributionDefaultCacheBehaviorToTerraform(this._defaultCacheBehavior),
-      logging_config: cloudfrontDistributionLoggingConfigToTerraform(this._loggingConfig),
+      default_cache_behavior: [cloudfrontDistributionDefaultCacheBehaviorToTerraform(this._defaultCacheBehavior)],
+      logging_config: [cloudfrontDistributionLoggingConfigToTerraform(this._loggingConfig)],
       ordered_cache_behavior: cdktf.listMapper(cloudfrontDistributionOrderedCacheBehaviorToTerraform)(this._orderedCacheBehavior),
       origin: cdktf.listMapper(cloudfrontDistributionOriginToTerraform)(this._origin),
       origin_group: cdktf.listMapper(cloudfrontDistributionOriginGroupToTerraform)(this._originGroup),
-      restrictions: cloudfrontDistributionRestrictionsToTerraform(this._restrictions),
-      viewer_certificate: cloudfrontDistributionViewerCertificateToTerraform(this._viewerCertificate),
+      restrictions: [cloudfrontDistributionRestrictionsToTerraform(this._restrictions)],
+      viewer_certificate: [cloudfrontDistributionViewerCertificateToTerraform(this._viewerCertificate)],
     };
   }
 }
@@ -2788,8 +2788,8 @@ export function s3BucketLifecycleRuleToTerraform(struct?: S3BucketLifecycleRule)
     enabled: cdktf.booleanToTerraform(struct!.enabled),
     prefix: cdktf.stringToTerraform(struct!.prefix),
     tags: cdktf.hashMapper(cdktf.anyToTerraform)(struct!.tags),
-    expiration: s3BucketLifecycleRuleExpirationToTerraform(struct!.expiration),
-    noncurrent_version_expiration: s3BucketLifecycleRuleNoncurrentVersionExpirationToTerraform(struct!.noncurrentVersionExpiration),
+    expiration: [s3BucketLifecycleRuleExpirationToTerraform(struct!.expiration)],
+    noncurrent_version_expiration: [s3BucketLifecycleRuleNoncurrentVersionExpirationToTerraform(struct!.noncurrentVersionExpiration)],
     noncurrent_version_transition: cdktf.listMapper(s3BucketLifecycleRuleNoncurrentVersionTransitionToTerraform)(struct!.noncurrentVersionTransition),
     transition: cdktf.listMapper(s3BucketLifecycleRuleTransitionToTerraform)(struct!.transition),
   }
@@ -2914,7 +2914,7 @@ export function s3BucketObjectLockConfigurationRuleToTerraform(struct?: S3Bucket
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
   return {
-    default_retention: s3BucketObjectLockConfigurationRuleDefaultRetentionToTerraform(struct!.defaultRetention),
+    default_retention: [s3BucketObjectLockConfigurationRuleDefaultRetentionToTerraform(struct!.defaultRetention)],
   }
 }
 
@@ -2962,7 +2962,7 @@ export function s3BucketObjectLockConfigurationToTerraform(struct?: S3BucketObje
   }
   return {
     object_lock_enabled: cdktf.stringToTerraform(struct!.objectLockEnabled),
-    rule: s3BucketObjectLockConfigurationRuleToTerraform(struct!.rule),
+    rule: [s3BucketObjectLockConfigurationRuleToTerraform(struct!.rule)],
   }
 }
 
@@ -3081,7 +3081,7 @@ export function s3BucketReplicationConfigurationRulesDestinationToTerraform(stru
     bucket: cdktf.stringToTerraform(struct!.bucket),
     replica_kms_key_id: cdktf.stringToTerraform(struct!.replicaKmsKeyId),
     storage_class: cdktf.stringToTerraform(struct!.storageClass),
-    access_control_translation: s3BucketReplicationConfigurationRulesDestinationAccessControlTranslationToTerraform(struct!.accessControlTranslation),
+    access_control_translation: [s3BucketReplicationConfigurationRulesDestinationAccessControlTranslationToTerraform(struct!.accessControlTranslation)],
   }
 }
 
@@ -3293,7 +3293,7 @@ export function s3BucketReplicationConfigurationRulesSourceSelectionCriteriaToTe
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
   return {
-    sse_kms_encrypted_objects: s3BucketReplicationConfigurationRulesSourceSelectionCriteriaSseKmsEncryptedObjectsToTerraform(struct!.sseKmsEncryptedObjects),
+    sse_kms_encrypted_objects: [s3BucketReplicationConfigurationRulesSourceSelectionCriteriaSseKmsEncryptedObjectsToTerraform(struct!.sseKmsEncryptedObjects)],
   }
 }
 
@@ -3371,9 +3371,9 @@ export function s3BucketReplicationConfigurationRulesToTerraform(struct?: S3Buck
     prefix: cdktf.stringToTerraform(struct!.prefix),
     priority: cdktf.numberToTerraform(struct!.priority),
     status: cdktf.stringToTerraform(struct!.status),
-    destination: s3BucketReplicationConfigurationRulesDestinationToTerraform(struct!.destination),
-    filter: s3BucketReplicationConfigurationRulesFilterToTerraform(struct!.filter),
-    source_selection_criteria: s3BucketReplicationConfigurationRulesSourceSelectionCriteriaToTerraform(struct!.sourceSelectionCriteria),
+    destination: [s3BucketReplicationConfigurationRulesDestinationToTerraform(struct!.destination)],
+    filter: [s3BucketReplicationConfigurationRulesFilterToTerraform(struct!.filter)],
+    source_selection_criteria: [s3BucketReplicationConfigurationRulesSourceSelectionCriteriaToTerraform(struct!.sourceSelectionCriteria)],
   }
 }
 
@@ -3514,7 +3514,7 @@ export function s3BucketServerSideEncryptionConfigurationRuleToTerraform(struct?
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
   return {
-    apply_server_side_encryption_by_default: s3BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultToTerraform(struct!.applyServerSideEncryptionByDefault),
+    apply_server_side_encryption_by_default: [s3BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultToTerraform(struct!.applyServerSideEncryptionByDefault)],
   }
 }
 
@@ -3557,7 +3557,7 @@ export function s3BucketServerSideEncryptionConfigurationToTerraform(struct?: S3
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
   return {
-    rule: s3BucketServerSideEncryptionConfigurationRuleToTerraform(struct!.rule),
+    rule: [s3BucketServerSideEncryptionConfigurationRuleToTerraform(struct!.rule)],
   }
 }
 
@@ -4203,11 +4203,11 @@ export class S3Bucket extends cdktf.TerraformResource {
       grant: cdktf.listMapper(s3BucketGrantToTerraform)(this._grant),
       lifecycle_rule: cdktf.listMapper(s3BucketLifecycleRuleToTerraform)(this._lifecycleRule),
       logging: cdktf.listMapper(s3BucketLoggingToTerraform)(this._logging),
-      object_lock_configuration: s3BucketObjectLockConfigurationToTerraform(this._objectLockConfiguration),
-      replication_configuration: s3BucketReplicationConfigurationToTerraform(this._replicationConfiguration),
-      server_side_encryption_configuration: s3BucketServerSideEncryptionConfigurationToTerraform(this._serverSideEncryptionConfiguration),
-      versioning: s3BucketVersioningToTerraform(this._versioning),
-      website: s3BucketWebsiteToTerraform(this._website),
+      object_lock_configuration: [s3BucketObjectLockConfigurationToTerraform(this._objectLockConfiguration)],
+      replication_configuration: [s3BucketReplicationConfigurationToTerraform(this._replicationConfiguration)],
+      server_side_encryption_configuration: [s3BucketServerSideEncryptionConfigurationToTerraform(this._serverSideEncryptionConfiguration)],
+      versioning: [s3BucketVersioningToTerraform(this._versioning)],
+      website: [s3BucketWebsiteToTerraform(this._website)],
     };
   }
 }

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/resource-types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/resource-types.test.ts.snap
@@ -125,10 +125,12 @@ export function cloudfrontDistributionCacheBehaviorForwardedValuesCookiesToTerra
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     forward: cdktf.stringToTerraform(struct!.forward),
     whitelisted_names: cdktf.listMapper(cdktf.stringToTerraform)(struct!.whitelistedNames),
-  }
+
+  }];
 }
 
 export class CloudfrontDistributionCacheBehaviorForwardedValuesCookiesOutputReference extends cdktf.ComplexObject {
@@ -196,12 +198,14 @@ export function cloudfrontDistributionCacheBehaviorForwardedValuesToTerraform(st
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     headers: cdktf.listMapper(cdktf.stringToTerraform)(struct!.headers),
     query_string: cdktf.booleanToTerraform(struct!.queryString),
     query_string_cache_keys: cdktf.listMapper(cdktf.stringToTerraform)(struct!.queryStringCacheKeys),
-    cookies: [cloudfrontDistributionCacheBehaviorForwardedValuesCookiesToTerraform(struct!.cookies)],
-  }
+    cookies: cloudfrontDistributionCacheBehaviorForwardedValuesCookiesToTerraform(struct!.cookies),
+
+  }];
 }
 
 export class CloudfrontDistributionCacheBehaviorForwardedValuesOutputReference extends cdktf.ComplexObject {
@@ -381,7 +385,7 @@ export function cloudfrontDistributionCacheBehaviorToTerraform(struct?: Cloudfro
     target_origin_id: cdktf.stringToTerraform(struct!.targetOriginId),
     trusted_signers: cdktf.listMapper(cdktf.stringToTerraform)(struct!.trustedSigners),
     viewer_protocol_policy: cdktf.stringToTerraform(struct!.viewerProtocolPolicy),
-    forwarded_values: [cloudfrontDistributionCacheBehaviorForwardedValuesToTerraform(struct!.forwardedValues)],
+    forwarded_values: cloudfrontDistributionCacheBehaviorForwardedValuesToTerraform(struct!.forwardedValues),
     lambda_function_association: cdktf.listMapper(cloudfrontDistributionCacheBehaviorLambdaFunctionAssociationToTerraform)(struct!.lambdaFunctionAssociation),
   }
 }
@@ -434,10 +438,12 @@ export function cloudfrontDistributionDefaultCacheBehaviorForwardedValuesCookies
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     forward: cdktf.stringToTerraform(struct!.forward),
     whitelisted_names: cdktf.listMapper(cdktf.stringToTerraform)(struct!.whitelistedNames),
-  }
+
+  }];
 }
 
 export class CloudfrontDistributionDefaultCacheBehaviorForwardedValuesCookiesOutputReference extends cdktf.ComplexObject {
@@ -505,12 +511,14 @@ export function cloudfrontDistributionDefaultCacheBehaviorForwardedValuesToTerra
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     headers: cdktf.listMapper(cdktf.stringToTerraform)(struct!.headers),
     query_string: cdktf.booleanToTerraform(struct!.queryString),
     query_string_cache_keys: cdktf.listMapper(cdktf.stringToTerraform)(struct!.queryStringCacheKeys),
-    cookies: [cloudfrontDistributionDefaultCacheBehaviorForwardedValuesCookiesToTerraform(struct!.cookies)],
-  }
+    cookies: cloudfrontDistributionDefaultCacheBehaviorForwardedValuesCookiesToTerraform(struct!.cookies),
+
+  }];
 }
 
 export class CloudfrontDistributionDefaultCacheBehaviorForwardedValuesOutputReference extends cdktf.ComplexObject {
@@ -673,7 +681,8 @@ export function cloudfrontDistributionDefaultCacheBehaviorToTerraform(struct?: C
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     allowed_methods: cdktf.listMapper(cdktf.stringToTerraform)(struct!.allowedMethods),
     cached_methods: cdktf.listMapper(cdktf.stringToTerraform)(struct!.cachedMethods),
     compress: cdktf.booleanToTerraform(struct!.compress),
@@ -685,9 +694,10 @@ export function cloudfrontDistributionDefaultCacheBehaviorToTerraform(struct?: C
     target_origin_id: cdktf.stringToTerraform(struct!.targetOriginId),
     trusted_signers: cdktf.listMapper(cdktf.stringToTerraform)(struct!.trustedSigners),
     viewer_protocol_policy: cdktf.stringToTerraform(struct!.viewerProtocolPolicy),
-    forwarded_values: [cloudfrontDistributionDefaultCacheBehaviorForwardedValuesToTerraform(struct!.forwardedValues)],
+    forwarded_values: cloudfrontDistributionDefaultCacheBehaviorForwardedValuesToTerraform(struct!.forwardedValues),
     lambda_function_association: cdktf.listMapper(cloudfrontDistributionDefaultCacheBehaviorLambdaFunctionAssociationToTerraform)(struct!.lambdaFunctionAssociation),
-  }
+
+  }];
 }
 
 export class CloudfrontDistributionDefaultCacheBehaviorOutputReference extends cdktf.ComplexObject {
@@ -915,11 +925,13 @@ export function cloudfrontDistributionLoggingConfigToTerraform(struct?: Cloudfro
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     bucket: cdktf.stringToTerraform(struct!.bucket),
     include_cookies: cdktf.booleanToTerraform(struct!.includeCookies),
     prefix: cdktf.stringToTerraform(struct!.prefix),
-  }
+
+  }];
 }
 
 export class CloudfrontDistributionLoggingConfigOutputReference extends cdktf.ComplexObject {
@@ -993,10 +1005,12 @@ export function cloudfrontDistributionOrderedCacheBehaviorForwardedValuesCookies
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     forward: cdktf.stringToTerraform(struct!.forward),
     whitelisted_names: cdktf.listMapper(cdktf.stringToTerraform)(struct!.whitelistedNames),
-  }
+
+  }];
 }
 
 export class CloudfrontDistributionOrderedCacheBehaviorForwardedValuesCookiesOutputReference extends cdktf.ComplexObject {
@@ -1064,12 +1078,14 @@ export function cloudfrontDistributionOrderedCacheBehaviorForwardedValuesToTerra
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     headers: cdktf.listMapper(cdktf.stringToTerraform)(struct!.headers),
     query_string: cdktf.booleanToTerraform(struct!.queryString),
     query_string_cache_keys: cdktf.listMapper(cdktf.stringToTerraform)(struct!.queryStringCacheKeys),
-    cookies: [cloudfrontDistributionOrderedCacheBehaviorForwardedValuesCookiesToTerraform(struct!.cookies)],
-  }
+    cookies: cloudfrontDistributionOrderedCacheBehaviorForwardedValuesCookiesToTerraform(struct!.cookies),
+
+  }];
 }
 
 export class CloudfrontDistributionOrderedCacheBehaviorForwardedValuesOutputReference extends cdktf.ComplexObject {
@@ -1249,7 +1265,7 @@ export function cloudfrontDistributionOrderedCacheBehaviorToTerraform(struct?: C
     target_origin_id: cdktf.stringToTerraform(struct!.targetOriginId),
     trusted_signers: cdktf.listMapper(cdktf.stringToTerraform)(struct!.trustedSigners),
     viewer_protocol_policy: cdktf.stringToTerraform(struct!.viewerProtocolPolicy),
-    forwarded_values: [cloudfrontDistributionOrderedCacheBehaviorForwardedValuesToTerraform(struct!.forwardedValues)],
+    forwarded_values: cloudfrontDistributionOrderedCacheBehaviorForwardedValuesToTerraform(struct!.forwardedValues),
     lambda_function_association: cdktf.listMapper(cloudfrontDistributionOrderedCacheBehaviorLambdaFunctionAssociationToTerraform)(struct!.lambdaFunctionAssociation),
   }
 }
@@ -1308,14 +1324,16 @@ export function cloudfrontDistributionOriginCustomOriginConfigToTerraform(struct
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     http_port: cdktf.numberToTerraform(struct!.httpPort),
     https_port: cdktf.numberToTerraform(struct!.httpsPort),
     origin_keepalive_timeout: cdktf.numberToTerraform(struct!.originKeepaliveTimeout),
     origin_protocol_policy: cdktf.stringToTerraform(struct!.originProtocolPolicy),
     origin_read_timeout: cdktf.numberToTerraform(struct!.originReadTimeout),
     origin_ssl_protocols: cdktf.listMapper(cdktf.stringToTerraform)(struct!.originSslProtocols),
-  }
+
+  }];
 }
 
 export class CloudfrontDistributionOriginCustomOriginConfigOutputReference extends cdktf.ComplexObject {
@@ -1424,9 +1442,11 @@ export function cloudfrontDistributionOriginS3OriginConfigToTerraform(struct?: C
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     origin_access_identity: cdktf.stringToTerraform(struct!.originAccessIdentity),
-  }
+
+  }];
 }
 
 export class CloudfrontDistributionOriginS3OriginConfigOutputReference extends cdktf.ComplexObject {
@@ -1495,8 +1515,8 @@ export function cloudfrontDistributionOriginToTerraform(struct?: CloudfrontDistr
     origin_id: cdktf.stringToTerraform(struct!.originId),
     origin_path: cdktf.stringToTerraform(struct!.originPath),
     custom_header: cdktf.listMapper(cloudfrontDistributionOriginCustomHeaderToTerraform)(struct!.customHeader),
-    custom_origin_config: [cloudfrontDistributionOriginCustomOriginConfigToTerraform(struct!.customOriginConfig)],
-    s3_origin_config: [cloudfrontDistributionOriginS3OriginConfigToTerraform(struct!.s3OriginConfig)],
+    custom_origin_config: cloudfrontDistributionOriginCustomOriginConfigToTerraform(struct!.customOriginConfig),
+    s3_origin_config: cloudfrontDistributionOriginS3OriginConfigToTerraform(struct!.s3OriginConfig),
   }
 }
 
@@ -1512,9 +1532,11 @@ export function cloudfrontDistributionOriginGroupFailoverCriteriaToTerraform(str
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     status_codes: cdktf.listMapper(cdktf.numberToTerraform)(struct!.statusCodes),
-  }
+
+  }];
 }
 
 export class CloudfrontDistributionOriginGroupFailoverCriteriaOutputReference extends cdktf.ComplexObject {
@@ -1584,7 +1606,7 @@ export function cloudfrontDistributionOriginGroupToTerraform(struct?: Cloudfront
   }
   return {
     origin_id: cdktf.stringToTerraform(struct!.originId),
-    failover_criteria: [cloudfrontDistributionOriginGroupFailoverCriteriaToTerraform(struct!.failoverCriteria)],
+    failover_criteria: cloudfrontDistributionOriginGroupFailoverCriteriaToTerraform(struct!.failoverCriteria),
     member: cdktf.listMapper(cloudfrontDistributionOriginGroupMemberToTerraform)(struct!.member),
   }
 }
@@ -1605,10 +1627,12 @@ export function cloudfrontDistributionRestrictionsGeoRestrictionToTerraform(stru
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     locations: cdktf.listMapper(cdktf.stringToTerraform)(struct!.locations),
     restriction_type: cdktf.stringToTerraform(struct!.restrictionType),
-  }
+
+  }];
 }
 
 export class CloudfrontDistributionRestrictionsGeoRestrictionOutputReference extends cdktf.ComplexObject {
@@ -1664,9 +1688,11 @@ export function cloudfrontDistributionRestrictionsToTerraform(struct?: Cloudfron
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
-    geo_restriction: [cloudfrontDistributionRestrictionsGeoRestrictionToTerraform(struct!.geoRestriction)],
-  }
+  return [{
+
+    geo_restriction: cloudfrontDistributionRestrictionsGeoRestrictionToTerraform(struct!.geoRestriction),
+
+  }];
 }
 
 export class CloudfrontDistributionRestrictionsOutputReference extends cdktf.ComplexObject {
@@ -1721,13 +1747,15 @@ export function cloudfrontDistributionViewerCertificateToTerraform(struct?: Clou
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     acm_certificate_arn: cdktf.stringToTerraform(struct!.acmCertificateArn),
     cloudfront_default_certificate: cdktf.booleanToTerraform(struct!.cloudfrontDefaultCertificate),
     iam_certificate_id: cdktf.stringToTerraform(struct!.iamCertificateId),
     minimum_protocol_version: cdktf.stringToTerraform(struct!.minimumProtocolVersion),
     ssl_support_method: cdktf.stringToTerraform(struct!.sslSupportMethod),
-  }
+
+  }];
 }
 
 export class CloudfrontDistributionViewerCertificateOutputReference extends cdktf.ComplexObject {
@@ -2263,13 +2291,13 @@ export class CloudfrontDistribution extends cdktf.TerraformResource {
       web_acl_id: cdktf.stringToTerraform(this._webAclId),
       cache_behavior: cdktf.listMapper(cloudfrontDistributionCacheBehaviorToTerraform)(this._cacheBehavior),
       custom_error_response: cdktf.listMapper(cloudfrontDistributionCustomErrorResponseToTerraform)(this._customErrorResponse),
-      default_cache_behavior: [cloudfrontDistributionDefaultCacheBehaviorToTerraform(this._defaultCacheBehavior)],
-      logging_config: [cloudfrontDistributionLoggingConfigToTerraform(this._loggingConfig)],
+      default_cache_behavior: cloudfrontDistributionDefaultCacheBehaviorToTerraform(this._defaultCacheBehavior),
+      logging_config: cloudfrontDistributionLoggingConfigToTerraform(this._loggingConfig),
       ordered_cache_behavior: cdktf.listMapper(cloudfrontDistributionOrderedCacheBehaviorToTerraform)(this._orderedCacheBehavior),
       origin: cdktf.listMapper(cloudfrontDistributionOriginToTerraform)(this._origin),
       origin_group: cdktf.listMapper(cloudfrontDistributionOriginGroupToTerraform)(this._originGroup),
-      restrictions: [cloudfrontDistributionRestrictionsToTerraform(this._restrictions)],
-      viewer_certificate: [cloudfrontDistributionViewerCertificateToTerraform(this._viewerCertificate)],
+      restrictions: cloudfrontDistributionRestrictionsToTerraform(this._restrictions),
+      viewer_certificate: cloudfrontDistributionViewerCertificateToTerraform(this._viewerCertificate),
     };
   }
 }
@@ -2574,11 +2602,13 @@ export function s3BucketLifecycleRuleExpirationToTerraform(struct?: S3BucketLife
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     date: cdktf.stringToTerraform(struct!.date),
     days: cdktf.numberToTerraform(struct!.days),
     expired_object_delete_marker: cdktf.booleanToTerraform(struct!.expiredObjectDeleteMarker),
-  }
+
+  }];
 }
 
 export class S3BucketLifecycleRuleExpirationOutputReference extends cdktf.ComplexObject {
@@ -2651,9 +2681,11 @@ export function s3BucketLifecycleRuleNoncurrentVersionExpirationToTerraform(stru
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     days: cdktf.numberToTerraform(struct!.days),
-  }
+
+  }];
 }
 
 export class S3BucketLifecycleRuleNoncurrentVersionExpirationOutputReference extends cdktf.ComplexObject {
@@ -2788,8 +2820,8 @@ export function s3BucketLifecycleRuleToTerraform(struct?: S3BucketLifecycleRule)
     enabled: cdktf.booleanToTerraform(struct!.enabled),
     prefix: cdktf.stringToTerraform(struct!.prefix),
     tags: cdktf.hashMapper(cdktf.anyToTerraform)(struct!.tags),
-    expiration: [s3BucketLifecycleRuleExpirationToTerraform(struct!.expiration)],
-    noncurrent_version_expiration: [s3BucketLifecycleRuleNoncurrentVersionExpirationToTerraform(struct!.noncurrentVersionExpiration)],
+    expiration: s3BucketLifecycleRuleExpirationToTerraform(struct!.expiration),
+    noncurrent_version_expiration: s3BucketLifecycleRuleNoncurrentVersionExpirationToTerraform(struct!.noncurrentVersionExpiration),
     noncurrent_version_transition: cdktf.listMapper(s3BucketLifecycleRuleNoncurrentVersionTransitionToTerraform)(struct!.noncurrentVersionTransition),
     transition: cdktf.listMapper(s3BucketLifecycleRuleTransitionToTerraform)(struct!.transition),
   }
@@ -2837,11 +2869,13 @@ export function s3BucketObjectLockConfigurationRuleDefaultRetentionToTerraform(s
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     days: cdktf.numberToTerraform(struct!.days),
     mode: cdktf.stringToTerraform(struct!.mode),
     years: cdktf.numberToTerraform(struct!.years),
-  }
+
+  }];
 }
 
 export class S3BucketObjectLockConfigurationRuleDefaultRetentionOutputReference extends cdktf.ComplexObject {
@@ -2913,9 +2947,11 @@ export function s3BucketObjectLockConfigurationRuleToTerraform(struct?: S3Bucket
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
-    default_retention: [s3BucketObjectLockConfigurationRuleDefaultRetentionToTerraform(struct!.defaultRetention)],
-  }
+  return [{
+
+    default_retention: s3BucketObjectLockConfigurationRuleDefaultRetentionToTerraform(struct!.defaultRetention),
+
+  }];
 }
 
 export class S3BucketObjectLockConfigurationRuleOutputReference extends cdktf.ComplexObject {
@@ -2960,10 +2996,12 @@ export function s3BucketObjectLockConfigurationToTerraform(struct?: S3BucketObje
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     object_lock_enabled: cdktf.stringToTerraform(struct!.objectLockEnabled),
-    rule: [s3BucketObjectLockConfigurationRuleToTerraform(struct!.rule)],
-  }
+    rule: s3BucketObjectLockConfigurationRuleToTerraform(struct!.rule),
+
+  }];
 }
 
 export class S3BucketObjectLockConfigurationOutputReference extends cdktf.ComplexObject {
@@ -3018,9 +3056,11 @@ export function s3BucketReplicationConfigurationRulesDestinationAccessControlTra
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     owner: cdktf.stringToTerraform(struct!.owner),
-  }
+
+  }];
 }
 
 export class S3BucketReplicationConfigurationRulesDestinationAccessControlTranslationOutputReference extends cdktf.ComplexObject {
@@ -3076,13 +3116,15 @@ export function s3BucketReplicationConfigurationRulesDestinationToTerraform(stru
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     account_id: cdktf.stringToTerraform(struct!.accountId),
     bucket: cdktf.stringToTerraform(struct!.bucket),
     replica_kms_key_id: cdktf.stringToTerraform(struct!.replicaKmsKeyId),
     storage_class: cdktf.stringToTerraform(struct!.storageClass),
-    access_control_translation: [s3BucketReplicationConfigurationRulesDestinationAccessControlTranslationToTerraform(struct!.accessControlTranslation)],
-  }
+    access_control_translation: s3BucketReplicationConfigurationRulesDestinationAccessControlTranslationToTerraform(struct!.accessControlTranslation),
+
+  }];
 }
 
 export class S3BucketReplicationConfigurationRulesDestinationOutputReference extends cdktf.ComplexObject {
@@ -3189,10 +3231,12 @@ export function s3BucketReplicationConfigurationRulesFilterToTerraform(struct?: 
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     prefix: cdktf.stringToTerraform(struct!.prefix),
     tags: cdktf.hashMapper(cdktf.anyToTerraform)(struct!.tags),
-  }
+
+  }];
 }
 
 export class S3BucketReplicationConfigurationRulesFilterOutputReference extends cdktf.ComplexObject {
@@ -3250,9 +3294,11 @@ export function s3BucketReplicationConfigurationRulesSourceSelectionCriteriaSseK
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     enabled: cdktf.booleanToTerraform(struct!.enabled),
-  }
+
+  }];
 }
 
 export class S3BucketReplicationConfigurationRulesSourceSelectionCriteriaSseKmsEncryptedObjectsOutputReference extends cdktf.ComplexObject {
@@ -3292,9 +3338,11 @@ export function s3BucketReplicationConfigurationRulesSourceSelectionCriteriaToTe
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
-    sse_kms_encrypted_objects: [s3BucketReplicationConfigurationRulesSourceSelectionCriteriaSseKmsEncryptedObjectsToTerraform(struct!.sseKmsEncryptedObjects)],
-  }
+  return [{
+
+    sse_kms_encrypted_objects: s3BucketReplicationConfigurationRulesSourceSelectionCriteriaSseKmsEncryptedObjectsToTerraform(struct!.sseKmsEncryptedObjects),
+
+  }];
 }
 
 export class S3BucketReplicationConfigurationRulesSourceSelectionCriteriaOutputReference extends cdktf.ComplexObject {
@@ -3371,9 +3419,9 @@ export function s3BucketReplicationConfigurationRulesToTerraform(struct?: S3Buck
     prefix: cdktf.stringToTerraform(struct!.prefix),
     priority: cdktf.numberToTerraform(struct!.priority),
     status: cdktf.stringToTerraform(struct!.status),
-    destination: [s3BucketReplicationConfigurationRulesDestinationToTerraform(struct!.destination)],
-    filter: [s3BucketReplicationConfigurationRulesFilterToTerraform(struct!.filter)],
-    source_selection_criteria: [s3BucketReplicationConfigurationRulesSourceSelectionCriteriaToTerraform(struct!.sourceSelectionCriteria)],
+    destination: s3BucketReplicationConfigurationRulesDestinationToTerraform(struct!.destination),
+    filter: s3BucketReplicationConfigurationRulesFilterToTerraform(struct!.filter),
+    source_selection_criteria: s3BucketReplicationConfigurationRulesSourceSelectionCriteriaToTerraform(struct!.sourceSelectionCriteria),
   }
 }
 
@@ -3395,10 +3443,12 @@ export function s3BucketReplicationConfigurationToTerraform(struct?: S3BucketRep
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     role: cdktf.stringToTerraform(struct!.role),
     rules: cdktf.listMapper(s3BucketReplicationConfigurationRulesToTerraform)(struct!.rules),
-  }
+
+  }];
 }
 
 export class S3BucketReplicationConfigurationOutputReference extends cdktf.ComplexObject {
@@ -3454,10 +3504,12 @@ export function s3BucketServerSideEncryptionConfigurationRuleApplyServerSideEncr
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     kms_master_key_id: cdktf.stringToTerraform(struct!.kmsMasterKeyId),
     sse_algorithm: cdktf.stringToTerraform(struct!.sseAlgorithm),
-  }
+
+  }];
 }
 
 export class S3BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultOutputReference extends cdktf.ComplexObject {
@@ -3513,9 +3565,11 @@ export function s3BucketServerSideEncryptionConfigurationRuleToTerraform(struct?
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
-    apply_server_side_encryption_by_default: [s3BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultToTerraform(struct!.applyServerSideEncryptionByDefault)],
-  }
+  return [{
+
+    apply_server_side_encryption_by_default: s3BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultToTerraform(struct!.applyServerSideEncryptionByDefault),
+
+  }];
 }
 
 export class S3BucketServerSideEncryptionConfigurationRuleOutputReference extends cdktf.ComplexObject {
@@ -3556,9 +3610,11 @@ export function s3BucketServerSideEncryptionConfigurationToTerraform(struct?: S3
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
-    rule: [s3BucketServerSideEncryptionConfigurationRuleToTerraform(struct!.rule)],
-  }
+  return [{
+
+    rule: s3BucketServerSideEncryptionConfigurationRuleToTerraform(struct!.rule),
+
+  }];
 }
 
 export class S3BucketServerSideEncryptionConfigurationOutputReference extends cdktf.ComplexObject {
@@ -3601,10 +3657,12 @@ export function s3BucketVersioningToTerraform(struct?: S3BucketVersioningOutputR
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     enabled: cdktf.booleanToTerraform(struct!.enabled),
     mfa_delete: cdktf.booleanToTerraform(struct!.mfaDelete),
-  }
+
+  }];
 }
 
 export class S3BucketVersioningOutputReference extends cdktf.ComplexObject {
@@ -3673,12 +3731,14 @@ export function s3BucketWebsiteToTerraform(struct?: S3BucketWebsiteOutputReferen
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     error_document: cdktf.stringToTerraform(struct!.errorDocument),
     index_document: cdktf.stringToTerraform(struct!.indexDocument),
     redirect_all_requests_to: cdktf.stringToTerraform(struct!.redirectAllRequestsTo),
     routing_rules: cdktf.stringToTerraform(struct!.routingRules),
-  }
+
+  }];
 }
 
 export class S3BucketWebsiteOutputReference extends cdktf.ComplexObject {
@@ -4203,11 +4263,11 @@ export class S3Bucket extends cdktf.TerraformResource {
       grant: cdktf.listMapper(s3BucketGrantToTerraform)(this._grant),
       lifecycle_rule: cdktf.listMapper(s3BucketLifecycleRuleToTerraform)(this._lifecycleRule),
       logging: cdktf.listMapper(s3BucketLoggingToTerraform)(this._logging),
-      object_lock_configuration: [s3BucketObjectLockConfigurationToTerraform(this._objectLockConfiguration)],
-      replication_configuration: [s3BucketReplicationConfigurationToTerraform(this._replicationConfiguration)],
-      server_side_encryption_configuration: [s3BucketServerSideEncryptionConfigurationToTerraform(this._serverSideEncryptionConfiguration)],
-      versioning: [s3BucketVersioningToTerraform(this._versioning)],
-      website: [s3BucketWebsiteToTerraform(this._website)],
+      object_lock_configuration: s3BucketObjectLockConfigurationToTerraform(this._objectLockConfiguration),
+      replication_configuration: s3BucketReplicationConfigurationToTerraform(this._replicationConfiguration),
+      server_side_encryption_configuration: s3BucketServerSideEncryptionConfigurationToTerraform(this._serverSideEncryptionConfiguration),
+      versioning: s3BucketVersioningToTerraform(this._versioning),
+      website: s3BucketWebsiteToTerraform(this._website),
     };
   }
 }
@@ -4393,10 +4453,12 @@ export function securityGroupTimeoutsToTerraform(struct?: SecurityGroupTimeoutsO
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     create: cdktf.stringToTerraform(struct!.create),
     delete: cdktf.stringToTerraform(struct!.delete),
-  }
+
+  }];
 }
 
 export class SecurityGroupTimeoutsOutputReference extends cdktf.ComplexObject {

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -690,9 +690,11 @@ export function deeplyNestedBlockTypesLifecycleRuleExpirationToTerraform(struct?
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     date: cdktf.stringToTerraform(struct!.date),
-  }
+
+  }];
 }
 
 export class DeeplyNestedBlockTypesLifecycleRuleExpirationOutputReference extends cdktf.ComplexObject {
@@ -741,7 +743,7 @@ export function deeplyNestedBlockTypesLifecycleRuleToTerraform(struct?: DeeplyNe
   }
   return {
     abort_incomplete_multipart_upload_days: cdktf.numberToTerraform(struct!.abortIncompleteMultipartUploadDays),
-    expiration: [deeplyNestedBlockTypesLifecycleRuleExpirationToTerraform(struct!.expiration)],
+    expiration: deeplyNestedBlockTypesLifecycleRuleExpirationToTerraform(struct!.expiration),
   }
 }
 
@@ -2142,9 +2144,11 @@ export function singleBlockTypeTimeoutsToTerraform(struct?: SingleBlockTypeTimeo
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
   }
-  return {
+  return [{
+
     create: cdktf.stringToTerraform(struct!.create),
-  }
+
+  }];
 }
 
 export class SingleBlockTypeTimeoutsOutputReference extends cdktf.ComplexObject {

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -741,7 +741,7 @@ export function deeplyNestedBlockTypesLifecycleRuleToTerraform(struct?: DeeplyNe
   }
   return {
     abort_incomplete_multipart_upload_days: cdktf.numberToTerraform(struct!.abortIncompleteMultipartUploadDays),
-    expiration: deeplyNestedBlockTypesLifecycleRuleExpirationToTerraform(struct!.expiration),
+    expiration: [deeplyNestedBlockTypesLifecycleRuleExpirationToTerraform(struct!.expiration)],
   }
 }
 

--- a/packages/@cdktf/provider-generator/lib/get/generator/emitter/attributes-emitter.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/emitter/attributes-emitter.ts
@@ -215,13 +215,6 @@ export class AttributesEmitter {
           `${att.terraformName}: ${defaultCheck}cdktf.booleanToTerraform(${varReference}),`
         );
         break;
-      case type.isList && type.isSingleItem:
-        this.code.line(
-          `${att.terraformName}: [${defaultCheck}${downcaseFirst(
-            type.name
-          )}ToTerraform(${varReference})],`
-        );
-        break;
       default:
         this.code.line(
           `${att.terraformName}: ${defaultCheck}${downcaseFirst(

--- a/packages/@cdktf/provider-generator/lib/get/generator/emitter/attributes-emitter.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/emitter/attributes-emitter.ts
@@ -215,6 +215,13 @@ export class AttributesEmitter {
           `${att.terraformName}: ${defaultCheck}cdktf.booleanToTerraform(${varReference}),`
         );
         break;
+      case type.isList && type.isSingleItem:
+        this.code.line(
+          `${att.terraformName}: [${defaultCheck}${downcaseFirst(
+            type.name
+          )}ToTerraform(${varReference})],`
+        );
+        break;
       default:
         this.code.line(
           `${att.terraformName}: ${defaultCheck}${downcaseFirst(

--- a/packages/@cdktf/provider-generator/lib/get/generator/emitter/struct-emitter.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/emitter/struct-emitter.ts
@@ -219,7 +219,12 @@ export class StructEmitter {
     );
     this.code.closeBlock();
 
-    this.code.openBlock("return");
+    if (struct.isSingleItem) {
+      this.code.line("return [{");
+      this.code.indent();
+    } else {
+      this.code.openBlock("return");
+    }
     for (const att of struct.isClass
       ? struct.attributes
       : struct.assignableAttributes) {
@@ -227,7 +232,12 @@ export class StructEmitter {
         this.attributesEmitter.emitToTerraform(att, true);
       }
     }
-    this.code.closeBlock(";");
+    if (struct.isSingleItem) {
+      this.code.unindent();
+      this.code.line("}];");
+    } else {
+      this.code.closeBlock(";");
+    }
     this.code.closeBlock();
     this.code.line();
   }

--- a/test/typescript/providers/test.ts
+++ b/test/typescript/providers/test.ts
@@ -54,7 +54,7 @@ describe("full integration test", () => {
       });
 
       test("single-item references", () => {
-        const namespace = stack.byId("myDeployment").metadata.namespace;
+        const namespace = stack.byId("myDeployment").metadata[0].namespace;
         expect(namespace).toContain("${");
         expect(namespace).toContain("myNamespace");
         expect(namespace).toContain(".metadata[0].name");
@@ -81,9 +81,11 @@ describe("full integration test", () => {
         });
 
         test("put method mutation", () => {
-          expect(instance.metadata_options).toEqual({
-            http_endpoint: "127.0.0.1",
-          });
+          expect(instance.metadata_options).toEqual([
+            {
+              http_endpoint: "127.0.0.1",
+            },
+          ]);
         });
       });
 

--- a/test/typescript/synth-app/__snapshots__/test.ts.snap
+++ b/test/typescript/synth-app/__snapshots__/test.ts.snap
@@ -39,7 +39,6 @@ exports[`full integration test synth synth generates JSON 1`] = `
     \\"aws\\": [
       {
         \\"region\\": \\"eu-central-1\\",
-        \\"assume_role\\": [],
         \\"ignore_tags\\": [
           {
             \\"keys\\": [
@@ -86,7 +85,6 @@ exports[`full integration test synth synth generates JSON 1`] = `
             \\"http_endpoint\\": \\"true\\"
           }
         ],
-        \\"root_block_device\\": [],
         \\"//\\": {
           \\"metadata\\": {
             \\"path\\": \\"hello-terra/Instance\\",
@@ -107,7 +105,6 @@ exports[`full integration test synth synth generates JSON 1`] = `
             \\"http_endpoint\\": \\"\${aws_instance.Instance.metadata_options[0].http_endpoint}\\"
           }
         ],
-        \\"root_block_device\\": [],
         \\"//\\": {
           \\"metadata\\": {
             \\"path\\": \\"hello-terra/Instance2\\",
@@ -124,29 +121,22 @@ exports[`full integration test synth synth generates JSON 1`] = `
           {
             \\"allow\\": [
               {}
-            ],
-            \\"block\\": []
+            ]
           }
         ],
         \\"rule\\": [
           {
             \\"name\\": \\"managed-rule-example\\",
             \\"priority\\": 1,
-            \\"action\\": [],
             \\"override_action\\": [
               {
                 \\"count\\": [
                   {}
-                ],
-                \\"none\\": []
+                ]
               }
             ],
             \\"statement\\": [
               {
-                \\"and_statement\\": [],
-                \\"byte_match_statement\\": [],
-                \\"geo_match_statement\\": [],
-                \\"ip_set_reference_statement\\": [],
                 \\"managed_rule_group_statement\\": [
                   {
                     \\"name\\": \\"managed-rule-example\\",
@@ -160,15 +150,7 @@ exports[`full integration test synth synth generates JSON 1`] = `
                       }
                     ]
                   }
-                ],
-                \\"not_statement\\": [],
-                \\"or_statement\\": [],
-                \\"rate_based_statement\\": [],
-                \\"regex_pattern_set_reference_statement\\": [],
-                \\"rule_group_reference_statement\\": [],
-                \\"size_constraint_statement\\": [],
-                \\"sqli_match_statement\\": [],
-                \\"xss_match_statement\\": []
+                ]
               }
             ],
             \\"visibility_config\\": [

--- a/test/typescript/synth-app/__snapshots__/test.ts.snap
+++ b/test/typescript/synth-app/__snapshots__/test.ts.snap
@@ -39,11 +39,14 @@ exports[`full integration test synth synth generates JSON 1`] = `
     \\"aws\\": [
       {
         \\"region\\": \\"eu-central-1\\",
-        \\"ignore_tags\\": {
-          \\"keys\\": [
-            \\"foo\\"
-          ]
-        }
+        \\"assume_role\\": [],
+        \\"ignore_tags\\": [
+          {
+            \\"keys\\": [
+              \\"foo\\"
+            ]
+          }
+        ]
       }
     ]
   },
@@ -67,18 +70,23 @@ exports[`full integration test synth synth generates JSON 1`] = `
       \\"Instance\\": {
         \\"ami\\": \\"ami-12345678\\",
         \\"instance_type\\": \\"t2.micro\\",
-        \\"credit_specification\\": {
-          \\"cpu_credits\\": \\"standard\\"
-        },
+        \\"credit_specification\\": [
+          {
+            \\"cpu_credits\\": \\"standard\\"
+          }
+        ],
         \\"ebs_block_device\\": [
           {
             \\"device_name\\": \\"/dev/sda1\\",
             \\"volume_size\\": 100
           }
         ],
-        \\"metadata_options\\": {
-          \\"http_endpoint\\": \\"true\\"
-        },
+        \\"metadata_options\\": [
+          {
+            \\"http_endpoint\\": \\"true\\"
+          }
+        ],
+        \\"root_block_device\\": [],
         \\"//\\": {
           \\"metadata\\": {
             \\"path\\": \\"hello-terra/Instance\\",
@@ -89,16 +97,100 @@ exports[`full integration test synth synth generates JSON 1`] = `
       \\"Instance2\\": {
         \\"ami\\": \\"ami-12345678\\",
         \\"instance_type\\": \\"t2.micro\\",
-        \\"credit_specification\\": {
-          \\"cpu_credits\\": \\"\${aws_instance.Instance.credit_specification[0].cpu_credits}\\"
-        },
-        \\"metadata_options\\": {
-          \\"http_endpoint\\": \\"\${aws_instance.Instance.metadata_options[0].http_endpoint}\\"
-        },
+        \\"credit_specification\\": [
+          {
+            \\"cpu_credits\\": \\"\${aws_instance.Instance.credit_specification[0].cpu_credits}\\"
+          }
+        ],
+        \\"metadata_options\\": [
+          {
+            \\"http_endpoint\\": \\"\${aws_instance.Instance.metadata_options[0].http_endpoint}\\"
+          }
+        ],
+        \\"root_block_device\\": [],
         \\"//\\": {
           \\"metadata\\": {
             \\"path\\": \\"hello-terra/Instance2\\",
             \\"uniqueId\\": \\"Instance2\\"
+          }
+        }
+      }
+    },
+    \\"aws_wafv2_web_acl\\": {
+      \\"wafv2\\": {
+        \\"name\\": \\"managed-rule-example\\",
+        \\"scope\\": \\"REGIONAL\\",
+        \\"default_action\\": [
+          {
+            \\"allow\\": [
+              {}
+            ],
+            \\"block\\": []
+          }
+        ],
+        \\"rule\\": [
+          {
+            \\"name\\": \\"managed-rule-example\\",
+            \\"priority\\": 1,
+            \\"action\\": [],
+            \\"override_action\\": [
+              {
+                \\"count\\": [
+                  {}
+                ],
+                \\"none\\": []
+              }
+            ],
+            \\"statement\\": [
+              {
+                \\"and_statement\\": [],
+                \\"byte_match_statement\\": [],
+                \\"geo_match_statement\\": [],
+                \\"ip_set_reference_statement\\": [],
+                \\"managed_rule_group_statement\\": [
+                  {
+                    \\"name\\": \\"managed-rule-example\\",
+                    \\"vendor_name\\": \\"AWS\\",
+                    \\"excluded_rule\\": [
+                      {
+                        \\"name\\": \\"SizeRestrictions_QUERYSTRING\\"
+                      },
+                      {
+                        \\"name\\": \\"SQLInjection_QUERYSTRING\\"
+                      }
+                    ]
+                  }
+                ],
+                \\"not_statement\\": [],
+                \\"or_statement\\": [],
+                \\"rate_based_statement\\": [],
+                \\"regex_pattern_set_reference_statement\\": [],
+                \\"rule_group_reference_statement\\": [],
+                \\"size_constraint_statement\\": [],
+                \\"sqli_match_statement\\": [],
+                \\"xss_match_statement\\": []
+              }
+            ],
+            \\"visibility_config\\": [
+              {
+                \\"cloudwatch_metrics_enabled\\": true,
+                \\"metric_name\\": \\"managed-rule-example\\",
+                \\"sampled_requests_enabled\\": true
+              }
+            ]
+          }
+        ],
+        \\"visibility_config\\": [
+          {
+            \\"cloudwatch_metrics_enabled\\": true,
+            \\"metric_name\\": \\"managed-rule-example\\",
+            \\"sampled_requests_enabled\\": true
+          }
+        ],
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"hello-terra/wafv2\\",
+            \\"uniqueId\\": \\"wafv2\\"
           }
         }
       }

--- a/test/typescript/synth-app/main.ts
+++ b/test/typescript/synth-app/main.ts
@@ -2,6 +2,7 @@ import { Construct } from "constructs";
 import { App, TerraformStack, TerraformOutput, Testing, Fn } from "cdktf";
 import { AwsProvider, sns } from "./.gen/providers/aws";
 import { Instance } from "./.gen/providers/aws/ec2";
+import { Wafv2WebAcl } from "./.gen/providers/aws/wafv2";
 
 export class HelloTerra extends TerraformStack {
   constructor(scope: Construct, id: string) {
@@ -66,6 +67,45 @@ export class HelloTerra extends TerraformStack {
           name: "test",
         },
       },
+    });
+
+    new Wafv2WebAcl(this, "wafv2", {
+      defaultAction: {
+        allow: {},
+      },
+      name: "managed-rule-example",
+      scope: "REGIONAL",
+      visibilityConfig: {
+        cloudwatchMetricsEnabled: true,
+        metricName: "managed-rule-example",
+        sampledRequestsEnabled: true,
+      },
+      rule: [
+        {
+          name: "managed-rule-example",
+          priority: 1,
+          overrideAction: {
+            count: {},
+          },
+          visibilityConfig: {
+            cloudwatchMetricsEnabled: true,
+            metricName: "managed-rule-example",
+            sampledRequestsEnabled: true,
+          },
+          statement: {
+            managedRuleGroupStatement: {
+              name: "managed-rule-example",
+              vendorName: "AWS",
+              excludedRule: [
+                {
+                  name: "SizeRestrictions_QUERYSTRING",
+                },
+                { name: "SQLInjection_QUERYSTRING" },
+              ],
+            },
+          },
+        },
+      ],
     });
   }
 }


### PR DESCRIPTION
Fixes #1182

The Terraform JSON supports either array or object for single block types. This returns to using an array like before.
`deepMerge` handles arrays differently than empty objects. Maybe we could change that, but likely what's there is necessary. Rather than try to get additional context to that point, it's easier to just use an array.