### PR TITLE
fix(provider-generator): Include "arn" when assignable

### DIFF
--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/resource-types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/resource-types.test.ts.snap
@@ -2904,6 +2904,10 @@ export interface S3BucketConfig extends cdktf.TerraformMetaArguments {
   */
   readonly acl?: string;
   /**
+  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#arn S3Bucket#arn}
+  */
+  readonly arn?: string;
+  /**
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#bucket S3Bucket#bucket}
   */
   readonly bucket?: string;
@@ -4744,6 +4748,7 @@ export class S3Bucket extends cdktf.TerraformResource {
     });
     this._accelerationStatus = config.accelerationStatus;
     this._acl = config.acl;
+    this._arn = config.arn;
     this._bucket = config.bucket;
     this._bucketPrefix = config.bucketPrefix;
     this._forceDestroy = config.forceDestroy;
@@ -4802,8 +4807,19 @@ export class S3Bucket extends cdktf.TerraformResource {
   }
 
   // arn - computed: true, optional: true, required: false
+  private _arn?: string; 
   public get arn() {
     return this.getStringAttribute('arn');
+  }
+  public set arn(value: string) {
+    this._arn = value;
+  }
+  public resetArn() {
+    this._arn = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get arnInput() {
+    return this._arn;
   }
 
   // bucket - computed: true, optional: true, required: false
@@ -5137,6 +5153,7 @@ export class S3Bucket extends cdktf.TerraformResource {
     return {
       acceleration_status: cdktf.stringToTerraform(this._accelerationStatus),
       acl: cdktf.stringToTerraform(this._acl),
+      arn: cdktf.stringToTerraform(this._arn),
       bucket: cdktf.stringToTerraform(this._bucket),
       bucket_prefix: cdktf.stringToTerraform(this._bucketPrefix),
       force_destroy: cdktf.booleanToTerraform(this._forceDestroy),

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
@@ -224,7 +224,7 @@ export class AttributeModel {
     if (this.isAssignable && !this.computed) {
       return false;
     }
-    const ignoreList = ["arn", "id"];
+    const ignoreList = ["id"];
     return ignoreList.includes(this.name);
   }
 }


### PR DESCRIPTION
Fixes #1669 

Adds "arn" as a mutable property on resources that say it should be assignable.