### PR TITLE
fix(cli): Fix template for Go not adding jsii import when using Terraform Cloud

### DIFF
--- a/packages/cdktf-cli/templates/go/.hooks.sscaff.js
+++ b/packages/cdktf-cli/templates/go/.hooks.sscaff.js
@@ -56,5 +56,8 @@ function terraformCloudConfig(baseName, organizationName, workspaceName) {
 		Workspaces:   cdktf.NewNamedRemoteWorkspace(jsii.String("${workspaceName}")),
 	})`);
 
+  // add import for jsii helper used above
+  result = result.replace(`"github.com/aws/constructs-go/constructs/v10"`, `"github.com/aws/constructs-go/constructs/v10"\n	"github.com/aws/jsii-runtime-go"`);
+
   writeFileSync('./main.go', result, 'utf-8');
 }


### PR DESCRIPTION
Resolves #1505
