### PR TITLE
feat(lib): Create assets for local modules

### DIFF
--- a/packages/cdktf/lib/terraform-module.ts
+++ b/packages/cdktf/lib/terraform-module.ts
@@ -4,9 +4,9 @@ import { TerraformProvider } from "./terraform-provider";
 import { deepMerge } from "./util";
 import { ITerraformDependable } from "./terraform-dependable";
 import { Token } from "./tokens";
-import * as path from "path";
 import { ref } from "./tfExpression";
 import { TokenMap } from "./tokens/private/token-map";
+import { TerraformAsset } from "./terraform-asset";
 
 export interface TerraformModuleOptions {
   readonly source: string;
@@ -33,7 +33,13 @@ export abstract class TerraformModule
     super(scope, id);
 
     if (options.source.startsWith("./") || options.source.startsWith("../")) {
-      this.source = path.join("../../..", options.source);
+      // Create an asset for the local module for better TFC support
+      const asset = new TerraformAsset(scope, `local-module-${id}`, {
+        path: options.source,
+      });
+
+      // Despite being a relative path already, further indicate it as such for Terraform handling
+      this.source = `./${asset.path}`;
     } else {
       this.source = options.source;
     }


### PR DESCRIPTION
Automatically create a `TerraformAsset` for any local module as specified in https://github.com/hashicorp/terraform-cdk/issues/664#issuecomment-831092035 and #948

Closes #946 (Really already fixed)
Supersedes #961

Draft since need to update some tests