### PR TITLE
feat(cli): warn users about misaligned CLI and library versions

### DIFF
--- a/packages/cdktf-cli/bin/cmds/handlers.ts
+++ b/packages/cdktf-cli/bin/cmds/handlers.ts
@@ -36,7 +36,10 @@ import {
   normalizeOutputPath,
 } from "../../lib/output";
 import { throwIfNotProjectDirectory } from "./helper/check-directory";
-import { checkEnvironment } from "./helper/check-environment";
+import {
+  checkEnvironment,
+  verifySimilarLibraryVersion,
+} from "./helper/check-environment";
 
 const chalkColour = new chalk.Instance();
 const config = cfg.readConfigSync();
@@ -162,6 +165,7 @@ export async function get(argv: any) {
   throwIfNotProjectDirectory();
   await displayVersionMessage();
   await checkEnvironment();
+  await verifySimilarLibraryVersion();
   const args = argv as {
     output: string;
     language: Language;

--- a/packages/cdktf-cli/bin/cmds/helper/check-environment.ts
+++ b/packages/cdktf-cli/bin/cmds/helper/check-environment.ts
@@ -1,7 +1,9 @@
 import * as path from "path";
 import * as semver from "semver";
 import { Errors } from "../../../lib/errors";
+import { logger } from "../../../lib/logging";
 import { exec } from "../../../lib/util";
+import { versionNumber } from "./version-check";
 
 function throwIfLowerVersion(
   language: string,
@@ -48,19 +50,103 @@ async function checkNodeVersion() {
   throwIfLowerVersion("Node.js", "14.17.0", out);
 }
 
-export async function checkEnvironment(projectPath = process.cwd()) {
-  await checkNodeVersion();
-
-  let language: string | undefined;
+function getLanguage(projectPath = process.cwd()): string | undefined {
   try {
     const cdktfJson = require(path.resolve(projectPath, "cdktf.json"));
-    language = cdktfJson.language;
+    return cdktfJson.language;
   } catch {
     // We can not detect the language
+    logger.debug(`Unable to detect language in ${projectPath}`);
+    return undefined;
   }
+}
 
-  switch (language) {
+export async function checkEnvironment() {
+  await checkNodeVersion();
+
+  switch (getLanguage()) {
     case "go":
       await checkGoVersion();
+  }
+}
+
+async function getNodeModuleVersion(): Promise<string | undefined> {
+  let output;
+  try {
+    output = await exec("npm", ["list", "cdktf", "--json"], {
+      env: process.env,
+    });
+  } catch (e) {
+    logger.info(`Unable to run 'npm list cdktf --json': ${e}`);
+    return undefined;
+  }
+
+  let json;
+  try {
+    json = JSON.parse(output);
+  } catch (e) {
+    logger.info(`Unable to parse output of 'npm list cdktf --json': ${e}`);
+    return undefined;
+  }
+
+  if (
+    !json.dependencies ||
+    !json.dependencies.cdktf ||
+    !json.dependencies.cdktf.version
+  ) {
+    logger.info(`Unable to find 'cdktf' in 'npm list cdktf --json': ${output}`);
+    return undefined;
+  }
+
+  return json.dependencies.cdktf.version;
+}
+
+export async function verifySimilarLibraryVersion() {
+  const language = getLanguage();
+  if (!language) {
+    // We could not detect the language, disabling the check
+    return;
+  }
+
+  const noOp = async () => {}; // eslint-disable-line @typescript-eslint/no-empty-function
+  const getLibraryVersionMap: Record<
+    string,
+    () => Promise<string | undefined | void>
+  > = {
+    typescript: getNodeModuleVersion,
+    go: noOp,
+    python: noOp,
+    csharp: noOp,
+    java: noOp,
+  };
+
+  const libVersion = await (getLibraryVersionMap[language] || noOp)();
+  if (!libVersion) {
+    // We could not detect the library version, disabling the check
+    return;
+  }
+
+  const cliVersion = versionNumber();
+
+  if (!libVersion) {
+    // We could not detect the library version, disabling the check
+    return;
+  }
+
+  if (cliVersion === "0.0.0") {
+    // We are running a development version
+    return;
+  }
+
+  if (semver.major(libVersion) !== semver.major(cliVersion)) {
+    throw Errors.Usage(
+      `The major version of the library (${libVersion}) and the CLI (${cliVersion}) are different. Please update the library to the same major version and regenerate your provider bindings with 'cdktf get' and update your prebuilt providers.`
+    );
+  }
+
+  if (semver.minor(libVersion) !== semver.minor(cliVersion)) {
+    throw Errors.Usage(
+      `The minor version of the library (${libVersion}) and the CLI (${cliVersion}) are different. Please update the library to the same minor version and regenerate your provider bindings with 'cdktf get' and update your prebuilt providers.`
+    );
   }
 }


### PR DESCRIPTION
This often a point of confiusion, especially if one accidentally updates the CLI and wonders why the previously working cdktf program does not work anymore
