### PR TITLE
chore(docs): remove extra punctuation and duplicate example

### DIFF
--- a/website/docs/cdktf/cli-reference/commands.mdx
+++ b/website/docs/cdktf/cli-reference/commands.mdx
@@ -109,13 +109,7 @@ Examples:
 Convert a local file.
 
 ```bash
-cat main.tf | cdktf convert > imported.ts`
-```
-
-Convert HCL in your clipboard to Python on OSX.
-
-```bash
-pbpaste | cdktf convert --language python | pbcopy
+cat main.tf | cdktf convert > imported.ts
 ```
 
 Convert HCL in your clipboard to Python on OSX.


### PR DESCRIPTION
The examples for the `convert` command included an extra "\`", and one of the examples is a duplicate.