### PR TITLE
fix: data can be null in some cases as well

### DIFF
--- a/packages/cdktf-cli/bin/cmds/ui/models/terraform-cloud.ts
+++ b/packages/cdktf-cli/bin/cmds/ui/models/terraform-cloud.ts
@@ -293,7 +293,7 @@ export class TerraformCloud implements Terraform {
       client.Applies.logs(result.relationships.apply.data.id).then(
         ({ data }) => {
           // In rare cases the backend sends an empty chunk of data back.
-          if (data.length) {
+          if (data && data.length) {
             stdout(Buffer.from(data, "utf8"));
           }
         }


### PR DESCRIPTION
Got this error while trying it running against Terraform Cloud in remote execution mode

```
⠙ synthesizing...
(node:80284) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
Running plan in the remote backend. To view this run in a browser, visit: https://a
pp.terraform.io/app/cdktf/workspaces/dschmidt-testing3/runs/run-w4enLFZttKxXrrrE
⠏ Deploying Stack: tmp.RpsjNA6F
Resources
 ~ NULL_RESOURCE        resource            null_resource.resource

Summary: 0 created, 0 updated, 0 destroyed.
/Users/danielschmidt/work/terraform-cdk/node_modules/yoga-layout-prebuilt/yoga-layout/build/Release/nbind.js:53
        throw ex;
        ^

TypeError: Cannot read property 'length' of undefined
    at /Users/danielschmidt/work/terraform-cdk/packages/cdktf-cli/bin/cmds/ui/models/terraform-cloud.js:218:26

```
