### PR TITLE
fix(cli): we should not send wait for approval if a stop has been issued

### DIFF
--- a/packages/cdktf-cli/lib/cdktf-project.ts
+++ b/packages/cdktf-cli/lib/cdktf-project.ts
@@ -344,6 +344,12 @@ export class CdktfProject {
 
   private stopAllStacks() {
     this.stacksToRun.forEach((stack) => stack.stop());
+    this.eventBuffer = this.eventBuffer.filter(
+      (event) =>
+        event.type === "projectUpdate"
+          ? event.value.type !== "waiting for approval" // we want to filter out the waiting for approval events
+          : true // we want all other types
+    );
   }
 
   private waitForApproval() {


### PR DESCRIPTION
When deploying stacks and we wait for approvals, if there have been stacks in a waiting for approval state we need to clear them out of our buffer if we stop all stacks, otherwise users need to click through them individually and might even allow individual stacks to be deployed by approving them.
