### PR TITLE
feat(lib): number[] Tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,17 @@
 
 **Breaking Changes**
 
-### Map Tokens [#1411](https://github.com/hashicorp/terraform-cdk/pull/1411)
+### Number[] Tokens [#1471](https://github.com/hashicorp/terraform-cdk/pull/1471)
 
-As part of an effort to use more native types, there are now tokens for maps of primitive values.
+As part of an effort to use more native types, there are now tokens for number[].
+There is now `Token.asNumberList()` which can be used to conver other values into number[].
 
-As a result, there is a minor breaking change:
+As a result of some standardization, there is a minor breaking change:
 
-- Map attributes have gone from `{ [key: string]: TYPE } | cdktf.IResolvable` to `{ [key: string]:TYPE }` when `TYPE` is `string, number, or boolean`.
-  - The most common impact is maps created by using Terraform functions (`Fn.(...)`) will now need to be passed to `Token.as<String/Number/Boolean>Map()` before assigning to a resource attribute.
+- Boolean[] attributes have gone from `boolean[]` to `Array<boolean | IResolvable> | IResolvable`.
+  - This is done because neither `boolean` or `boolean[]` is representable by a token.
+  - This should make it easier to pass around `boolean[]` between resources and fuctions.
+  - For jsii languages (especially Java and C#), these types will end up as `List<Object>`.
 
 ## 0.8.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Number[] Tokens [#1471](https://github.com/hashicorp/terraform-cdk/pull/1471)
 
-As part of an effort to use more native types, there are now tokens for number[].
-There is now `Token.asNumberList()` which can be used to conver other values into number[].
+As part of an effort to use more native types, there are now tokens for `number[]`.
+This is mostly an internal change, but there is now `Token.asNumberList()` which can be used to convert other values into `number[]`.
 
 As a result of some standardization, there is a minor breaking change:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## Unreleased
+
+**Breaking Changes**
+
+### Map Tokens [#1411](https://github.com/hashicorp/terraform-cdk/pull/1411)
+
+As part of an effort to use more native types, there are now tokens for maps of primitive values.
+
+As a result, there is a minor breaking change:
+
+- Map attributes have gone from `{ [key: string]: TYPE } | cdktf.IResolvable` to `{ [key: string]:TYPE }` when `TYPE` is `string, number, or boolean`.
+  - The most common impact is maps created by using Terraform functions (`Fn.(...)`) will now need to be passed to `Token.as<String/Number/Boolean>Map()` before assigning to a resource attribute.
+
 ## 0.8.6
 
 ### fix

--- a/packages/@cdktf/provider-generator/lib/__tests__/__snapshots__/edge-provider-schema.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/__tests__/__snapshots__/edge-provider-schema.test.ts.snap
@@ -1226,7 +1226,7 @@ export interface OptionalAttributeResourceConfig extends cdktf.TerraformMetaArgu
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/optional_attribute_resource#boolList OptionalAttributeResource#boolList}
   */
-  readonly boolList?: boolean[];
+  readonly boolList?: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable;
 }
 
 /**
@@ -1354,11 +1354,11 @@ export class OptionalAttributeResource extends cdktf.TerraformResource {
   }
 
   // boolList - computed: false, optional: true, required: false
-  private _boolList?: boolean[]; 
+  private _boolList?: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable; 
   public get boolList() {
     return this.getBooleanAttribute('boolList') as any;
   }
-  public set boolList(value: boolean[]) {
+  public set boolList(value: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable) {
     this._boolList = value;
   }
   public resetBoolList() {
@@ -1420,7 +1420,7 @@ export interface OptionalComputedAttributeResourceConfig extends cdktf.Terraform
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/optional_computed_attribute_resource#boolList OptionalComputedAttributeResource#boolList}
   */
-  readonly boolList?: boolean[];
+  readonly boolList?: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable;
 }
 
 /**
@@ -1548,11 +1548,11 @@ export class OptionalComputedAttributeResource extends cdktf.TerraformResource {
   }
 
   // boolList - computed: true, optional: true, required: false
-  private _boolList?: boolean[]; 
+  private _boolList?: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable; 
   public get boolList() {
     return this.getBooleanAttribute('boolList') as any;
   }
-  public set boolList(value: boolean[]) {
+  public set boolList(value: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable) {
     this._boolList = value;
   }
   public resetBoolList() {
@@ -1614,7 +1614,7 @@ export interface RequiredAttributeResourceConfig extends cdktf.TerraformMetaArgu
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/required_attribute_resource#boolList RequiredAttributeResource#boolList}
   */
-  readonly boolList: boolean[];
+  readonly boolList: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable;
 }
 
 /**
@@ -1727,11 +1727,11 @@ export class RequiredAttributeResource extends cdktf.TerraformResource {
   }
 
   // boolList - computed: false, optional: false, required: true
-  private _boolList?: boolean[]; 
+  private _boolList?: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable; 
   public get boolList() {
     return this.getBooleanAttribute('boolList') as any;
   }
-  public set boolList(value: boolean[]) {
+  public set boolList(value: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable) {
     this._boolList = value;
   }
   // Temporarily expose input value. Use with caution.

--- a/packages/@cdktf/provider-generator/lib/__tests__/__snapshots__/edge-provider-schema.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/__tests__/__snapshots__/edge-provider-schema.test.ts.snap
@@ -1215,6 +1215,18 @@ export interface OptionalAttributeResourceConfig extends cdktf.TerraformMetaArgu
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/optional_attribute_resource#bool OptionalAttributeResource#bool}
   */
   readonly bool?: boolean | cdktf.IResolvable;
+  /**
+  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/optional_attribute_resource#strList OptionalAttributeResource#strList}
+  */
+  readonly strList?: string[];
+  /**
+  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/optional_attribute_resource#numList OptionalAttributeResource#numList}
+  */
+  readonly numList?: number[];
+  /**
+  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/optional_attribute_resource#boolList OptionalAttributeResource#boolList}
+  */
+  readonly boolList?: boolean[];
 }
 
 /**
@@ -1252,6 +1264,9 @@ export class OptionalAttributeResource extends cdktf.TerraformResource {
     this._str = config.str;
     this._num = config.num;
     this._bool = config.bool;
+    this._strList = config.strList;
+    this._numList = config.numList;
+    this._boolList = config.boolList;
   }
 
   // ==========
@@ -1306,6 +1321,54 @@ export class OptionalAttributeResource extends cdktf.TerraformResource {
     return this._bool;
   }
 
+  // strList - computed: false, optional: true, required: false
+  private _strList?: string[]; 
+  public get strList() {
+    return this.getListAttribute('strList');
+  }
+  public set strList(value: string[]) {
+    this._strList = value;
+  }
+  public resetStrList() {
+    this._strList = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get strListInput() {
+    return this._strList;
+  }
+
+  // numList - computed: false, optional: true, required: false
+  private _numList?: number[]; 
+  public get numList() {
+    return this.getNumberListAttribute('numList');
+  }
+  public set numList(value: number[]) {
+    this._numList = value;
+  }
+  public resetNumList() {
+    this._numList = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get numListInput() {
+    return this._numList;
+  }
+
+  // boolList - computed: false, optional: true, required: false
+  private _boolList?: boolean[]; 
+  public get boolList() {
+    return this.getBooleanAttribute('boolList') as any;
+  }
+  public set boolList(value: boolean[]) {
+    this._boolList = value;
+  }
+  public resetBoolList() {
+    this._boolList = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get boolListInput() {
+    return this._boolList;
+  }
+
   // =========
   // SYNTHESIS
   // =========
@@ -1315,6 +1378,9 @@ export class OptionalAttributeResource extends cdktf.TerraformResource {
       str: cdktf.stringToTerraform(this._str),
       num: cdktf.numberToTerraform(this._num),
       bool: cdktf.booleanToTerraform(this._bool),
+      strList: cdktf.listMapper(cdktf.stringToTerraform)(this._strList),
+      numList: cdktf.listMapper(cdktf.numberToTerraform)(this._numList),
+      boolList: cdktf.listMapper(cdktf.booleanToTerraform)(this._boolList),
     };
   }
 }
@@ -1343,6 +1409,18 @@ export interface OptionalComputedAttributeResourceConfig extends cdktf.Terraform
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/optional_computed_attribute_resource#bool OptionalComputedAttributeResource#bool}
   */
   readonly bool?: boolean | cdktf.IResolvable;
