### PR TITLE
fix(lib): check for null objects and don't try to reverse undefined or null

### DIFF
--- a/packages/cdktf/lib/tfExpression.ts
+++ b/packages/cdktf/lib/tfExpression.ts
@@ -24,7 +24,7 @@ class TFExpression extends Intrinsic implements IResolvable {
         .join(", ")}]`;
     }
 
-    if (typeof resolvedArg === "object") {
+    if (typeof resolvedArg === "object" && resolvedArg !== null) {
       return `{${Object.keys(resolvedArg)
         .map((key) => `${key} = ${this.resolveArg(context, arg[key])}`)
         .join(", ")}}`;
@@ -185,7 +185,7 @@ function markAsInner(arg: any) {
     }
   });
 
-  if (typeof arg === "object") {
+  if (typeof arg === "object" && arg !== null) {
     if (Array.isArray(arg)) {
       arg.forEach(markAsInner);
     } else {

--- a/packages/cdktf/lib/tokens/token.ts
+++ b/packages/cdktf/lib/tokens/token.ts
@@ -190,9 +190,12 @@ export class Tokenization {
       const reversedNumber = Tokenization.reverseNumber(x);
       return reversedNumber ? [reversedNumber] : [];
     }
+    if (typeof x === "object" && x !== null) {
+      const reversedMap = Tokenization.reverseMap(x);
+      return reversedMap ? [reversedMap] : [];
+    }
 
-    const reversedMap = Tokenization.reverseMap(x);
-    return reversedMap ? [reversedMap] : [];
+    return []; // null or undefined cannot be reversed
   }
 
   /**

--- a/packages/cdktf/test/functions.test.ts
+++ b/packages/cdktf/test/functions.test.ts
@@ -423,6 +423,9 @@ test("undefined and null", () => {
   new TerraformOutput(stack, "test-output", {
     value: Fn.coalesce([null, local.asString, undefined, 42, false]),
   });
+  new TerraformOutput(stack, "json-object", {
+    value: Fn.jsonencode({ a: "hello", b: 123, c: null, d: undefined }),
+  });
 
   expect(Testing.synth(stack)).toMatchInlineSnapshot(`
     "{
@@ -430,6 +433,9 @@ test("undefined and null", () => {
         \\"value\\": \\"hello world\\"
       },
       \\"output\\": {
+        \\"json-object\\": {
+          \\"value\\": \\"\${jsonencode({a = \\\\\\"hello\\\\\\", b = 123, c = null})}\\"
+        },
         \\"test-output\\": {
           \\"value\\": \\"\${coalesce(local.value, 42, false)}\\"
         }


### PR DESCRIPTION
in JS typeof null === 'object' => true so we need an explicit check for null

also adds a testcase for this fix
