### PR TITLE
chore(provider-generator): Include Provider Version in Generated Bindings

### DIFF
--- a/packages/@cdktf/provider-generator/lib/__tests__/__snapshots__/edge-provider-schema.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/__tests__/__snapshots__/edge-provider-schema.test.ts.snap
@@ -79,8 +79,7 @@ export class EdgeProvider extends cdktf.TerraformProvider {
     super(scope, id, {
       terraformResourceType: 'edge',
       terraformGeneratorMetadata: {
-        providerName: 'edge',
-        providerVersionConstraint: 'undefined'
+        providerName: 'edge'
       },
       terraformProviderSource: 'undefined'
     });

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/__snapshots__/read-schema.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/__snapshots__/read-schema.test.ts.snap
@@ -674,6 +674,9 @@ Object {
         }
       }
     }
+  },
+  "provider_versions": {
+    "registry.terraform.io/hashicorp/null": "3.1.0"
   }
 },
 }

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/provider.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/provider.test.ts.snap
@@ -1185,8 +1185,7 @@ export class AwsProvider extends cdktf.TerraformProvider {
     super(scope, id, {
       terraformResourceType: 'aws',
       terraformGeneratorMetadata: {
-        providerName: 'aws',
-        providerVersionConstraint: 'undefined'
+        providerName: 'aws'
       },
       terraformProviderSource: 'undefined'
     });

--- a/packages/@cdktf/provider-generator/lib/get/generator/emitter/resource-emitter.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/emitter/resource-emitter.ts
@@ -118,9 +118,7 @@ export class ResourceEmitter {
     this.code.line(
       `terraformResourceType: '${resource.terraformResourceType}',`
     );
-    this.code.open(`terraformGeneratorMetadata: {`);
-    this.code.line(`providerName: '${resource.provider}'`);
-    this.code.close(`},`);
+    this.emitTerraformGeneratorMetadata(resource);
     this.code.line(`provider: config.provider,`);
     this.code.line(`dependsOn: config.dependsOn,`);
     this.code.line(`count: config.count,`);
@@ -133,15 +131,37 @@ export class ResourceEmitter {
     this.code.line(
       `terraformResourceType: '${resource.terraformResourceType}',`
     );
-    this.code.open(`terraformGeneratorMetadata: {`);
-    this.code.line(`providerName: '${resource.provider}',`);
-    this.code.line(
-      `providerVersionConstraint: '${resource.providerVersionConstraint}'`
-    );
-    this.code.close(`},`);
+    this.emitTerraformGeneratorMetadata(resource);
     this.code.line(
       `terraformProviderSource: '${resource.terraformProviderSource}'`
     );
     this.code.close(`});`);
+  }
+
+  private emitTerraformGeneratorMetadata(resource: ResourceModel) {
+    this.code.open(`terraformGeneratorMetadata: {`);
+    this.code.line(
+      `providerName: '${resource.provider}'${
+        resource.providerVersion || resource.providerVersionConstraint
+          ? ","
+          : ""
+      }`
+    );
+
+    if (resource.providerVersion) {
+      this.code.line(
+        `providerVersion: '${resource.providerVersion}'${
+          resource.providerVersionConstraint ? "," : ""
+        }`
+      );
+    }
+
+    if (resource.providerVersionConstraint) {
+      this.code.line(
+        `providerVersionConstraint: '${resource.providerVersionConstraint}'`
+      );
+    }
+
+    this.code.close(`},`);
   }
 }

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/resource-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/resource-model.ts
@@ -31,6 +31,7 @@ export class ResourceModel {
   public baseName: string;
   public provider: string;
   public providerVersionConstraint?: string;
+  public providerVersion?: string;
   public terraformProviderSource?: string;
   public fileName: string;
   public attributes: AttributeModel[];

--- a/packages/@cdktf/provider-generator/lib/get/generator/provider-generator.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/provider-generator.ts
@@ -55,7 +55,9 @@ export class TerraformProviderGenerator {
     }
 
     for (const [fqpn, provider] of Object.entries(schema.provider_schemas)) {
-      const providerVersion = schema.provider_versions?.fqpn;
+      const providerVersion = schema.provider_versions
+        ? schema.provider_versions[fqpn]
+        : undefined;
 
       if (
         this.providerConstraints &&

--- a/packages/@cdktf/provider-generator/lib/get/generator/provider-generator.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/provider-generator.ts
@@ -55,13 +55,15 @@ export class TerraformProviderGenerator {
     }
 
     for (const [fqpn, provider] of Object.entries(schema.provider_schemas)) {
+      const providerVersion = schema.provider_versions?.fqpn;
+
       if (
         this.providerConstraints &&
         this.providerConstraints.find((p) => isMatching(p, fqpn))
       ) {
-        this.emitProvider(fqpn, provider);
+        this.emitProvider(fqpn, provider, providerVersion);
       } else if (!this.providerConstraints) {
-        this.emitProvider(fqpn, provider);
+        this.emitProvider(fqpn, provider, providerVersion);
       }
     }
   }
@@ -70,10 +72,22 @@ export class TerraformProviderGenerator {
     await this.code.save(outdir);
   }
 
-  private emitProvider(fqpn: string, provider: Provider) {
+  private emitProvider(
+    fqpn: string,
+    provider: Provider,
+    providerVersion?: string
+  ) {
     const name = fqpn.split("/").pop();
     if (!name) {
       throw new Error(`can't handle ${fqpn}`);
+    }
+
+    let constraint: ConstructsMakerTarget | undefined;
+    if (this.providerConstraints) {
+      constraint = this.providerConstraints.find((p) => isMatching(p, fqpn));
+      if (!constraint) {
+        throw new Error(`can't handle ${fqpn}`);
+      }
     }
 
     const resourceModels: ResourceModel[] = [];
@@ -96,6 +110,12 @@ export class TerraformProviderGenerator {
     const namespacedResources: Record<NamespaceName, ResourceModel[]> = {};
     const files: string[] = [];
     resourceModels.forEach((resourceModel) => {
+      if (constraint) {
+        resourceModel.providerVersionConstraint = constraint.version;
+        resourceModel.terraformProviderSource = constraint.source;
+      }
+      resourceModel.providerVersion = providerVersion;
+
       if (resourceModel.namespace) {
         const namespace = resourceModel.namespace.name;
         if (!namespacedResources[namespace]) {
@@ -120,16 +140,11 @@ export class TerraformProviderGenerator {
         provider.provider,
         "provider"
       );
-      if (this.providerConstraints) {
-        const constraint = this.providerConstraints.find((p) =>
-          isMatching(p, fqpn)
-        );
-        if (!constraint) {
-          throw new Error(`can't handle ${fqpn}`);
-        }
+      if (constraint) {
         providerResource.providerVersionConstraint = constraint.version;
         providerResource.terraformProviderSource = constraint.source;
       }
+      providerResource.providerVersion = providerVersion;
       files.push(this.emitResourceFile(providerResource));
     }
 

--- a/packages/cdktf/lib/terraform-provider.ts
+++ b/packages/cdktf/lib/terraform-provider.ts
@@ -55,7 +55,9 @@ export abstract class TerraformProvider extends TerraformElement {
       terraform: {
         required_providers: {
           [this.terraformResourceType]: {
-            version: this.terraformGeneratorMetadata?.providerVersionConstraint,
+            version:
+              this.terraformGeneratorMetadata?.providerVersion ||
+              this.terraformGeneratorMetadata?.providerVersionConstraint, // fallback to previous to ease transition
             source: this.terraformProviderSource,
           },
         },

--- a/packages/cdktf/lib/terraform-resource.ts
+++ b/packages/cdktf/lib/terraform-resource.ts
@@ -37,6 +37,7 @@ export interface TerraformMetaArguments {
 export interface TerraformProviderGeneratorMetadata {
   readonly providerName: string;
   readonly providerVersionConstraint?: string;
+  readonly providerVersion?: string;
 }
 
 export interface TerraformResourceConfig extends TerraformMetaArguments {

--- a/test/csharp/synth-app/__snapshots__/test.ts.snap
+++ b/test/csharp/synth-app/__snapshots__/test.ts.snap
@@ -36,7 +36,7 @@ exports[`csharp full integration test synth synth generates JSON 1`] = `
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"hashicorp/null\\",
-        \\"version\\": \\"3.1.0\\"
+        \\"version\\": \\"3.1.1\\"
       }
     }
   }

--- a/test/csharp/synth-app/__snapshots__/test.ts.snap
+++ b/test/csharp/synth-app/__snapshots__/test.ts.snap
@@ -36,7 +36,7 @@ exports[`csharp full integration test synth synth generates JSON 1`] = `
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"hashicorp/null\\",
-        \\"version\\": \\"~> 3.1.0\\"
+        \\"version\\": \\"3.1.0\\"
       }
     }
   }

--- a/test/go/synth-app/__snapshots__/test.ts.snap
+++ b/test/go/synth-app/__snapshots__/test.ts.snap
@@ -37,7 +37,7 @@ exports[`Go full integration test synth synth generates JSON 1`] = `
     \\"required_providers\\": {
       \\"random\\": {
         \\"source\\": \\"hashicorp/random\\",
-        \\"version\\": \\"3.1.0\\"
+        \\"version\\": \\"3.1.2\\"
       }
     }
   }

--- a/test/go/synth-app/__snapshots__/test.ts.snap
+++ b/test/go/synth-app/__snapshots__/test.ts.snap
@@ -37,7 +37,7 @@ exports[`Go full integration test synth synth generates JSON 1`] = `
     \\"required_providers\\": {
       \\"random\\": {
         \\"source\\": \\"hashicorp/random\\",
-        \\"version\\": \\"~> 3.1.0\\"
+        \\"version\\": \\"3.1.0\\"
       }
     }
   }

--- a/test/java/synth-app/__snapshots__/test.ts.snap
+++ b/test/java/synth-app/__snapshots__/test.ts.snap
@@ -50,11 +50,11 @@ exports[`java full integration synth generates JSON 1`] = `
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"hashicorp/null\\",
-        \\"version\\": \\"~> 3.1.0\\"
+        \\"version\\": \\"3.1.0\\"
       },
       \\"random\\": {
         \\"source\\": \\"hashicorp/random\\",
-        \\"version\\": \\"~> 3.1.0\\"
+        \\"version\\": \\"3.1.0\\"
       }
     }
   }

--- a/test/java/synth-app/__snapshots__/test.ts.snap
+++ b/test/java/synth-app/__snapshots__/test.ts.snap
@@ -50,11 +50,11 @@ exports[`java full integration synth generates JSON 1`] = `
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"hashicorp/null\\",
-        \\"version\\": \\"3.1.0\\"
+        \\"version\\": \\"3.1.1\\"
       },
       \\"random\\": {
         \\"source\\": \\"hashicorp/random\\",
-        \\"version\\": \\"3.1.0\\"
+        \\"version\\": \\"3.1.2\\"
       }
     }
   }

--- a/test/python/asset/__snapshots__/test.ts.snap
+++ b/test/python/asset/__snapshots__/test.ts.snap
@@ -49,7 +49,7 @@ exports[`python full integration test assets synth generates JSON and copies fil
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"hashicorp/null\\",
-        \\"version\\": \\"~> 3.1.0\\"
+        \\"version\\": \\"3.1.0\\"
       }
     }
   }

--- a/test/python/asset/__snapshots__/test.ts.snap
+++ b/test/python/asset/__snapshots__/test.ts.snap
@@ -49,7 +49,7 @@ exports[`python full integration test assets synth generates JSON and copies fil
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"hashicorp/null\\",
-        \\"version\\": \\"3.1.0\\"
+        \\"version\\": \\"3.1.1\\"
       }
     }
   }

--- a/test/python/multiple-stacks/__snapshots__/test.ts.snap
+++ b/test/python/multiple-stacks/__snapshots__/test.ts.snap
@@ -36,7 +36,7 @@ exports[`python full integration test synth synth generates JSON for both stacks
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"hashicorp/null\\",
-        \\"version\\": \\"3.1.0\\"
+        \\"version\\": \\"3.1.1\\"
       }
     }
   }
@@ -79,7 +79,7 @@ exports[`python full integration test synth synth generates JSON for both stacks
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"hashicorp/null\\",
-        \\"version\\": \\"3.1.0\\"
+        \\"version\\": \\"3.1.1\\"
       }
     }
   }

--- a/test/python/multiple-stacks/__snapshots__/test.ts.snap
+++ b/test/python/multiple-stacks/__snapshots__/test.ts.snap
@@ -36,7 +36,7 @@ exports[`python full integration test synth synth generates JSON for both stacks
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"hashicorp/null\\",
-        \\"version\\": \\"~> 3.1.0\\"
+        \\"version\\": \\"3.1.0\\"
       }
     }
   }
@@ -79,7 +79,7 @@ exports[`python full integration test synth synth generates JSON for both stacks
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"hashicorp/null\\",
-        \\"version\\": \\"~> 3.1.0\\"
+        \\"version\\": \\"3.1.0\\"
       }
     }
   }

--- a/test/python/providers/__snapshots__/test.ts.snap
+++ b/test/python/providers/__snapshots__/test.ts.snap
@@ -66,7 +66,7 @@ exports[`python full integration 3rd party synth generates JSON 1`] = `
     \\"required_providers\\": {
       \\"docker\\": {
         \\"source\\": \\"kreuzwerker/docker\\",
-        \\"version\\": \\"~> 2.15\\"
+        \\"version\\": \\"2.16.0\\"
       }
     }
   }

--- a/test/python/synth-app/__snapshots__/test.ts.snap
+++ b/test/python/synth-app/__snapshots__/test.ts.snap
@@ -53,7 +53,7 @@ exports[`python full integration test synth synth generates JSON 1`] = `
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"hashicorp/null\\",
-        \\"version\\": \\"~> 3.1.0\\"
+        \\"version\\": \\"3.1.0\\"
       }
     }
   }

