### PR TITLE
chore: fix edge provider tests in pre-release pipeline

### DIFF
--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -39,6 +39,11 @@ jobs:
         with:
           name: dist
           path: dist
+      - name: Upload edge-provider bindings
+        uses: actions/upload-artifact@v2
+        with:
+          name: edge-provider-bindings
+          path: packages/@cdktf/provider-generator/edge-provider-bindings
       - name: publish tag
         run: git push --follow-tags
       - name: installing test dependencies
@@ -65,6 +70,11 @@ jobs:
         with:
           name: dist
           path: dist
+      - name: Download edge-provider bindings
+        uses: actions/download-artifact@v2
+        with:
+          name: edge-provider-bindings
+          path: test/edge-provider-bindings
       - name: install test dependencies
         run: cd test && yarn
       - name: integration tests


### PR DESCRIPTION
Same as https://github.com/hashicorp/terraform-cdk/pull/1408 but for `Release@Next`