### PR TITLE
feat(lib): Map Tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 **Breaking Changes**
 
+### Map Tokens [#1411](https://github.com/hashicorp/terraform-cdk/pull/1411)
+
+As part of an effort to use more native types, there are now tokens for maps of primitive values.
+
+As a result, there is a minor breaking change:
+
+- Map attributes have gone from `{ [key: string]: TYPE } | cdktf.IResolvable` to `{ [key: string]:TYPE }` when `TYPE` is `string, number, or boolean`.
+  - The most common impact is maps created by using Terraform functions (`Fn.(...)`) will now need to be passed to `Token.as<String/Number/Boolean>Map()` before assigning to a resource attribute.
+
 ### Number[] Tokens [#1471](https://github.com/hashicorp/terraform-cdk/pull/1471)
 
 As part of an effort to use more native types, there are now tokens for `number[]`.

--- a/packages/@cdktf/provider-generator/lib/__tests__/__snapshots__/edge-provider-schema.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/__tests__/__snapshots__/edge-provider-schema.test.ts.snap
@@ -279,6 +279,7 @@ export * from './required-attribute-resource';
 export * from './optional-attribute-resource';
 export * from './optional-computed-attribute-resource';
 export * from './list-block-resource';
+export * from './map-resource';
 export * from './edge-provider';
 
 "