--- a/test/python/synth-app/__snapshots__/test.ts.snap
+++ b/test/python/synth-app/__snapshots__/test.ts.snap
@@ -53,7 +53,7 @@ exports[`python full integration test synth synth generates JSON 1`] = `
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"hashicorp/null\\",
-        \\"version\\": \\"3.1.0\\"
+        \\"version\\": \\"3.1.1\\"
       }
     }
   }

--- a/test/python/terraform-functions/__snapshots__/test.ts.snap
+++ b/test/python/terraform-functions/__snapshots__/test.ts.snap
@@ -62,7 +62,7 @@ exports[`python terraform functions test synth synth generates JSON 1`] = `
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"hashicorp/null\\",
-        \\"version\\": \\"~> 3.1.0\\"
+        \\"version\\": \\"3.1.0\\"
       }
     }
   }

--- a/test/python/terraform-functions/__snapshots__/test.ts.snap
+++ b/test/python/terraform-functions/__snapshots__/test.ts.snap
@@ -62,7 +62,7 @@ exports[`python terraform functions test synth synth generates JSON 1`] = `
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"hashicorp/null\\",
-        \\"version\\": \\"3.1.0\\"
+        \\"version\\": \\"3.1.1\\"
       }
     }
   }

--- a/test/typescript/feature-flags/__snapshots__/test.ts.snap
+++ b/test/typescript/feature-flags/__snapshots__/test.ts.snap
@@ -49,8 +49,7 @@ exports[`full integration test with allowSepCharsInLogicalIds feature 1`] = `
     },
     \\"required_providers\\": {
       \\"null\\": {
-        \\"source\\": \\"null\\",
-        \\"version\\": \\"undefined\\"
+        \\"source\\": \\"null\\"
       }
     }
   }
