### PR TITLE
chore(cli): remove deploying resource overview

### DIFF
--- a/packages/cdktf-cli/lib/stack-execution.ts
+++ b/packages/cdktf-cli/lib/stack-execution.ts
@@ -7,12 +7,8 @@ import { Errors } from "./errors";
 import { TerraformJson } from "./terraform-json";
 import { TerraformCloud } from "./models/terraform-cloud";
 import { TerraformCli } from "./models/terraform-cli";
-import {
-  TerraformPlan,
-  Terraform,
-  DeployingResource,
-} from "./models/terraform";
-import { getConstructIdsForOutputs, parseOutput } from "./output";
+import { TerraformPlan, Terraform } from "./models/terraform";
+import { getConstructIdsForOutputs } from "./output";
 
 export type StackEvent =
   | {
@@ -44,7 +40,6 @@ type ProgressEvent =
       stackName: string;
       stateName: string;
       stdout: string;
-      updatedResources: DeployingResource[];
     };
 
 export interface StackContext {
@@ -184,7 +179,6 @@ const services = {
         stackName: stack.name,
         stateName: "deploy",
         stdout,
-        updatedResources: parseOutput(stdout),
       });
     });
   },
@@ -210,7 +204,6 @@ const services = {
         stackName: stack.name,
         stateName: "destroy",
         stdout,
-        updatedResources: parseOutput(stdout),
       });
     });
   },


### PR DESCRIPTION
Originally I wanted to make the cdktf-project class functional, but it was harder than anticipated with not enough benefit in readability. This PR now only removes a status object we had in place for compatibility while moving to the streaming log view.

