### PR TITLE
fix(cli): Fix indentation of RemoteBackend in CSharp and Java template

### DIFF
--- a/packages/cdktf-cli/templates/csharp/.hooks.sscaff.js
+++ b/packages/cdktf-cli/templates/csharp/.hooks.sscaff.js
@@ -50,7 +50,7 @@ function terraformCloudConfig(baseName, organizationName, workspaceName) {
   template = readFileSync('./Main.cs', 'utf-8');
 
   result = template.replace(`new MyApp(app, "${baseName}");`, `MyApp stack = new MyApp(app, "${baseName}");
-new RemoteBackend(stack, new RemoteBackendProps { Hostname = "app.terraform.io", Organization = "${organizationName}", Workspaces = new NamedRemoteWorkspace("${workspaceName}") });`);
+            new RemoteBackend(stack, new RemoteBackendProps { Hostname = "app.terraform.io", Organization = "${organizationName}", Workspaces = new NamedRemoteWorkspace("${workspaceName}") });`);
 
   writeFileSync('./Main.cs', result, 'utf-8');
 }

--- a/packages/cdktf-cli/templates/java/.hooks.sscaff.js
+++ b/packages/cdktf-cli/templates/java/.hooks.sscaff.js
@@ -47,7 +47,7 @@ import com.hashicorp.cdktf.NamedRemoteWorkspace;
 import com.hashicorp.cdktf.RemoteBackend;
 import com.hashicorp.cdktf.RemoteBackendProps;`);
   result = result.replace(`new Main(app, "${baseName}");`, `Main stack = new Main(app, "${baseName}");
-new RemoteBackend(stack, RemoteBackendProps.builder().hostname("app.terraform.io").organization("${organizationName}").workspaces(new NamedRemoteWorkspace("${workspaceName}")).build());`);
+        new RemoteBackend(stack, RemoteBackendProps.builder().hostname("app.terraform.io").organization("${organizationName}").workspaces(new NamedRemoteWorkspace("${workspaceName}")).build());`);
 
   writeFileSync('./src/main/java/com/mycompany/app/Main.java', result, 'utf-8');
 }


### PR DESCRIPTION
- fix(cli): fix indentation of RemoteBackend in CSharp template
- fix(cli): fix indentation of RemoteBackend in Java template

Closes #1494