@@ -106,8 +105,7 @@ exports[`full integration test with excludeStackIdFromLogicalIds feature 1`] = `
     },
     \\"required_providers\\": {
       \\"null\\": {
-        \\"source\\": \\"null\\",
-        \\"version\\": \\"undefined\\"
+        \\"source\\": \\"null\\"
       }
     }
   }
@@ -163,8 +161,7 @@ exports[`full integration test without features 1`] = `
     },
     \\"required_providers\\": {
       \\"null\\": {
-        \\"source\\": \\"null\\",
-        \\"version\\": \\"undefined\\"
+        \\"source\\": \\"null\\"
       }
     }
   }

--- a/test/typescript/feature-flags/__snapshots__/test.ts.snap
+++ b/test/typescript/feature-flags/__snapshots__/test.ts.snap
@@ -50,7 +50,7 @@ exports[`full integration test with allowSepCharsInLogicalIds feature 1`] = `
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"null\\",
-        \\"version\\": \\"3.1.0\\"
+        \\"version\\": \\"3.1.1\\"
       }
     }
   }
@@ -107,7 +107,7 @@ exports[`full integration test with excludeStackIdFromLogicalIds feature 1`] = `
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"null\\",
-        \\"version\\": \\"3.1.0\\"
+        \\"version\\": \\"3.1.1\\"
       }
     }
   }
