### PR TITLE
fix: update specified nodejs version to >=12.16 to reflect our actual requirements

### DIFF
--- a/examples/typescript/azure-app-service/package.json
+++ b/examples/typescript/azure-app-service/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=10.12"
+    "node": ">=12.16"
   },
   "dependencies": {
     "cdktf": "0.0.0",

--- a/examples/typescript/azure-service-bus-queue-trigger/package.json
+++ b/examples/typescript/azure-service-bus-queue-trigger/package.json
@@ -17,7 +17,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=10.12"
+    "node": ">=12.16"
   },
   "dependencies": {
     "@cdktf/provider-azurerm": "^0.2.9",

--- a/examples/typescript/azure/package.json
+++ b/examples/typescript/azure/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=10.12"
+    "node": ">=12.16"
   },
   "dependencies": {
     "cdktf": "0.0.0",

--- a/examples/typescript/backends/azurerm/package.json
+++ b/examples/typescript/backends/azurerm/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=10.12"
+    "node": ">=12.16"
   },
   "dependencies": {
     "cdktf": "0.0.0",

--- a/examples/typescript/backends/gcs/package.json
+++ b/examples/typescript/backends/gcs/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=10.12"
+    "node": ">=12.16"
   },
   "dependencies": {
     "cdktf": "0.0.0",

--- a/examples/typescript/backends/remote/package.json
+++ b/examples/typescript/backends/remote/package.json
@@ -18,7 +18,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=10.12"
+    "node": ">=12.16"
   },
   "dependencies": {
     "cdktf": "0.0.0",

--- a/examples/typescript/backends/s3/package.json
+++ b/examples/typescript/backends/s3/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=10.12"
+    "node": ">=12.16"
   },
   "dependencies": {
     "cdktf": "0.0.0",

--- a/examples/typescript/google-cloudrun/package.json
+++ b/examples/typescript/google-cloudrun/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=10.12"
+    "node": ">=12.16"
   },
   "dependencies": {
     "cdktf": "0.0.0",

--- a/examples/typescript/google/package.json
+++ b/examples/typescript/google/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=10.12"
+    "node": ">=12.16"
   },
   "dependencies": {
     "cdktf": "0.0.0",

--- a/examples/typescript/kubernetes/package.json
+++ b/examples/typescript/kubernetes/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=10.12"
+    "node": ">=12.16"
   },
   "dependencies": {
     "cdktf": "0.0.0",

--- a/examples/typescript/ucloud/package.json
+++ b/examples/typescript/ucloud/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=10.12"
+    "node": ">=12.16"
   },
   "dependencies": {
     "cdktf": "0.0.0",

--- a/examples/typescript/vault/package.json
+++ b/examples/typescript/vault/package.json
@@ -19,7 +19,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=10.12"
+    "node": ">=12.16"
   },
   "dependencies": {
     "cdktf": "0.0.0",

--- a/packages/@cdktf/hcl2cdk/test/convertProject.test.ts
+++ b/packages/@cdktf/hcl2cdk/test/convertProject.test.ts
@@ -66,7 +66,7 @@ app.synth();`,
           "upgrade:next": "npm i cdktf@next cdktf-cli@next"
         },
         "engines": {
-          "node": ">=10.12"
+          "node": ">=12.16"
         },
         "dependencies": {
           "cdktf": "next",

--- a/packages/cdktf-cli/templates/typescript/package.json
+++ b/packages/cdktf-cli/templates/typescript/package.json
@@ -17,6 +17,6 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=10.12"
+    "node": ">=12.16"
   }
 }


### PR DESCRIPTION
Node 12 has been required for quite some time already, the examples (and our template) only weren't updated yet.

For example see this check which already exists: https://github.com/hashicorp/terraform-cdk/blob/c4222503c4571b4b368fea8c4921ed1d5ab8b899/packages/cdktf-cli/bin/cmds/helper/check-environment.ts#L55