### PR TITLE
chore: use distinct GitHub token to push changes

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -69,10 +69,6 @@ jobs:
   update-snapshots-linux:
     needs: update-snapshots-setup
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      checks: write
     container:
       image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     env:
@@ -133,8 +129,13 @@ jobs:
           git fetch
           git add .
           git commit -s -m "chore: update snapshots (posix)"
-          git pull --rebase --strategy recursive --strategy-option theirs
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+
+      - name: Push changes
+        if: steps.self_mutation.outputs.self_mutation_happened
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.TERRAFORM_CDK_PUSH_GITHUB_TOKEN }}
+          branch: ${{ github.event.pull_request.head.ref }}
 
   update-snapshots-windows:
     # running after linux will base this run on those results
@@ -218,5 +219,10 @@ jobs:
           git fetch
           git add .
           git commit -s -m "chore: update snapshots (windows)"
-          git pull --rebase --strategy recursive --strategy-option theirs
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+
+      - name: Push changes
+        if: steps.self_mutation.outputs.self_mutation_happened
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.TERRAFORM_CDK_PUSH_GITHUB_TOKEN }}
+          branch: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/yarn-upgrade.yml
+++ b/.github/workflows/yarn-upgrade.yml
@@ -74,9 +74,6 @@ jobs:
   pr:
     name: Create Pull Request
     needs: upgrade
-    permissions:
-      contents: write
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Check Out
@@ -107,3 +104,4 @@ jobs:
             Ran npm-check-updates and yarn upgrade to keep the `yarn.lock` file up-to-date.
           labels: dependencies,auto-approve
           team-reviewers: cdktf
+          token: ${{ secrets.TERRAFORM_CDK_PUSH_GITHUB_TOKEN }}

--- a/packages/cdktf/test/__snapshots__/variable.test.ts.snap
+++ b/packages/cdktf/test/__snapshots__/variable.test.ts.snap
@@ -106,7 +106,7 @@ exports[`reference 1`] = `
   \\"resource\\": {
     \\"test_resource\\": {
       \\"test-resource\\": {
-        \\"name\\": \\"\${var.test-variable}\\"
+        \\"name\\": \\"\${var.test-variablasdasdadse}\\"
       }
     }
   },


### PR DESCRIPTION
Using the actions default token does not trigger a CI run, see https://github.community/t/push-from-action-does-not-trigger-subsequent-action/16854

I created a new token with the team-tf-cdk user and used it here.

