### PR TITLE
fix(cli): improve cli error handling

### DIFF
--- a/packages/cdktf-cli/bin/cdktf.ts
+++ b/packages/cdktf-cli/bin/cdktf.ts
@@ -83,6 +83,7 @@ yargs
   .command(require("./cmds/watch"))
   .command(require("./cmds/output"))
   .recommendCommands()
+  .exitProcess(false)
   .wrap(yargs.terminalWidth())
   .showHelpOnFail(false)
   .env("CDKTF")

--- a/packages/cdktf-cli/bin/cdktf.ts
+++ b/packages/cdktf-cli/bin/cdktf.ts
@@ -8,6 +8,7 @@ import * as fs from "fs-extra";
 import { terraformVersion } from "./cmds/helper/terraform";
 import { DISPLAY_VERSION } from "./cmds/helper/version-check";
 import { readCDKTFManifest } from "../lib/util";
+import { IsErrorType } from "../lib/errors";
 
 const ensurePluginCache = (): string => {
   const pluginCachePath =
@@ -128,15 +129,27 @@ yargs
       process.exit(1);
     },
   })
-  .fail((_message, error) => {
-    if (error) {
-      console.error(error.stack);
+  .fail(async (message, error) => {
+    // will not stop the process, but stops further execution of the handler function
+    // this is called first because yargs is not waiting for this async function
+    yargs.exit(1, error);
+
+    // set if e.g. the validation of command arguments failed
+    if (message) {
+      console.log(message);
     }
 
-    terraformVersion.then((tfVersion) => {
+    // set if e.g. an handler threw an error while being invoked
+    if (IsErrorType(error, "Usage")) {
+      console.error(error.message);
+    } else if (error) {
+      console.error(error.stack);
+      const tfVersion = await terraformVersion;
       console.error(`
-Debug Information:
-    Terraform CDK version: ${DISPLAY_VERSION}
-    Terraform version: ${tfVersion}`);
-    });
+  Debug Information:
+      Terraform CDK version: ${DISPLAY_VERSION}
+      Terraform version: ${tfVersion}`);
+    }
+
+    process.exit(1);
   }).argv;

--- a/packages/cdktf-cli/bin/cmds/convert.ts
+++ b/packages/cdktf-cli/bin/cmds/convert.ts
@@ -37,13 +37,7 @@ class Command implements yargs.CommandModule {
     Errors.setScope("convert");
     // deferred require to keep cdktf-cli main entrypoint small (e.g. for fast shell completions)
     const api = requireHandlers();
-
-    try {
-      await api.convert(argv);
-    } catch (e) {
-      console.error(e);
-      process.exit(1);
-    }
+    await api.convert(argv);
   }
 }
 

--- a/packages/cdktf-cli/bin/cmds/convert.ts
+++ b/packages/cdktf-cli/bin/cmds/convert.ts
@@ -3,7 +3,7 @@ import { Errors } from "../../lib/errors";
 import { requireHandlers } from "./helper/utilities";
 
 class Command implements yargs.CommandModule {
-  public readonly command = "convert [OPTIONS]";
+  public readonly command = "convert";
   public readonly describe =
     "Converts a single file of HCL configuration to CDK for Terraform. Takes the file to be converted on stdin.";
 

--- a/packages/cdktf-cli/bin/cmds/convert.ts
+++ b/packages/cdktf-cli/bin/cmds/convert.ts
@@ -1,8 +1,9 @@
 import yargs from "yargs";
 import { Errors } from "../../lib/errors";
+import { BaseCommand } from "./helper/base-command";
 import { requireHandlers } from "./helper/utilities";
 
-class Command implements yargs.CommandModule {
+class Command extends BaseCommand {
   public readonly command = "convert";
   public readonly describe =
     "Converts a single file of HCL configuration to CDK for Terraform. Takes the file to be converted on stdin.";
@@ -33,7 +34,7 @@ class Command implements yargs.CommandModule {
       })
       .showHelpOnFail(true);
 
-  public async handler(argv: any) {
+  public async handleCommand(argv: any) {
     Errors.setScope("convert");
     // deferred require to keep cdktf-cli main entrypoint small (e.g. for fast shell completions)
     const api = requireHandlers();

--- a/packages/cdktf-cli/bin/cmds/deploy.ts
+++ b/packages/cdktf-cli/bin/cmds/deploy.ts
@@ -2,10 +2,11 @@ import * as yargs from "yargs";
 import { config as cfg } from "@cdktf/provider-generator";
 import { requireHandlers } from "./helper/utilities";
 import { Errors } from "../../lib/errors";
+import { BaseCommand } from "./helper/base-command";
 
 const config = cfg.readConfigSync();
 
-class Command implements yargs.CommandModule {
+class Command extends BaseCommand {
   public readonly command = "deploy [stacks...]";
   public readonly describe = "Deploy the given stacks";
   public readonly aliases = ["apply"];
@@ -60,7 +61,7 @@ class Command implements yargs.CommandModule {
       })
       .showHelpOnFail(true);
 
-  public async handler(argv: any) {
+  public async handleCommand(argv: any) {
     Errors.setScope("deploy");
     // deferred require to keep cdktf-cli main entrypoint small (e.g. for fast shell completions)
     const api = requireHandlers();

--- a/packages/cdktf-cli/bin/cmds/deploy.ts
+++ b/packages/cdktf-cli/bin/cmds/deploy.ts
@@ -6,7 +6,7 @@ import { Errors } from "../../lib/errors";
 const config = cfg.readConfigSync();
 
 class Command implements yargs.CommandModule {
-  public readonly command = "deploy [OPTIONS] [stacks..]";
+  public readonly command = "deploy [stacks...]";
   public readonly describe = "Deploy the given stacks";
   public readonly aliases = ["apply"];
 

--- a/packages/cdktf-cli/bin/cmds/deploy.ts
+++ b/packages/cdktf-cli/bin/cmds/deploy.ts
@@ -6,7 +6,7 @@ import { Errors } from "../../lib/errors";
 const config = cfg.readConfigSync();
 
 class Command implements yargs.CommandModule {
-  public readonly command = "deploy [OPTIONS] <stacks..>";
+  public readonly command = "deploy [OPTIONS] [stacks..]";
   public readonly describe = "Deploy the given stacks";
   public readonly aliases = ["apply"];
 

--- a/packages/cdktf-cli/bin/cmds/deploy.ts
+++ b/packages/cdktf-cli/bin/cmds/deploy.ts
@@ -64,12 +64,7 @@ class Command implements yargs.CommandModule {
     Errors.setScope("deploy");
     // deferred require to keep cdktf-cli main entrypoint small (e.g. for fast shell completions)
     const api = requireHandlers();
-    try {
-      await api.deploy(argv);
-    } catch (e) {
-      console.error(e);
-      process.exit(1);
-    }
+    await api.deploy(argv);
   }
 }
 

--- a/packages/cdktf-cli/bin/cmds/destroy.ts
+++ b/packages/cdktf-cli/bin/cmds/destroy.ts
@@ -2,10 +2,11 @@ import * as yargs from "yargs";
 import { config as cfg } from "@cdktf/provider-generator";
 import { requireHandlers } from "./helper/utilities";
 import { Errors } from "../../lib/errors";
+import { BaseCommand } from "./helper/base-command";
 
 const config = cfg.readConfigSync();
 
-class Command implements yargs.CommandModule {
+class Command extends BaseCommand {
   public readonly command = "destroy [stacks..]";
   public readonly describe = "Destroy the given stacks";
 
@@ -47,7 +48,7 @@ class Command implements yargs.CommandModule {
       })
       .showHelpOnFail(true);
 
-  public async handler(argv: any) {
+  public async handleCommand(argv: any) {
     Errors.setScope("destroy");
     // deferred require to keep cdktf-cli main entrypoint small (e.g. for fast shell completions)
     const api = requireHandlers();

--- a/packages/cdktf-cli/bin/cmds/destroy.ts
+++ b/packages/cdktf-cli/bin/cmds/destroy.ts
@@ -6,7 +6,7 @@ import { Errors } from "../../lib/errors";
 const config = cfg.readConfigSync();
 
 class Command implements yargs.CommandModule {
-  public readonly command = "destroy [OPTIONS] <stacks..>";
+  public readonly command = "destroy [OPTIONS] [stacks..]";
   public readonly describe = "Destroy the given stacks";
 
   public readonly builder = (args: yargs.Argv) =>

--- a/packages/cdktf-cli/bin/cmds/destroy.ts
+++ b/packages/cdktf-cli/bin/cmds/destroy.ts
@@ -49,15 +49,9 @@ class Command implements yargs.CommandModule {
 
   public async handler(argv: any) {
     Errors.setScope("destroy");
-
     // deferred require to keep cdktf-cli main entrypoint small (e.g. for fast shell completions)
     const api = requireHandlers();
-    try {
-      await api.destroy(argv);
-    } catch (e) {
-      console.error(e);
-      process.exit(1);
-    }
+    await api.destroy(argv);
   }
 }
 

--- a/packages/cdktf-cli/bin/cmds/destroy.ts
+++ b/packages/cdktf-cli/bin/cmds/destroy.ts
@@ -6,7 +6,7 @@ import { Errors } from "../../lib/errors";
 const config = cfg.readConfigSync();
 
 class Command implements yargs.CommandModule {
-  public readonly command = "destroy [OPTIONS] [stacks..]";
+  public readonly command = "destroy [stacks..]";
   public readonly describe = "Destroy the given stacks";
 
   public readonly builder = (args: yargs.Argv) =>

--- a/packages/cdktf-cli/bin/cmds/diff.ts
+++ b/packages/cdktf-cli/bin/cmds/diff.ts
@@ -6,7 +6,7 @@ import { Errors } from "../../lib/errors";
 const config = cfg.readConfigSync();
 
 class Command implements yargs.CommandModule {
-  public readonly command = "diff [stack] [OPTIONS]";
+  public readonly command = "diff [stack]";
   public readonly describe =
     "Perform a diff (terraform plan) for the given stack";
   public readonly aliases = ["plan"];

--- a/packages/cdktf-cli/bin/cmds/diff.ts
+++ b/packages/cdktf-cli/bin/cmds/diff.ts
@@ -35,12 +35,7 @@ class Command implements yargs.CommandModule {
     Errors.setScope("diff");
     // deferred require to keep cdktf-cli main entrypoint small (e.g. for fast shell completions)
     const api = requireHandlers();
-    try {
-      await api.diff(argv);
-    } catch (e) {
-      console.error(e);
-      process.exit(1);
-    }
+    await api.diff(argv);
   }
 }
 

--- a/packages/cdktf-cli/bin/cmds/diff.ts
+++ b/packages/cdktf-cli/bin/cmds/diff.ts
@@ -2,10 +2,11 @@ import yargs from "yargs";
 import { config as cfg } from "@cdktf/provider-generator";
 import { requireHandlers } from "./helper/utilities";
 import { Errors } from "../../lib/errors";
+import { BaseCommand } from "./helper/base-command";
 
 const config = cfg.readConfigSync();
 
-class Command implements yargs.CommandModule {
+class Command extends BaseCommand {
   public readonly command = "diff [stack]";
   public readonly describe =
     "Perform a diff (terraform plan) for the given stack";
@@ -31,7 +32,7 @@ class Command implements yargs.CommandModule {
       })
       .showHelpOnFail(true);
 
-  public async handler(argv: any) {
+  public async handleCommand(argv: any) {
     Errors.setScope("diff");
     // deferred require to keep cdktf-cli main entrypoint small (e.g. for fast shell completions)
     const api = requireHandlers();

--- a/packages/cdktf-cli/bin/cmds/get.ts
+++ b/packages/cdktf-cli/bin/cmds/get.ts
@@ -31,12 +31,7 @@ class Command implements yargs.CommandModule {
     Errors.setScope("get");
     // deferred require to keep cdktf-cli main entrypoint small (e.g. for fast shell completions)
     const api = requireHandlers();
-    try {
-      await api.get(argv);
-    } catch (e) {
-      console.error(e);
-      process.exit(1);
-    }
+    await api.get(argv);
   }
 }
 

--- a/packages/cdktf-cli/bin/cmds/get.ts
+++ b/packages/cdktf-cli/bin/cmds/get.ts
@@ -2,9 +2,10 @@ import yargs from "yargs";
 import { LANGUAGES, config as cfg } from "@cdktf/provider-generator";
 import { requireHandlers } from "./helper/utilities";
 import { Errors } from "../../lib/errors";
+import { BaseCommand } from "./helper/base-command";
 const config = cfg.readConfigSync();
 
-class Command implements yargs.CommandModule {
+class Command extends BaseCommand {
   public readonly command = "get";
   public readonly describe =
     "Generate CDK Constructs for Terraform providers and modules.";
@@ -27,7 +28,7 @@ class Command implements yargs.CommandModule {
         choices: LANGUAGES,
       });
 
-  public async handler(argv: any) {
+  public async handleCommand(argv: any) {
     Errors.setScope("get");
     // deferred require to keep cdktf-cli main entrypoint small (e.g. for fast shell completions)
     const api = requireHandlers();

--- a/packages/cdktf-cli/bin/cmds/get.ts
+++ b/packages/cdktf-cli/bin/cmds/get.ts
@@ -5,7 +5,7 @@ import { Errors } from "../../lib/errors";
 const config = cfg.readConfigSync();
 
 class Command implements yargs.CommandModule {
-  public readonly command = "get [OPTIONS]";
+  public readonly command = "get";
   public readonly describe =
     "Generate CDK Constructs for Terraform providers and modules.";
 

--- a/packages/cdktf-cli/bin/cmds/handlers.ts
+++ b/packages/cdktf-cli/bin/cmds/handlers.ts
@@ -176,10 +176,9 @@ export async function get(argv: any) {
   ];
 
   if (constraints.length === 0) {
-    console.error(
-      `ERROR: Please specify providers or modules in "cdktf.json" config file`
+    throw Errors.Usage(
+      `Please specify providers or modules in "cdktf.json" config file`
     );
-    process.exit(1);
   }
 
   await renderInk(

--- a/packages/cdktf-cli/bin/cmds/helper/base-command.ts
+++ b/packages/cdktf-cli/bin/cmds/helper/base-command.ts
@@ -1,0 +1,13 @@
+import yargs from "yargs";
+
+export abstract class BaseCommand implements yargs.CommandModule {
+  public readonly handler = async (args: any) => {
+    // only run command if not doing shell completions
+    // required due to a bug in yargs: https://github.com/yargs/yargs/issues/1965
+    if (!args.getYargsCompletions) {
+      await this.handleCommand(args);
+    }
+  };
+
+  abstract handleCommand(args: any): Promise<void>;
+}

--- a/packages/cdktf-cli/bin/cmds/init.ts
+++ b/packages/cdktf-cli/bin/cmds/init.ts
@@ -50,12 +50,7 @@ class Command implements yargs.CommandModule {
     Errors.setScope("init");
     // deferred require to keep cdktf-cli main entrypoint small (e.g. for fast shell completions)
     const api = requireHandlers();
-    try {
-      await api.init(argv);
-    } catch (e) {
-      console.error(e);
-      process.exit(1);
-    }
+    await api.init(argv);
   }
 }
 

--- a/packages/cdktf-cli/bin/cmds/init.ts
+++ b/packages/cdktf-cli/bin/cmds/init.ts
@@ -7,7 +7,7 @@ import { Errors } from "../../lib/errors";
 const pkg = readPackageJson();
 
 class Command implements yargs.CommandModule {
-  public readonly command = "init [OPTIONS]";
+  public readonly command = "init";
   public readonly describe = "Create a new cdktf project from a template.";
   public readonly builder = (args: yargs.Argv) =>
     args

--- a/packages/cdktf-cli/bin/cmds/init.ts
+++ b/packages/cdktf-cli/bin/cmds/init.ts
@@ -3,10 +3,11 @@ import yargs from "yargs";
 import { templates } from "./helper/init-templates";
 import { readPackageJson, requireHandlers } from "./helper/utilities";
 import { Errors } from "../../lib/errors";
+import { BaseCommand } from "./helper/base-command";
 
 const pkg = readPackageJson();
 
-class Command implements yargs.CommandModule {
+class Command extends BaseCommand {
   public readonly command = "init";
   public readonly describe = "Create a new cdktf project from a template.";
   public readonly builder = (args: yargs.Argv) =>
@@ -46,7 +47,7 @@ class Command implements yargs.CommandModule {
       })
       .strict();
 
-  public async handler(argv: any) {
+  public async handleCommand(argv: any) {
     Errors.setScope("init");
     // deferred require to keep cdktf-cli main entrypoint small (e.g. for fast shell completions)
     const api = requireHandlers();

--- a/packages/cdktf-cli/bin/cmds/list.ts
+++ b/packages/cdktf-cli/bin/cmds/list.ts
@@ -2,10 +2,11 @@ import yargs from "yargs";
 import { config as cfg } from "@cdktf/provider-generator";
 import { requireHandlers } from "./helper/utilities";
 import { Errors } from "../../lib/errors";
+import { BaseCommand } from "./helper/base-command";
 
 const config = cfg.readConfigSync();
 
-class Command implements yargs.CommandModule {
+class Command extends BaseCommand {
   public readonly command = "list";
   public readonly describe = "List stacks in app.";
 
@@ -23,7 +24,7 @@ class Command implements yargs.CommandModule {
       })
       .showHelpOnFail(true);
 
-  public async handler(argv: any) {
+  public async handleCommand(argv: any) {
     Errors.setScope("list");
     // deferred require to keep cdktf-cli main entrypoint small (e.g. for fast shell completions)
     const api = requireHandlers();

--- a/packages/cdktf-cli/bin/cmds/list.ts
+++ b/packages/cdktf-cli/bin/cmds/list.ts
@@ -27,12 +27,7 @@ class Command implements yargs.CommandModule {
     Errors.setScope("list");
     // deferred require to keep cdktf-cli main entrypoint small (e.g. for fast shell completions)
     const api = requireHandlers();
-    try {
-      await api.list(argv);
-    } catch (e) {
-      console.error(e);
-      process.exit(1);
-    }
+    await api.list(argv);
   }
 }
 

--- a/packages/cdktf-cli/bin/cmds/list.ts
+++ b/packages/cdktf-cli/bin/cmds/list.ts
@@ -6,7 +6,7 @@ import { Errors } from "../../lib/errors";
 const config = cfg.readConfigSync();
 
 class Command implements yargs.CommandModule {
-  public readonly command = "list [OPTIONS]";
+  public readonly command = "list";
   public readonly describe = "List stacks in app.";
 
   public readonly builder = (args: yargs.Argv) =>

--- a/packages/cdktf-cli/bin/cmds/login.ts
+++ b/packages/cdktf-cli/bin/cmds/login.ts
@@ -1,14 +1,15 @@
 import yargs from "yargs";
 import { requireHandlers } from "./helper/utilities";
 import { Errors } from "../../lib/errors";
+import { BaseCommand } from "./helper/base-command";
 
-class Command implements yargs.CommandModule {
+class Command extends BaseCommand {
   public readonly command = "login";
   public readonly describe =
     "Retrieves an API token to connect to Terraform Cloud.";
   public readonly builder = (args: yargs.Argv) => args.showHelpOnFail(true);
 
-  public async handler(argv: any) {
+  public async handleCommand(argv: any) {
     Errors.setScope("login");
     // deferred require to keep cdktf-cli main entrypoint small (e.g. for fast shell completions)
     const api = requireHandlers();

--- a/packages/cdktf-cli/bin/cmds/login.ts
+++ b/packages/cdktf-cli/bin/cmds/login.ts
@@ -12,12 +12,7 @@ class Command implements yargs.CommandModule {
     Errors.setScope("login");
     // deferred require to keep cdktf-cli main entrypoint small (e.g. for fast shell completions)
     const api = requireHandlers();
-    try {
-      await api.login(argv);
-    } catch (e) {
-      console.error(e);
-      process.exit(1);
-    }
+    await api.login(argv);
   }
 }
 

--- a/packages/cdktf-cli/bin/cmds/output.ts
+++ b/packages/cdktf-cli/bin/cmds/output.ts
@@ -6,7 +6,7 @@ import { Errors } from "../../lib/errors";
 const config = cfg.readConfigSync();
 
 class Command implements yargs.CommandModule {
-  public readonly command = "output [OPTIONS] [stacks..]";
+  public readonly command = "output [stacks..]";
   public readonly describe = "Prints the output of stacks";
   public readonly aliases = ["outputs"];
 

--- a/packages/cdktf-cli/bin/cmds/output.ts
+++ b/packages/cdktf-cli/bin/cmds/output.ts
@@ -6,7 +6,7 @@ import { Errors } from "../../lib/errors";
 const config = cfg.readConfigSync();
 
 class Command implements yargs.CommandModule {
-  public readonly command = "output [OPTIONS] <stacks..>";
+  public readonly command = "output [OPTIONS] [stacks..]";
   public readonly describe = "Prints the output of stacks";
   public readonly aliases = ["outputs"];
 

--- a/packages/cdktf-cli/bin/cmds/output.ts
+++ b/packages/cdktf-cli/bin/cmds/output.ts
@@ -46,12 +46,7 @@ class Command implements yargs.CommandModule {
     Errors.setScope("output");
     // deferred require to keep cdktf-cli main entrypoint small (e.g. for fast shell completions)
     const api = requireHandlers();
-    try {
-      await api.output(argv);
-    } catch (e) {
-      console.error(e);
-      process.exit(1);
-    }
+    await api.output(argv);
   }
 }
 

--- a/packages/cdktf-cli/bin/cmds/output.ts
+++ b/packages/cdktf-cli/bin/cmds/output.ts
@@ -2,10 +2,11 @@ import * as yargs from "yargs";
 import { config as cfg } from "@cdktf/provider-generator";
 import { requireHandlers } from "./helper/utilities";
 import { Errors } from "../../lib/errors";
+import { BaseCommand } from "./helper/base-command";
 
 const config = cfg.readConfigSync();
 
-class Command implements yargs.CommandModule {
+class Command extends BaseCommand {
   public readonly command = "output [stacks..]";
   public readonly describe = "Prints the output of stacks";
   public readonly aliases = ["outputs"];
@@ -42,7 +43,7 @@ class Command implements yargs.CommandModule {
       })
       .showHelpOnFail(true);
 
-  public async handler(argv: any) {
+  public async handleCommand(argv: any) {
     Errors.setScope("output");
     // deferred require to keep cdktf-cli main entrypoint small (e.g. for fast shell completions)
     const api = requireHandlers();

--- a/packages/cdktf-cli/bin/cmds/synth.ts
+++ b/packages/cdktf-cli/bin/cmds/synth.ts
@@ -6,7 +6,7 @@ import { Errors } from "../../lib/errors";
 const config = cfg.readConfigSync();
 
 class Command implements yargs.CommandModule {
-  public readonly command = "synth [OPTIONS]";
+  public readonly command = "synth";
   public readonly describe =
     "Synthesizes Terraform code for the given app in a directory.";
   public readonly aliases = ["synthesize"];

--- a/packages/cdktf-cli/bin/cmds/synth.ts
+++ b/packages/cdktf-cli/bin/cmds/synth.ts
@@ -2,10 +2,11 @@ import yargs from "yargs";
 import { config as cfg } from "@cdktf/provider-generator";
 import { requireHandlers } from "./helper/utilities";
 import { Errors } from "../../lib/errors";
+import { BaseCommand } from "./helper/base-command";
 
 const config = cfg.readConfigSync();
 
-class Command implements yargs.CommandModule {
+class Command extends BaseCommand {
   public readonly command = "synth";
   public readonly describe =
     "Synthesizes Terraform code for the given app in a directory.";
@@ -34,7 +35,7 @@ class Command implements yargs.CommandModule {
       })
       .showHelpOnFail(true);
 
-  public async handler(argv: any) {
+  public async handleCommand(argv: any) {
     Errors.setScope("synth");
     // deferred require to keep cdktf-cli main entrypoint small (e.g. for fast shell completions)
     const api = requireHandlers();

--- a/packages/cdktf-cli/bin/cmds/synth.ts
+++ b/packages/cdktf-cli/bin/cmds/synth.ts
@@ -38,12 +38,7 @@ class Command implements yargs.CommandModule {
     Errors.setScope("synth");
     // deferred require to keep cdktf-cli main entrypoint small (e.g. for fast shell completions)
     const api = requireHandlers();
-    try {
-      await api.synth(argv);
-    } catch (e) {
-      console.error(e);
-      process.exit(1);
-    }
+    await api.synth(argv);
   }
 }
 

--- a/packages/cdktf-cli/bin/cmds/watch.ts
+++ b/packages/cdktf-cli/bin/cmds/watch.ts
@@ -2,10 +2,11 @@ import * as yargs from "yargs";
 import { config as cfg } from "@cdktf/provider-generator";
 import { requireHandlers } from "./helper/utilities";
 import { Errors } from "../../lib/errors";
+import { BaseCommand } from "./helper/base-command";
 
 const config = cfg.readConfigSync();
 
-class Command implements yargs.CommandModule {
+class Command extends BaseCommand {
   public readonly command = "watch [stacks..]";
   public readonly describe =
     "[experimental] Watch for file changes and automatically trigger a deploy";
@@ -42,7 +43,7 @@ class Command implements yargs.CommandModule {
       })
       .showHelpOnFail(true);
 
-  public async handler(argv: any) {
+  public async handleCommand(argv: any) {
     Errors.setScope("watch");
     // deferred require to keep cdktf-cli main entrypoint small (e.g. for fast shell completions)
     const api = requireHandlers();

--- a/packages/cdktf-cli/bin/cmds/watch.ts
+++ b/packages/cdktf-cli/bin/cmds/watch.ts
@@ -46,12 +46,7 @@ class Command implements yargs.CommandModule {
     Errors.setScope("watch");
     // deferred require to keep cdktf-cli main entrypoint small (e.g. for fast shell completions)
     const api = requireHandlers();
-    try {
-      await api.watch(argv);
-    } catch (e) {
-      console.error(e);
-      process.exit(1);
-    }
+    await api.watch(argv);
   }
 }
 

--- a/packages/cdktf-cli/bin/cmds/watch.ts
+++ b/packages/cdktf-cli/bin/cmds/watch.ts
@@ -6,7 +6,7 @@ import { Errors } from "../../lib/errors";
 const config = cfg.readConfigSync();
 
 class Command implements yargs.CommandModule {
-  public readonly command = "watch [OPTIONS] [stacks..]";
+  public readonly command = "watch [stacks..]";
   public readonly describe =
     "[experimental] Watch for file changes and automatically trigger a deploy";
 

--- a/packages/cdktf-cli/bin/cmds/watch.ts
+++ b/packages/cdktf-cli/bin/cmds/watch.ts
@@ -6,7 +6,7 @@ import { Errors } from "../../lib/errors";
 const config = cfg.readConfigSync();
 
 class Command implements yargs.CommandModule {
-  public readonly command = "watch [OPTIONS] <stacks..>";
+  public readonly command = "watch [OPTIONS] [stacks..]";
   public readonly describe =
     "[experimental] Watch for file changes and automatically trigger a deploy";
 

--- a/packages/cdktf-cli/lib/errors.ts
+++ b/packages/cdktf-cli/lib/errors.ts
@@ -14,13 +14,19 @@ async function report(command: string, payload: Record<string, any>) {
   await ReportRequest(reportParams);
 }
 
-function reportPrefixedError(type: string, command: string) {
+type ErrorType = "Internal" | "External" | "Usage";
+export function IsErrorType(error: any, type: ErrorType): boolean {
+  return error && error.__type === type;
+}
+
+function reportPrefixedError(type: ErrorType, command: string) {
   return (message: string, context?: Record<string, any>) => {
     report(command, { ...context, message, type });
     const err: any = new Error(`${type} Error: ${message}`);
     Object.entries(context || {}).forEach(([key, value]) => {
       err[key] = value;
     });
+    err.__type = type;
     return err;
   };
 }

--- a/packages/cdktf-cli/package.json
+++ b/packages/cdktf-cli/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@cdktf/hcl2cdk": "0.0.0",
     "@cdktf/hcl2json": "0.0.0",
+    "@types/yargs": "^17.0.10",
     "cdktf": "0.0.0",
     "constructs": "^10.0.25",
     "ink-select-input": "^4.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2009,6 +2009,13 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/yargs@^17.0.10":
+  version "17.0.10"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.10.tgz#591522fce85d8739bca7b8bb90d048e4478d186a"
+  integrity sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==
+  dependencies:
+    "@types/yargs-parser" "*"
+
 "@types/yauzl@^2.9.1":
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.9.2.tgz#c48e5d56aff1444409e39fa164b0b4d4552a7b7a"


### PR DESCRIPTION
- chore(deps): update yargs type defs
- fix(cli): be explicit about yargs not exiting the process on failure
- fix(cli): make stack positional argument optional
- fix(cli): exit the process on uncaught errors from yargs handlers
- fix(cli): throw Usage error instead of local process.exit()
- refactor(cli): Don't catch errors locally in command handlers as they are now caught properly on a global level in .fail()
