### PR TITLE
fix(provider-generator): rename String resource

### DIFF
--- a/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
@@ -24,6 +24,10 @@ const uniqueClassName = (className: string): string => {
   return className;
 };
 
+const isReservedClassName = (className: string): boolean => {
+  return ["string"].includes(className.toLowerCase());
+};
+
 class Parser {
   private structs = new Array<Struct>();
 
@@ -51,6 +55,10 @@ class Parser {
         optional: true,
         computed: false,
       };
+    }
+
+    if (isReservedClassName(baseName)) {
+      baseName = `${baseName}_resource`;
     }
 
     const className = uniqueClassName(toPascalCase(baseName));

--- a/test/java/synth-app/Main.java
+++ b/test/java/synth-app/Main.java
@@ -9,6 +9,9 @@ import com.hashicorp.cdktf.Testing;
 import imports.nullprovider.NullProvider;
 import imports.nullprovider.Resource;
 
+import imports.random.RandomProvider;
+import imports.random.StringResource;
+
 public class Main extends TerraformStack
 {
     public Main(final Construct scope, final String id) {
@@ -16,6 +19,9 @@ public class Main extends TerraformStack
 
         NullProvider.Builder.create(this, "Null").build();
         Resource resource = Resource.Builder.create(this, "NullResource").build();
+
+        RandomProvider.Builder.create(this, "Random").build();
+        StringResource stringResource = StringResource.Builder.create(this, "RandomString").length(42).build();
     }
 
     public static void main(String[] args) {

--- a/test/java/synth-app/__snapshots__/test.ts.snap
+++ b/test/java/synth-app/__snapshots__/test.ts.snap
@@ -14,11 +14,18 @@ exports[`java full integration synth generates JSON 1`] = `
       \\"null\\": {
         \\"version\\": \\"~> 3.1.0\\",
         \\"source\\": \\"hashicorp/null\\"
+      },
+      \\"random\\": {
+        \\"version\\": \\"~> 3.1.0\\",
+        \\"source\\": \\"hashicorp/random\\"
       }
     }
   },
   \\"provider\\": {
     \\"null\\": [
+      {}
+    ],
+    \\"random\\": [
       {}
     ]
   },
@@ -29,6 +36,17 @@ exports[`java full integration synth generates JSON 1`] = `
           \\"metadata\\": {
             \\"path\\": \\"java-simple/NullResource\\",
             \\"uniqueId\\": \\"NullResource\\"
+          }
+        }
+      }
+    },
+    \\"random_string\\": {
+      \\"RandomString\\": {
+        \\"length\\": 42,
+        \\"//\\": {
+          \\"metadata\\": {
+            \\"path\\": \\"java-simple/RandomString\\",
+            \\"uniqueId\\": \\"RandomString\\"
           }
         }
       }

--- a/test/java/synth-app/cdktf.json
+++ b/test/java/synth-app/cdktf.json
@@ -1,7 +1,7 @@
 {
   "language": "java",
   "app": "mvn -e -q compile exec:java",
-  "terraformProviders": ["hashicorp/null@~> 3.1.0"],
+  "terraformProviders": ["hashicorp/null@~> 3.1.0", "hashicorp/random@~> 3.1.0"],
   "context": {
     "excludeStackIdFromLogicalIds": "true"
   }


### PR DESCRIPTION
The random provider has a resource named String, the conflict with the native class causes the java build to fail.

Closes #1376
