### PR TITLE
feat(cli): stop TFC plans when we discard / stop / ctrl-c

### DIFF
--- a/packages/cdktf-cli/bin/cmds/helper/init.ts
+++ b/packages/cdktf-cli/bin/cmds/helper/init.ts
@@ -81,7 +81,6 @@ This means that your Terraform state file will be stored locally on disk in a fi
 
   const projectInfo: Project = await gatherInfo(
     token,
-    templateInfo.Name,
     argv.projectName,
     argv.projectDescription
   );
@@ -215,7 +214,6 @@ function copyLocalModules(
 
 async function gatherInfo(
   token: string,
-  templateName: string,
   projectName?: string,
   projectDescription?: string
 ): Promise<Project> {
@@ -282,7 +280,7 @@ async function gatherInfo(
       {
         name: "workspace",
         message: "Terraform Cloud Workspace Name",
-        default: templateName,
+        default: project.Name,
       },
     ]);
     project.OrganizationName = organizationSelect;

--- a/packages/cdktf-cli/lib/cdktf-stack.ts
+++ b/packages/cdktf-cli/lib/cdktf-stack.ts
@@ -5,6 +5,7 @@ import { stackExecutionMachine } from "./stack-execution";
 import { TerraformPlan } from "./models/terraform";
 import { NestedTerraformOutputs } from "./output";
 import { logger } from "./logging";
+import { extractJsonLogIfPresent } from "./server/terraform-logs";
 
 export type StackUpdate =
   | {
@@ -63,23 +64,6 @@ export type StackApprovalUpdate = {
   approve: () => void;
   reject: () => void;
 };
-
-function extractJsonLogLineIfPresent(logLine: string): string {
-  try {
-    const extractedMessage = JSON.parse(logLine)["@message"];
-    return extractedMessage ? extractedMessage : logLine;
-  } catch {
-    return logLine;
-  }
-}
-
-function extractJsonLogIfPresent(logLines: string): string {
-  return logLines
-    .split("\n")
-    .map(extractJsonLogLineIfPresent)
-    .map((line) => line.trim())
-    .join("\n");
-}
 
 export class CdktfStack {
   public stateMachine: InterpreterFrom<typeof stackExecutionMachine>;

--- a/packages/cdktf-cli/lib/cdktf-stack.ts
+++ b/packages/cdktf-cli/lib/cdktf-stack.ts
@@ -104,7 +104,7 @@ export class CdktfStack {
                   `[${event.stackName}](${event.stateName}): ${message}`
                 );
                 if (onLog) {
-                  onLog({ message: event.message });
+                  onLog({ message });
                 }
               }
 

--- a/packages/cdktf-cli/lib/models/schema.ts
+++ b/packages/cdktf-cli/lib/models/schema.ts
@@ -148,6 +148,10 @@ const refreshComplete = baseMessage.extend({
   }),
 });
 
+const logMessage = baseMessage.extend({
+  type: z.literal("log"),
+});
+
 export const schema = z.union([
   version,
   plannedChange,
@@ -163,6 +167,7 @@ export const schema = z.union([
   provisionErrored,
   refreshStart,
   refreshComplete,
+  logMessage,
 ]);
 
 export type ActionTypes = z.infer<typeof action>;

--- a/packages/cdktf-cli/lib/models/terraform-cli.ts
+++ b/packages/cdktf-cli/lib/models/terraform-cli.ts
@@ -172,7 +172,7 @@ export class TerraformCli implements Terraform {
     }
   }
 
-  // We don't need to clean anything up for a running execution in the CLI
+  // We don't need to clean anything up for a running execution in the CLI since there is no left-over state in contrast to an open Terraform Cloud run
   public async abort() {
     return;
   }

--- a/packages/cdktf-cli/lib/models/terraform-cli.ts
+++ b/packages/cdktf-cli/lib/models/terraform-cli.ts
@@ -171,4 +171,9 @@ export class TerraformCli implements Terraform {
         "cdktf/" + version + " (+https://github.com/hashicorp/terraform-cdk)";
     }
   }
+
+  // We don't need to clean anything up for a running execution in the CLI
+  public async abort() {
+    return;
+  }
 }

