### PR TITLE
chore: pin pip version

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,6 +29,8 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+      - name: Pin pip version
+        run: python -m pip install pip==22.0.4
       - name: installing dependencies and build
         run: |
           yarn install
@@ -76,6 +78,8 @@ jobs:
         with:
           name: edge-provider-bindings
           path: test/edge-provider-bindings
+      - name: Pin pip version
+        run: python -m pip install pip==22.0.4
       - name: install test dependencies
         run: cd test && yarn
       - name: integration tests
@@ -103,6 +107,8 @@ jobs:
         with:
           terraform_wrapper: false
           terraform_version: ${{ matrix.terraform }}
+      - name: Pin pip version
+        run: python -m pip install pip==22.0.4
       - name: Install pipenv
         run: pip install pipenv
       - name: Install Go


### PR DESCRIPTION
It seems like windows uses a different python version than linux, causing package installation issues.


## TODO

- [ ] If it works also change release job