### PR TITLE
fix: stringValue rated valid strings as unescaped double quotes

### DIFF
--- a/packages/cdktf/lib/terraform-functions.ts
+++ b/packages/cdktf/lib/terraform-functions.ts
@@ -13,7 +13,7 @@ type TFValueValidator = (value: any) => TFValue;
 type ExecutableTfFunction = (...args: any[]) => IResolvable;
 
 function hasUnescapedDoubleQuotes(str: string) {
-  return /\\([\s\S])|(")/.test(str);
+  return /(^|[^\\])([\\]{2})*"/.test(str);
 }
 
 // Validators


### PR DESCRIPTION
Hey there, 👋

we had problems regarding the double quote escape check when giving a windows-like path to `Fn.templatefile()`. Interestingly, there wasn't even a double quote in the string: `C:\\Users\\someuser\\somepath`

I'm not sure I completely understand the logic behind hasUnescapedDoubleQuotes, but I created a different attempt at the regex:
* takes escaped backslashes into consideration (infinitely)
* Takes begin-of-file into consideration

I also added a few more tests regarding this. My tests are more dynamic and since I tried to stick with your current testing layout, I had to use some replaces to modify the expected value.