### PR TITLE
fix(release): Use non default terraform versions as specified in test matrix for Release and Release Next workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
       image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     env:
       CHECKPOINT_DISABLE: "1"
+      TERRAFORM_VERSION: ${{ matrix.terraform }}
     steps:
       - uses: actions/checkout@v2
       - name: Download dist
@@ -80,6 +81,7 @@ jobs:
         env:
           TEST_TARGET: ${{ matrix.target }}
           TERRAFORM_CLOUD_TOKEN: ${{ secrets.TERRAFORM_CLOUD_TOKEN }}
+          TERRAFORM_BINARY_NAME: "terraform${{ matrix.terraform }}"
           NODE_OPTIONS: "--max-old-space-size=7168"
 
   release_github:

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -64,6 +64,7 @@ jobs:
       image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     env:
       CHECKPOINT_DISABLE: "1"
+      TERRAFORM_VERSION: ${{ matrix.terraform }}
     steps:
       - uses: actions/checkout@v2
       - name: Download dist
@@ -83,6 +84,7 @@ jobs:
         env:
           TEST_TARGET: ${{ matrix.target }}
           TERRAFORM_CLOUD_TOKEN: ${{ secrets.TERRAFORM_CLOUD_TOKEN }}
+          TERRAFORM_BINARY_NAME: "terraform${{ matrix.terraform }}"
           NODE_OPTIONS: "--max-old-space-size=7168"
 
   release_npm:


### PR DESCRIPTION
aligns with ci that runs on PR (and already does this)
