### PR TITLE
chore: align versions to an unpublished version

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,7 +32,7 @@ jobs:
       - name: installing dependencies and build
         run: |
           yarn install
-          tools/align-version.sh
+          tools/align-version.sh "-dev.$GITHUB_RUN_ID"
           yarn build
           yarn package
       - name: Upload dist

--- a/packages/cdktf-cli/lib/init.ts
+++ b/packages/cdktf-cli/lib/init.ts
@@ -65,7 +65,11 @@ export async function determineDeps(
   version: string = pkg.version,
   dist?: string
 ): Promise<Deps> {
-  const pythonVersion = version.replace(/-pre\./g, ".dev");
+  // TS: cdktf-0.10.1-dev.2160938258
+  // Py: cdktf-0.10.1.dev1658821493.tar.gz
+  const pythonVersion = version
+    .replace(/-pre\./g, ".dev")
+    .replace(/-dev\./g, ".dev");
 
   if (dist) {
     const ret = {


### PR DESCRIPTION
Aligning the versions to the current cdktf version misleads pypi to verify the published sha of the package is the same as the one we install locally. Using an unpublished version (by adding a suffix) will ensure this check can never find a version to compare against.
