### PR TITLE
feat(lib): Add nullable field to terraform variables

### DIFF
--- a/packages/cdktf/lib/terraform-variable.ts
+++ b/packages/cdktf/lib/terraform-variable.ts
@@ -81,6 +81,11 @@ export interface TerraformVariableConfig {
   readonly type?: string;
 
   readonly sensitive?: boolean;
+
+  /*
+   * The nullable argument in a variable block controls whether the module caller may assign the value null to the variable.
+   */
+  readonly nullable?: boolean;
 }
 
 export class TerraformVariable
@@ -91,6 +96,7 @@ export class TerraformVariable
   public readonly description?: string;
   public readonly type?: string;
   public readonly sensitive?: boolean;
+  public readonly nullable?: boolean;
 
   constructor(scope: Construct, id: string, config: TerraformVariableConfig) {
     super(scope, id);
@@ -99,6 +105,7 @@ export class TerraformVariable
     this.description = config.description;
     this.type = config.type;
     this.sensitive = config.sensitive;
+    this.nullable = config.nullable;
   }
 
   public get stringValue(): string {
@@ -135,6 +142,7 @@ export class TerraformVariable
       description: this.description,
       type: this.type,
       sensitive: this.sensitive,
+      nullable: this.nullable,
     };
   }
 

--- a/packages/cdktf/test/__snapshots__/variable.test.ts.snap
+++ b/packages/cdktf/test/__snapshots__/variable.test.ts.snap
@@ -60,6 +60,17 @@ exports[`map collection type 1`] = `
 }"
 `;
 
+exports[`nullable variable 1`] = `
+"{
+  \\"variable\\": {
+    \\"test-variable\\": {
+      \\"nullable\\": true,
+      \\"type\\": \\"string\\"
+    }
+  }
+}"
+`;
+
 exports[`number type 1`] = `
 "{
   \\"variable\\": {

--- a/packages/cdktf/test/variable.test.ts
+++ b/packages/cdktf/test/variable.test.ts
@@ -157,3 +157,14 @@ test("variable with variable default", () => {
   });
   expect(Testing.synth(stack)).toMatchSnapshot();
 });
+
+test("nullable variable", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+
+  new TerraformVariable(stack, "test-variable", {
+    type: "string",
+    nullable: true,
+  });
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});


### PR DESCRIPTION
Fixes #1432

Adds the `nullable` field to `TerraformVariable` in order to handle usage of the field in HCL files from Terraform v1.1.0 and later.