### PR TITLE
chore: add make website command to preview docs website

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+# Default: run this if working on the website locally to run in watch mode.
+website:
+	@echo "==> Downloading latest Docker image..."
+	@docker pull hashicorp/terraform-website:full
+	@echo "==> Starting website in Docker..."
+	@docker run \
+		--interactive \
+		--rm \
+		--tty \
+		--workdir "/website" \
+		--volume "$(shell pwd):/website/ext/terraform-cdk" \
+		--publish "3000:3000" \
+		hashicorp/terraform-website:full \
+		npm start
+
+.DEFAULT_GOAL := website
+.PHONY: website

--- a/website/README.md
+++ b/website/README.md
@@ -23,7 +23,7 @@ You should preview all of your changes locally before creating a pull request. T
 **Launch Site Locally**
 
 1. Navigate into your local `terraform-cdk` top-level directory and run `make website`.
-1. Open `http://localhost:4567` in your web browser. While the preview is running, you can edit pages and Next.js will automatically rebuild them.
+1. Open `http://localhost:3000` in your web browser. While the preview is running, you can edit pages and Next.js will automatically rebuild them.
 1. When you're done with the preview, press `ctrl-C` in your terminal to stop the server.
 
 ### Deployment


### PR DESCRIPTION
This PR adds a `Makefile` with the command `make website`, which allows the caller to preview the Terraform website with the changes in their local copy of this repo.