### PR TITLE
feat(cli): allow multiple stacks in the output command

### DIFF
--- a/packages/cdktf-cli/bin/cmds/handlers.ts
+++ b/packages/cdktf-cli/bin/cmds/handlers.ts
@@ -312,7 +312,7 @@ export async function output(argv: any) {
   await checkEnvironment();
   const command = argv.app;
   const outDir = argv.output;
-  const stack = argv.stack;
+  const stacks = argv.stacks;
   const includeSensitiveOutputs = argv.outputsFileIncludeSensitiveOutputs;
   let outputsPath: string | undefined = undefined;
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -327,7 +327,7 @@ export async function output(argv: any) {
   await renderInk(
     React.createElement(Output, {
       outDir,
-      targetStack: stack,
+      targetStacks: stacks,
       synthCommand: command,
       onOutputsRetrieved,
       outputsPath,

--- a/packages/cdktf-cli/bin/cmds/output.ts
+++ b/packages/cdktf-cli/bin/cmds/output.ts
@@ -6,13 +6,13 @@ import { Errors } from "../../lib/errors";
 const config = cfg.readConfigSync();
 
 class Command implements yargs.CommandModule {
-  public readonly command = "output [stack] [OPTIONS]";
-  public readonly describe = "Prints the output of a stack";
+  public readonly command = "output [OPTIONS] <stacks..>";
+  public readonly describe = "Prints the output of stacks";
   public readonly aliases = ["outputs"];
 
   public readonly builder = (args: yargs.Argv) =>
     args
-      .positional("stack", {
+      .positional("stacks", {
         desc: "Get outputs of stack which matches the given id only. Required when more than one stack is present in the app",
         type: "string",
       })

--- a/packages/cdktf-cli/bin/cmds/output.ts
+++ b/packages/cdktf-cli/bin/cmds/output.ts
@@ -13,7 +13,7 @@ class Command implements yargs.CommandModule {
   public readonly builder = (args: yargs.Argv) =>
     args
       .positional("stacks", {
-        desc: "Get outputs of stack which matches the given id only. Required when more than one stack is present in the app",
+        desc: "Get outputs of the stacks matching the given ids. Required when more than one stack is present in the app",
         type: "string",
       })
       .option("app", {

--- a/packages/cdktf-cli/bin/cmds/ui/output.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/output.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable no-control-regex */
-import React, { useState } from "react";
+import React from "react";
 import { NestedTerraformOutputs } from "../../../lib/output";
 import { useCdktfProject } from "./hooks/cdktf-project";
 import { StreamView, OutputsBottomBar, StatusBottomBar } from "./components";
 
 type OutputConfig = {
   outDir: string;
-  targetStack?: string;
+  targetStacks?: string[];
   synthCommand: string;
   onOutputsRetrieved: (outputs: NestedTerraformOutputs) => void;
   outputsPath?: string;
@@ -14,26 +14,23 @@ type OutputConfig = {
 
 export const Output = ({
   outDir,
-  targetStack,
+  targetStacks,
   synthCommand,
   onOutputsRetrieved,
   outputsPath,
 }: OutputConfig): React.ReactElement => {
-  const [outputs, setOutputs] = useState<NestedTerraformOutputs>();
-  const { status, logEntries } = useCdktfProject(
+  const { status, logEntries, returnValue } = useCdktfProject(
     { outDir, synthCommand },
     async (project) => {
-      const out = await project.fetchOutputs({ stackName: targetStack });
-      setOutputs(out);
-      if (out && onOutputsRetrieved) {
-        onOutputsRetrieved(out);
-      }
+      const outputs = await project.fetchOutputs({ stackNames: targetStacks });
+      onOutputsRetrieved(outputs);
+      return outputs;
     }
   );
 
   const bottomBar =
     status.type === "done" ? (
-      <OutputsBottomBar outputs={outputs} outputsFile={outputsPath} />
+      <OutputsBottomBar outputs={returnValue} outputsFile={outputsPath} />
     ) : (
       <StatusBottomBar status={status} />
     );

--- a/packages/cdktf-cli/lib/cdktf-stack.ts
+++ b/packages/cdktf-cli/lib/cdktf-stack.ts
@@ -364,11 +364,11 @@ export class CdktfStack {
     return this.waitOnMachineDone();
   }
 
-  public async fetchOutputs(stackName?: string) {
+  public async fetchOutputs() {
     this.stateMachine.send({
       type: "START",
       targetAction: "output",
-      targetStack: stackName,
+      targetStack: this.stackName,
     });
 
     await this.waitOnMachineDone();

--- a/website/docs/cdktf/cli-reference/commands.mdx
+++ b/website/docs/cdktf/cli-reference/commands.mdx
@@ -511,10 +511,10 @@ $ cdktf output --help
 ```
 cdktf output [stack] [OPTIONS]
 
-Prints the output of a stack
+Prints the output of stacks
 
 Positionals:
-  stack  Get outputs of stack which matches the given id only. Required when more than one stack is present in the app                                                                                                [string]
+  stacks  Get outputs of the stacks matching the given ids. Required when more than one stack is present in the app                                                                                                  [string]
 
 Options:
       --version                                 Show version number                                                                                                                                                  [boolean]


### PR DESCRIPTION
This should help users getting outputs on their stacks quicker. As outputs fetch the last state from the Terraform State there is no special order to take
