### PR TITLE
fix: Update Remote State Outputs documentation

### DIFF
--- a/website/docs/cdktf/concepts/variables-and-outputs.mdx
+++ b/website/docs/cdktf/concepts/variables-and-outputs.mdx
@@ -237,7 +237,7 @@ class Consumer extends TerraformStack {
     });
 
     new TerraformOutput(this, "random-remote-pet", {
-      value: remoteState.getString("id"),
+      value: remoteState.getString("random-pet"),
     });
   }
 }


### PR DESCRIPTION
You can access to RemoteState by id of the Output which is `random-pet` in this case.