--- a/packages/cdktf-cli/lib/models/terraform-cloud.ts
+++ b/packages/cdktf-cli/lib/models/terraform-cloud.ts
@@ -113,7 +113,7 @@ export class TerraformCloud implements Terraform {
   private configurationVersionId?: string;
   public readonly workDir: string;
   public run?: TerraformCloudClient.Run;
-  private lastLogMessage = "";
+  private lastLogMessageLength = 0;
 
   constructor(
     public readonly abortSignal: AbortSignal,
@@ -315,11 +315,11 @@ export class TerraformCloud implements Terraform {
 
         // We only want to send what we have not seen yet.
         const bufferWithoutLastKnown = buffer
-          .toString("utf8")
-          .replace(this.lastLogMessage, "");
+          .subarray(this.lastLogMessageLength)
+          .toString("utf8");
         if (bufferWithoutLastKnown.trim().length) {
           sendLog(bufferWithoutLastKnown, false);
-          this.lastLogMessage = buffer.toString("utf8");
+          this.lastLogMessageLength = buffer.length;
         }
       }
     });

--- a/packages/cdktf-cli/lib/models/terraform-cloud.ts
+++ b/packages/cdktf-cli/lib/models/terraform-cloud.ts
@@ -393,7 +393,7 @@ export class TerraformCloud implements Terraform {
   public async abort(): Promise<void> {
     if (!this.run) {
       throw Errors.Internal(
-        "No run is present to abort, this means we called abort before the plan wa started"
+        "No run is present to abort, this means we called abort before the plan was started"
       );
     }
 

--- a/packages/cdktf-cli/lib/models/terraform-cloud.ts
+++ b/packages/cdktf-cli/lib/models/terraform-cloud.ts
@@ -14,6 +14,7 @@ import archiver from "archiver";
 import { WritableStreamBuffer } from "stream-buffers";
 import { SynthesizedStack } from "../synth-stack";
 import { logger } from "../logging";
+import { Errors } from "../errors";
 export class TerraformCloudPlan
   extends AbstractTerraformPlan
   implements TerraformPlan
@@ -114,7 +115,6 @@ export class TerraformCloud implements Terraform {
   public run?: TerraformCloudClient.Run;
 
   constructor(
-    // TFC does not support abort yet: https://github.com/hashicorp/terraform-cdk/issues/1607
     public readonly abortSignal: AbortSignal,
     public readonly stack: SynthesizedStack,
     public readonly config: TerraformJsonConfigBackendRemote,
@@ -146,6 +146,9 @@ export class TerraformCloud implements Terraform {
     }
 
     this.client = new TerraformCloudClient.TerraformCloud(this.token);
+    this.abortSignal.addEventListener("abort", () => {
+      this.removeRun("cancel");
+    });
   }
 
   @BeautifyErrors("IsRemoteWorkspace")
@@ -376,6 +379,17 @@ export class TerraformCloud implements Terraform {
     return (await this.workspace()).attributes.terraformVersion;
   }
 
+  @BeautifyErrors("Abort")
+  public async abort(): Promise<void> {
+    if (!this.run) {
+      throw Errors.Internal(
+        "No run is present to abort, this means we called abort before the plan wa started"
+      );
+    }
+
+    await this.removeRun("discard");
+  }
+
   @BeautifyErrors("Output")
   public async output(): Promise<{ [key: string]: TerraformOutput }> {
     const sendLog = this.createLogSender("output");
@@ -452,6 +466,23 @@ export class TerraformCloud implements Terraform {
         );
         return false;
     }
+  }
+
+  private async removeRun(action: "cancel" | "discard") {
+    if (!this.run) {
+      logger.debug("No run to remove");
+      return;
+    }
+
+    const url = `https://app.terraform.io/app/${this.organizationName}/workspaces/${this.workspaceName}/runs/${this.run.id}`;
+    logger.info(`${action}ing run ${url}`);
+    this.client.Runs.action(action, this.run.id)
+      .then(() => {
+        logger.debug(`Cancelled run ${url}`);
+      })
+      .catch(() => {
+        logger.error(`Failed to cancel run, please cancel manually at ${url}`);
+      });
   }
 
   private async waitForConfigurationVersionToBeReady(

--- a/packages/cdktf-cli/lib/models/terraform.ts
+++ b/packages/cdktf-cli/lib/models/terraform.ts
@@ -117,4 +117,5 @@ export interface Terraform {
   deploy(planFile: string, stdout: (chunk: Buffer) => any): Promise<void>;
   destroy(stdout: (chunk: Buffer) => any): Promise<void>;
   output(): Promise<{ [key: string]: TerraformOutput }>;
+  abort: () => Promise<void>;
 }

--- a/packages/cdktf-cli/lib/output.ts
+++ b/packages/cdktf-cli/lib/output.ts
@@ -75,6 +75,7 @@ const mapActionToState = (action: ActionTypes, done: boolean) => {
       return DeployingResourceApplyState.WAITING;
   }
 };
+// This is deprecated and will be removed in a future version.
 const parseJsonOutputLine = (
   line: string
 ): Omit<DeployingResource, "action"> | undefined => {
@@ -90,7 +91,7 @@ const parseJsonOutputLine = (
     message = schema.parse(json);
   } catch (err) {
     if (err instanceof z.ZodError) {
-      logger.warn(
+      logger.trace(
         `Error parsing line into schema: ${JSON.stringify(
           err.errors
         )} => ${line}`

--- a/packages/cdktf-cli/lib/server/terraform-logs.ts
+++ b/packages/cdktf-cli/lib/server/terraform-logs.ts
@@ -1,0 +1,16 @@
+function extractJsonLogLineIfPresent(logLine: string): string {
+  try {
+    const extractedMessage = JSON.parse(logLine)["@message"];
+    return extractedMessage ? extractedMessage : logLine;
+  } catch {
+    return logLine;
+  }
+}
+
+export function extractJsonLogIfPresent(logLines: string): string {
+  return logLines
+    .split("\n")
+    .map(extractJsonLogLineIfPresent)
+    .map((line) => line.trim())
+    .join("\n");
+}

--- a/packages/cdktf-cli/lib/stack-execution.ts
+++ b/packages/cdktf-cli/lib/stack-execution.ts
@@ -228,7 +228,7 @@ const services = {
     const tf = context.terraform;
     if (!tf) {
       throw Errors.Internal(
-        "No terraform cli found, initializeTerraform needs to be run first"
+        "No Terraform CLI found, initializeTerraform needs to be run first"
       );
     }
 

--- a/packages/cdktf-cli/test/lib/stack-execution.test.ts
+++ b/packages/cdktf-cli/test/lib/stack-execution.test.ts
@@ -16,16 +16,17 @@ function getStateMachine({
   diff = mockAsyncFunction({ needsApply: true }),
   deploy = mockAsyncFunction(null),
   destroy = mockAsyncFunction(null),
+  abort = mockAsyncFunction(null),
   gatherOutputs = mockAsyncFunction({ outputs: {}, outputsByConstructId: {} }),
   targetActionIs = guards.targetActionIs,
   autoApprove = guards.autoApprove,
   planNeedsNoApply = guards.planNeedsNoApply,
 }: Partial<StateMachineConfig>) {
-  const abort = new AbortController();
+  const abortCtl = new AbortController();
   const stateMachine = interpret(
     stackExecutionMachine
       .withContext({
-        abortSignal: abort.signal,
+        abortSignal: abortCtl.signal,
         onProgress: jest.fn(),
         stack: {
           name: "StackA",
@@ -44,6 +45,7 @@ function getStateMachine({
           deploy,
           destroy,
           gatherOutputs,
+          abort,
         },
         guards: {
           targetActionIs: targetActionIs as any, // since it's a custom guard

--- a/packages/cdktf-cli/test/lib/terraform-logs.test.ts
+++ b/packages/cdktf-cli/test/lib/terraform-logs.test.ts
@@ -1,0 +1,47 @@
+import { extractJsonLogIfPresent } from "../../lib/server/terraform-logs";
+
+describe("extractJsonLogIfPresent", () => {
+  it("parses log lines", () => {
+    expect(
+      extractJsonLogIfPresent(
+        `{"@level":"info","@message":"Terraform 1.1.7","@module":"terraform.ui","@timestamp":"2022-03-24T14:17:24.197605Z","terraform":"1.1.7","type":"version","ui":"1.0"}`
+      )
+    ).toMatchInlineSnapshot(`"Terraform 1.1.7"`);
+  });
+
+  it("parses other log lines", () => {
+    expect(
+      extractJsonLogIfPresent(
+        `{"@level":"info","@message":"null_resource.sleep-58_null-resource_82B91199: Provisioning with 'local-exec'...","@module":"terraform.ui","@timestamp":"2022-03-24T14:17:28.041062Z","hook":{"resource":{"addr":"null_resource.sleep-58_null-resource_82B91199","module":"","resource":"null_resource.sleep-58_null-resource_82B91199","implied_provider":"null","resource_type":"null_resource","resource_name":"sleep-58_null-resource_82B91199","resource_key":null},"provisioner":"local-exec"},"type":"provision_start"}`
+      )
+    ).toMatchInlineSnapshot(
+      `"null_resource.sleep-58_null-resource_82B91199: Provisioning with 'local-exec'..."`
+    );
+  });
+
+  it("parses multiple log lines", () => {
+    expect(
+      extractJsonLogIfPresent(
+        `Terraform v1.1.7
+          on linux_amd64
+          Initializing plugins and modules...
+          {"@level":"info","@message":"Terraform 1.1.7","@module":"terraform.ui","@timestamp":"2022-03-24T14:31:23.670459Z","terraform":"1.1.7","type":"version","ui":"1.0"}
+          {"@level":"info","@message":"null_resource.sleep-78_null-resource_BC9416E8 (sleep-78/null-resource): Plan to create","@module":"terraform.ui","@timestamp":"2022-03-24T14:31:25.720398Z","change":{"resource":{"addr":"null_resource.sleep-78_null-resource_BC9416E8","module":"","resource":"null_resource.sleep-78_null-resource_BC9416E8","implied_provider":"null","resource_type":"null_resource","resource_name":"sleep-78_null-resource_BC9416E8","resource_key":null},"action":"create"},"type":"planned_change"}
+          {"@level":"info","@message":"null_resource.sleep-72_null-resource_6139DD69 (sleep-72/null-resource): Plan to create","@module":"terraform.ui","@timestamp":"2022-03-24T14:31:25.720653Z","change":{"resource":{"addr":"null_resource.sleep-72_null-resource_6139DD69","module":"","resource":"null_resource.sleep-72_null-resource_6139DD69","implied_provider":"null","resource_type":"null_resource","resource_name":"sleep-72_null-resource_6139DD69","resource_key":null},"action":"create"},"type":"planned_change"}
+          {"@level":"info","@message":"null_resource.sleep-71_null-resource_28FC0011 (sleep-71/null-resource): Plan to create","@module":"terraform.ui","@timestamp":"2022-03-24T14:31:25.720700Z","change":{"resource":{"addr":"null_resource.sleep-71_null-resource_28FC0011","module":"","resource":"null_resource.sleep-71_null-resource_28FC0011","implied_provider":"null","resource_type":"null_resource","resource_name":"sleep-71_null-resource_28FC0011","resource_key":null},"action":"create"},"type":"planned_change"}
+          {"@level":"info","@message":"null_resource.sleep-73_null-resource_48B30717 (sleep-73/null-resource): Plan to create","@module":"terraform.ui","@timestamp":"2022-03-24T14:31:25.720720Z","change":{"resource":{"addr":"null_resource.sleep-73_null-resource_48B30717","module":"","resource":"null_resource.sleep-73_null-resource_48B30717","implied_provider":"null","resource_type":"null_resource","resource_name":"sleep-73_null-resource_48B30717","resource_key":null},"action":"create"},"type":"planned_change"}
+          {"@level":"info","@message":"null_resource.sleep-79_null-resource_7E1E3312 (sleep-79/null-resource): Plan to create","@module":"terraform.ui","@timestamp":"2022-03-24T14:31:25.720738Z","change":{"resource":{"addr":"null_resource.sleep-79_null-resource_7E1E3312","module":"","resource":"null_resource.sleep-79_null-resource_7E1E3312","implied_provider":"null","resource_type":"null_resource","resource_name":"sleep-79_null-resource_7E1E3312","resource_key":null},"action":"create"},"type":"planned_change"}`
+      )
+    ).toMatchInlineSnapshot(`
+        "Terraform v1.1.7
+        on linux_amd64
+        Initializing plugins and modules...
+        Terraform 1.1.7
+        null_resource.sleep-78_null-resource_BC9416E8 (sleep-78/null-resource): Plan to create
+        null_resource.sleep-72_null-resource_6139DD69 (sleep-72/null-resource): Plan to create
+        null_resource.sleep-71_null-resource_28FC0011 (sleep-71/null-resource): Plan to create
+        null_resource.sleep-73_null-resource_48B30717 (sleep-73/null-resource): Plan to create
+        null_resource.sleep-79_null-resource_7E1E3312 (sleep-79/null-resource): Plan to create"
+      `);
+  });
+});


### PR DESCRIPTION
This PR makes sure we clean up what we leave behind in TFC when we run apply / destroy.

Closes #1607 and #482