@@ -164,7 +164,7 @@ exports[`full integration test without features 1`] = `
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"null\\",
-        \\"version\\": \\"3.1.0\\"
+        \\"version\\": \\"3.1.1\\"
       }
     }
   }

--- a/test/typescript/feature-flags/__snapshots__/test.ts.snap
+++ b/test/typescript/feature-flags/__snapshots__/test.ts.snap
@@ -49,7 +49,8 @@ exports[`full integration test with allowSepCharsInLogicalIds feature 1`] = `
     },
     \\"required_providers\\": {
       \\"null\\": {
-        \\"source\\": \\"null\\"
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"3.1.0\\"
       }
     }
   }
@@ -105,7 +106,8 @@ exports[`full integration test with excludeStackIdFromLogicalIds feature 1`] = `
     },
     \\"required_providers\\": {
       \\"null\\": {
-        \\"source\\": \\"null\\"
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"3.1.0\\"
       }
     }
   }
@@ -161,7 +163,8 @@ exports[`full integration test without features 1`] = `
     },
     \\"required_providers\\": {
       \\"null\\": {
-        \\"source\\": \\"null\\"
+        \\"source\\": \\"null\\",
+        \\"version\\": \\"3.1.0\\"
       }
     }
   }

--- a/test/typescript/multiple-stacks/__snapshots__/test.ts.snap
+++ b/test/typescript/multiple-stacks/__snapshots__/test.ts.snap
@@ -57,7 +57,7 @@ exports[`multiple stacks CLI-driven workflow synth 1`] = `
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"null\\",
-        \\"version\\": \\" ~> 3.1.0\\"
+        \\"version\\": \\"3.1.0\\"
       }
     }
   }
@@ -121,7 +121,7 @@ exports[`multiple stacks CLI-driven workflow synth 2`] = `
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"null\\",
-        \\"version\\": \\" ~> 3.1.0\\"
+        \\"version\\": \\"3.1.0\\"
       }
     }
   }

