### PR TITLE
feat(cli): properly shutdown subprocesses on abort

### DIFF
--- a/packages/cdktf-cli/bin/cdktf
+++ b/packages/cdktf-cli/bin/cdktf
@@ -1,2 +1,2 @@
-#!/usr/bin/env node
-require('./cdktf.js');
+#!/usr/bin/env node --experimental-abortcontroller
+require("./cdktf.js");

--- a/packages/cdktf-cli/bin/cdktf
+++ b/packages/cdktf-cli/bin/cdktf
@@ -1,2 +1,2 @@
-#!/usr/bin/env node --experimental-abortcontroller
+#!/usr/bin/env node
 require("./cdktf.js");

--- a/packages/cdktf-cli/bin/cmds/helper/check-environment.ts
+++ b/packages/cdktf-cli/bin/cmds/helper/check-environment.ts
@@ -45,7 +45,7 @@ async function checkGoVersion() {
 
 async function checkNodeVersion() {
   const out = await getBinaryVersion("node", "--version");
-  throwIfLowerVersion("Node.js", "14.0.0", out);
+  throwIfLowerVersion("Node.js", "14.17.0", out);
 }
 
 export async function checkEnvironment(projectPath = process.cwd()) {

--- a/packages/cdktf-cli/bin/cmds/helper/terraform-check.ts
+++ b/packages/cdktf-cli/bin/cmds/helper/terraform-check.ts
@@ -29,7 +29,7 @@ export const terraformCheck = async (): Promise<void> => {
       dependencies: [],
     };
 
-    const terraform = new TerraformCli(fakeStack);
+    const terraform = new TerraformCli(new AbortController().signal, fakeStack);
 
     const terraformVersion = await terraform.version();
     const terraformVersionMatches = terraformVersion.match(VERSION_REGEXP);

--- a/packages/cdktf-cli/bin/cmds/helper/terraform-check.ts
+++ b/packages/cdktf-cli/bin/cmds/helper/terraform-check.ts
@@ -3,6 +3,7 @@ import * as semver from "semver";
 import { SynthesizedStack } from "../../../lib/synth-stack";
 import { existsSync } from "fs-extra";
 import * as path from "path";
+import { AbortController } from "node-abort-controller"; // polyfill until we update to node 14
 
 const MIN_SUPPORTED_VERSION = "0.13.0";
 const VERSION_REGEXP = /Terraform v\d+.\d+.\d+/;

--- a/packages/cdktf-cli/bin/cmds/ui/hooks/cdktf-project.ts
+++ b/packages/cdktf-cli/bin/cmds/ui/hooks/cdktf-project.ts
@@ -60,6 +60,13 @@ export function useCdktfProject<T>(
       },
     });
 
