### PR TITLE
fix(cli): allow init command to run in a directory containing a README.md

### DIFF
--- a/packages/cdktf-cli/bin/cmds/helper/init.ts
+++ b/packages/cdktf-cli/bin/cmds/helper/init.ts
@@ -32,9 +32,13 @@ import { init, Project } from "../../../lib";
 
 const chalkColour = new chalk.Instance();
 
+const isReadme = (file: string) => file.toLowerCase() === "readme.md";
+
 export function checkForEmptyDirectory(dir: string) {
   if (
-    fs.readdirSync(dir).filter((f) => !f.startsWith(".") && f !== logFileName)
+    fs
+      .readdirSync(dir)
+      .filter((f) => !f.startsWith(".") && f !== logFileName && !isReadme(f))
       .length > 0
   ) {
     console.error(


### PR DESCRIPTION
When creating a new Git repository via Github one can easily add a README.md resulting in an non-empty new git repo in which cdktf init won't work then

Related to #1697