+  /**
+  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/optional_computed_attribute_resource#strList OptionalComputedAttributeResource#strList}
+  */
+  readonly strList?: string[];
+  /**
+  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/optional_computed_attribute_resource#numList OptionalComputedAttributeResource#numList}
+  */
+  readonly numList?: number[];
+  /**
+  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/optional_computed_attribute_resource#boolList OptionalComputedAttributeResource#boolList}
+  */
+  readonly boolList?: boolean[];
 }
 
 /**
@@ -1380,6 +1458,9 @@ export class OptionalComputedAttributeResource extends cdktf.TerraformResource {
     this._str = config.str;
     this._num = config.num;
     this._bool = config.bool;
+    this._strList = config.strList;
+    this._numList = config.numList;
+    this._boolList = config.boolList;
   }
 
   // ==========
@@ -1434,6 +1515,54 @@ export class OptionalComputedAttributeResource extends cdktf.TerraformResource {
     return this._bool;
   }
 
+  // strList - computed: true, optional: true, required: false
+  private _strList?: string[]; 
+  public get strList() {
+    return this.getListAttribute('strList');
+  }
+  public set strList(value: string[]) {
+    this._strList = value;
+  }
+  public resetStrList() {
+    this._strList = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get strListInput() {
+    return this._strList;
+  }
+
+  // numList - computed: true, optional: true, required: false
+  private _numList?: number[]; 
+  public get numList() {
+    return this.getNumberListAttribute('numList');
+  }
+  public set numList(value: number[]) {
+    this._numList = value;
+  }
+  public resetNumList() {
+    this._numList = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get numListInput() {
+    return this._numList;
+  }
+
+  // boolList - computed: true, optional: true, required: false
+  private _boolList?: boolean[]; 
+  public get boolList() {
+    return this.getBooleanAttribute('boolList') as any;
+  }
+  public set boolList(value: boolean[]) {
+    this._boolList = value;
+  }
+  public resetBoolList() {
+    this._boolList = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get boolListInput() {
+    return this._boolList;
+  }
+
   // =========
   // SYNTHESIS
   // =========
@@ -1443,6 +1572,9 @@ export class OptionalComputedAttributeResource extends cdktf.TerraformResource {
       str: cdktf.stringToTerraform(this._str),
       num: cdktf.numberToTerraform(this._num),
       bool: cdktf.booleanToTerraform(this._bool),
+      strList: cdktf.listMapper(cdktf.stringToTerraform)(this._strList),
+      numList: cdktf.listMapper(cdktf.numberToTerraform)(this._numList),
+      boolList: cdktf.listMapper(cdktf.booleanToTerraform)(this._boolList),
     };
   }
 }
@@ -1471,6 +1603,18 @@ export interface RequiredAttributeResourceConfig extends cdktf.TerraformMetaArgu
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/required_attribute_resource#bool RequiredAttributeResource#bool}
   */
   readonly bool: boolean | cdktf.IResolvable;
+  /**
+  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/required_attribute_resource#strList RequiredAttributeResource#strList}
+  */
+  readonly strList: string[];
+  /**
+  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/required_attribute_resource#numList RequiredAttributeResource#numList}
+  */
+  readonly numList: number[];
+  /**
+  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/edge/r/required_attribute_resource#boolList RequiredAttributeResource#boolList}
+  */
+  readonly boolList: boolean[];
 }
 
 /**
@@ -1508,6 +1652,9 @@ export class RequiredAttributeResource extends cdktf.TerraformResource {
     this._str = config.str;
     this._num = config.num;
     this._bool = config.bool;
+    this._strList = config.strList;
+    this._numList = config.numList;
+    this._boolList = config.boolList;
   }
 
   // ==========
@@ -1553,6 +1700,45 @@ export class RequiredAttributeResource extends cdktf.TerraformResource {
     return this._bool;
   }
 
+  // strList - computed: false, optional: false, required: true
+  private _strList?: string[]; 
+  public get strList() {
+    return this.getListAttribute('strList');
+  }
+  public set strList(value: string[]) {
+    this._strList = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get strListInput() {
+    return this._strList;
+  }
+
+  // numList - computed: false, optional: false, required: true
+  private _numList?: number[]; 
+  public get numList() {
+    return this.getNumberListAttribute('numList');
+  }
+  public set numList(value: number[]) {
+    this._numList = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get numListInput() {
+    return this._numList;
+  }
+
+  // boolList - computed: false, optional: false, required: true
+  private _boolList?: boolean[]; 
+  public get boolList() {
+    return this.getBooleanAttribute('boolList') as any;
+  }
+  public set boolList(value: boolean[]) {
+    this._boolList = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get boolListInput() {
+    return this._boolList;
+  }
+
   // =========
   // SYNTHESIS
   // =========
@@ -1562,6 +1748,9 @@ export class RequiredAttributeResource extends cdktf.TerraformResource {
       str: cdktf.stringToTerraform(this._str),
       num: cdktf.numberToTerraform(this._num),
       bool: cdktf.booleanToTerraform(this._bool),
+      strList: cdktf.listMapper(cdktf.stringToTerraform)(this._strList),
+      numList: cdktf.listMapper(cdktf.numberToTerraform)(this._numList),
+      boolList: cdktf.listMapper(cdktf.booleanToTerraform)(this._boolList),
     };
   }
 }

--- a/packages/@cdktf/provider-generator/lib/__tests__/edge-provider-schema/builder.ts
+++ b/packages/@cdktf/provider-generator/lib/__tests__/edge-provider-schema/builder.ts
@@ -149,4 +149,35 @@ export class SchemaBuilder {
       });
     return this;
   }
+
+  public addAllPrimitiveListTypes({
+    required,
+    computed,
+    prefix = "",
+  }: {
+    required: boolean;
+    computed: boolean;
+    prefix?: string;
+  }): SchemaBuilder {
+    this.attribute({
+      name: prefix + "strList",
+      type: ["list", "string"],
+      required,
+      computed,
+    })
+      .attribute({
+        name: prefix + "numList",
+        type: ["list", "number"],
+        required,
+        computed,
+      })
+      .attribute({
+        name: prefix + "boolList",
+        type: ["list", "bool"],
+        required,
+        computed,
+      });
+
+    return this;
+  }
 }

--- a/packages/@cdktf/provider-generator/lib/__tests__/edge-provider-schema/index.ts
+++ b/packages/@cdktf/provider-generator/lib/__tests__/edge-provider-schema/index.ts
@@ -3,14 +3,17 @@ import { schema, SchemaBuilder as S } from "./builder";
 
 const required_attribute_resource = new S()
   .addAllPrimitiveTypes({ required: true, computed: false })
+  .addAllPrimitiveListTypes({ required: true, computed: false })
   .build();
 
 const optional_attribute_resource = new S()
   .addAllPrimitiveTypes({ required: false, computed: false })
+  .addAllPrimitiveListTypes({ required: false, computed: false })
   .build();
 
 const optional_computed_attribute_resource = new S()
   .addAllPrimitiveTypes({ required: false, computed: true })
+  .addAllPrimitiveListTypes({ required: false, computed: true })
   .build();
 
 const list_block_resource = new S()

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/resource-types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/resource-types.test.ts.snap
@@ -1965,8 +1965,7 @@ export class CloudfrontDistributionOriginGroupFailoverCriteriaOutputReference ex
   // status_codes - computed: false, optional: false, required: true
   private _statusCodes?: number[]; 
   public get statusCodes() {
-    // Getting the computed value is not yet implemented
-    return this.interpolationForAttribute('status_codes') as any;
+    return this.getNumberListAttribute('status_codes');
   }
   public set statusCodes(value: number[]) {
     this._statusCodes = value;

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -1207,8 +1207,7 @@ export class NumberList extends cdktf.TerraformResource {
   // foo_required - computed: false, optional: false, required: true
   private _fooRequired?: number[]; 
   public get fooRequired() {
-    // Getting the computed value is not yet implemented
-    return this.interpolationForAttribute('foo_required') as any;
+    return this.getNumberListAttribute('foo_required');
   }
   public set fooRequired(value: number[]) {
     this._fooRequired = value;
@@ -1221,8 +1220,7 @@ export class NumberList extends cdktf.TerraformResource {
   // foo_optional - computed: false, optional: true, required: false
   private _fooOptional?: number[]; 
   public get fooOptional() {
-    // Getting the computed value is not yet implemented
-    return this.interpolationForAttribute('foo_optional') as any;
+    return this.getNumberListAttribute('foo_optional');
   }
   public set fooOptional(value: number[]) {
     this._fooOptional = value;

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -13,11 +13,11 @@ export interface BooleanListConfig extends cdktf.TerraformMetaArguments {
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/boolean_list#foo_required BooleanList#foo_required}
   */
