### PR TITLE
feat(tests): add test which confirms that modules now support sets

### DIFF
--- a/test/typescript/modules/__snapshots__/test.ts.snap
+++ b/test/typescript/modules/__snapshots__/test.ts.snap
@@ -38,7 +38,11 @@ exports[`full integration test build modules posix 1`] = `
           \\"uniqueId\\": \\"localmodule\\"
         }
       },
-      \\"source\\": \\"./assets/localmodulelocalmodule/97F51B069A2EA5F1B6BA8B6C0FED84E4\\"
+      \\"set\\": [
+        \\"test\\",
+        \\"sets\\"
+      ],
+      \\"source\\": \\"./assets/localmodulelocalmodule/D2650B692714A27106B347431A9F0397\\"
     }
   },
   \\"terraform\\": {

--- a/test/typescript/modules/local-module/main.tf
+++ b/test/typescript/modules/local-module/main.tf
@@ -4,6 +4,11 @@ variable "enabled" {
   default     = true
 }
 
+variable "set" {
+  description = "Making sure bindings can be created for modules using the set type"
+  type = set(string)
+}
+
 output "create_cmd_bin" {
   description = "The full bin path & command used on create"
   value       = "foo"

--- a/test/typescript/modules/main.ts
+++ b/test/typescript/modules/main.ts
@@ -11,7 +11,9 @@ export class HelloTerra extends TerraformStack {
       path: "terraform.tfstate",
     });
 
-    new OurLocalModule(this, "local-module", {});
+    new OurLocalModule(this, "local-module", {
+      set: ["test", "sets"],
+    });
     new Gcloud(this, "gcloud", {});
     new IamAccount(this, "iam", {
       accountAlias: "cdktf",


### PR DESCRIPTION
#1415 already enabled support for `set` types in modules (by treating them as arrays, which works as Terraform represents sets as arrays as well).

This test confirms that we render set types as arrays and thereby closes #928