--- a/test/typescript/multiple-stacks/__snapshots__/test.ts.snap
+++ b/test/typescript/multiple-stacks/__snapshots__/test.ts.snap
@@ -57,7 +57,7 @@ exports[`multiple stacks CLI-driven workflow synth 1`] = `
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"null\\",
-        \\"version\\": \\"3.1.0\\"
+        \\"version\\": \\"3.1.1\\"
       }
     }
   }
@@ -121,7 +121,7 @@ exports[`multiple stacks CLI-driven workflow synth 2`] = `
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"null\\",
-        \\"version\\": \\"3.1.0\\"
+        \\"version\\": \\"3.1.1\\"
       }
     }
   }

--- a/test/typescript/synth-app/__snapshots__/test.ts.snap
+++ b/test/typescript/synth-app/__snapshots__/test.ts.snap
@@ -169,7 +169,7 @@ exports[`full integration test synth synth generates JSON 1`] = `
     \\"required_providers\\": {
       \\"aws\\": {
         \\"source\\": \\"aws\\",
-        \\"version\\": \\"~> 2.0\\"
+        \\"version\\": \\"2.70.1\\"
       }
     }
   }


### PR DESCRIPTION
Fixes #684
Fixes #228
Fixes #318
Fixes #43

The exact version of the resolved provider is now recorded as metadata for the generated provider and resources. For the provider, this exact version is used in `required_providers` block to ensure a consistent experience and give users more control over the provider version used.

Also omitting version constraints when either is undefined.