-  readonly fooRequired: boolean[];
+  readonly fooRequired: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable;
   /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/boolean_list#foo_optional BooleanList#foo_optional}
   */
-  readonly fooOptional?: boolean[];
+  readonly fooOptional?: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable;
 }
 
 /**
@@ -61,11 +61,11 @@ export class BooleanList extends cdktf.TerraformResource {
   // ==========
 
   // foo_required - computed: false, optional: false, required: true
-  private _fooRequired?: boolean[]; 
+  private _fooRequired?: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable; 
   public get fooRequired() {
     return this.getBooleanAttribute('foo_required') as any;
   }
-  public set fooRequired(value: boolean[]) {
+  public set fooRequired(value: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable) {
     this._fooRequired = value;
   }
   // Temporarily expose input value. Use with caution.
@@ -74,11 +74,11 @@ export class BooleanList extends cdktf.TerraformResource {
   }
 
   // foo_optional - computed: false, optional: true, required: false
-  private _fooOptional?: boolean[]; 
+  private _fooOptional?: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable; 
   public get fooOptional() {
     return this.getBooleanAttribute('foo_optional') as any;
   }
-  public set fooOptional(value: boolean[]) {
+  public set fooOptional(value: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable) {
     this._fooOptional = value;
   }
   public resetFooOptional() {

--- a/packages/@cdktf/provider-generator/lib/get/generator/emitter/attributes-emitter.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/emitter/attributes-emitter.ts
@@ -135,6 +135,9 @@ export class AttributesEmitter {
     if (type.isStringList) {
       return `this.getListAttribute('${att.terraformName}')`;
     }
+    if (type.isNumberList) {
+      return `this.getNumberListAttribute('${att.terraformName}')`;
+    }
     if (type.isNumber) {
       return `this.getNumberAttribute('${att.terraformName}')`;
     }

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
@@ -58,6 +58,9 @@ export class AttributeTypeModel {
       return `{ [key: string]: ${this._type} } | cdktf.IResolvable`;
     if (this.isList && !this.isComputed && this.isSingleItem)
       return `${this._type}`;
+    // neither boolean nor boolean[] is tokenizable, so both parts need IResolvable
+    if (this.isList && this._type === TokenizableTypes.BOOLEAN)
+      return "Array<boolean | cdktf.IResolvable> | cdktf.IResolvable";
     if (this.isList && !this.isComputed) return `${this._type}[]`;
     if (
       this.isList &&

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
@@ -15,6 +15,7 @@ export enum TokenizableTypes {
   STRING = "string",
   STRING_LIST = "string[]",
   NUMBER = "number",
+  NUMBER_LIST = "number[]",
   BOOLEAN = "boolean",
 }
 

--- a/packages/cdktf/lib/complex-computed-list.ts
+++ b/packages/cdktf/lib/complex-computed-list.ts
@@ -23,6 +23,12 @@ abstract class ComplexComputedAttribute implements IInterpolatingParent {
     return this.interpolationForAttribute(terraformAttribute);
   }
 
+  public getNumberListAttribute(terraformAttribute: string) {
+    return Token.asNumberList(
+      this.interpolationForAttribute(terraformAttribute)
+    );
+  }
+
   public abstract interpolationForAttribute(terraformAttribute: string): any;
 }
 

--- a/packages/cdktf/lib/terraform-data-source.ts
+++ b/packages/cdktf/lib/terraform-data-source.ts
@@ -56,6 +56,12 @@ export class TerraformDataSource
     return this.interpolationForAttribute(terraformAttribute);
   }
 
+  public getNumberListAttribute(terraformAttribute: string) {
+    return Token.asNumberList(
+      this.interpolationForAttribute(terraformAttribute)
+    );
+  }
+
   public get fqn(): string {
     return Token.asString(
       `data.${this.terraformResourceType}.${this.friendlyUniqueId}`

--- a/packages/cdktf/lib/terraform-functions.ts
+++ b/packages/cdktf/lib/terraform-functions.ts
@@ -2,7 +2,7 @@ import { Tokenization } from "./tokens/token";
 import { call } from "./tfExpression";
 import { IResolvable } from "./tokens/resolvable";
 import { TokenMap } from "./tokens/private/token-map";
-import { TokenString } from "./tokens/private/encoding";
+import { TokenString, extractTokenDouble } from "./tokens/private/encoding";
 import { rawString } from ".";
 
 // We use branding here to ensure we internally only handle validated values
@@ -65,6 +65,10 @@ function listOf(type: TFValueValidator): TFValueValidator {
         }
 
         if (TokenString.forListToken(item).test()) {
+          return item;
+        }
+
+        if (extractTokenDouble(item, true) !== undefined) {
           return item;
         }
 

--- a/packages/cdktf/lib/terraform-output.ts
+++ b/packages/cdktf/lib/terraform-output.ts
@@ -2,9 +2,10 @@ import { Construct } from "constructs";
 import { TerraformElement } from "./terraform-element";
 import { deepMerge } from "./util";
 import { ITerraformDependable } from "./terraform-dependable";
-import { Expression, ref, Tokenization } from ".";
+import { Expression, ref } from ".";
 import { isArray } from "util";
 import { ITerraformAddressable } from "./terraform-addressable";
+import { Token } from "./tokens";
 
 export interface TerraformOutputConfig {
   readonly value: Expression | ITerraformDependable;
@@ -57,7 +58,7 @@ export class TerraformOutput extends TerraformElement {
   }
 
   private synthesizeValue(arg: any): any {
-    if (Tokenization.isResolvable(arg)) {
+    if (Token.isUnresolved(arg)) {
       return arg;
     }
 

--- a/packages/cdktf/lib/terraform-resource.ts
+++ b/packages/cdktf/lib/terraform-resource.ts
@@ -87,6 +87,12 @@ export class TerraformResource
     return this.interpolationForAttribute(terraformAttribute);
   }
 
+  public getNumberListAttribute(terraformAttribute: string) {
+    return Token.asNumberList(
+      this.interpolationForAttribute(terraformAttribute)
+    );
+  }
+
   public get fqn(): string {
     return Token.asString(
       `${this.terraformResourceType}.${this.friendlyUniqueId}`

--- a/packages/cdktf/lib/tokens/private/encoding.ts
+++ b/packages/cdktf/lib/tokens/private/encoding.ts
@@ -129,6 +129,12 @@ export function containsListTokenElement(xs: any[]) {
   );
 }
 
+export function containsNumberListTokenElement(xs: any[]) {
+  return xs.some(
+    (x) => typeof x === "number" && extractTokenDouble(x, true) !== undefined
+  );
+}
+
 export function isComplexElement(xs: any) {
   return (
     typeof xs === "object" &&
@@ -152,10 +158,12 @@ export function unresolved(obj: any): boolean {
   if (typeof obj === "string") {
     return TokenString.forString(obj).test();
   } else if (typeof obj === "number") {
-    return extractTokenDouble(obj) !== undefined;
+    return extractTokenDouble(obj, false) !== undefined;
   } else if (Array.isArray(obj) && obj.length === 1) {
     return (
-      typeof obj[0] === "string" && TokenString.forListToken(obj[0]).test()
+      (typeof obj[0] === "string" && TokenString.forListToken(obj[0]).test()) ||
+      (typeof obj[0] === "number" &&
+        extractTokenDouble(obj[0], true) !== undefined)
     );
   } else {
     return Tokenization.isResolvable(obj);
@@ -188,6 +196,9 @@ export function unresolved(obj: any): boolean {
 // tslint:disable-next-line:no-bitwise
 const DOUBLE_TOKEN_MARKER_BITS = 0xfdff << 16;
 
+// tslint:disable-next-line:no-bitwise
+const DOUBLE_LIST_TOKEN_MARKER_BITS = 0xfbff << 16;
+
 /**
  * Highest encodable number
  */
