### PR TITLE
fix(cli): fix path for `.terraform` directory

### DIFF
--- a/packages/cdktf-cli/lib/models/terraform-cloud.ts
+++ b/packages/cdktf-cli/lib/models/terraform-cloud.ts
@@ -530,7 +530,7 @@ export class TerraformCloud implements Terraform {
 
   private removeLocalTerraformDirectory() {
     try {
-      fs.rmSync(path.resolve(this.stack.synthesizedStackPath, ".terraform"), {
+      fs.rmSync(path.resolve(this.stack.workingDirectory, ".terraform"), {
         recursive: true,
       });
     } catch (error) {


### PR DESCRIPTION
previously this always tried to delete e.g. `cdktf.out/stacks/a/cdk.tf.json/.terraform` which probably always failed.

Related to #1470.