@@ -1187,6 +1188,131 @@ export class ListBlockResource extends cdktf.TerraformResource {
       singleopt: listBlockResourceSingleoptToTerraform(this._singleopt.internalValue),
       singlereq: listBlockResourceSinglereqToTerraform(this._singlereq.internalValue),
       singleComputedBlock: listBlockResourceSingleComputedBlockToTerraform(this._singleComputedBlock.internalValue),
+    };
+  }
+}
+"
+`;
+
+exports[`Edge Provider Schema compiles to Typescript: map-resource.ts 1`] = `
+"// https://www.terraform.io/docs/providers/edge/r/map_resource.html
+// generated from terraform resource schema
+
+import { Construct } from 'constructs';
+import * as cdktf from 'cdktf';
+
+// Configuration
+
+export interface MapResourceConfig extends cdktf.TerraformMetaArguments {
+  /**
+  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/map_resource.html#optMap MapResource#optMap}
+  */
+  readonly optMap?: { [key: string]: string };
+  /**
+  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/map_resource.html#reqMap MapResource#reqMap}
+  */
+  readonly reqMap: { [key: string]: boolean };
+  /**
+  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/map_resource.html#computedMap MapResource#computedMap}
+  */
+  readonly computedMap?: { [key: string]: number };
+}
+
+/**
+* Represents a {@link https://www.terraform.io/docs/providers/edge/r/map_resource.html map_resource}
+*/
+export class MapResource extends cdktf.TerraformResource {
+
+  // =================
+  // STATIC PROPERTIES
+  // =================
+  public static readonly tfResourceType: string = \\"map_resource\\";
+
+  // ===========
+  // INITIALIZER
+  // ===========
+
+  /**
+  * Create a new {@link https://www.terraform.io/docs/providers/edge/r/map_resource.html map_resource} Resource
+  *
+  * @param scope The scope in which to define this construct
+  * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
+  * @param options MapResourceConfig
+  */
+  public constructor(scope: Construct, id: string, config: MapResourceConfig) {
+    super(scope, id, {
+      terraformResourceType: 'map_resource',
+      terraformGeneratorMetadata: {
+        providerName: 'edge'
+      },
+      provider: config.provider,
+      dependsOn: config.dependsOn,
+      count: config.count,
+      lifecycle: config.lifecycle
+    });
+    this._optMap = config.optMap;
+    this._reqMap = config.reqMap;
+    this._computedMap = config.computedMap;
+  }
+
+  // ==========
+  // ATTRIBUTES
+  // ==========
+
+  // optMap - computed: false, optional: true, required: false
+  private _optMap?: { [key: string]: string }; 
+  public get optMap() {
+    return this.getMapAttribute('optMap');
+  }
+  public set optMap(value: { [key: string]: string }) {
+    this._optMap = value;
+  }
+  public resetOptMap() {
+    this._optMap = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get optMapInput() {
+    return this._optMap;
+  }
+
+  // reqMap - computed: false, optional: false, required: true
+  private _reqMap?: { [key: string]: boolean }; 
+  public get reqMap() {
+    return this.getMapAttribute('reqMap');
+  }
+  public set reqMap(value: { [key: string]: boolean }) {
+    this._reqMap = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get reqMapInput() {
+    return this._reqMap;
+  }
+
+  // computedMap - computed: true, optional: true, required: false
+  private _computedMap?: { [key: string]: number }; 
+  public get computedMap() {
+    return this.getMapAttribute('computedMap');
+  }
+  public set computedMap(value: { [key: string]: number }) {
+    this._computedMap = value;
+  }
+  public resetComputedMap() {
+    this._computedMap = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get computedMapInput() {
+    return this._computedMap;
+  }
+
+  // =========
+  // SYNTHESIS
+  // =========
+
+  protected synthesizeAttributes(): { [name: string]: any } {
+    return {
+      optMap: cdktf.hashMapper(cdktf.anyToTerraform)(this._optMap),
+      reqMap: cdktf.hashMapper(cdktf.anyToTerraform)(this._reqMap),
+      computedMap: cdktf.hashMapper(cdktf.anyToTerraform)(this._computedMap),
     };
   }
 }

--- a/packages/@cdktf/provider-generator/lib/__tests__/__snapshots__/edge-provider-schema.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/__tests__/__snapshots__/edge-provider-schema.test.ts.snap
@@ -1482,7 +1482,8 @@ export class OptionalAttributeResource extends cdktf.TerraformResource {
   // boolList - computed: false, optional: true, required: false
   private _boolList?: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable; 
   public get boolList() {
-    return this.getBooleanAttribute('boolList') as any;
+    // Getting the computed value is not yet implemented
+    return this.interpolationForAttribute('boolList') as any;
   }
   public set boolList(value: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable) {
     this._boolList = value;
@@ -1676,7 +1677,8 @@ export class OptionalComputedAttributeResource extends cdktf.TerraformResource {
   // boolList - computed: true, optional: true, required: false
   private _boolList?: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable; 
   public get boolList() {
-    return this.getBooleanAttribute('boolList') as any;
+    // Getting the computed value is not yet implemented
+    return this.interpolationForAttribute('boolList') as any;
   }
   public set boolList(value: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable) {
     this._boolList = value;
@@ -1855,7 +1857,8 @@ export class RequiredAttributeResource extends cdktf.TerraformResource {
   // boolList - computed: false, optional: false, required: true
   private _boolList?: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable; 
   public get boolList() {
-    return this.getBooleanAttribute('boolList') as any;
+    // Getting the computed value is not yet implemented
+    return this.interpolationForAttribute('boolList') as any;
   }
   public set boolList(value: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable) {
     this._boolList = value;

--- a/packages/@cdktf/provider-generator/lib/__tests__/__snapshots__/edge-provider-schema.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/__tests__/__snapshots__/edge-provider-schema.test.ts.snap
@@ -1262,7 +1262,7 @@ export class MapResource extends cdktf.TerraformResource {
   // optMap - computed: false, optional: true, required: false
   private _optMap?: { [key: string]: string }; 
   public get optMap() {
-    return this.getMapAttribute('optMap');
+    return this.getStringMapAttribute('optMap');
   }
   public set optMap(value: { [key: string]: string }) {
     this._optMap = value;
@@ -1278,7 +1278,7 @@ export class MapResource extends cdktf.TerraformResource {
   // reqMap - computed: false, optional: false, required: true
   private _reqMap?: { [key: string]: boolean }; 
   public get reqMap() {
-    return this.getMapAttribute('reqMap');
+    return this.getBooleanMapAttribute('reqMap');
   }
   public set reqMap(value: { [key: string]: boolean }) {
     this._reqMap = value;
@@ -1291,7 +1291,7 @@ export class MapResource extends cdktf.TerraformResource {
   // computedMap - computed: true, optional: true, required: false
   private _computedMap?: { [key: string]: number }; 
   public get computedMap() {
-    return this.getMapAttribute('computedMap');
+    return this.getNumberMapAttribute('computedMap');
   }
   public set computedMap(value: { [key: string]: number }) {
     this._computedMap = value;
@@ -1310,9 +1310,9 @@ export class MapResource extends cdktf.TerraformResource {
 
   protected synthesizeAttributes(): { [name: string]: any } {
     return {
-      optMap: cdktf.hashMapper(cdktf.anyToTerraform)(this._optMap),
-      reqMap: cdktf.hashMapper(cdktf.anyToTerraform)(this._reqMap),
-      computedMap: cdktf.hashMapper(cdktf.anyToTerraform)(this._computedMap),
+      optMap: cdktf.hashMapper(cdktf.stringToTerraform)(this._optMap),
+      reqMap: cdktf.hashMapper(cdktf.booleanToTerraform)(this._reqMap),
+      computedMap: cdktf.hashMapper(cdktf.numberToTerraform)(this._computedMap),
     };
   }
 }

--- a/packages/@cdktf/provider-generator/lib/__tests__/__snapshots__/edge-provider-schema.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/__tests__/__snapshots__/edge-provider-schema.test.ts.snap
@@ -1211,7 +1211,7 @@ export interface MapResourceConfig extends cdktf.TerraformMetaArguments {
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/map_resource.html#reqMap MapResource#reqMap}
   */
-  readonly reqMap: { [key: string]: boolean };
+  readonly reqMap: { [key: string]: (boolean | cdktf.IResolvable) };
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/map_resource.html#computedMap MapResource#computedMap}
   */
@@ -1276,11 +1276,11 @@ export class MapResource extends cdktf.TerraformResource {
   }
 
   // reqMap - computed: false, optional: false, required: true
-  private _reqMap?: { [key: string]: boolean }; 
+  private _reqMap?: { [key: string]: (boolean | cdktf.IResolvable) }; 
   public get reqMap() {
     return this.getBooleanMapAttribute('reqMap');
   }
-  public set reqMap(value: { [key: string]: boolean }) {
+  public set reqMap(value: { [key: string]: (boolean | cdktf.IResolvable) }) {
     this._reqMap = value;
   }
   // Temporarily expose input value. Use with caution.

--- a/packages/@cdktf/provider-generator/lib/__tests__/__snapshots__/edge-provider-schema.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/__tests__/__snapshots__/edge-provider-schema.test.ts.snap
@@ -1195,7 +1195,7 @@ export class ListBlockResource extends cdktf.TerraformResource {
 `;
 
 exports[`Edge Provider Schema compiles to Typescript: map-resource.ts 1`] = `
-"// https://www.terraform.io/docs/providers/edge/r/map_resource.html
+"// https://www.terraform.io/docs/providers/edge/r/map_resource
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -1205,21 +1205,21 @@ import * as cdktf from 'cdktf';
 
 export interface MapResourceConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/map_resource.html#optMap MapResource#optMap}
+  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/map_resource#optMap MapResource#optMap}
   */
   readonly optMap?: { [key: string]: string };
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/map_resource.html#reqMap MapResource#reqMap}
+  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/map_resource#reqMap MapResource#reqMap}
   */
   readonly reqMap: { [key: string]: (boolean | cdktf.IResolvable) };
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/map_resource.html#computedMap MapResource#computedMap}
+  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/map_resource#computedMap MapResource#computedMap}
   */
   readonly computedMap?: { [key: string]: number };
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/edge/r/map_resource.html map_resource}
+* Represents a {@link https://www.terraform.io/docs/providers/edge/r/map_resource map_resource}
 */
 export class MapResource extends cdktf.TerraformResource {
 
@@ -1233,7 +1233,7 @@ export class MapResource extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/edge/r/map_resource.html map_resource} Resource
+  * Create a new {@link https://www.terraform.io/docs/providers/edge/r/map_resource map_resource} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope

--- a/packages/@cdktf/provider-generator/lib/__tests__/edge-provider-schema/index.ts
+++ b/packages/@cdktf/provider-generator/lib/__tests__/edge-provider-schema/index.ts
@@ -63,6 +63,27 @@ const list_block_resource = new S()
   })
   .build();
 
+const map_resource = new S()
+  .attribute({
+    name: "optMap",
+    type: ["map", "string"],
+    required: false,
+    computed: false,
+  })
+  .attribute({
+    name: "reqMap",
+    type: ["map", "bool"],
+    required: true,
+    computed: false,
+  })
+  .attribute({
+    name: "computedMap",
+    type: ["map", "number"],
+    required: false,
+    computed: true,
+  })
+  .build();
+
 export const edgeSchema: ProviderSchema = schema({
   name: "edge",
   provider: new S().addAllPrimitivePermutations().build(),
@@ -71,6 +92,7 @@ export const edgeSchema: ProviderSchema = schema({
     optional_attribute_resource,
     optional_computed_attribute_resource,
     list_block_resource,
+    map_resource,
   },
   dataSources: {},
 });

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/complex-computed-types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/complex-computed-types.test.ts.snap
@@ -299,7 +299,7 @@ export class AcmCertificate extends cdktf.TerraformResource {
   // tags - computed: false, optional: true, required: false
   private _tags?: { [key: string]: string }; 
   public get tags() {
-    return this.getMapAttribute('tags');
+    return this.getStringMapAttribute('tags');
   }
   public set tags(value: { [key: string]: string }) {
     this._tags = value;
@@ -361,7 +361,7 @@ export class AcmCertificate extends cdktf.TerraformResource {
       domain_name: cdktf.stringToTerraform(this._domainName),
       private_key: cdktf.stringToTerraform(this._privateKey),
       subject_alternative_names: cdktf.listMapper(cdktf.stringToTerraform)(this._subjectAlternativeNames),
-      tags: cdktf.hashMapper(cdktf.anyToTerraform)(this._tags),
+      tags: cdktf.hashMapper(cdktf.stringToTerraform)(this._tags),
       validation_method: cdktf.stringToTerraform(this._validationMethod),
       options: acmCertificateOptionsToTerraform(this._options.internalValue),
     };

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/complex-computed-types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/complex-computed-types.test.ts.snap
@@ -37,7 +37,7 @@ export interface AcmCertificateConfig extends cdktf.TerraformMetaArguments {
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/acm_certificate#tags AcmCertificate#tags}
   */
-  readonly tags?: { [key: string]: string } | cdktf.IResolvable;
+  readonly tags?: { [key: string]: string };
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/acm_certificate#validation_method AcmCertificate#validation_method}
   */
@@ -297,12 +297,11 @@ export class AcmCertificate extends cdktf.TerraformResource {
   }
 
   // tags - computed: false, optional: true, required: false
-  private _tags?: { [key: string]: string } | cdktf.IResolvable; 
+  private _tags?: { [key: string]: string }; 
   public get tags() {
-    // Getting the computed value is not yet implemented
-    return this.interpolationForAttribute('tags') as any;
+    return this.getMapAttribute('tags');
   }
-  public set tags(value: { [key: string]: string } | cdktf.IResolvable) {
+  public set tags(value: { [key: string]: string }) {
     this._tags = value;
   }
   public resetTags() {

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/resource-types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/resource-types.test.ts.snap
@@ -45,7 +45,7 @@ export interface CloudfrontDistributionConfig extends cdktf.TerraformMetaArgumen
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#tags CloudfrontDistribution#tags}
   */
-  readonly tags?: { [key: string]: string } | cdktf.IResolvable;
+  readonly tags?: { [key: string]: string };
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#wait_for_deployment CloudfrontDistribution#wait_for_deployment}
   */
@@ -2587,12 +2587,11 @@ export class CloudfrontDistribution extends cdktf.TerraformResource {
   }
 
   // tags - computed: false, optional: true, required: false
-  private _tags?: { [key: string]: string } | cdktf.IResolvable; 
+  private _tags?: { [key: string]: string }; 
   public get tags() {
-    // Getting the computed value is not yet implemented
-    return this.interpolationForAttribute('tags') as any;
+    return this.getMapAttribute('tags');
   }
-  public set tags(value: { [key: string]: string } | cdktf.IResolvable) {
+  public set tags(value: { [key: string]: string }) {
     this._tags = value;
   }
   public resetTags() {
@@ -2949,7 +2948,7 @@ export interface S3BucketConfig extends cdktf.TerraformMetaArguments {
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#tags S3Bucket#tags}
   */
-  readonly tags?: { [key: string]: string } | cdktf.IResolvable;
+  readonly tags?: { [key: string]: string };
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#website_domain S3Bucket#website_domain}
   */
@@ -3337,7 +3336,7 @@ export interface S3BucketLifecycleRule {
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#tags S3Bucket#tags}
   */
-  readonly tags?: { [key: string]: string } | cdktf.IResolvable;
+  readonly tags?: { [key: string]: string };
   /**
   * expiration block
   * 
@@ -3921,7 +3920,7 @@ export interface S3BucketReplicationConfigurationRulesFilter {
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#tags S3Bucket#tags}
   */
-  readonly tags?: { [key: string]: string } | cdktf.IResolvable;
+  readonly tags?: { [key: string]: string };
 }
 
 export function s3BucketReplicationConfigurationRulesFilterToTerraform(struct?: S3BucketReplicationConfigurationRulesFilterOutputReference | S3BucketReplicationConfigurationRulesFilter): any {
@@ -3991,12 +3990,11 @@ export class S3BucketReplicationConfigurationRulesFilterOutputReference extends 
   }
 
   // tags - computed: false, optional: true, required: false
-  private _tags?: { [key: string]: string } | cdktf.IResolvable; 
+  private _tags?: { [key: string]: string }; 
   public get tags() {
-    // Getting the computed value is not yet implemented
-    return this.interpolationForAttribute('tags') as any;
+    return this.getMapAttribute('tags');
   }
-  public set tags(value: { [key: string]: string } | cdktf.IResolvable) {
+  public set tags(value: { [key: string]: string }) {
     this._tags = value;
   }
   public resetTags() {
@@ -4966,12 +4964,11 @@ export class S3Bucket extends cdktf.TerraformResource {
   }
 
   // tags - computed: false, optional: true, required: false
-  private _tags?: { [key: string]: string } | cdktf.IResolvable; 
+  private _tags?: { [key: string]: string }; 
   public get tags() {
-    // Getting the computed value is not yet implemented
-    return this.interpolationForAttribute('tags') as any;
+    return this.getMapAttribute('tags');
   }
-  public set tags(value: { [key: string]: string } | cdktf.IResolvable) {
+  public set tags(value: { [key: string]: string }) {
     this._tags = value;
   }
   public resetTags() {
@@ -5232,7 +5229,7 @@ export interface SecurityGroupConfig extends cdktf.TerraformMetaArguments {
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#tags SecurityGroup#tags}
   */
-  readonly tags?: { [key: string]: string } | cdktf.IResolvable;
+  readonly tags?: { [key: string]: string };
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#vpc_id SecurityGroup#vpc_id}
   */
@@ -5613,12 +5610,11 @@ export class SecurityGroup extends cdktf.TerraformResource {
   }
 
   // tags - computed: false, optional: true, required: false
-  private _tags?: { [key: string]: string } | cdktf.IResolvable; 
+  private _tags?: { [key: string]: string }; 
   public get tags() {
-    // Getting the computed value is not yet implemented
-    return this.interpolationForAttribute('tags') as any;
+    return this.getMapAttribute('tags');
   }
-  public set tags(value: { [key: string]: string } | cdktf.IResolvable) {
+  public set tags(value: { [key: string]: string }) {
     this._tags = value;
   }
   public resetTags() {

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/resource-types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/resource-types.test.ts.snap
@@ -2589,7 +2589,7 @@ export class CloudfrontDistribution extends cdktf.TerraformResource {
   // tags - computed: false, optional: true, required: false
   private _tags?: { [key: string]: string }; 
   public get tags() {
-    return this.getMapAttribute('tags');
+    return this.getStringMapAttribute('tags');
   }
   public set tags(value: { [key: string]: string }) {
     this._tags = value;
@@ -2785,7 +2785,7 @@ export class CloudfrontDistribution extends cdktf.TerraformResource {
       is_ipv6_enabled: cdktf.booleanToTerraform(this._isIpv6Enabled),
       price_class: cdktf.stringToTerraform(this._priceClass),
       retain_on_delete: cdktf.booleanToTerraform(this._retainOnDelete),
-      tags: cdktf.hashMapper(cdktf.anyToTerraform)(this._tags),
+      tags: cdktf.hashMapper(cdktf.stringToTerraform)(this._tags),
       wait_for_deployment: cdktf.booleanToTerraform(this._waitForDeployment),
       web_acl_id: cdktf.stringToTerraform(this._webAclId),
       cache_behavior: cdktf.listMapper(cloudfrontDistributionCacheBehaviorToTerraform)(this._cacheBehavior),
@@ -3372,7 +3372,7 @@ export function s3BucketLifecycleRuleToTerraform(struct?: S3BucketLifecycleRule)
     abort_incomplete_multipart_upload_days: cdktf.numberToTerraform(struct!.abortIncompleteMultipartUploadDays),
     enabled: cdktf.booleanToTerraform(struct!.enabled),
     prefix: cdktf.stringToTerraform(struct!.prefix),
-    tags: cdktf.hashMapper(cdktf.anyToTerraform)(struct!.tags),
+    tags: cdktf.hashMapper(cdktf.stringToTerraform)(struct!.tags),
     expiration: s3BucketLifecycleRuleExpirationToTerraform(struct!.expiration),
     noncurrent_version_expiration: s3BucketLifecycleRuleNoncurrentVersionExpirationToTerraform(struct!.noncurrentVersionExpiration),
     noncurrent_version_transition: cdktf.listMapper(s3BucketLifecycleRuleNoncurrentVersionTransitionToTerraform)(struct!.noncurrentVersionTransition),
@@ -3930,7 +3930,7 @@ export function s3BucketReplicationConfigurationRulesFilterToTerraform(struct?: 
   }
   return {
     prefix: cdktf.stringToTerraform(struct!.prefix),
-    tags: cdktf.hashMapper(cdktf.anyToTerraform)(struct!.tags),
+    tags: cdktf.hashMapper(cdktf.stringToTerraform)(struct!.tags),
   }
 }
 
@@ -3992,7 +3992,7 @@ export class S3BucketReplicationConfigurationRulesFilterOutputReference extends 
   // tags - computed: false, optional: true, required: false
   private _tags?: { [key: string]: string }; 
   public get tags() {
-    return this.getMapAttribute('tags');
+    return this.getStringMapAttribute('tags');
   }
   public set tags(value: { [key: string]: string }) {
     this._tags = value;
@@ -4966,7 +4966,7 @@ export class S3Bucket extends cdktf.TerraformResource {
   // tags - computed: false, optional: true, required: false
   private _tags?: { [key: string]: string }; 
   public get tags() {
-    return this.getMapAttribute('tags');
+    return this.getStringMapAttribute('tags');
   }
   public set tags(value: { [key: string]: string }) {
     this._tags = value;
@@ -5174,7 +5174,7 @@ export class S3Bucket extends cdktf.TerraformResource {
       policy: cdktf.stringToTerraform(this._policy),
       region: cdktf.stringToTerraform(this._region),
       request_payer: cdktf.stringToTerraform(this._requestPayer),
-      tags: cdktf.hashMapper(cdktf.anyToTerraform)(this._tags),
+      tags: cdktf.hashMapper(cdktf.stringToTerraform)(this._tags),
       website_domain: cdktf.stringToTerraform(this._websiteDomain),
       website_endpoint: cdktf.stringToTerraform(this._websiteEndpoint),
       cors_rule: cdktf.listMapper(s3BucketCorsRuleToTerraform)(this._corsRule),
@@ -5612,7 +5612,7 @@ export class SecurityGroup extends cdktf.TerraformResource {
   // tags - computed: false, optional: true, required: false
   private _tags?: { [key: string]: string }; 
   public get tags() {
-    return this.getMapAttribute('tags');
+    return this.getStringMapAttribute('tags');
   }
   public set tags(value: { [key: string]: string }) {
     this._tags = value;
@@ -5669,7 +5669,7 @@ export class SecurityGroup extends cdktf.TerraformResource {
       name: cdktf.stringToTerraform(this._name),
       name_prefix: cdktf.stringToTerraform(this._namePrefix),
       revoke_rules_on_delete: cdktf.booleanToTerraform(this._revokeRulesOnDelete),
-      tags: cdktf.hashMapper(cdktf.anyToTerraform)(this._tags),
+      tags: cdktf.hashMapper(cdktf.stringToTerraform)(this._tags),
       vpc_id: cdktf.stringToTerraform(this._vpcId),
       timeouts: securityGroupTimeoutsToTerraform(this._timeouts.internalValue),
     };

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -118,11 +118,11 @@ export interface BooleanMapConfig extends cdktf.TerraformMetaArguments {
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/boolean_map#foo_computed_optional BooleanMap#foo_computed_optional}
   */
-  readonly fooComputedOptional?: { [key: string]: boolean };
+  readonly fooComputedOptional?: { [key: string]: (boolean | cdktf.IResolvable) };
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/boolean_map#foo_optional BooleanMap#foo_optional}
   */
-  readonly fooOptional?: { [key: string]: boolean };
+  readonly fooOptional?: { [key: string]: (boolean | cdktf.IResolvable) };
 }
 
 /**
@@ -171,11 +171,11 @@ export class BooleanMap extends cdktf.TerraformResource {
   }
 
   // foo_computed_optional - computed: true, optional: true, required: false
-  private _fooComputedOptional?: { [key: string]: boolean }; 
+  private _fooComputedOptional?: { [key: string]: (boolean | cdktf.IResolvable) }; 
   public get fooComputedOptional() {
     return this.getBooleanMapAttribute('foo_computed_optional');
   }
-  public set fooComputedOptional(value: { [key: string]: boolean }) {
+  public set fooComputedOptional(value: { [key: string]: (boolean | cdktf.IResolvable) }) {
     this._fooComputedOptional = value;
   }
   public resetFooComputedOptional() {
@@ -187,11 +187,11 @@ export class BooleanMap extends cdktf.TerraformResource {
   }
 
   // foo_optional - computed: false, optional: true, required: false
-  private _fooOptional?: { [key: string]: boolean }; 
+  private _fooOptional?: { [key: string]: (boolean | cdktf.IResolvable) }; 
   public get fooOptional() {
     return this.getBooleanMapAttribute('foo_optional');
   }
-  public set fooOptional(value: { [key: string]: boolean }) {
+  public set fooOptional(value: { [key: string]: (boolean | cdktf.IResolvable) }) {
     this._fooOptional = value;
   }
   public resetFooOptional() {

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -1557,7 +1557,7 @@ export class PrimitiveDynamic extends cdktf.TerraformResource {
 
   // foo_computed - computed: true, optional: false, required: false
   public fooComputed(key: string): any {
-    return new { [key: string]: any }(this, 'foo_computed').lookup(key);
+    return new cdktf.AnyMap(this, 'foo_computed').lookup(key);
   }
 
   // foo_computed_optional - computed: true, optional: true, required: false

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -173,7 +173,7 @@ export class BooleanMap extends cdktf.TerraformResource {
   // foo_computed_optional - computed: true, optional: true, required: false
   private _fooComputedOptional?: { [key: string]: boolean }; 
   public get fooComputedOptional() {
-    return this.getMapAttribute('foo_computed_optional');
+    return this.getBooleanMapAttribute('foo_computed_optional');
   }
   public set fooComputedOptional(value: { [key: string]: boolean }) {
     this._fooComputedOptional = value;
@@ -189,7 +189,7 @@ export class BooleanMap extends cdktf.TerraformResource {
   // foo_optional - computed: false, optional: true, required: false
   private _fooOptional?: { [key: string]: boolean }; 
   public get fooOptional() {
-    return this.getMapAttribute('foo_optional');
+    return this.getBooleanMapAttribute('foo_optional');
   }
   public set fooOptional(value: { [key: string]: boolean }) {
     this._fooOptional = value;
@@ -208,8 +208,8 @@ export class BooleanMap extends cdktf.TerraformResource {
 
   protected synthesizeAttributes(): { [name: string]: any } {
     return {
-      foo_computed_optional: cdktf.hashMapper(cdktf.anyToTerraform)(this._fooComputedOptional),
-      foo_optional: cdktf.hashMapper(cdktf.anyToTerraform)(this._fooOptional),
+      foo_computed_optional: cdktf.hashMapper(cdktf.booleanToTerraform)(this._fooComputedOptional),
+      foo_optional: cdktf.hashMapper(cdktf.booleanToTerraform)(this._fooOptional),
     };
   }
 }
@@ -1317,7 +1317,7 @@ export class NumberMap extends cdktf.TerraformResource {
   // foo_computed_optional - computed: true, optional: true, required: false
   private _fooComputedOptional?: { [key: string]: number }; 
   public get fooComputedOptional() {
-    return this.getMapAttribute('foo_computed_optional');
+    return this.getNumberMapAttribute('foo_computed_optional');
   }
   public set fooComputedOptional(value: { [key: string]: number }) {
     this._fooComputedOptional = value;
@@ -1333,7 +1333,7 @@ export class NumberMap extends cdktf.TerraformResource {
   // foo_optional - computed: false, optional: true, required: false
   private _fooOptional?: { [key: string]: number }; 
   public get fooOptional() {
-    return this.getMapAttribute('foo_optional');
+    return this.getNumberMapAttribute('foo_optional');
   }
   public set fooOptional(value: { [key: string]: number }) {
     this._fooOptional = value;
@@ -1352,8 +1352,8 @@ export class NumberMap extends cdktf.TerraformResource {
 
   protected synthesizeAttributes(): { [name: string]: any } {
     return {
-      foo_computed_optional: cdktf.hashMapper(cdktf.anyToTerraform)(this._fooComputedOptional),
-      foo_optional: cdktf.hashMapper(cdktf.anyToTerraform)(this._fooOptional),
+      foo_computed_optional: cdktf.hashMapper(cdktf.numberToTerraform)(this._fooComputedOptional),
+      foo_optional: cdktf.hashMapper(cdktf.numberToTerraform)(this._fooOptional),
     };
   }
 }
@@ -1563,7 +1563,7 @@ export class PrimitiveDynamic extends cdktf.TerraformResource {
   // foo_computed_optional - computed: true, optional: true, required: false
   private _fooComputedOptional?: { [key: string]: any }; 
   public get fooComputedOptional() {
-    return this.getMapAttribute('foo_computed_optional');
+    return this.getAnyMapAttribute('foo_computed_optional');
   }
   public set fooComputedOptional(value: { [key: string]: any }) {
     this._fooComputedOptional = value;
@@ -1579,7 +1579,7 @@ export class PrimitiveDynamic extends cdktf.TerraformResource {
   // foo_optional - computed: false, optional: true, required: false
   private _fooOptional?: { [key: string]: any }; 
   public get fooOptional() {
-    return this.getMapAttribute('foo_optional');
+    return this.getAnyMapAttribute('foo_optional');
   }
   public set fooOptional(value: { [key: string]: any }) {
     this._fooOptional = value;
@@ -1595,7 +1595,7 @@ export class PrimitiveDynamic extends cdktf.TerraformResource {
   // foo_required - computed: false, optional: false, required: true
   private _fooRequired?: { [key: string]: any }; 
   public get fooRequired() {
-    return this.getMapAttribute('foo_required');
+    return this.getAnyMapAttribute('foo_required');
   }
   public set fooRequired(value: { [key: string]: any }) {
     this._fooRequired = value;
@@ -2526,7 +2526,7 @@ export class StringMap extends cdktf.TerraformResource {
   // subject_alternative_names_computed_optional - computed: true, optional: true, required: false
   private _subjectAlternativeNamesComputedOptional?: { [key: string]: string }; 
   public get subjectAlternativeNamesComputedOptional() {
-    return this.getMapAttribute('subject_alternative_names_computed_optional');
+    return this.getStringMapAttribute('subject_alternative_names_computed_optional');
   }
   public set subjectAlternativeNamesComputedOptional(value: { [key: string]: string }) {
     this._subjectAlternativeNamesComputedOptional = value;
@@ -2542,7 +2542,7 @@ export class StringMap extends cdktf.TerraformResource {
   // subject_alternative_names_optional - computed: false, optional: true, required: false
   private _subjectAlternativeNamesOptional?: { [key: string]: string }; 
   public get subjectAlternativeNamesOptional() {
-    return this.getMapAttribute('subject_alternative_names_optional');
+    return this.getStringMapAttribute('subject_alternative_names_optional');
   }
   public set subjectAlternativeNamesOptional(value: { [key: string]: string }) {
     this._subjectAlternativeNamesOptional = value;
@@ -2561,8 +2561,8 @@ export class StringMap extends cdktf.TerraformResource {
 
   protected synthesizeAttributes(): { [name: string]: any } {
     return {
-      subject_alternative_names_computed_optional: cdktf.hashMapper(cdktf.anyToTerraform)(this._subjectAlternativeNamesComputedOptional),
-      subject_alternative_names_optional: cdktf.hashMapper(cdktf.anyToTerraform)(this._subjectAlternativeNamesOptional),
+      subject_alternative_names_computed_optional: cdktf.hashMapper(cdktf.stringToTerraform)(this._subjectAlternativeNamesComputedOptional),
+      subject_alternative_names_optional: cdktf.hashMapper(cdktf.stringToTerraform)(this._subjectAlternativeNamesOptional),
     };
   }
 }

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -63,7 +63,8 @@ export class BooleanList extends cdktf.TerraformResource {
   // foo_required - computed: false, optional: false, required: true
   private _fooRequired?: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable; 
   public get fooRequired() {
-    return this.getBooleanAttribute('foo_required') as any;
+    // Getting the computed value is not yet implemented
+    return this.interpolationForAttribute('foo_required') as any;
   }
   public set fooRequired(value: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable) {
     this._fooRequired = value;
@@ -76,7 +77,8 @@ export class BooleanList extends cdktf.TerraformResource {
   // foo_optional - computed: false, optional: true, required: false
   private _fooOptional?: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable; 
   public get fooOptional() {
-    return this.getBooleanAttribute('foo_optional') as any;
+    // Getting the computed value is not yet implemented
+    return this.interpolationForAttribute('foo_optional') as any;
   }
   public set fooOptional(value: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable) {
     this._fooOptional = value;
@@ -116,11 +118,11 @@ export interface BooleanMapConfig extends cdktf.TerraformMetaArguments {
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/boolean_map#foo_computed_optional BooleanMap#foo_computed_optional}
   */
-  readonly fooComputedOptional?: { [key: string]: boolean } | cdktf.IResolvable;
+  readonly fooComputedOptional?: { [key: string]: boolean };
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/boolean_map#foo_optional BooleanMap#foo_optional}
   */
-  readonly fooOptional?: { [key: string]: boolean } | cdktf.IResolvable;
+  readonly fooOptional?: { [key: string]: boolean };
 }
 
 /**
@@ -169,11 +171,11 @@ export class BooleanMap extends cdktf.TerraformResource {
   }
 
   // foo_computed_optional - computed: true, optional: true, required: false
-  private _fooComputedOptional?: { [key: string]: boolean } | cdktf.IResolvable; 
+  private _fooComputedOptional?: { [key: string]: boolean }; 
   public get fooComputedOptional() {
-    return this.getBooleanAttribute('foo_computed_optional') as any;
+    return this.getMapAttribute('foo_computed_optional');
   }
-  public set fooComputedOptional(value: { [key: string]: boolean } | cdktf.IResolvable) {
+  public set fooComputedOptional(value: { [key: string]: boolean }) {
     this._fooComputedOptional = value;
   }
   public resetFooComputedOptional() {
@@ -185,11 +187,11 @@ export class BooleanMap extends cdktf.TerraformResource {
   }
 
   // foo_optional - computed: false, optional: true, required: false
-  private _fooOptional?: { [key: string]: boolean } | cdktf.IResolvable; 
+  private _fooOptional?: { [key: string]: boolean }; 
   public get fooOptional() {
-    return this.getBooleanAttribute('foo_optional') as any;
+    return this.getMapAttribute('foo_optional');
   }
-  public set fooOptional(value: { [key: string]: boolean } | cdktf.IResolvable) {
+  public set fooOptional(value: { [key: string]: boolean }) {
     this._fooOptional = value;
   }
   public resetFooOptional() {
@@ -1260,11 +1262,11 @@ export interface NumberMapConfig extends cdktf.TerraformMetaArguments {
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/number_map#foo_computed_optional NumberMap#foo_computed_optional}
   */
-  readonly fooComputedOptional?: { [key: string]: number } | cdktf.IResolvable;
+  readonly fooComputedOptional?: { [key: string]: number };
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/number_map#foo_optional NumberMap#foo_optional}
   */
-  readonly fooOptional?: { [key: string]: number } | cdktf.IResolvable;
+  readonly fooOptional?: { [key: string]: number };
 }
 
 /**
@@ -1313,12 +1315,11 @@ export class NumberMap extends cdktf.TerraformResource {
   }
 
   // foo_computed_optional - computed: true, optional: true, required: false
-  private _fooComputedOptional?: { [key: string]: number } | cdktf.IResolvable; 
+  private _fooComputedOptional?: { [key: string]: number }; 
   public get fooComputedOptional() {
-    // Getting the computed value is not yet implemented
-    return this.interpolationForAttribute('foo_computed_optional') as any;
+    return this.getMapAttribute('foo_computed_optional');
   }
-  public set fooComputedOptional(value: { [key: string]: number } | cdktf.IResolvable) {
+  public set fooComputedOptional(value: { [key: string]: number }) {
     this._fooComputedOptional = value;
   }
   public resetFooComputedOptional() {
@@ -1330,12 +1331,11 @@ export class NumberMap extends cdktf.TerraformResource {
   }
 
   // foo_optional - computed: false, optional: true, required: false
-  private _fooOptional?: { [key: string]: number } | cdktf.IResolvable; 
+  private _fooOptional?: { [key: string]: number }; 
   public get fooOptional() {
-    // Getting the computed value is not yet implemented
-    return this.interpolationForAttribute('foo_optional') as any;
+    return this.getMapAttribute('foo_optional');
   }
-  public set fooOptional(value: { [key: string]: number } | cdktf.IResolvable) {
+  public set fooOptional(value: { [key: string]: number }) {
     this._fooOptional = value;
   }
   public resetFooOptional() {
@@ -1503,15 +1503,15 @@ export interface PrimitiveDynamicConfig extends cdktf.TerraformMetaArguments {
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/primitive_dynamic#foo_computed_optional PrimitiveDynamic#foo_computed_optional}
   */
-  readonly fooComputedOptional?: { [key: string]: any } | cdktf.IResolvable;
+  readonly fooComputedOptional?: { [key: string]: any };
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/primitive_dynamic#foo_optional PrimitiveDynamic#foo_optional}
   */
-  readonly fooOptional?: { [key: string]: any } | cdktf.IResolvable;
+  readonly fooOptional?: { [key: string]: any };
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/primitive_dynamic#foo_required PrimitiveDynamic#foo_required}
   */
-  readonly fooRequired: { [key: string]: any } | cdktf.IResolvable;
+  readonly fooRequired: { [key: string]: any };
 }
 
 /**
@@ -1557,16 +1557,15 @@ export class PrimitiveDynamic extends cdktf.TerraformResource {
 
   // foo_computed - computed: true, optional: false, required: false
   public fooComputed(key: string): any {
-    return new { [key: string]: any } | cdktf.IResolvable(this, 'foo_computed').lookup(key);
+    return new { [key: string]: any }(this, 'foo_computed').lookup(key);
   }
 
   // foo_computed_optional - computed: true, optional: true, required: false
-  private _fooComputedOptional?: { [key: string]: any } | cdktf.IResolvable; 
+  private _fooComputedOptional?: { [key: string]: any }; 
   public get fooComputedOptional() {
-    // Getting the computed value is not yet implemented
-    return this.interpolationForAttribute('foo_computed_optional') as any;
+    return this.getMapAttribute('foo_computed_optional');
   }
-  public set fooComputedOptional(value: { [key: string]: any } | cdktf.IResolvable) {
+  public set fooComputedOptional(value: { [key: string]: any }) {
     this._fooComputedOptional = value;
   }
   public resetFooComputedOptional() {
@@ -1578,12 +1577,11 @@ export class PrimitiveDynamic extends cdktf.TerraformResource {
   }
 
   // foo_optional - computed: false, optional: true, required: false
-  private _fooOptional?: { [key: string]: any } | cdktf.IResolvable; 
+  private _fooOptional?: { [key: string]: any }; 
   public get fooOptional() {
-    // Getting the computed value is not yet implemented
-    return this.interpolationForAttribute('foo_optional') as any;
+    return this.getMapAttribute('foo_optional');
   }
-  public set fooOptional(value: { [key: string]: any } | cdktf.IResolvable) {
+  public set fooOptional(value: { [key: string]: any }) {
     this._fooOptional = value;
   }
   public resetFooOptional() {
@@ -1595,12 +1593,11 @@ export class PrimitiveDynamic extends cdktf.TerraformResource {
   }
 
   // foo_required - computed: false, optional: false, required: true
-  private _fooRequired?: { [key: string]: any } | cdktf.IResolvable; 
+  private _fooRequired?: { [key: string]: any }; 
   public get fooRequired() {
-    // Getting the computed value is not yet implemented
-    return this.interpolationForAttribute('foo_required') as any;
+    return this.getMapAttribute('foo_required');
   }
-  public set fooRequired(value: { [key: string]: any } | cdktf.IResolvable) {
+  public set fooRequired(value: { [key: string]: any }) {
     this._fooRequired = value;
   }
   // Temporarily expose input value. Use with caution.
@@ -2474,11 +2471,11 @@ export interface StringMapConfig extends cdktf.TerraformMetaArguments {
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/string_map#subject_alternative_names_computed_optional StringMap#subject_alternative_names_computed_optional}
   */
-  readonly subjectAlternativeNamesComputedOptional?: { [key: string]: string } | cdktf.IResolvable;
+  readonly subjectAlternativeNamesComputedOptional?: { [key: string]: string };
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/string_map#subject_alternative_names_optional StringMap#subject_alternative_names_optional}
   */
-  readonly subjectAlternativeNamesOptional?: { [key: string]: string } | cdktf.IResolvable;
+  readonly subjectAlternativeNamesOptional?: { [key: string]: string };
 }
 
 /**
@@ -2527,12 +2524,11 @@ export class StringMap extends cdktf.TerraformResource {
   }
 
   // subject_alternative_names_computed_optional - computed: true, optional: true, required: false
-  private _subjectAlternativeNamesComputedOptional?: { [key: string]: string } | cdktf.IResolvable; 
+  private _subjectAlternativeNamesComputedOptional?: { [key: string]: string }; 
   public get subjectAlternativeNamesComputedOptional() {
-    // Getting the computed value is not yet implemented
-    return this.interpolationForAttribute('subject_alternative_names_computed_optional') as any;
+    return this.getMapAttribute('subject_alternative_names_computed_optional');
   }
-  public set subjectAlternativeNamesComputedOptional(value: { [key: string]: string } | cdktf.IResolvable) {
+  public set subjectAlternativeNamesComputedOptional(value: { [key: string]: string }) {
     this._subjectAlternativeNamesComputedOptional = value;
   }
   public resetSubjectAlternativeNamesComputedOptional() {
@@ -2544,12 +2540,11 @@ export class StringMap extends cdktf.TerraformResource {
   }
 
   // subject_alternative_names_optional - computed: false, optional: true, required: false
-  private _subjectAlternativeNamesOptional?: { [key: string]: string } | cdktf.IResolvable; 
+  private _subjectAlternativeNamesOptional?: { [key: string]: string }; 
   public get subjectAlternativeNamesOptional() {
-    // Getting the computed value is not yet implemented
-    return this.interpolationForAttribute('subject_alternative_names_optional') as any;
+    return this.getMapAttribute('subject_alternative_names_optional');
   }
-  public set subjectAlternativeNamesOptional(value: { [key: string]: string } | cdktf.IResolvable) {
+  public set subjectAlternativeNamesOptional(value: { [key: string]: string }) {
     this._subjectAlternativeNamesOptional = value;
   }
   public resetSubjectAlternativeNamesOptional() {

--- a/packages/@cdktf/provider-generator/lib/get/generator/emitter/attributes-emitter.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/emitter/attributes-emitter.ts
@@ -144,6 +144,9 @@ export class AttributesEmitter {
     if (type.isBoolean) {
       return `this.getBooleanAttribute('${att.terraformName}') as any`;
     }
+    if (type.isMap) {
+      return `this.getMapAttribute('${att.terraformName}')`;
+    }
     if (process.env.DEBUG) {
       console.error(
         `The attribute ${JSON.stringify(att)} isn't implemented yet`

--- a/packages/@cdktf/provider-generator/lib/get/generator/emitter/attributes-emitter.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/emitter/attributes-emitter.ts
@@ -1,6 +1,6 @@
 import { CodeMaker } from "codemaker";
 import { AttributeModel } from "../models";
-import { downcaseFirst } from "../../../util";
+import { downcaseFirst, uppercaseFirst } from "../../../util";
 import { CUSTOM_DEFAULTS } from "../custom-defaults";
 
 function titleCase(value: string) {
@@ -145,7 +145,9 @@ export class AttributesEmitter {
       return `this.getBooleanAttribute('${att.terraformName}') as any`;
     }
     if (type.isMap) {
-      return `this.getMapAttribute('${att.terraformName}')`;
+      return `this.get${uppercaseFirst(att.mapType)}MapAttribute('${
+        att.terraformName
+      }')`;
     }
     if (process.env.DEBUG) {
       console.error(

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
@@ -144,6 +144,9 @@ export class AttributeModel {
     if (type.isBooleanMap) {
       return `boolean`;
     }
+    if (type.isAnyMap) {
+      return `any`;
+    }
     if (process.env.DEBUG) {
       console.error(
         `The attribute ${JSON.stringify(this)} isn't implemented yet`

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
@@ -135,16 +135,16 @@ export class AttributeModel {
 
   public get mapType(): string {
     const type = this.type;
-    if (type.isStringMap) {
+    if (type.isStringMap || (type.isMap && type.innerType === "string")) {
       return `string`;
     }
-    if (type.isNumberMap) {
+    if (type.isNumberMap || (type.isMap && type.innerType === "number")) {
       return `number`;
     }
-    if (type.isBooleanMap) {
+    if (type.isBooleanMap || (type.isMap && type.innerType === "boolean")) {
       return `boolean`;
     }
-    if (type.isAnyMap) {
+    if (type.isAnyMap || (type.isMap && type.innerType === "any")) {
       return `any`;
     }
     if (process.env.DEBUG) {

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
@@ -135,16 +135,16 @@ export class AttributeModel {
 
   public get mapType(): string {
     const type = this.type;
-    if (type.isStringMap || (type.isMap && type.innerType === "string")) {
+    if (type.isStringMap) {
       return `string`;
     }
-    if (type.isNumberMap || (type.isMap && type.innerType === "number")) {
+    if (type.isNumberMap) {
       return `number`;
     }
-    if (type.isBooleanMap || (type.isMap && type.innerType === "boolean")) {
+    if (type.isBooleanMap) {
       return `boolean`;
     }
-    if (type.isAnyMap || (type.isMap && type.innerType === "any")) {
+    if (type.isAnyMap) {
       return `any`;
     }
     if (process.env.DEBUG) {

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
@@ -54,8 +54,7 @@ export class AttributeTypeModel {
     if (this.isStringMap) return `cdktf.StringMap`;
     if (this.isNumberMap) return `cdktf.NumberMap`;
     if (this.isBooleanMap) return `cdktf.BooleanMap`;
-    if (this.isMap)
-      return `{ [key: string]: ${this._type} } | cdktf.IResolvable`;
+    if (this.isMap) return `{ [key: string]: ${this._type} }`;
     if (this.isList && !this.isComputed && this.isSingleItem)
       return `${this._type}`;
     // neither boolean nor boolean[] is tokenizable, so both parts need IResolvable
@@ -111,7 +110,9 @@ export class AttributeTypeModel {
   }
 
   public get isBoolean(): boolean {
-    return this._type === TokenizableTypes.BOOLEAN || this.isBooleanMap;
+    return (
+      this._type === TokenizableTypes.BOOLEAN && !this.isList && !this.isMap
+    );
   }
 
   public get isStringMap(): boolean {

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
@@ -54,6 +54,7 @@ export class AttributeTypeModel {
     if (this.isStringMap) return `cdktf.StringMap`;
     if (this.isNumberMap) return `cdktf.NumberMap`;
     if (this.isBooleanMap) return `cdktf.BooleanMap`;
+    if (this.isAnyMap) return `cdktf.AnyMap`;
     if (this.isMap) return `{ [key: string]: ${this._type} }`;
     if (this.isList && !this.isComputed && this.isSingleItem)
       return `${this._type}`;
@@ -139,6 +140,12 @@ export class AttributeTypeModel {
       this.isMap &&
       this._type === TokenizableTypes.BOOLEAN &&
       this.isComputed
+    );
+  }
+
+  public get isAnyMap(): boolean {
+    return (
+      !this.isOptional && this.isMap && this._type === "any" && this.isComputed
     );
   }
 

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
@@ -51,28 +51,51 @@ export class AttributeTypeModel {
   }
 
   public get name(): string {
+    // computed map wrappers
     if (this.isStringMap) return `cdktf.StringMap`;
     if (this.isNumberMap) return `cdktf.NumberMap`;
     if (this.isBooleanMap) return `cdktf.BooleanMap`;
     if (this.isAnyMap) return `cdktf.AnyMap`;
-    if (this.isMap) return `{ [key: string]: ${this._type} }`;
+
+    // map of booleans has token support, but booleans don't
+    if (this.isMap && this._type === TokenizableTypes.BOOLEAN)
+      return `{ [key: string]: (${this._type} | cdktf.IResolvable) }`;
+
+    // other maps with token support
+    if (this.isTokenizableMap) return `{ [key: string]: ${this._type} }`;
+
+    // maps without token support
+    if (this.isMap)
+      return `{ [key: string]: ${this._type} } | cdktf.IResolvable`;
+
+    // single item list
     if (this.isList && !this.isComputed && this.isSingleItem)
       return `${this._type}`;
+
     // neither boolean nor boolean[] is tokenizable, so both parts need IResolvable
     if (this.isList && this._type === TokenizableTypes.BOOLEAN)
       return "Array<boolean | cdktf.IResolvable> | cdktf.IResolvable";
+
+    // non-computed list
     if (this.isList && !this.isComputed) return `${this._type}[]`;
+
+    // computed lists of simple types
     if (
       this.isList &&
       this.isComputed &&
       (this.isPrimitive || !this.struct?.isClass)
     )
       return `${this._type}[]`;
+
+    // complex computed list
     if (this.isList && this.isComputed && this.isComplex)
       return `${this._type}`;
 
+    // boolean
     if (this._type === TokenizableTypes.BOOLEAN)
       return `boolean | cdktf.IResolvable`;
+
+    // all other types
     return this._type;
   }
 
@@ -146,6 +169,14 @@ export class AttributeTypeModel {
   public get isAnyMap(): boolean {
     return (
       !this.isOptional && this.isMap && this._type === "any" && this.isComputed
+    );
+  }
+
+  public get isTokenizableMap(): boolean {
+    return (
+      this.isMap &&
+      !this.isList &&
+      Object.values(TokenizableTypes).includes(this._type as TokenizableTypes)
     );
   }
 

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
@@ -52,10 +52,10 @@ export class AttributeTypeModel {
 
   public get name(): string {
     // computed map wrappers
-    if (this.isStringMap) return `cdktf.StringMap`;
-    if (this.isNumberMap) return `cdktf.NumberMap`;
-    if (this.isBooleanMap) return `cdktf.BooleanMap`;
-    if (this.isAnyMap) return `cdktf.AnyMap`;
+    if (this.isComputedStringMap) return `cdktf.StringMap`;
+    if (this.isComputedNumberMap) return `cdktf.NumberMap`;
+    if (this.isComputedBooleanMap) return `cdktf.BooleanMap`;
+    if (this.isComputedAnyMap) return `cdktf.AnyMap`;
 
     // map of booleans has token support, but booleans don't
     if (this.isMap && this._type === TokenizableTypes.BOOLEAN)
@@ -140,36 +140,35 @@ export class AttributeTypeModel {
   }
 
   public get isStringMap(): boolean {
-    return (
-      !this.isOptional &&
-      this.isMap &&
-      this._type === TokenizableTypes.STRING &&
-      this.isComputed
-    );
+    return this.isMap && this._type === TokenizableTypes.STRING;
+  }
+
+  public get isComputedStringMap(): boolean {
+    return this.isStringMap && this.isComputed && !this.isOptional;
   }
 
   public get isNumberMap(): boolean {
-    return (
-      !this.isOptional &&
-      this.isMap &&
-      this._type === TokenizableTypes.NUMBER &&
-      this.isComputed
-    );
+    return this.isMap && this._type === TokenizableTypes.NUMBER;
+  }
+
+  public get isComputedNumberMap(): boolean {
+    return this.isNumberMap && this.isComputed && !this.isOptional;
   }
 
   public get isBooleanMap(): boolean {
-    return (
-      !this.isOptional &&
-      this.isMap &&
-      this._type === TokenizableTypes.BOOLEAN &&
-      this.isComputed
-    );
+    return this.isMap && this._type === TokenizableTypes.BOOLEAN;
+  }
+
+  public get isComputedBooleanMap(): boolean {
+    return this.isBooleanMap && this.isComputed && !this.isOptional;
   }
 
   public get isAnyMap(): boolean {
-    return (
-      !this.isOptional && this.isMap && this._type === "any" && this.isComputed
-    );
+    return this.isMap && this._type === "any";
+  }
+
+  public get isComputedAnyMap(): boolean {
+    return this.isAnyMap && this.isComputed && !this.isOptional;
   }
 
   public get isTokenizableMap(): boolean {

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
@@ -176,7 +176,10 @@ export class AttributeTypeModel {
     return (
       this.isMap &&
       !this.isList &&
-      Object.values(TokenizableTypes).includes(this._type as TokenizableTypes)
+      (Object.values(TokenizableTypes).includes(
+        this._type as TokenizableTypes
+      ) ||
+        this._type === "any")
     );
   }
 

--- a/packages/@cdktf/provider-generator/lib/util.ts
+++ b/packages/@cdktf/provider-generator/lib/util.ts
@@ -82,3 +82,15 @@ export function downcaseFirst(str: string): string {
   }
   return `${str[0].toLocaleLowerCase()}${str.slice(1)}`;
 }
+
+/**
+ * Uppercase the first character in a string.
+ *
+ * @param str the string to be processed.
+ */
+export function uppercaseFirst(str: string): string {
+  if (str === "") {
+    return str;
+  }
+  return `${str[0].toLocaleUpperCase()}${str.slice(1)}`;
+}

--- a/packages/cdktf/lib/complex-computed-list.ts
+++ b/packages/cdktf/lib/complex-computed-list.ts
@@ -81,6 +81,21 @@ export class BooleanMap {
   }
 }
 
+export class AnyMap {
+  constructor(
+    protected terraformResource: ITerraformResource,
+    protected terraformAttribute: string
+  ) {}
+
+  public lookup(key: string): any {
+    return Token.asAny(
+      this.terraformResource.interpolationForAttribute(
+        `${this.terraformAttribute}["${key}"]`
+      )
+    );
+  }
+}
+
 export class ComplexComputedList extends ComplexComputedAttribute {
   constructor(
     protected terraformResource: IInterpolatingParent,

--- a/packages/cdktf/lib/complex-computed-list.ts
+++ b/packages/cdktf/lib/complex-computed-list.ts
@@ -28,9 +28,27 @@ abstract class ComplexComputedAttribute implements IInterpolatingParent {
       this.interpolationForAttribute(terraformAttribute)
     );
   }
+  
+  public getStringMapAttribute(terraformAttribute: string) {
+    return Token.asStringMap(
+      this.interpolationForAttribute(terraformAttribute)
+    );
+  }
 
-  public getMapAttribute(terraformAttribute: string) {
-    return Token.asMap(this.interpolationForAttribute(terraformAttribute));
+  public getNumberMapAttribute(terraformAttribute: string) {
+    return Token.asNumberMap(
+      this.interpolationForAttribute(terraformAttribute)
+    );
+  }
+
+  public getBooleanMapAttribute(terraformAttribute: string) {
+    return Token.asBooleanMap(
+      this.interpolationForAttribute(terraformAttribute)
+    );
+  }
+
+  public getAnyMapAttribute(terraformAttribute: string) {
+    return Token.asAnyMap(this.interpolationForAttribute(terraformAttribute));
   }
 
   public abstract interpolationForAttribute(terraformAttribute: string): any;

--- a/packages/cdktf/lib/complex-computed-list.ts
+++ b/packages/cdktf/lib/complex-computed-list.ts
@@ -28,7 +28,7 @@ abstract class ComplexComputedAttribute implements IInterpolatingParent {
       this.interpolationForAttribute(terraformAttribute)
     );
   }
-  
+
   public getStringMapAttribute(terraformAttribute: string) {
     return Token.asStringMap(
       this.interpolationForAttribute(terraformAttribute)
@@ -101,7 +101,7 @@ export class BooleanMap {
 
 export class AnyMap {
   constructor(
-    protected terraformResource: ITerraformResource,
+    protected terraformResource: IInterpolatingParent,
     protected terraformAttribute: string
   ) {}
 

--- a/packages/cdktf/lib/complex-computed-list.ts
+++ b/packages/cdktf/lib/complex-computed-list.ts
@@ -29,6 +29,10 @@ abstract class ComplexComputedAttribute implements IInterpolatingParent {
     );
   }
 
+  public getMapAttribute(terraformAttribute: string) {
+    return Token.asMap(this.interpolationForAttribute(terraformAttribute));
+  }
+
   public abstract interpolationForAttribute(terraformAttribute: string): any;
 }
 

--- a/packages/cdktf/lib/runtime.ts
+++ b/packages/cdktf/lib/runtime.ts
@@ -9,6 +9,7 @@
 import {
   containsComplexElement,
   isComplexElement,
+  containsMapToken,
 } from "./tokens/private/encoding";
 import { Tokenization } from "./tokens";
 
@@ -55,6 +56,10 @@ export function hashMapper(elementMapper: Mapper): Mapper {
 
     // We can't treat strings as hashes (likely a token or a misconfiguration)
     if (typeof x === "string") {
+      return x;
+    }
+    
+    if (containsMapToken(x)) {
       return x;
     }
 

--- a/packages/cdktf/lib/runtime.ts
+++ b/packages/cdktf/lib/runtime.ts
@@ -58,7 +58,7 @@ export function hashMapper(elementMapper: Mapper): Mapper {
     if (typeof x === "string") {
       return x;
     }
-    
+
     if (containsMapToken(x)) {
       return x;
     }

--- a/packages/cdktf/lib/terraform-data-source.ts
+++ b/packages/cdktf/lib/terraform-data-source.ts
@@ -62,8 +62,26 @@ export class TerraformDataSource
     );
   }
   
-  public getMapAttribute(terraformAttribute: string) {
-    return Token.asMap(this.interpolationForAttribute(terraformAttribute));
+  public getStringMapAttribute(terraformAttribute: string) {
+    return Token.asStringMap(
+      this.interpolationForAttribute(terraformAttribute)
+    );
+  }
+
+  public getNumberMapAttribute(terraformAttribute: string) {
+    return Token.asNumberMap(
+      this.interpolationForAttribute(terraformAttribute)
+    );
+  }
+
+  public getBooleanMapAttribute(terraformAttribute: string) {
+    return Token.asBooleanMap(
+      this.interpolationForAttribute(terraformAttribute)
+    );
+  }
+
+  public getAnyMapAttribute(terraformAttribute: string) {
+    return Token.asAnyMap(this.interpolationForAttribute(terraformAttribute));
   }
 
   public get fqn(): string {

--- a/packages/cdktf/lib/terraform-data-source.ts
+++ b/packages/cdktf/lib/terraform-data-source.ts
@@ -61,7 +61,7 @@ export class TerraformDataSource
       this.interpolationForAttribute(terraformAttribute)
     );
   }
-  
+
   public getStringMapAttribute(terraformAttribute: string) {
     return Token.asStringMap(
       this.interpolationForAttribute(terraformAttribute)

--- a/packages/cdktf/lib/terraform-data-source.ts
+++ b/packages/cdktf/lib/terraform-data-source.ts
@@ -61,6 +61,10 @@ export class TerraformDataSource
       this.interpolationForAttribute(terraformAttribute)
     );
   }
+  
+  public getMapAttribute(terraformAttribute: string) {
+    return Token.asMap(this.interpolationForAttribute(terraformAttribute));
+  }
 
   public get fqn(): string {
     return Token.asString(

--- a/packages/cdktf/lib/terraform-functions.ts
+++ b/packages/cdktf/lib/terraform-functions.ts
@@ -71,7 +71,7 @@ function listOf(type: TFValueValidator): TFValueValidator {
         if (extractTokenDouble(item, true) !== undefined) {
           return item;
         }
-        
+
         if (TokenString.forMapToken(item).test()) {
           return item;
         }

--- a/packages/cdktf/lib/terraform-functions.ts
+++ b/packages/cdktf/lib/terraform-functions.ts
@@ -71,6 +71,10 @@ function listOf(type: TFValueValidator): TFValueValidator {
         if (extractTokenDouble(item, true) !== undefined) {
           return item;
         }
+        
+        if (TokenString.forMapToken(item).test()) {
+          return item;
+        }
 
         if (typeof item === "string") {
           const tokenList = Tokenization.reverseString(item);

--- a/packages/cdktf/lib/terraform-resource.ts
+++ b/packages/cdktf/lib/terraform-resource.ts
@@ -93,8 +93,26 @@ export class TerraformResource
     );
   }
   
-  public getMapAttribute(terraformAttribute: string) {
-    return Token.asMap(this.interpolationForAttribute(terraformAttribute));
+  public getStringMapAttribute(terraformAttribute: string) {
+    return Token.asStringMap(
+      this.interpolationForAttribute(terraformAttribute)
+    );
+  }
+
+  public getNumberMapAttribute(terraformAttribute: string) {
+    return Token.asNumberMap(
+      this.interpolationForAttribute(terraformAttribute)
+    );
+  }
+
+  public getBooleanMapAttribute(terraformAttribute: string) {
+    return Token.asBooleanMap(
+      this.interpolationForAttribute(terraformAttribute)
+    );
+  }
+
+  public getAnyMapAttribute(terraformAttribute: string) {
+    return Token.asAnyMap(this.interpolationForAttribute(terraformAttribute));
   }
 
   public get fqn(): string {

--- a/packages/cdktf/lib/terraform-resource.ts
+++ b/packages/cdktf/lib/terraform-resource.ts
@@ -92,7 +92,7 @@ export class TerraformResource
       this.interpolationForAttribute(terraformAttribute)
     );
   }
-  
+
   public getStringMapAttribute(terraformAttribute: string) {
     return Token.asStringMap(
       this.interpolationForAttribute(terraformAttribute)

--- a/packages/cdktf/lib/terraform-resource.ts
+++ b/packages/cdktf/lib/terraform-resource.ts
@@ -92,6 +92,10 @@ export class TerraformResource
       this.interpolationForAttribute(terraformAttribute)
     );
   }
+  
+  public getMapAttribute(terraformAttribute: string) {
+    return Token.asMap(this.interpolationForAttribute(terraformAttribute));
+  }
 
   public get fqn(): string {
     return Token.asString(

--- a/packages/cdktf/lib/tokens/private/resolve.ts
+++ b/packages/cdktf/lib/tokens/private/resolve.ts
@@ -14,6 +14,7 @@ import {
   TokenString,
   unresolved,
   containsNumberListTokenElement,
+  containsMapToken,
 } from "./encoding";
 import { TokenMap } from "./token-map";
 
@@ -180,6 +181,11 @@ export function resolve(obj: any, options: IResolveOptions): any {
       .filter((x) => typeof x !== "undefined");
 
     return arr;
+  }
+
+  // check for tokenized map
+  if (containsMapToken(obj)) {
+    return options.resolver.resolveMap(obj, makeContext()[0]);
   }
 
   //

--- a/packages/cdktf/lib/tokens/private/resolve.ts
+++ b/packages/cdktf/lib/tokens/private/resolve.ts
@@ -17,6 +17,7 @@ import {
   containsMapToken,
 } from "./encoding";
 import { TokenMap } from "./token-map";
+import { Token } from "../token";
 
 // This file should not be exported to consumers, resolving should happen through Construct.resolve()
 
@@ -122,6 +123,15 @@ export function resolve(obj: any, options: IResolveOptions): any {
       );
     }
 
+    if (
+      obj === Token.STRING_MAP_TOKEN_VALUE ||
+      obj === Token.ANY_MAP_TOKEN_VALUE
+    ) {
+      throw new Error(
+        "Found an encoded map token in a scalar string context. Use 'Fn.lookup(map, key, default)' (not 'map[key]') to extract values from token maps."
+      );
+    }
+
     let str: string = obj;
 
     const tokenStr = TokenString.forString(str);
@@ -152,6 +162,12 @@ export function resolve(obj: any, options: IResolveOptions): any {
   // number - potentially decode Tokenized number
   //
   if (typeof obj === "number") {
+    if (obj === Token.NUMBER_MAP_TOKEN_VALUE) {
+      throw new Error(
+        "Found an encoded map token in a scalar number context. Use 'Fn.lookup(map, key, default)' (not 'map[key]') to extract values from token maps."
+      );
+    }
+
     return resolveNumberToken(obj, makeContext()[0]);
   }
 

--- a/packages/cdktf/lib/tokens/private/token-map.ts
+++ b/packages/cdktf/lib/tokens/private/token-map.ts
@@ -100,7 +100,7 @@ export class TokenMap {
   ): { [key: string]: any } {
     return cachedValue(token, MAP_SYMBOL, () => {
       const key = this.registerStringKey(token, displayHint);
-      return [`${BEGIN_MAP_TOKEN_MARKER}${key}${END_TOKEN_MARKER}`];
+      return { [`${BEGIN_MAP_TOKEN_MARKER}${key}${END_TOKEN_MARKER}`]: key };
     });
   }
 

--- a/packages/cdktf/lib/tokens/private/token-map.ts
+++ b/packages/cdktf/lib/tokens/private/token-map.ts
@@ -94,13 +94,16 @@ export class TokenMap {
   /**
    * Generate a unique string for this Token, returning a key
    */
-  public registerMap(
+  public registerMap<V>(
     token: IResolvable,
+    mapValue: V,
     displayHint?: string
-  ): { [key: string]: any } {
+  ): { [key: string]: V } {
     return cachedValue(token, MAP_SYMBOL, () => {
       const key = this.registerStringKey(token, displayHint);
-      return { [`${BEGIN_MAP_TOKEN_MARKER}${key}${END_TOKEN_MARKER}`]: key };
+      return {
+        [`${BEGIN_MAP_TOKEN_MARKER}${key}${END_TOKEN_MARKER}`]: mapValue,
+      };
     });
   }
 

--- a/packages/cdktf/lib/tokens/resolvable.ts
+++ b/packages/cdktf/lib/tokens/resolvable.ts
@@ -212,7 +212,7 @@ export class DefaultTokenResolver implements ITokenResolver {
     }
     return context.resolve(token);
   }
-  
+
   public resolveMap(xs: { [key: string]: any }, context: IResolveContext) {
     const keys = Object.keys(xs);
     if (keys.length !== 1) {

--- a/packages/cdktf/lib/tokens/resolvable.ts
+++ b/packages/cdktf/lib/tokens/resolvable.ts
@@ -95,6 +95,11 @@ export interface ITokenResolver {
    * Resolve a tokenized number list
    */
   resolveNumberList(l: number[], context: IResolveContext): any;
+
+  /**
+   * Resolve a tokenized map
+   */
+  resolveMap(m: { [key: string]: any }, context: IResolveContext): any;
 }
 
 /**
@@ -206,5 +211,23 @@ export class DefaultTokenResolver implements ITokenResolver {
       return xs;
     }
     return context.resolve(token);
+  }
+  
+  public resolveMap(xs: { [key: string]: any }, context: IResolveContext) {
+    const keys = Object.keys(xs);
+    if (keys.length !== 1) {
+      throw new Error(`Cannot add elements to map token, got: ${xs}`);
+    }
+
+    const str = TokenString.forMapToken(keys[0]);
+    const tokenMap = TokenMap.instance();
+    const fragments = str.split(tokenMap.lookupToken.bind(tokenMap));
+    if (fragments.length !== 1) {
+      throw new Error(
+        `Cannot concatenate strings in a tokenized map, got: ${xs[0]}`
+      );
+    }
+
+    return fragments.mapTokens({ mapToken: context.resolve }).firstValue;
   }
 }

--- a/packages/cdktf/lib/tokens/token.ts
+++ b/packages/cdktf/lib/tokens/token.ts
@@ -93,6 +93,20 @@ export class Token {
   }
 
   /**
+   * Return a reversible map representation of this token
+   */
+  public static asMap(
+    value: any,
+    options: EncodingOptions = {}
+  ): { [key: string]: any } {
+    // since the return value is basically an object, just encode always
+    return TokenMap.instance().registerMap(
+      Token.asAny(value),
+      options.displayHint
+    );
+  }
+
+  /**
    * Return a resolvable representation of the given value
    */
   public static asAny(value: any): IResolvable {
@@ -128,7 +142,9 @@ export class Tokenization {
       const reversedNumber = Tokenization.reverseNumber(x);
       return reversedNumber ? [reversedNumber] : [];
     }
-    return [];
+
+    const reversedMap = Tokenization.reverseMap(x);
+    return reversedMap ? [reversedMap] : [];
   }
 
   /**
@@ -157,6 +173,13 @@ export class Tokenization {
    */
   public static reverseNumberList(l: number[]): IResolvable | undefined {
     return TokenMap.instance().lookupNumberList(l);
+  }
+
+  /**
+   * Un-encode a Tokenized value from a map
+   */
+  public static reverseMap(m: { [key: string]: any }): IResolvable | undefined {
+    return TokenMap.instance().lookupMap(m);
   }
 
   /**

--- a/packages/cdktf/lib/tokens/token.ts
+++ b/packages/cdktf/lib/tokens/token.ts
@@ -97,13 +97,55 @@ export class Token {
    */
   public static asMap(
     value: any,
+    mapValue: any,
     options: EncodingOptions = {}
   ): { [key: string]: any } {
     // since the return value is basically an object, just encode always
     return TokenMap.instance().registerMap(
       Token.asAny(value),
+      mapValue,
       options.displayHint
     );
+  }
+
+  /**
+   * Return a reversible map representation of this token
+   */
+  public static asStringMap(
+    value: any,
+    options: EncodingOptions = {}
+  ): { [key: string]: string } {
+    return this.asMap(value, "", options);
+  }
+
+  /**
+   * Return a reversible map representation of this token
+   */
+  public static asNumberMap(
+    value: any,
+    options: EncodingOptions = {}
+  ): { [key: string]: number } {
+    return this.asMap(value, 0, options);
+  }
+
+  /**
+   * Return a reversible map representation of this token
+   */
+  public static asBooleanMap(
+    value: any,
+    options: EncodingOptions = {}
+  ): { [key: string]: boolean } {
+    return this.asMap(value, true, options);
+  }
+
+  /**
+   * Return a reversible map representation of this token
+   */
+  public static asAnyMap(
+    value: any,
+    options: EncodingOptions = {}
+  ): { [key: string]: any } {
+    return this.asMap(value, "any", options);
   }
 
   /**

--- a/packages/cdktf/lib/tokens/token.ts
+++ b/packages/cdktf/lib/tokens/token.ts
@@ -108,6 +108,8 @@ export class Token {
     );
   }
 
+  public static readonly STRING_MAP_TOKEN_VALUE = "String Map Token Value";
+
   /**
    * Return a reversible map representation of this token
    */
@@ -115,8 +117,10 @@ export class Token {
     value: any,
     options: EncodingOptions = {}
   ): { [key: string]: string } {
-    return this.asMap(value, "", options);
+    return this.asMap(value, Token.STRING_MAP_TOKEN_VALUE, options);
   }
+
+  public static readonly NUMBER_MAP_TOKEN_VALUE = -123456789;
 
   /**
    * Return a reversible map representation of this token
@@ -125,7 +129,7 @@ export class Token {
     value: any,
     options: EncodingOptions = {}
   ): { [key: string]: number } {
-    return this.asMap(value, 0, options);
+    return this.asMap(value, Token.NUMBER_MAP_TOKEN_VALUE, options);
   }
 
   /**
@@ -138,6 +142,8 @@ export class Token {
     return this.asMap(value, true, options);
   }
 
+  public static readonly ANY_MAP_TOKEN_VALUE = "Any Map Token Value";
+
   /**
    * Return a reversible map representation of this token
    */
@@ -145,7 +151,7 @@ export class Token {
     value: any,
     options: EncodingOptions = {}
   ): { [key: string]: any } {
-    return this.asMap(value, "any", options);
+    return this.asMap(value, Token.ANY_MAP_TOKEN_VALUE, options);
   }
 
   /**

--- a/packages/cdktf/test/__snapshots__/data-source.test.ts.snap
+++ b/packages/cdktf/test/__snapshots__/data-source.test.ts.snap
@@ -60,6 +60,37 @@ exports[`minimal configuration 1`] = `
 }"
 `;
 
+exports[`with any map 1`] = `
+"{
+  \\"data\\": {
+    \\"test_data_source\\": {
+      \\"test\\": {
+        \\"name\\": \\"foo\\"
+      }
+    }
+  },
+  \\"provider\\": {
+    \\"test\\": [
+      {}
+    ]
+  },
+  \\"resource\\": {
+    \\"test_resource\\": {
+      \\"test-resource\\": {
+        \\"name\\": \\"\${data.test_data_source.test.any_map[\\\\\\"id\\\\\\"]}\\"
+      }
+    }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"test\\": {
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
+  }
+}"
+`;
+
 exports[`with boolean map 1`] = `
 "{
   \\"data\\": {

--- a/packages/cdktf/test/__snapshots__/data-source.test.ts.snap
+++ b/packages/cdktf/test/__snapshots__/data-source.test.ts.snap
@@ -71,7 +71,8 @@ exports[`with any map 1`] = `
   },
   \\"provider\\": {
     \\"test\\": [
-      {}
+      {
+      }
     ]
   },
   \\"resource\\": {

--- a/packages/cdktf/test/data-source.test.ts
+++ b/packages/cdktf/test/data-source.test.ts
@@ -74,6 +74,21 @@ test("with boolean map", () => {
   ).toMatchSnapshot();
 });
 
+test("with any map", () => {
+  expect(
+    Testing.synthScope((stack) => {
+      new TestProvider(stack, "provider", {});
+
+      const dataSource = new TestDataSource(stack, "test", {
+        name: "foo",
+      });
+      new TestResource(stack, "test-resource", {
+        name: Token.asString(dataSource.anyMap("id")),
+      });
+    })
+  ).toMatchSnapshot();
+});
+
 test("dependent data source", () => {
   expect(
     Testing.synthScope((stack) => {

--- a/packages/cdktf/test/helper/data-source.ts
+++ b/packages/cdktf/test/helper/data-source.ts
@@ -6,6 +6,7 @@ import {
   StringMap,
   NumberMap,
   BooleanMap,
+  AnyMap,
 } from "../../lib";
 import { TestProviderMetadata } from "./provider";
 import { stringToTerraform } from "../../lib/runtime";
@@ -47,6 +48,10 @@ export class TestDataSource extends TerraformDataSource {
 
   public booleanMap(key: string) {
     return new BooleanMap(this, "boolean_map").lookup(key);
+  }
+
+  public anyMap(key: string) {
+    return new AnyMap(this, "any_map").lookup(key);
   }
 
   protected synthesizeAttributes(): { [p: string]: any } {

--- a/test/csharp/edge/Main.cs
+++ b/test/csharp/edge/Main.cs
@@ -73,7 +73,10 @@ namespace MyCompany.MyApp
             new RequiredAttributeResource(this, "from_map", new RequiredAttributeResourceConfig {
                 Bool = Token.AsAny(Fn.Lookup(map.ReqMap, "key1", false)),
                 Str = Token.AsString(Fn.Lookup(map.OptMap, "key1", "missing")),
-                Num = Token.AsNumber(Fn.Lookup(map.ComputedMap, "key1", 0))
+                Num = Token.AsNumber(Fn.Lookup(map.ComputedMap, "key1", 0)),
+                StrList = new [] { Token.AsString(Fn.Lookup(map.OptMap, "key1", "missing")) },
+                NumList = new [] { Token.AsNumber(Fn.Lookup(map.ComputedMap, "key1", 0)) },
+                BoolList = new [] { Token.AsAny(Fn.Lookup(map.ReqMap, "key1", false)) }
             });
 
             // passing a reference to a complete map

--- a/test/csharp/edge/Main.cs
+++ b/test/csharp/edge/Main.cs
@@ -26,8 +26,8 @@ namespace MyCompany.MyApp
                 Singlereq = new ListBlockResourceSinglereq { Reqbool = true, Reqnum = 1, Reqstr = "reqstr" }
             });
             var map = new MapResource(this, "map", new MapResourceConfig {
-                OptMap = new Struct { Key1 = "value1" },
-                ReqMap = new Struct { Key1 = true }
+                OptMap = new Dictionary<string, string> { ["Key1"] = "value1" },
+                ReqMap = new Dictionary<string, bool> { ["Key1"] = true }
             });
 
             // plain values
@@ -72,8 +72,8 @@ namespace MyCompany.MyApp
             // required values FROM map
             new RequiredAttributeResource(this, "from_map", new RequiredAttributeResourceConfig {
                 Bool = Token.AsAny(Fn.Lookup(map.ReqMap, "key1", false)),
-                Str = Fn.Lookup(map.OptMap, "key1", "missing"),
-                Num = Fn.Lookup(map.ComputedMap, "key1", 0)
+                Str = Token.AsString(Fn.Lookup(map.OptMap, "key1", "missing")),
+                Num = Token.AsNumber(Fn.Lookup(map.ComputedMap, "key1", 0))
             });
 
             // passing a reference to a complete map

--- a/test/csharp/edge/Main.cs
+++ b/test/csharp/edge/Main.cs
@@ -25,7 +25,7 @@ namespace MyCompany.MyApp
                 Req = new [] { new ListBlockResourceReq { Reqbool = true, Reqnum = 1, Reqstr = "reqstr" }, new ListBlockResourceReq { Reqbool = false, Reqnum = 0, Reqstr = "reqstr2" } },
                 Singlereq = new ListBlockResourceSinglereq { Reqbool = true, Reqnum = 1, Reqstr = "reqstr" }
             });
-            var map = new MapResource(this, "map", new Struct {
+            var map = new MapResource(this, "map", new MapResourceConfig {
                 OptMap = new Struct { Key1 = "value1" },
                 ReqMap = new Struct { Key1 = true }
             });
@@ -70,14 +70,14 @@ namespace MyCompany.MyApp
             // });
 
             // required values FROM map
-            new RequiredAttributeResource(this, "from_map", new Struct {
-                Bool = Fn.Lookup(map.ReqMap, "key1", false),
+            new RequiredAttributeResource(this, "from_map", new RequiredAttributeResourceConfig {
+                Bool = Token.AsAny(Fn.Lookup(map.ReqMap, "key1", false)),
                 Str = Fn.Lookup(map.OptMap, "key1", "missing"),
                 Num = Fn.Lookup(map.ComputedMap, "key1", 0)
             });
 
             // passing a reference to a complete map
-            new MapResource(this, "map_reference", new Struct {
+            new MapResource(this, "map_reference", new MapResourceConfig {
                 OptMap = map.OptMap,
                 ReqMap = map.ReqMap
             });

--- a/test/csharp/edge/Main.cs
+++ b/test/csharp/edge/Main.cs
@@ -25,6 +25,10 @@ namespace MyCompany.MyApp
                 Req = new [] { new ListBlockResourceReq { Reqbool = true, Reqnum = 1, Reqstr = "reqstr" }, new ListBlockResourceReq { Reqbool = false, Reqnum = 0, Reqstr = "reqstr2" } },
                 Singlereq = new ListBlockResourceSinglereq { Reqbool = true, Reqnum = 1, Reqstr = "reqstr" }
             });
+            var map = new MapResource(this, "map", new Struct {
+                OptMap = new Struct { Key1 = "value1" },
+                ReqMap = new Struct { Key1 = true }
+            });
 
             // plain values
             new RequiredAttributeResource(this, "plain", new RequiredAttributeResourceConfig {
@@ -64,6 +68,19 @@ namespace MyCompany.MyApp
             //     Req = new [] { list.Singlereq },
             //     Singlereq = list.Singlereq
             // });
+
+            // required values FROM map
+            new RequiredAttributeResource(this, "from_map", new Struct {
+                Bool = Fn.Lookup(map.ReqMap, "key1", false),
+                Str = Fn.Lookup(map.OptMap, "key1", "missing"),
+                Num = Fn.Lookup(map.ComputedMap, "key1", 0)
+            });
+
+            // passing a reference to a complete map
+            new MapResource(this, "map_reference", new Struct {
+                OptMap = map.OptMap,
+                ReqMap = map.ReqMap
+            });
         }
     }
 

--- a/test/csharp/edge/Main.cs
+++ b/test/csharp/edge/Main.cs
@@ -27,7 +27,7 @@ namespace MyCompany.MyApp
             });
             var map = new MapResource(this, "map", new MapResourceConfig {
                 OptMap = new Dictionary<string, string> { ["Key1"] = "value1" },
-                ReqMap = new Dictionary<string, bool> { ["Key1"] = true }
+                ReqMap = new Dictionary<string, object> { ["Key1"] = true }
             });
 
             // plain values

--- a/test/csharp/edge/test.ts
+++ b/test/csharp/edge/test.ts
@@ -149,5 +149,28 @@ describe("csharp full integration test synth", () => {
       // Expands single item references
       expect(item.req[0]).toMatchInlineSnapshot();
     });
+
+    it("item references a map", () => {
+      const item = stack.byId("from_map");
+
+      // Expands map references
+      expect(item.bool).toEqual(
+        '${lookup(map_resource.map.reqMap, "key1", false)}'
+      );
+      expect(item.str).toEqual(
+        '${lookup(map_resource.map.optMap, "key1", "missing")}'
+      );
+      expect(item.num).toEqual(
+        '${lookup(map_resource.map.computedMap, "key1", 0)}'
+      );
+    });
+
+    it("item references a full map", () => {
+      const item = stack.byId("map_reference");
+
+      // Expands map references
+      expect(item.reqMap).toEqual("${map_resource.map.reqMap}");
+      expect(item.optMap).toEqual("${map_resource.map.optMap}");
+    });
   });
 });

--- a/test/csharp/edge/test.ts
+++ b/test/csharp/edge/test.ts
@@ -163,6 +163,15 @@ describe("csharp full integration test synth", () => {
       expect(item.num).toEqual(
         '${lookup(map_resource.map.computedMap, "key1", 0)}'
       );
+      expect(item.boolList).toEqual([
+        '${lookup(map_resource.map.reqMap, "key1", false)}',
+      ]);
+      expect(item.strList).toEqual([
+        '${lookup(map_resource.map.optMap, "key1", "missing")}',
+      ]);
+      expect(item.numList).toEqual([
+        '${lookup(map_resource.map.computedMap, "key1", 0)}',
+      ]);
     });
 
     it("item references a full map", () => {

--- a/test/java/edge/Main.java
+++ b/test/java/edge/Main.java
@@ -25,6 +25,10 @@ class ReferenceStack extends TerraformStack {
         ListBlockResource list = ListBlockResource.Builder.create(this, "list").req(arrlist)
                 .singlereq(ListBlockResourceSinglereq.builder().reqbool(true).reqnum(1).reqstr("reqstr").build())
                 .build();
+        MapResource map = MapResource.Builder.create(this, "map")
+                .optMap(Map.of("key1", "value1"))
+                .reqMap(Map.of("key1", true))
+                .build();
 
         // plain values
         RequiredAttributeResource.Builder.create(this, "plain")
@@ -64,6 +68,19 @@ class ReferenceStack extends TerraformStack {
         //         .req(Collections.singletonList(list.getSinglereq()))
         //         .singlereq(list.getSinglereq())
         //         .build();
+
+        // required values FROM map
+        RequiredAttributeResource.Builder.create(this, "from_map")
+                .bool(Fn.lookup(map.getReqMap(), "key1", false))
+                .str(Fn.lookup(map.getOptMap(), "key1", "missing"))
+                .num(Fn.lookup(map.getComputedMap(), "key1", 0))
+                .build();
+
+        // passing a reference to a complete map
+        MapResource.Builder.create(this, "map_reference")
+                .optMap(map.getOptMap())
+                .reqMap(map.getReqMap())
+                .build();
     }
 }
 

--- a/test/java/edge/Main.java
+++ b/test/java/edge/Main.java
@@ -26,8 +26,8 @@ class ReferenceStack extends TerraformStack {
                 .singlereq(ListBlockResourceSinglereq.builder().reqbool(true).reqnum(1).reqstr("reqstr").build())
                 .build();
         MapResource map = MapResource.Builder.create(this, "map")
-                .optMap(Map.of("key1", "value1"))
-                .reqMap(Map.of("key1", true))
+                .optMap(Collections.singletonMap("key1", "value1"))
+                .reqMap(Collections.singletonMap("key1", true))
                 .build();
 
         // plain values
@@ -71,7 +71,7 @@ class ReferenceStack extends TerraformStack {
 
         // required values FROM map
         RequiredAttributeResource.Builder.create(this, "from_map")
-                .bool(Fn.lookup(map.getReqMap(), "key1", false))
+                .bool(Token.asAny(Fn.lookup(map.getReqMap(), "key1", false)))
                 .str(Fn.lookup(map.getOptMap(), "key1", "missing"))
                 .num(Fn.lookup(map.getComputedMap(), "key1", 0))
                 .build();

--- a/test/java/edge/Main.java
+++ b/test/java/edge/Main.java
@@ -74,6 +74,9 @@ class ReferenceStack extends TerraformStack {
                 .bool(Token.asAny(Fn.lookup(map.getReqMap(), "key1", false)))
                 .str(Token.asString(Fn.lookup(map.getOptMap(), "key1", "missing")))
                 .num(Token.asNumber(Fn.lookup(map.getComputedMap(), "key1", 0)))
+                .strList(Collections.singletonList(Token.asString(Fn.lookup(map.getOptMap(), "key1", "missing"))))
+                .numList(Collections.singletonList(Token.asNumber(Fn.lookup(map.getComputedMap(), "key1", 0))))
+                .boolList(Collections.singletonList(Token.asAny(Fn.lookup(map.getReqMap(), "key1", false))))
                 .build();
 
         // passing a reference to a complete map

--- a/test/java/edge/Main.java
+++ b/test/java/edge/Main.java
@@ -72,8 +72,8 @@ class ReferenceStack extends TerraformStack {
         // required values FROM map
         RequiredAttributeResource.Builder.create(this, "from_map")
                 .bool(Token.asAny(Fn.lookup(map.getReqMap(), "key1", false)))
-                .str(Fn.lookup(map.getOptMap(), "key1", "missing"))
-                .num(Fn.lookup(map.getComputedMap(), "key1", 0))
+                .str(Token.asString(Fn.lookup(map.getOptMap(), "key1", "missing")))
+                .num(Token.asNumber(Fn.lookup(map.getComputedMap(), "key1", 0)))
                 .build();
 
         // passing a reference to a complete map

--- a/test/java/edge/test.ts
+++ b/test/java/edge/test.ts
@@ -192,6 +192,15 @@ describe("java full integration", () => {
       expect(item.num).toEqual(
         '${lookup(map_resource.map.computedMap, "key1", 0)}'
       );
+      expect(item.boolList).toEqual([
+        '${lookup(map_resource.map.reqMap, "key1", false)}',
+      ]);
+      expect(item.strList).toEqual([
+        '${lookup(map_resource.map.optMap, "key1", "missing")}',
+      ]);
+      expect(item.numList).toEqual([
+        '${lookup(map_resource.map.computedMap, "key1", 0)}',
+      ]);
     });
 
     it("item references a full map", () => {

--- a/test/java/edge/test.ts
+++ b/test/java/edge/test.ts
@@ -178,5 +178,28 @@ describe("java full integration", () => {
       // Expands single item references
       expect(item.req[0]).toMatchInlineSnapshot();
     });
+
+    it("item references a map", () => {
+      const item = stack.byId("from_map");
+
+      // Expands map references
+      expect(item.bool).toEqual(
+        '${lookup(map_resource.map.reqMap, "key1", false)}'
+      );
+      expect(item.str).toEqual(
+        '${lookup(map_resource.map.optMap, "key1", "missing")}'
+      );
+      expect(item.num).toEqual(
+        '${lookup(map_resource.map.computedMap, "key1", 0)}'
+      );
+    });
+
+    it("item references a full map", () => {
+      const item = stack.byId("map_reference");
+
+      // Expands map references
+      expect(item.reqMap).toEqual("${map_resource.map.reqMap}");
+      expect(item.optMap).toEqual("${map_resource.map.optMap}");
+    });
   });
 });

--- a/test/python/edge/main.py
+++ b/test/python/edge/main.py
@@ -70,7 +70,7 @@ class ReferenceStack(TerraformStack):
         # required values FROM map
         edge.RequiredAttributeResource(self, "from_map",
             bool=Token().as_any(Fn.lookup(map.req_map, "key1", False)),
-            str=Fn.lookup(map.opt_map, "key1", "missing"),
+            str=Token().as_string(Fn.lookup(map.opt_map, "key1", "missing")),
             num=Token().as_number(Fn.lookup(map.computed_map, "key1", 0))
         )
 

--- a/test/python/edge/main.py
+++ b/test/python/edge/main.py
@@ -71,7 +71,10 @@ class ReferenceStack(TerraformStack):
         edge.RequiredAttributeResource(self, "from_map",
             bool=Token().as_any(Fn.lookup(map.req_map, "key1", False)),
             str=Token().as_string(Fn.lookup(map.opt_map, "key1", "missing")),
-            num=Token().as_number(Fn.lookup(map.computed_map, "key1", 0))
+            num=Token().as_number(Fn.lookup(map.computed_map, "key1", 0)),
+            str_list=[Token().as_string(Fn.lookup(map.opt_map, "key1", "missing"))],
+            num_list=[Token().as_number(Fn.lookup(map.computed_map, "key1", 0))],
+            bool_list=[Token().as_any(Fn.lookup(map.req_map, "key1", False))]
         )
 
         # passing a reference to a complete map

--- a/test/python/edge/main.py
+++ b/test/python/edge/main.py
@@ -20,6 +20,10 @@ class ReferenceStack(TerraformStack):
             ],
             singlereq={"reqbool": True, "reqnum": 1, "reqstr": "reqstr"}
         )
+        map = edge.MapResource(self, "map",
+            opt_map={"key1": "value1"},
+            req_map={"key1": True}
+        )
 
         # plain values
         edge.RequiredAttributeResource(self, "plain",
@@ -61,6 +65,19 @@ class ReferenceStack(TerraformStack):
         edge.ListBlockResource(self, "list_literal",
             req=[list.singlereq],
             singlereq=list.singlereq
+        )
+
+        # required values FROM map
+        edge.RequiredAttributeResource(self, "from_map",
+            bool=Fn.lookup(map.req_map, "key1", False),
+            str=Fn.lookup(map.opt_map, "key1", "missing"),
+            num=Fn.lookup(map.computed_map, "key1", 0)
+        )
+
+        # passing a reference to a complete map
+        edge.MapResource(self, "map_reference",
+            opt_map=map.opt_map,
+            req_map=map.req_map
         )
 
 # CDKTF supports referencing inputs from providers (Terraform does not)

--- a/test/python/edge/main.py
+++ b/test/python/edge/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import os
 from constructs import Construct
-from cdktf import App, Fn, TerraformStack
+from cdktf import App, Fn, TerraformStack, Token
 import imports.edge as edge
 
 # Using references to resource attributes as resource arguments
@@ -69,7 +69,7 @@ class ReferenceStack(TerraformStack):
 
         # required values FROM map
         edge.RequiredAttributeResource(self, "from_map",
-            bool=Fn.lookup(map.req_map, "key1", False),
+            bool=Token.as_any(Fn.lookup(map.req_map, "key1", False)),
             str=Fn.lookup(map.opt_map, "key1", "missing"),
             num=Fn.lookup(map.computed_map, "key1", 0)
         )

--- a/test/python/edge/main.py
+++ b/test/python/edge/main.py
@@ -69,9 +69,9 @@ class ReferenceStack(TerraformStack):
 
         # required values FROM map
         edge.RequiredAttributeResource(self, "from_map",
-            bool=Token.as_any(Fn.lookup(map.req_map, "key1", False)),
+            bool=Token().as_any(Fn.lookup(map.req_map, "key1", False)),
             str=Fn.lookup(map.opt_map, "key1", "missing"),
-            num=Fn.lookup(map.computed_map, "key1", 0)
+            num=Token().as_number(Fn.lookup(map.computed_map, "key1", 0))
         )
 
         # passing a reference to a complete map

--- a/test/python/edge/test.ts
+++ b/test/python/edge/test.ts
@@ -160,5 +160,28 @@ describe("full integration test", () => {
         }
       `);
     });
+
+    it("item references a map", () => {
+      const item = stack.byId("from_map");
+
+      // Expands map references
+      expect(item.bool).toEqual(
+        '${lookup(map_resource.map.reqMap, "key1", false)}'
+      );
+      expect(item.str).toEqual(
+        '${lookup(map_resource.map.optMap, "key1", "missing")}'
+      );
+      expect(item.num).toEqual(
+        '${lookup(map_resource.map.computedMap, "key1", 0)}'
+      );
+    });
+
+    it("item references a full map", () => {
+      const item = stack.byId("map_reference");
+
+      // Expands map references
+      expect(item.reqMap).toEqual("${map_resource.map.reqMap}");
+      expect(item.optMap).toEqual("${map_resource.map.optMap}");
+    });
   });
 });

--- a/test/python/edge/test.ts
+++ b/test/python/edge/test.ts
@@ -174,6 +174,15 @@ describe("full integration test", () => {
       expect(item.num).toEqual(
         '${lookup(map_resource.map.computedMap, "key1", 0)}'
       );
+      expect(item.boolList).toEqual([
+        '${lookup(map_resource.map.reqMap, "key1", false)}',
+      ]);
+      expect(item.strList).toEqual([
+        '${lookup(map_resource.map.optMap, "key1", "missing")}',
+      ]);
+      expect(item.numList).toEqual([
+        '${lookup(map_resource.map.computedMap, "key1", 0)}',
+      ]);
     });
 
     it("item references a full map", () => {

--- a/test/typescript/edge/main.ts
+++ b/test/typescript/edge/main.ts
@@ -72,6 +72,9 @@ export class ReferenceStack extends TerraformStack {
       bool: Fn.lookup(map.reqMap, "key1", false),
       str: Fn.lookup(map.optMap, "key1", "missing"),
       num: Fn.lookup(map.computedMap, "key1", 0),
+      strList: [Fn.lookup(map.optMap, "key1", "missing")],
+      numList: [Fn.lookup(map.computedMap, "key1", 0)],
+      boolList: [Fn.lookup(map.reqMap, "key1", false)],
     });
 
     // passing a reference to a complete map

--- a/test/typescript/edge/main.ts
+++ b/test/typescript/edge/main.ts
@@ -20,6 +20,10 @@ export class ReferenceStack extends TerraformStack {
       ],
       singlereq: { reqbool: false, reqnum: 1, reqstr: "reqstr" },
     });
+    const map = new edge.MapResource(this, "map", {
+      optMap: { key1: "value1" },
+      reqMap: { key1: true },
+    });
 
     // plain values
     new edge.RequiredAttributeResource(this, "plain", {
@@ -61,6 +65,19 @@ export class ReferenceStack extends TerraformStack {
     new edge.ListBlockResource(this, "list_literal", {
       req: [list.singlereq],
       singlereq: list.singlereq,
+    });
+
+    // required values FROM map
+    new edge.RequiredAttributeResource(this, "from_map", {
+      bool: Fn.lookup(map.reqMap, "key1", false),
+      str: Fn.lookup(map.optMap, "key1", "missing"),
+      num: Fn.lookup(map.computedMap, "key1", 0),
+    });
+
+    // passing a reference to a complete map
+    new edge.MapResource(this, "map_reference", {
+      optMap: map.optMap,
+      reqMap: map.reqMap,
     });
   }
 }

--- a/test/typescript/edge/test.ts
+++ b/test/typescript/edge/test.ts
@@ -175,6 +175,15 @@ describe("edge provider test", () => {
       expect(item.num).toEqual(
         '${lookup(map_resource.map.computedMap, "key1", 0)}'
       );
+      expect(item.boolList).toEqual([
+        '${lookup(map_resource.map.reqMap, "key1", false)}',
+      ]);
+      expect(item.strList).toEqual([
+        '${lookup(map_resource.map.optMap, "key1", "missing")}',
+      ]);
+      expect(item.numList).toEqual([
+        '${lookup(map_resource.map.computedMap, "key1", 0)}',
+      ]);
     });
 
     it("item references a full map", () => {

--- a/test/typescript/edge/test.ts
+++ b/test/typescript/edge/test.ts
@@ -161,5 +161,28 @@ describe("edge provider test", () => {
         }
       `);
     });
+
+    it("item references a map", () => {
+      const item = stack.byId("from_map");
+
+      // Expands map references
+      expect(item.bool).toEqual(
+        '${lookup(map_resource.map.reqMap, "key1", false)}'
+      );
+      expect(item.str).toEqual(
+        '${lookup(map_resource.map.optMap, "key1", "missing")}'
+      );
+      expect(item.num).toEqual(
+        '${lookup(map_resource.map.computedMap, "key1", 0)}'
+      );
+    });
+
+    it("item references a full map", () => {
+      const item = stack.byId("map_reference");
+
+      // Expands map references
+      expect(item.reqMap).toEqual("${map_resource.map.reqMap}");
+      expect(item.optMap).toEqual("${map_resource.map.optMap}");
+    });
   });
 });


### PR DESCRIPTION
Dividing up #1299, starting with tokens for map (string indexed / Record<string, any>) types as these are quite common.

Some points that came up from the original design:

- Map value type needs to be exact in order for jsii to work. Added support for all primitive types and left `IResolvable` option for types of maps
- Added an `AnyMap` computed wrapper for completions sake
- boolean maps support tokens, but since booleans don't, added `IResolvable` to the value type in that case
- Didn't fully handle `map<list>` type since current code doesn't distinguish between that and `list<map>` type. It's very rare, so that can be a different project down the road
- Added a fix for the C# edge provider Constructs version error
- I didn't add to the go edge provider test. I could take a stab at it, but probably for someone with go experience (or we can add later).