### PR TITLE
chore: remove depreciation warning for `fs.rmdir`

### DIFF
--- a/packages/cdktf-cli/bin/cmds/helper/synth-stack.ts
+++ b/packages/cdktf-cli/bin/cmds/helper/synth-stack.ts
@@ -130,7 +130,7 @@ Command output on stdout:
     );
 
     for (const orphanedDirectory of orphanedDirectories) {
-      fs.rmdirSync(orphanedDirectory, { recursive: true });
+      fs.rmSync(orphanedDirectory, { recursive: true });
     }
 
     return stacks;

--- a/packages/cdktf-cli/bin/cmds/ui/models/terraform-cloud.ts
+++ b/packages/cdktf-cli/bin/cmds/ui/models/terraform-cloud.ts
@@ -455,10 +455,9 @@ export class TerraformCloud implements Terraform {
 
   private removeLocalTerraformDirectory() {
     try {
-      fs.rmdirSync(
-        path.resolve(this.stack.synthesizedStackPath, ".terraform"),
-        { recursive: true }
-      );
+      fs.rmSync(path.resolve(this.stack.synthesizedStackPath, ".terraform"), {
+        recursive: true,
+      });
     } catch (error) {
       logger.debug(`Could not remove .terraform folder`, error);
     }

--- a/packages/cdktf/lib/terraform-asset.ts
+++ b/packages/cdktf/lib/terraform-asset.ts
@@ -112,7 +112,7 @@ export class TerraformAsset extends Resource {
     // Cleanup existing assets
     const previousVersionsFolder = path.join(basePath, this.namedFolder);
     if (fs.existsSync(previousVersionsFolder)) {
-      fs.rmdirSync(previousVersionsFolder, { recursive: true });
+      fs.rmSync(previousVersionsFolder, { recursive: true });
     }
 
     const targetPath = path.join(basePath, this.path);


### PR DESCRIPTION
I believe this is a Node16 depreciation message:
``` shell
(node:22795) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)

```

I encountered it today when `cdktf` deleted an old stack that was unused. It performed fine, but threw out this error.