+    const onAbort = () => {
+      project.hardAbort();
+    };
+    process.on("SIGINT", onAbort);
+    process.on("SIGTERM", onAbort);
+    process.on("SIGQUIT", onAbort);
+
     projectCallback(project)
       .then((value) => {
         setReturnValue(value);

--- a/packages/cdktf-cli/lib/ambient.d.ts
+++ b/packages/cdktf-cli/lib/ambient.d.ts
@@ -1,2 +1,8 @@
 declare module '@skorfmann/ink-confirm-input';
 declare module '@npmcli/ci-detect';
+
+declare module 'child_process' {
+    interface SpawnOptions  {
+        signal?: AbortSignal;
+    }
+}

--- a/packages/cdktf-cli/lib/index.ts
+++ b/packages/cdktf-cli/lib/index.ts
@@ -110,7 +110,7 @@ export class CdktfProject {
     const ac = new AbortController();
     const abortSignal = ac.signal;
 
-    this.hardAbort = ac.abort;
+    this.hardAbort = ac.abort.bind(ac);
     this.stateMachine = interpret(
       projectExecutionMachine.withContext({
         synthCommand,

--- a/packages/cdktf-cli/lib/index.ts
+++ b/packages/cdktf-cli/lib/index.ts
@@ -5,6 +5,7 @@
 
 import { interpret, InterpreterFrom } from "xstate";
 import { Language } from "@cdktf/provider-generator";
+import { AbortController } from "node-abort-controller"; // polyfill until we update to node 16
 export { init, Project, InitArgs } from "./init";
 export { get, GetStatus } from "./get";
 import { SynthesizedStack } from "./synth-stack";

--- a/packages/cdktf-cli/lib/index.ts
+++ b/packages/cdktf-cli/lib/index.ts
@@ -90,6 +90,7 @@ export class CdktfProject {
   public outputs?: Record<string, any>;
   public outputsByConstructId?: NestedTerraformOutputs;
   public deployingResources?: DeployingResource[];
+  public hardAbort: () => void;
 
   constructor({
     synthCommand,
@@ -106,12 +107,17 @@ export class CdktfProject {
     autoApprove?: boolean;
     workingDirectory?: string;
   }) {
+    const ac = new AbortController();
+    const abortSignal = ac.signal;
+
+    this.hardAbort = ac.abort;
     this.stateMachine = interpret(
       projectExecutionMachine.withContext({
         synthCommand,
         outDir: outDir,
         autoApprove,
         workingDirectory,
+        abortSignal,
 
         onProgress: (event) => {
           switch (event.type) {

--- a/packages/cdktf-cli/lib/models/terraform-cloud.ts
+++ b/packages/cdktf-cli/lib/models/terraform-cloud.ts
@@ -114,6 +114,8 @@ export class TerraformCloud implements Terraform {
   public run?: TerraformCloudClient.Run;
 
   constructor(
+    // TODO: teach TerraformCloudClient abort signals
+    public readonly abortSignal: AbortSignal,
     public readonly stack: SynthesizedStack,
     public readonly config: TerraformJsonConfigBackendRemote,
     isSpeculative = false,

--- a/packages/cdktf-cli/lib/models/terraform-cloud.ts
+++ b/packages/cdktf-cli/lib/models/terraform-cloud.ts
@@ -114,7 +114,7 @@ export class TerraformCloud implements Terraform {
   public run?: TerraformCloudClient.Run;
 
   constructor(
-    // TODO: teach TerraformCloudClient abort signals
+    // TFC does not support abort yet: https://github.com/hashicorp/terraform-cdk/issues/1607
     public readonly abortSignal: AbortSignal,
     public readonly stack: SynthesizedStack,
     public readonly config: TerraformJsonConfigBackendRemote,

--- a/packages/cdktf-cli/lib/project-execution.ts
+++ b/packages/cdktf-cli/lib/project-execution.ts
@@ -1,6 +1,7 @@
 // Each action drives itself to completion and exposes updates to the user.
 
 import { assign, createMachine } from "xstate";
+import { AbortController } from "node-abort-controller"; // polyfill until we update to node 16
 import { SynthStack, SynthesizedStack } from "./synth-stack";
 import { Errors } from "./errors";
 import { TerraformJson } from "./terraform-json";

--- a/packages/cdktf-cli/lib/project-execution.ts
+++ b/packages/cdktf-cli/lib/project-execution.ts
@@ -61,6 +61,7 @@ export interface ProjectContext {
   outputs?: Record<string, any>;
   outputsByConstructId?: Record<string, any>;
   onProgress: (event: ProgressEvent) => void;
+  abortSignal: AbortSignal;
 }
 
 function extractError(_context: any, event: any): string {
@@ -132,6 +133,7 @@ function getLogCallbackForStack(
 }
 
 async function getTerraformClient(
+  abortSignal: AbortSignal,
   stack: SynthesizedStack,
   isSpeculative: boolean,
   sendLog: (stateName: string) => (message: string, isError?: boolean) => void
@@ -140,6 +142,7 @@ async function getTerraformClient(
 
   if (parsedStack.terraform?.backend?.remote) {
     const tfClient = new TerraformCloud(
+      abortSignal,
       stack,
       parsedStack.terraform.backend.remote,
       isSpeculative,
@@ -149,12 +152,13 @@ async function getTerraformClient(
       return tfClient;
     }
   }
-  return new TerraformCli(stack, sendLog);
+  return new TerraformCli(abortSignal, stack, sendLog);
 }
 
 const services = {
   synthProject: async (context: ProjectContext) => {
     const stacks = await SynthStack.synth(
+      context.abortSignal,
       context.synthCommand,
       context.outDir,
       context.workingDirectory
@@ -174,6 +178,7 @@ const services = {
       context.targetAction!
     );
     const terraform = await getTerraformClient(
+      context.abortSignal,
       stack,
       isSpeculative,
       getLogCallbackForStack(context)
@@ -286,6 +291,7 @@ const projectExecutionMachine = createMachine<ProjectContext, ProjectEvent>(
       synthCommand: "",
       workingDirectory: "",
       outDir: "",
+      abortSignal: new AbortController().signal,
     },
     states: {
       idle: {

--- a/packages/cdktf-cli/lib/server/WatchClient.ts
+++ b/packages/cdktf-cli/lib/server/WatchClient.ts
@@ -84,6 +84,8 @@ export class WatchClient {
 
   private sourceFileWatcher?: chokidar.FSWatcher;
   private outDirWatcher?: chokidar.FSWatcher;
+  private abortSignal: AbortSignal;
+  public abort: () => void;
 
   constructor(options: WatchClientOptions) {
     this.targetDir = options.targetDir;
@@ -95,6 +97,9 @@ export class WatchClient {
       );
     this.autoApprove = options.autoApprove;
     this.targetStack = options.targetStack;
+    const ac = new AbortController();
+    this.abortSignal = ac.signal;
+    this.abort = ac.abort;
   }
 
   public isRunning(): boolean {
@@ -120,6 +125,7 @@ export class WatchClient {
     try {
       const stacks = (
         await SynthStack.synth(
+          this.abortSignal,
           this.synthCommand,
           this.targetDir,
           process.cwd(),
@@ -244,9 +250,12 @@ export class WatchClient {
 
   // todo: optimization: cache instance as long as backend does not change
   private async getTerraform(): Promise<Terraform> {
+    // TOOD: implement abort properly for watch
+    const ac = new AbortController();
     const stack = await this.getTargetStack();
     if (stack.json.terraform?.backend?.remote) {
       const terraformCloud = new TerraformCloud(
+        ac.signal,
         stack as Stack,
         stack.json.terraform?.backend?.remote
       );
@@ -258,7 +267,7 @@ export class WatchClient {
         // return terraformCloud;
       }
     }
-    return new TerraformCli(stack as Stack);
+    return new TerraformCli(ac.signal, stack as Stack);
   }
 
   public async start() {

--- a/packages/cdktf-cli/lib/server/WatchClient.ts
+++ b/packages/cdktf-cli/lib/server/WatchClient.ts
@@ -1,6 +1,7 @@
 import * as chokidar from "chokidar";
 import { DeepReadonly } from "utility-types";
 import isDeepEqual from "lodash.isequal";
+import { AbortController } from "node-abort-controller"; // polyfill until we update to node 16
 import { SynthesizedStack, SynthStack } from "../synth-stack";
 import { DeployingResource, Terraform } from "../models/terraform";
 import { TerraformCli } from "../models/terraform-cli";

--- a/packages/cdktf-cli/lib/synth-stack.ts
+++ b/packages/cdktf-cli/lib/synth-stack.ts
@@ -26,6 +26,7 @@ type SynthOrigin = "watch";
 
 export class SynthStack {
   public static async synth(
+    abortSignal: AbortSignal,
     command: string,
     outdir: string,
     workingDirectory = process.cwd(),
@@ -57,6 +58,7 @@ export class SynthStack {
           CDKTF_CONTINUE_SYNTH_ON_ERROR_ANNOTATIONS: "true", // we want to display the errors ourselves
         },
         cwd: workingDirectory,
+        signal: abortSignal,
       });
     } catch (e) {
       const errorOutput = chalkColour`{redBright cdktf encountered an error while synthesizing}

--- a/packages/cdktf-cli/package.json
+++ b/packages/cdktf-cli/package.json
@@ -37,6 +37,7 @@
     "constructs": "^10.0.25",
     "jsii": "^1.54.0",
     "jsii-pacmak": "^1.54.0",
+    "node-abort-controller": "^3.0.1",
     "yargs": "^17.3"
   },
   "eslintConfig": {

--- a/packages/cdktf-cli/test/lib/project-execution.test.ts
+++ b/packages/cdktf-cli/test/lib/project-execution.test.ts
@@ -4,6 +4,7 @@ import {
   guards,
 } from "../../lib/project-execution";
 import { interpret } from "xstate";
+import { AbortController } from "node-abort-controller"; // polyfill until we update to node 16
 
 function mockAsyncFunction(returnValue: any) {
   return jest.fn(() => Promise.resolve(returnValue));

--- a/packages/cdktf-cli/test/lib/project-execution.test.ts
+++ b/packages/cdktf-cli/test/lib/project-execution.test.ts
@@ -21,9 +21,11 @@ function getStateMachine({
   autoApprove = guards.autoApprove,
   planNeedsNoApply = guards.planNeedsNoApply,
 }: Partial<StateMachineConfig>) {
+  const abort = new AbortController();
   const stateMachine = interpret(
     projectExecutionMachine
       .withContext({
+        abortSignal: abort.signal,
         onProgress: jest.fn(),
         synthCommand: "npx ts-node my-app.ts",
         outDir: "/tmp/cdktf-project/out",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8160,6 +8160,11 @@ nock@*, nock@^13.2.4:
     lodash.set "^4.3.2"
     propagate "^2.0.0"
 
+node-abort-controller@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-3.0.1.tgz#f91fa50b1dee3f909afabb7e261b1e1d6b0cb74e"
+  integrity sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw==
+
 node-fetch@2.6.7, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"


### PR DESCRIPTION
This PR ensures that when we receive a termination signal we stop all corresponding node processes. I'd consider it out of scope to stop / delete terraform cloud runs. I'm not even sure if stopping requests for TFC is worth it.

Closes #771

You can see in the watch tab below how the terraform apply command is aborted
![abort](https://user-images.githubusercontent.com/1337046/156396351-3c8a105b-2420-471c-8e44-bfb5c6858c69.gif)


Created https://github.com/hashicorp/terraform-cdk/issues/1607 as follow up to abort TFC runs
