### PR TITLE
fix(tests): Windows needs special docker host override to work

### DIFF
--- a/packages/cdktf/test/helper/provider.ts
+++ b/packages/cdktf/test/helper/provider.ts
@@ -57,5 +57,10 @@ export class DockerProvider extends TerraformProvider {
       },
       terraformProviderSource: "kreuzwerker/docker",
     });
+
+    // Windows needs the special docker host configuration to work
+    if (process.platform === "win32") {
+      this.addOverride("host", "npipe:////.//pipe//docker_engine");
+    }
   }
 }


### PR DESCRIPTION
Hey there, 👋

this is a little addition to the test helper, adding `npipe:////.//pipe//docker_engine` as host for the docker provider, if the tests are run on windows.

It is a workaround mentioned here: https://github.com/hashicorp/terraform-provider-docker/issues/180#issuecomment-579144846