@@ -208,7 +219,7 @@ const BITS32 = Math.pow(2, 32);
  *
  * We use this to encode Token ordinals.
  */
-export function createTokenDouble(x: number) {
+export function createTokenDouble(x: number, list: boolean) {
   if (Math.floor(x) !== x || x < 0) {
     throw new Error("Can only encode positive integers");
   }
@@ -224,7 +235,9 @@ export function createTokenDouble(x: number) {
 
   // This needs an "x >> 32" but that will make it a 32-bit number instead
   // of a 64-bit number.
-  ints[1] = (shr32(x) & 0xffff) | DOUBLE_TOKEN_MARKER_BITS; // Top 16 bits of number and the mask
+  ints[1] =
+    (shr32(x) & 0xffff) |
+    (list ? DOUBLE_LIST_TOKEN_MARKER_BITS : DOUBLE_TOKEN_MARKER_BITS); // Top 16 bits of number and the mask
   // tslint:enable:no-bitwise
 
   return new Float64Array(buf)[0];
@@ -249,14 +262,20 @@ function shl32(x: number) {
  *
  * Returns undefined if the float is a not an encoded token.
  */
-export function extractTokenDouble(encoded: number): number | undefined {
+export function extractTokenDouble(
+  encoded: number,
+  list: boolean
+): number | undefined {
   const buf = new ArrayBuffer(8);
   new Float64Array(buf)[0] = encoded;
 
   const ints = new Uint32Array(buf);
 
   // tslint:disable:no-bitwise
-  if ((ints[1] & 0xffff0000) !== DOUBLE_TOKEN_MARKER_BITS) {
+  if (
+    (ints[1] & 0xffff0000) !==
+    (list ? DOUBLE_LIST_TOKEN_MARKER_BITS : DOUBLE_TOKEN_MARKER_BITS)
+  ) {
     return undefined;
   }
 

--- a/packages/cdktf/lib/tokens/private/resolve.ts
+++ b/packages/cdktf/lib/tokens/private/resolve.ts
@@ -9,7 +9,12 @@ import {
   StringConcat,
 } from "../resolvable";
 import { TokenizedStringFragments } from "../string-fragments";
-import { containsListTokenElement, TokenString, unresolved } from "./encoding";
+import {
+  containsListTokenElement,
+  TokenString,
+  unresolved,
+  containsNumberListTokenElement,
+} from "./encoding";
 import { TokenMap } from "./token-map";
 
 // This file should not be exported to consumers, resolving should happen through Construct.resolve()
@@ -164,6 +169,10 @@ export function resolve(obj: any, options: IResolveOptions): any {
   if (Array.isArray(obj)) {
     if (containsListTokenElement(obj)) {
       return options.resolver.resolveList(obj, makeContext()[0]);
+    }
+
+    if (containsNumberListTokenElement(obj)) {
+      return options.resolver.resolveNumberList(obj, makeContext()[0]);
     }
 
     const arr = obj

--- a/packages/cdktf/lib/tokens/private/token-map.ts
+++ b/packages/cdktf/lib/tokens/private/token-map.ts
@@ -162,7 +162,7 @@ export class TokenMap {
     if (xs.length !== 1) {
       return undefined;
     }
-    const tokenIndex = extractTokenDouble(xs[0], false);
+    const tokenIndex = extractTokenDouble(xs[0], true);
     if (tokenIndex === undefined) {
       return undefined;
     }

--- a/packages/cdktf/lib/tokens/resolvable.ts
+++ b/packages/cdktf/lib/tokens/resolvable.ts
@@ -201,7 +201,7 @@ export class DefaultTokenResolver implements ITokenResolver {
       throw new Error(`Cannot add elements to list token, got: ${xs}`);
     }
 
-    const token = TokenMap.instance().lookupNumberToken(xs[0]);
+    const token = TokenMap.instance().lookupNumberList(xs);
     if (token === undefined) {
       return xs;
     }

--- a/packages/cdktf/lib/tokens/resolvable.ts
+++ b/packages/cdktf/lib/tokens/resolvable.ts
@@ -1,6 +1,6 @@
 // Copied from https://github.com/aws/constructs/blob/e01e47f78ef1e9b600efcd23ff7705aa8d384017/lib/resolvable.ts
 import { IConstruct } from "constructs";
-import { TokenString } from "./private/encoding";
+import { TokenString, extractTokenDouble } from "./private/encoding";
 import { TokenMap } from "./private/token-map";
 import { TokenizedStringFragments } from "./string-fragments";
 
@@ -90,6 +90,11 @@ export interface ITokenResolver {
    * Resolve a tokenized list
    */
   resolveList(l: string[], context: IResolveContext): any;
+
+  /**
+   * Resolve a tokenized number list
+   */
+  resolveNumberList(l: number[], context: IResolveContext): any;
 }
 
 /**
@@ -188,5 +193,18 @@ export class DefaultTokenResolver implements ITokenResolver {
     }
 
     return fragments.mapTokens({ mapToken: context.resolve }).firstValue;
+  }
+
+  public resolveNumberList(xs: number[], context: IResolveContext) {
+    // Must be a singleton list token, because concatenation is not allowed.
+    if (xs.length !== 1) {
+      throw new Error(`Cannot add elements to list token, got: ${xs}`);
+    }
+
+    const token = TokenMap.instance().lookupNumberToken(xs[0]);
+    if (token === undefined) {
+      return xs;
+    }
+    return context.resolve(token);
   }
 }

--- a/packages/cdktf/lib/tokens/resolvable.ts
+++ b/packages/cdktf/lib/tokens/resolvable.ts
@@ -1,6 +1,6 @@
 // Copied from https://github.com/aws/constructs/blob/e01e47f78ef1e9b600efcd23ff7705aa8d384017/lib/resolvable.ts
 import { IConstruct } from "constructs";
-import { TokenString, extractTokenDouble } from "./private/encoding";
+import { TokenString } from "./private/encoding";
 import { TokenMap } from "./private/token-map";
 import { TokenizedStringFragments } from "./string-fragments";
 

--- a/packages/cdktf/lib/tokens/token.ts
+++ b/packages/cdktf/lib/tokens/token.ts
@@ -83,6 +83,16 @@ export class Token {
   }
 
   /**
+   * Return a reversible list representation of this token
+   */
+  public static asNumberList(value: any): number[] {
+    if (Array.isArray(value) && value.every((x) => typeof x === "number")) {
+      return value;
+    }
+    return TokenMap.instance().registerNumberList(Token.asAny(value));
+  }
+
+  /**
    * Return a resolvable representation of the given value
    */
   public static asAny(value: any): IResolvable {
@@ -107,7 +117,12 @@ export class Tokenization {
     }
     if (Array.isArray(x)) {
       const reversedList = Tokenization.reverseList(x);
-      return reversedList ? [reversedList] : [];
+      if (reversedList) {
+        return [reversedList];
+      }
+
+      const reversedNumberList = Tokenization.reverseNumberList(x);
+      return reversedNumberList ? [reversedNumberList] : [];
     }
     if (typeof x === "number") {
       const reversedNumber = Tokenization.reverseNumber(x);
@@ -135,6 +150,13 @@ export class Tokenization {
    */
   public static reverseList(l: string[]): IResolvable | undefined {
     return TokenMap.instance().lookupList(l);
+  }
+
+  /**
+   * Un-encode a Tokenized value from a list
+   */
+  public static reverseNumberList(l: number[]): IResolvable | undefined {
+    return TokenMap.instance().lookupNumberList(l);
   }
 
   /**

--- a/packages/cdktf/test/__snapshots__/resource.test.ts.snap
+++ b/packages/cdktf/test/__snapshots__/resource.test.ts.snap
@@ -112,6 +112,35 @@ exports[`minimal configuration 1`] = `
 }"
 `;
 
+exports[`number[] attributes 1`] = `
+"{
+  \\"output\\": {
+    \\"number-list\\": {
+      \\"value\\": \\"\${test_resource.resource.number_list_value}\\"
+    }
+  },
+  \\"provider\\": {
+    \\"test\\": [
+      {}
+    ]
+  },
+  \\"resource\\": {
+    \\"test_resource\\": {
+      \\"resource\\": {
+        \\"name\\": \\"foo\\"
+      }
+    }
+  },
+  \\"terraform\\": {
+    \\"required_providers\\": {
+      \\"test\\": {
+        \\"version\\": \\"~> 2.0\\"
+      }
+    }
+  }
+}"
+`;
+
 exports[`numeric attributes 1`] = `
 "{
   \\"output\\": {

--- a/packages/cdktf/test/helper/resource.ts
+++ b/packages/cdktf/test/helper/resource.ts
@@ -62,6 +62,10 @@ export class TestResource extends TerraformResource {
   public get anyList() {
     return this.interpolationForAttribute("any_list") as any;
   }
+
+  public get numberList() {
+    return this.getNumberListAttribute("number_list_value");
+  }
 }
 
 export class OtherTestResource extends TerraformResource {

--- a/packages/cdktf/test/resource.test.ts
+++ b/packages/cdktf/test/resource.test.ts
@@ -178,3 +178,19 @@ test("tokens as ids", () => {
     `"You cannot use a Token (e.g. a reference to an attribute) as the id of a construct"`
   );
 });
+
+test("number[] attributes", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+  new TestProvider(stack, "provider", {});
+
+  const foo = new TestResource(stack, "resource", {
+    name: "foo",
+  });
+
+  new TerraformOutput(stack, "number-list", {
+    value: foo.numberList,
+  });
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});

--- a/test/csharp/edge/Main.cs
+++ b/test/csharp/edge/Main.cs
@@ -30,14 +30,20 @@ namespace MyCompany.MyApp
             new RequiredAttributeResource(this, "plain", new RequiredAttributeResourceConfig {
                 Bool = res.Bool,
                 Str = res.Str,
-                Num = res.Num
+                Num = res.Num,
+                StrList = res.StrList,
+                NumList = res.NumList,
+                BoolList = res.BoolList
             });
 
             // required values FROM required single item lists
             new RequiredAttributeResource(this, "from_single_list", new RequiredAttributeResourceConfig {
                 Bool = list.Singlereq.Reqbool,
                 Str = list.Singlereq.Reqstr,
-                Num = list.Singlereq.Reqnum
+                Num = list.Singlereq.Reqnum,
+                StrList = new [] { list.Singlereq.Reqstr },
+                NumList = new [] { list.Singlereq.Reqnum },
+                BoolList = new [] { list.Singlereq.Reqbool }
             });
 
             // required values FROM required multi item lists

--- a/test/csharp/edge/test.ts
+++ b/test/csharp/edge/test.ts
@@ -71,6 +71,15 @@ describe("csharp full integration test synth", () => {
       expect(stack.byId("plain").bool).toEqual(
         "${optional_attribute_resource.test.bool}"
       );
+      expect(stack.byId("plain").strList).toEqual(
+        "${optional_attribute_resource.test.strList}"
+      );
+      expect(stack.byId("plain").numList).toEqual(
+        "${optional_attribute_resource.test.numList}"
+      );
+      expect(stack.byId("plain").boolList).toEqual(
+        "${optional_attribute_resource.test.boolList}"
+      );
     });
 
     it("item references a required single item lists required values", () => {
@@ -85,6 +94,15 @@ describe("csharp full integration test synth", () => {
       expect(item.num).toEqual(
         "${list_block_resource.list.singlereq[0].reqnum}"
       );
+      expect(item.boolList).toEqual([
+        "${list_block_resource.list.singlereq[0].reqbool}",
+      ]);
+      expect(item.strList).toEqual([
+        "${list_block_resource.list.singlereq[0].reqstr}",
+      ]);
+      expect(item.numList).toEqual([
+        "${list_block_resource.list.singlereq[0].reqnum}",
+      ]);
     });
 
     it.skip("item references required values from multi-item lists", () => {
@@ -100,6 +118,15 @@ describe("csharp full integration test synth", () => {
       expect(item.num).toEqual(
         '${lookup(element(list_block_resource.list.req, 0), "reqnum", 0)}'
       );
+      expect(item.boolList).toEqual([
+        '${lookup(element(list_block_resource.list.req, 0), "reqbool", false)}',
+      ]);
+      expect(item.strList).toEqual([
+        '${lookup(element(list_block_resource.list.req, 0), "reqstr", "fallback")}',
+      ]);
+      expect(item.numList).toEqual([
+        '${lookup(element(list_block_resource.list.req, 0), "reqnum", 0)}',
+      ]);
     });
 
     it.skip("item references a required single item list", () => {

--- a/test/go/edge/main.go
+++ b/test/go/edge/main.go
@@ -56,8 +56,8 @@ func NewReferenceStack(scope constructs.Construct, id string) cdktf.TerraformSta
 		Str:  list.Singlereq().Reqstr(),
 		Num:  list.Singlereq().Reqnum(),
 		StrList: &[]*string{list.Singlereq().Reqstr()},
-		NumList: &[]*jsii.Number{list.Singlereq().Reqnum()},
-		BoolList: &[]*bool{true},//list.Singlereq().Reqbool()},
+		NumList: &[]*int{list.Singlereq().Reqnum()},
+		BoolList: &[]*bool{jsii.Bool(true)},//list.Singlereq().Reqbool()},
 	})
 
 	// required values FROM required multi item lists
@@ -114,8 +114,8 @@ func NewProviderStack(scope constructs.Construct, id string) cdktf.TerraformStac
 		Num:  providerOpt.Reqnum(),
 		Str:  providerOpt.Reqstr(),
 		StrList: &[]*string{providerOpt.Reqstr()},
-		NumList: &[]*jsii.Number{providerOpt.Reqnum()},
-		BoolList: &[]*bool{true},//providerOpt.Reqbool()},
+		NumList: &[]*int{providerOpt.Reqnum()},
+		BoolList: &[]*bool{jsii.Bool(true)},//providerOpt.Reqbool()},
 	})
 
 	edge.NewOptionalAttributeResource(stack, jsii.String("optOpt"), &edge.OptionalAttributeResourceConfig{
@@ -135,8 +135,8 @@ func NewProviderStack(scope constructs.Construct, id string) cdktf.TerraformStac
 		Num:  providerFull.Reqnum(),
 		Str:  providerFull.Reqstr(),
 		StrList: &[]*string{providerFull.Reqstr()},
-		NumList: &[]*jsii.Number{providerFull.Reqnum()},
-		BoolList: &[]*bool{true},//providerFull.Reqbool()},
+		NumList: &[]*int{providerFull.Reqnum()},
+		BoolList: &[]*bool{jsii.Bool(true)},//providerFull.Reqbool()},
 	})
 
 	edge.NewOptionalAttributeResource(stack, jsii.String("optFull"), &edge.OptionalAttributeResourceConfig{

--- a/test/go/edge/main.go
+++ b/test/go/edge/main.go
@@ -44,6 +44,9 @@ func NewReferenceStack(scope constructs.Construct, id string) cdktf.TerraformSta
 		Bool: jsii.Bool(true),
 		Str:  res.Str(),
 		Num:  res.Num(),
+		StrList: res.StrList(),
+		NumList: res.NumList(),
+		BoolList: res.BoolList(),
 	})
 
 	// required values FROM required single item lists
@@ -52,6 +55,9 @@ func NewReferenceStack(scope constructs.Construct, id string) cdktf.TerraformSta
 		Bool: jsii.Bool(true),
 		Str:  list.Singlereq().Reqstr(),
 		Num:  list.Singlereq().Reqnum(),
+		StrList: &[]*string{list.Singlereq().Reqstr()},
+		NumList: &[]*number{list.Singlereq().Reqnum()},
+		BoolList: &[]*bool{list.Singlereq().Reqbool()},
 	})
 
 	// required values FROM required multi item lists
@@ -107,6 +113,9 @@ func NewProviderStack(scope constructs.Construct, id string) cdktf.TerraformStac
 		Bool: providerOpt.Reqbool(),
 		Num:  providerOpt.Reqnum(),
 		Str:  providerOpt.Reqstr(),
+		StrList: &[]*string{providerOpt.Reqstr()},
+		NumList: &[]*number{providerOpt.Reqnum()},
+		BoolList: &[]*bool{providerOpt.Reqbool()},
 	})
 
 	edge.NewOptionalAttributeResource(stack, jsii.String("optOpt"), &edge.OptionalAttributeResourceConfig{
@@ -125,6 +134,9 @@ func NewProviderStack(scope constructs.Construct, id string) cdktf.TerraformStac
 		Bool: providerFull.Reqbool(),
 		Num:  providerFull.Reqnum(),
 		Str:  providerFull.Reqstr(),
+		StrList: &[]*string{providerFull.Reqstr()},
+		NumList: &[]*number{providerFull.Reqnum()},
+		BoolList: &[]*bool{providerFull.Reqbool()},
 	})
 
 	edge.NewOptionalAttributeResource(stack, jsii.String("optFull"), &edge.OptionalAttributeResourceConfig{

--- a/test/go/edge/main.go
+++ b/test/go/edge/main.go
@@ -56,8 +56,8 @@ func NewReferenceStack(scope constructs.Construct, id string) cdktf.TerraformSta
 		Str:  list.Singlereq().Reqstr(),
 		Num:  list.Singlereq().Reqnum(),
 		StrList: &[]*string{list.Singlereq().Reqstr()},
-		NumList: &[]*number{list.Singlereq().Reqnum()},
-		BoolList: &[]*bool{list.Singlereq().Reqbool()},
+		NumList: &[]*jsii.Number{list.Singlereq().Reqnum()},
+		BoolList: &[]*bool{true},//list.Singlereq().Reqbool()},
 	})
 
 	// required values FROM required multi item lists
@@ -114,8 +114,8 @@ func NewProviderStack(scope constructs.Construct, id string) cdktf.TerraformStac
 		Num:  providerOpt.Reqnum(),
 		Str:  providerOpt.Reqstr(),
 		StrList: &[]*string{providerOpt.Reqstr()},
-		NumList: &[]*number{providerOpt.Reqnum()},
-		BoolList: &[]*bool{providerOpt.Reqbool()},
+		NumList: &[]*jsii.Number{providerOpt.Reqnum()},
+		BoolList: &[]*bool{true},//providerOpt.Reqbool()},
 	})
 
 	edge.NewOptionalAttributeResource(stack, jsii.String("optOpt"), &edge.OptionalAttributeResourceConfig{
@@ -135,8 +135,8 @@ func NewProviderStack(scope constructs.Construct, id string) cdktf.TerraformStac
 		Num:  providerFull.Reqnum(),
 		Str:  providerFull.Reqstr(),
 		StrList: &[]*string{providerFull.Reqstr()},
-		NumList: &[]*number{providerFull.Reqnum()},
-		BoolList: &[]*bool{providerFull.Reqbool()},
+		NumList: &[]*jsii.Number{providerFull.Reqnum()},
+		BoolList: &[]*bool{true},//providerFull.Reqbool()},
 	})
 
 	edge.NewOptionalAttributeResource(stack, jsii.String("optFull"), &edge.OptionalAttributeResourceConfig{

--- a/test/go/edge/main.go
+++ b/test/go/edge/main.go
@@ -46,7 +46,7 @@ func NewReferenceStack(scope constructs.Construct, id string) cdktf.TerraformSta
 		Num:  res.Num(),
 		StrList: res.StrList(),
 		NumList: res.NumList(),
-		BoolList: res.BoolList(),
+		BoolList: &[]*bool{jsii.Bool(true)},//res.BoolList(),
 	})
 
 	// required values FROM required single item lists

--- a/test/go/edge/main.go
+++ b/test/go/edge/main.go
@@ -56,7 +56,7 @@ func NewReferenceStack(scope constructs.Construct, id string) cdktf.TerraformSta
 		Str:  list.Singlereq().Reqstr(),
 		Num:  list.Singlereq().Reqnum(),
 		StrList: &[]*string{list.Singlereq().Reqstr()},
-		NumList: &[]*int{list.Singlereq().Reqnum()},
+		NumList: &[]*float64{list.Singlereq().Reqnum()},
 		BoolList: &[]*bool{jsii.Bool(true)},//list.Singlereq().Reqbool()},
 	})
 
@@ -114,7 +114,7 @@ func NewProviderStack(scope constructs.Construct, id string) cdktf.TerraformStac
 		Num:  providerOpt.Reqnum(),
 		Str:  providerOpt.Reqstr(),
 		StrList: &[]*string{providerOpt.Reqstr()},
-		NumList: &[]*int{providerOpt.Reqnum()},
+		NumList: &[]*float64{providerOpt.Reqnum()},
 		BoolList: &[]*bool{jsii.Bool(true)},//providerOpt.Reqbool()},
 	})
 
@@ -135,7 +135,7 @@ func NewProviderStack(scope constructs.Construct, id string) cdktf.TerraformStac
 		Num:  providerFull.Reqnum(),
 		Str:  providerFull.Reqstr(),
 		StrList: &[]*string{providerFull.Reqstr()},
-		NumList: &[]*int{providerFull.Reqnum()},
+		NumList: &[]*float64{providerFull.Reqnum()},
 		BoolList: &[]*bool{jsii.Bool(true)},//providerFull.Reqbool()},
 	})
 

--- a/test/java/edge/Main.java
+++ b/test/java/edge/Main.java
@@ -31,6 +31,9 @@ class ReferenceStack extends TerraformStack {
                 .bool(true) // res.getBool();
                 .str(res.getStr())
                 .num(res.getNum())
+                .strList(res.getStrList())
+                .numList(res.getNumList())
+                .boolList(res.getBoolList())
                 .build();
 
         // required values FROM required single item lists
@@ -38,6 +41,9 @@ class ReferenceStack extends TerraformStack {
                 .bool(true) // list.getSinglereq().getReqbool();
                 .str(list.getSinglereq().getReqstr())
                 .num(list.getSinglereq().getReqnum())
+                .strList(List.of(list.getSinglereq().getReqstr()))
+                .numList(List.of(list.getSinglereq().getReqnum()))
+                .boolList(List.of(list.getSinglereq().getReqbool()))
                 .build();
 
         // required values FROM required multi item lists

--- a/test/java/edge/Main.java
+++ b/test/java/edge/Main.java
@@ -28,17 +28,17 @@ class ReferenceStack extends TerraformStack {
 
         // plain values
         RequiredAttributeResource.Builder.create(this, "plain")
-                .bool(true) // res.getBool();
+                .bool(true) // res.getBool())
                 .str(res.getStr())
                 .num(res.getNum())
                 .strList(res.getStrList())
                 .numList(res.getNumList())
-                .boolList(res.getBoolList())
+                .boolList(Collections.singletonList(true) /*res.getBoolList()*/)
                 .build();
 
         // required values FROM required single item lists
         RequiredAttributeResource.Builder.create(this, "from_single_list")
-                .bool(true) // list.getSinglereq().getReqbool();
+                .bool(true) // list.getSinglereq().getReqbool())
                 .str(list.getSinglereq().getReqstr())
                 .num(list.getSinglereq().getReqnum())
                 .strList(Collections.singletonList(list.getSinglereq().getReqstr()))

--- a/test/java/edge/Main.java
+++ b/test/java/edge/Main.java
@@ -41,9 +41,9 @@ class ReferenceStack extends TerraformStack {
                 .bool(true) // list.getSinglereq().getReqbool();
                 .str(list.getSinglereq().getReqstr())
                 .num(list.getSinglereq().getReqnum())
-                .strList(List.of(list.getSinglereq().getReqstr()))
-                .numList(List.of(list.getSinglereq().getReqnum()))
-                .boolList(List.of(list.getSinglereq().getReqbool()))
+                .strList(Collections.singletonList(list.getSinglereq().getReqstr()))
+                .numList(Collections.singletonList(list.getSinglereq().getReqnum()))
+                .boolList(Collections.singletonList(list.getSinglereq().getReqbool()))
                 .build();
 
         // required values FROM required multi item lists
@@ -97,6 +97,9 @@ class ProviderStack extends TerraformStack {
                 .bool(true)
                 .num(Token.asNumber(providerOpt.getReqnum()))
                 .str(Token.asString(providerOpt.getReqstr()))
+                .strList(Collections.singletonList(providerOpt.getReqstr()))
+                .numList(Collections.singletonList(providerOpt.getReqnum()))
+                .boolList(Collections.singletonList(providerOpt.getReqbool()))
                 .build();
 
         OptionalAttributeResource.Builder.create(this, "optOpt")
@@ -116,6 +119,9 @@ class ProviderStack extends TerraformStack {
                 .bool(true)
                 .num(Token.asNumber(providerFull.getReqnum()))
                 .str(Token.asString(providerFull.getReqstr()))
+                .strList(Collections.singletonList(providerFull.getReqstr()))
+                .numList(Collections.singletonList(providerFull.getReqnum()))
+                .boolList(Collections.singletonList(providerFull.getReqbool()))
                 .build();
 
         OptionalAttributeResource.Builder.create(this, "optFull")

--- a/test/java/edge/test.ts
+++ b/test/java/edge/test.ts
@@ -90,26 +90,29 @@ describe("java full integration", () => {
       expect(stack.byId("plain").num).toEqual(
         "${optional_attribute_resource.test.num}"
       );
-      expect(stack.byId("plain").bool).toEqual(
-        "${optional_attribute_resource.test.bool}"
-      );
+      // Not supported in Java
+      // expect(stack.byId("plain").bool).toEqual(
+      //   "${optional_attribute_resource.test.bool}"
+      // );
       expect(stack.byId("plain").strList).toEqual(
         "${optional_attribute_resource.test.strList}"
       );
       expect(stack.byId("plain").numList).toEqual(
         "${optional_attribute_resource.test.numList}"
       );
-      expect(stack.byId("plain").boolList).toEqual(
-        "${optional_attribute_resource.test.boolList}"
-      );
+      // Not supported in Java
+      // expect(stack.byId("plain").boolList).toEqual(
+      //   "${optional_attribute_resource.test.boolList}"
+      // );
     });
 
     it("item references a required single item lists required values", () => {
       const item = stack.byId("from_single_list");
 
-      expect(item.bool).toEqual(
-        "${list_block_resource.list.singlereq[0].reqbool}"
-      );
+      // Not supported in Java
+      // expect(item.bool).toEqual(
+      //   "${list_block_resource.list.singlereq[0].reqbool}"
+      // );
       expect(item.str).toEqual(
         "${list_block_resource.list.singlereq[0].reqstr}"
       );

--- a/test/java/edge/test.ts
+++ b/test/java/edge/test.ts
@@ -90,25 +90,41 @@ describe("java full integration", () => {
       expect(stack.byId("plain").num).toEqual(
         "${optional_attribute_resource.test.num}"
       );
-      // Not supported in Java
-      // expect(stack.byId("plain").bool).toEqual(
-      //   "${optional_attribute_resource.test.bool}"
-      // );
+      expect(stack.byId("plain").bool).toEqual(
+        "${optional_attribute_resource.test.bool}"
+      );
+      expect(stack.byId("plain").strList).toEqual(
+        "${optional_attribute_resource.test.strList}"
+      );
+      expect(stack.byId("plain").numList).toEqual(
+        "${optional_attribute_resource.test.numList}"
+      );
+      expect(stack.byId("plain").boolList).toEqual(
+        "${optional_attribute_resource.test.boolList}"
+      );
     });
 
     it("item references a required single item lists required values", () => {
       const item = stack.byId("from_single_list");
 
-      // Not supported in Java
-      // expect(item.bool).toEqual(
-      //   "${list_block_resource.list.singlereq[0].reqbool}"
-      // );
+      expect(item.bool).toEqual(
+        "${list_block_resource.list.singlereq[0].reqbool}"
+      );
       expect(item.str).toEqual(
         "${list_block_resource.list.singlereq[0].reqstr}"
       );
       expect(item.num).toEqual(
         "${list_block_resource.list.singlereq[0].reqnum}"
       );
+      expect(item.boolList).toEqual([
+        "${list_block_resource.list.singlereq[0].reqbool}",
+      ]);
+      expect(item.strList).toEqual([
+        "${list_block_resource.list.singlereq[0].reqstr}",
+      ]);
+      expect(item.numList).toEqual([
+        "${list_block_resource.list.singlereq[0].reqnum}",
+      ]);
     });
 
     // Not supported in Java
@@ -116,16 +132,24 @@ describe("java full integration", () => {
       const item = stack.byId("from_list");
 
       // Direct access is not supported, we have to go through terraform functions
-      // Not supported in Java
-      // expect(item.bool).toEqual(
-      //   '${lookup(element(list_block_resource.list.req, 0), "reqbool", false)}'
-      // );
+      expect(item.bool).toEqual(
+        '${lookup(element(list_block_resource.list.req, 0), "reqbool", false)}'
+      );
       expect(item.str).toEqual(
         '${lookup(element(list_block_resource.list.req, 0), "reqstr", "fallback")}'
       );
       expect(item.num).toEqual(
         '${lookup(element(list_block_resource.list.req, 0), "reqnum", 0)}'
       );
+      expect(item.boolList).toEqual([
+        '${lookup(element(list_block_resource.list.req, 0), "reqbool", false)}',
+      ]);
+      expect(item.strList).toEqual([
+        '${lookup(element(list_block_resource.list.req, 0), "reqstr", "fallback")}',
+      ]);
+      expect(item.numList).toEqual([
+        '${lookup(element(list_block_resource.list.req, 0), "reqnum", 0)}',
+      ]);
     });
 
     // Not supported in Java

--- a/test/python/edge/main.py
+++ b/test/python/edge/main.py
@@ -25,14 +25,20 @@ class ReferenceStack(TerraformStack):
         edge.RequiredAttributeResource(self, "plain",
             bool=res.bool,
             str=res.str,
-            num=res.num
+            num=res.num,
+            str_list=res.str_list,
+            num_list=res.num_list,
+            bool_list=res.bool_list
         )
 
         # required values FROM required single item lists
         edge.RequiredAttributeResource(self, "from_single_list",
             bool=list.singlereq.reqbool,
             str=list.singlereq.reqstr,
-            num=list.singlereq.reqnum
+            num=list.singlereq.reqnum,
+            str_list=[list.singlereq.reqstr],
+            num_list=[list.singlereq.reqnum],
+            bool_list=[list.singlereq.reqbool]
         )
 
         # required values FROM required multi item lists

--- a/test/python/edge/main.py
+++ b/test/python/edge/main.py
@@ -45,7 +45,10 @@ class ReferenceStack(TerraformStack):
         # edge.RequiredAttributeResource(self, "from_list",
         #     bool=Fn.lookup(Fn.element(list.req, 0), "reqbool", False),
         #     str=Fn.lookup(Fn.element(list.req, 0), "reqstr", "fallback"),
-        #     num=Fn.lookup(Fn.element(list.req, 0), "reqnum", 0)
+        #     num=Fn.lookup(Fn.element(list.req, 0), "reqnum", 0),
+        #     str_list=[Fn.lookup(Fn.element(list.req, 0), "reqstr", "fallback")],
+        #     num_list=[Fn.lookup(Fn.element(list.req, 0), "reqnum", 0)],
+        #     bool_list=[Fn.lookup(Fn.element(list.req, 0), "reqbool", False)]
         # )
 
         # passing a reference to a complete list
@@ -87,7 +90,10 @@ class ProviderStack(TerraformStack):
         edge.RequiredAttributeResource(self, "reqOpt",
             bool=provider_opt.reqbool,
             num=provider_opt.reqnum,
-            str=provider_opt.reqstr
+            str=provider_opt.reqstr,
+            str_list=[provider_opt.reqstr],
+            num_list=[provider_opt.reqnum],
+            bool_list=[provider_opt.reqbool]
         )
 
         edge.OptionalAttributeResource(self, "optOpt",
@@ -105,7 +111,10 @@ class ProviderStack(TerraformStack):
         edge.RequiredAttributeResource(self, "reqFull",
             bool=provider_full.reqbool,
             num=provider_full.reqnum,
-            str=provider_full.reqstr
+            str=provider_full.reqstr,
+            str_list=[provider_full.reqstr],
+            num_list=[provider_full.reqnum],
+            bool_list=[provider_full.reqbool]
         )
 
         edge.OptionalAttributeResource(self, "optFull",

--- a/test/python/edge/test.ts
+++ b/test/python/edge/test.ts
@@ -58,6 +58,15 @@ describe("full integration test", () => {
       expect(stack.byId("plain").bool).toEqual(
         "${optional_attribute_resource.test.bool}"
       );
+      expect(stack.byId("plain").strList).toEqual(
+        "${optional_attribute_resource.test.strList}"
+      );
+      expect(stack.byId("plain").numList).toEqual(
+        "${optional_attribute_resource.test.numList}"
+      );
+      expect(stack.byId("plain").boolList).toEqual(
+        "${optional_attribute_resource.test.boolList}"
+      );
     });
 
     it("item references a required single item lists required values", () => {
@@ -72,6 +81,15 @@ describe("full integration test", () => {
       expect(item.num).toEqual(
         "${list_block_resource.list.singlereq[0].reqnum}"
       );
+      expect(item.boolList).toEqual([
+        "${list_block_resource.list.singlereq[0].reqbool}",
+      ]);
+      expect(item.strList).toEqual([
+        "${list_block_resource.list.singlereq[0].reqstr}",
+      ]);
+      expect(item.numList).toEqual([
+        "${list_block_resource.list.singlereq[0].reqnum}",
+      ]);
     });
 
     it.skip("item references required values from multi-item lists", () => {
@@ -87,6 +105,15 @@ describe("full integration test", () => {
       expect(item.num).toEqual(
         '${lookup(element(list_block_resource.list.req, 0), "reqnum", 0)}'
       );
+      expect(item.boolList).toEqual([
+        '${lookup(element(list_block_resource.list.req, 0), "reqbool", false)}',
+      ]);
+      expect(item.strList).toEqual([
+        '${lookup(element(list_block_resource.list.req, 0), "reqstr", "fallback")}',
+      ]);
+      expect(item.numList).toEqual([
+        '${lookup(element(list_block_resource.list.req, 0), "reqnum", 0)}',
+      ]);
     });
 
     it.skip("item references a required single item list", () => {

--- a/test/typescript/edge/main.ts
+++ b/test/typescript/edge/main.ts
@@ -26,6 +26,9 @@ export class ReferenceStack extends TerraformStack {
       bool: res.bool,
       str: res.str,
       num: res.num,
+      strList: res.strList,
+      numList: res.numList,
+      boolList: res.boolList,
     });
 
     // required values FROM required single item lists
@@ -33,6 +36,9 @@ export class ReferenceStack extends TerraformStack {
       bool: list.singlereq.reqbool,
       str: list.singlereq.reqstr,
       num: list.singlereq.reqnum,
+      strList: [list.singlereq.reqstr],
+      numList: [list.singlereq.reqnum],
+      boolList: [list.singlereq.reqbool],
     });
 
     // required values FROM required multi item lists
@@ -40,6 +46,9 @@ export class ReferenceStack extends TerraformStack {
       bool: Fn.lookup(Fn.element(list.req, 0), "reqbool", false),
       str: Fn.lookup(Fn.element(list.req, 0), "reqstr", "fallback"),
       num: Fn.lookup(Fn.element(list.req, 0), "reqnum", 0),
+      strList: [Fn.lookup(Fn.element(list.req, 0), "reqstr", "fallback")],
+      numList: [Fn.lookup(Fn.element(list.req, 0), "reqnum", 0)],
+      boolList: [Fn.lookup(Fn.element(list.req, 0), "reqbool", false)],
     });
 
     // passing a reference to a complete list
@@ -84,6 +93,9 @@ export class ProviderStack extends TerraformStack {
       bool: providerOpt.reqbool!,
       num: providerOpt.reqnum!,
       str: providerOpt.reqstr!,
+      strList: [providerOpt.reqstr!],
+      numList: [providerOpt.reqnum!],
+      boolList: [providerOpt.reqbool!],
     });
 
     new edge.OptionalAttributeResource(this, "optOpt", {
@@ -102,6 +114,9 @@ export class ProviderStack extends TerraformStack {
       bool: providerFull.reqbool!,
       num: providerFull.reqnum!,
       str: providerFull.reqstr!,
+      strList: [providerFull.reqstr!],
+      numList: [providerFull.reqnum!],
+      boolList: [providerFull.reqbool!],
     });
 
     new edge.OptionalAttributeResource(this, "optFull", {

--- a/test/typescript/edge/test.ts
+++ b/test/typescript/edge/test.ts
@@ -82,15 +82,15 @@ describe("edge provider test", () => {
       expect(item.num).toEqual(
         "${list_block_resource.list.singlereq[0].reqnum}"
       );
-      expect(item.boolList).toEqual(
-        "[${list_block_resource.list.singlereq[0].reqbool}]"
-      );
-      expect(item.strList).toEqual(
-        "[${list_block_resource.list.singlereq[0].reqstr}]"
-      );
-      expect(item.numList).toEqual(
-        "[${list_block_resource.list.singlereq[0].reqnum}]"
-      );
+      expect(item.boolList).toEqual([
+        "${list_block_resource.list.singlereq[0].reqbool}",
+      ]);
+      expect(item.strList).toEqual([
+        "${list_block_resource.list.singlereq[0].reqstr}",
+      ]);
+      expect(item.numList).toEqual([
+        "${list_block_resource.list.singlereq[0].reqnum}",
+      ]);
     });
 
     it("item references required values from multi-item lists", () => {
@@ -106,15 +106,15 @@ describe("edge provider test", () => {
       expect(item.num).toEqual(
         '${lookup(element(list_block_resource.list.req, 0), "reqnum", 0)}'
       );
-      expect(item.boolList).toEqual(
-        '[${lookup(element(list_block_resource.list.req, 0), "reqbool", false)}]'
-      );
-      expect(item.strList).toEqual(
-        '[${lookup(element(list_block_resource.list.req, 0), "reqstr", "fallback")}]'
-      );
-      expect(item.numList).toEqual(
-        '[${lookup(element(list_block_resource.list.req, 0), "reqnum", 0)}]'
-      );
+      expect(item.boolList).toEqual([
+        '${lookup(element(list_block_resource.list.req, 0), "reqbool", false)}',
+      ]);
+      expect(item.strList).toEqual([
+        '${lookup(element(list_block_resource.list.req, 0), "reqstr", "fallback")}',
+      ]);
+      expect(item.numList).toEqual([
+        '${lookup(element(list_block_resource.list.req, 0), "reqnum", 0)}',
+      ]);
     });
 
     it("item references a required single item list", () => {

--- a/test/typescript/edge/test.ts
+++ b/test/typescript/edge/test.ts
@@ -59,6 +59,15 @@ describe("edge provider test", () => {
       expect(stack.byId("plain").bool).toEqual(
         "${optional_attribute_resource.test.bool}"
       );
+      expect(stack.byId("plain").strList).toEqual(
+        "${optional_attribute_resource.test.strList}"
+      );
+      expect(stack.byId("plain").numList).toEqual(
+        "${optional_attribute_resource.test.numList}"
+      );
+      expect(stack.byId("plain").boolList).toEqual(
+        "${optional_attribute_resource.test.boolList}"
+      );
     });
 
     it("item references a required single item lists required values", () => {
@@ -72,6 +81,15 @@ describe("edge provider test", () => {
       );
       expect(item.num).toEqual(
         "${list_block_resource.list.singlereq[0].reqnum}"
+      );
+      expect(item.boolList).toEqual(
+        "[${list_block_resource.list.singlereq[0].reqbool}]"
+      );
+      expect(item.strList).toEqual(
+        "[${list_block_resource.list.singlereq[0].reqstr}]"
+      );
+      expect(item.numList).toEqual(
+        "[${list_block_resource.list.singlereq[0].reqnum}]"
       );
     });
 
@@ -87,6 +105,15 @@ describe("edge provider test", () => {
       );
       expect(item.num).toEqual(
         '${lookup(element(list_block_resource.list.req, 0), "reqnum", 0)}'
+      );
+      expect(item.boolList).toEqual(
+        '[${lookup(element(list_block_resource.list.req, 0), "reqbool", false)}]'
+      );
+      expect(item.strList).toEqual(
+        '[${lookup(element(list_block_resource.list.req, 0), "reqstr", "fallback")}]'
+      );
+      expect(item.numList).toEqual(
+        '[${lookup(element(list_block_resource.list.req, 0), "reqnum", 0)}]'
       );
     });
 


### PR DESCRIPTION
Dividing up #1299, adding token support for `number[]`.

Combines the concepts from `number` and `string[]` tokens by using a single element array using a subset of the available bits as a marker for the token.