### PR TITLE
chore: update constructs to 10.0.12

### DIFF
--- a/examples/typescript/aws-cloudfront-proxy/package.json
+++ b/examples/typescript/aws-cloudfront-proxy/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "cdktf": "0.0.0",
-    "constructs": "^10.0.5"
+    "constructs": "^10.0.12"
   },
   "devDependencies": {
     "@types/jest": "27.0.1",

--- a/examples/typescript/aws-multiple-stacks/package.json
+++ b/examples/typescript/aws-multiple-stacks/package.json
@@ -19,7 +19,7 @@
     "cdktf-cli": "0.0.0"
   },
   "dependencies": {
-    "constructs": "^10.0.5",
+    "constructs": "^10.0.12",
     "cdktf": "0.0.0"
   }
 }

--- a/examples/typescript/aws-prebuilt/package.json
+++ b/examples/typescript/aws-prebuilt/package.json
@@ -19,6 +19,6 @@
   "dependencies": {
     "@cdktf/provider-aws": "^0.0.19",
     "cdktf": "0.0.0",
-    "constructs": "^10.0.5"
+    "constructs": "^10.0.12"
   }
 }

--- a/examples/typescript/azure-app-service/package.json
+++ b/examples/typescript/azure-app-service/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "cdktf": "0.0.0",
-    "constructs": "^10.0.5"
+    "constructs": "^10.0.12"
   },
   "devDependencies": {
     "@types/jest": "27.0.1",

--- a/examples/typescript/azure-service-bus-queue-trigger/package.json
+++ b/examples/typescript/azure-service-bus-queue-trigger/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@cdktf/provider-azurerm": "^0.2.9",
     "cdktf": "^0.6.2",
-    "constructs": "^10.0.5"
+    "constructs": "^10.0.12"
   },
   "devDependencies": {
     "@types/jest": "^27.0.2",

--- a/examples/typescript/azure/package.json
+++ b/examples/typescript/azure/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "cdktf": "0.0.0",
-    "constructs": "^10.0.5"
+    "constructs": "^10.0.12"
   },
   "devDependencies": {
     "@types/jest": "27.0.1",

--- a/examples/typescript/backends/azurerm/package.json
+++ b/examples/typescript/backends/azurerm/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "cdktf": "0.0.0",
-    "constructs": "^10.0.5"
+    "constructs": "^10.0.12"
   },
   "devDependencies": {
     "@types/jest": "27.0.1",

--- a/examples/typescript/backends/gcs/package.json
+++ b/examples/typescript/backends/gcs/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "cdktf": "0.0.0",
-    "constructs": "^10.0.5"
+    "constructs": "^10.0.12"
   },
   "devDependencies": {
     "@types/jest": "27.0.1",

--- a/examples/typescript/backends/remote/package.json
+++ b/examples/typescript/backends/remote/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "cdktf": "0.0.0",
-    "constructs": "^10.0.5"
+    "constructs": "^10.0.12"
   },
   "devDependencies": {
     "@types/jest": "27.0.1",

--- a/examples/typescript/backends/s3/package.json
+++ b/examples/typescript/backends/s3/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "cdktf": "0.0.0",
-    "constructs": "^10.0.5"
+    "constructs": "^10.0.12"
   },
   "devDependencies": {
     "@types/jest": "27.0.1",

--- a/examples/typescript/docker/package.json
+++ b/examples/typescript/docker/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "cdktf": "0.0.0",
-    "constructs": "^10.0.5"
+    "constructs": "^10.0.12"
   },
   "devDependencies": {
     "@types/jest": "27.0.1",

--- a/examples/typescript/google-cloudrun/package.json
+++ b/examples/typescript/google-cloudrun/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "cdktf": "0.0.0",
-    "constructs": "^10.0.5"
+    "constructs": "^10.0.12"
   },
   "devDependencies": {
     "@types/jest": "27.0.1",

--- a/examples/typescript/google/package.json
+++ b/examples/typescript/google/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "cdktf": "0.0.0",
-    "constructs": "^10.0.5"
+    "constructs": "^10.0.12"
   },
   "devDependencies": {
     "@types/jest": "27.0.1",

--- a/examples/typescript/kubernetes/package.json
+++ b/examples/typescript/kubernetes/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "cdktf": "0.0.0",
-    "constructs": "^10.0.5"
+    "constructs": "^10.0.12"
   },
   "devDependencies": {
     "@types/jest": "27.0.1",

--- a/examples/typescript/ucloud/package.json
+++ b/examples/typescript/ucloud/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "cdktf": "0.0.0",
-    "constructs": "^10.0.5"
+    "constructs": "^10.0.12"
   },
   "devDependencies": {
     "@types/jest": "27.0.1",

--- a/examples/typescript/vault/package.json
+++ b/examples/typescript/vault/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "cdktf": "0.0.0",
-    "constructs": "^10.0.5"
+    "constructs": "^10.0.12"
   },
   "devDependencies": {
     "@types/jest": "27.0.1",

--- a/packages/cdktf-cli/package.json
+++ b/packages/cdktf-cli/package.json
@@ -32,7 +32,7 @@
     "@cdktf/hcl2cdk": "0.0.0",
     "@cdktf/hcl2json": "0.0.0",
     "cdktf": "0.0.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.0.12",
     "jsii": "^1.46.0",
     "jsii-pacmak": "^1.46.0",
     "yargs": "^17.0"

--- a/packages/cdktf/package.json
+++ b/packages/cdktf/package.json
@@ -83,7 +83,7 @@
     "@types/node": "^14.0.26",
     "@typescript-eslint/eslint-plugin": "^4.28.1",
     "@typescript-eslint/parser": "^4.28.1",
-    "constructs": "^10.0.0",
+    "constructs": "^10.0.12",
     "eslint": "^7.29.0",
     "jest": "^26.6.3",
     "jsii": "^1.46.0",
@@ -99,6 +99,6 @@
   ],
   "stability": "experimental",
   "peerDependencies": {
-    "constructs": "^10.0.0"
+    "constructs": "^10.0.12"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3663,10 +3663,10 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
-constructs@^10.0.0, constructs@^10.0.5:
-  version "10.0.10"
-  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.0.10.tgz#ab0dfcecfb7f10419c512cd3f5b809ef034882cc"
-  integrity sha512-lQqY39wuQksXfm63rxcplif8CpW7ZuGWqQNGG/qoxfVeBjG4DWpCzD3K3pVukRCe+EhvsIvLpZxfL6SKLAfvlw==
+constructs@^10.0.12:
+  version "10.0.12"
+  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.0.12.tgz#64f314d87f7cdf6da127c9eb0bf6a3d990989c4a"
+  integrity sha512-wVQcQgwwK7b//7yI54/3hundmXAw7RBpuy5f6yIBFNceJr8feTK6Cs2I2f3+gp3/ikszzTouLup9AzxioEEXPQ==
 
 content-disposition@0.5.3:
   version "0.5.3"


### PR DESCRIPTION
This fixes a CI issue with CSharp integration tests
