### PR TITLE
fix(lib): Add new optional AWS route attributes

### DIFF
--- a/packages/@cdktf/provider-generator/lib/get/generator/custom-defaults.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/custom-defaults.ts
@@ -70,6 +70,7 @@ export const CUSTOM_DEFAULTS: { [fullName: string]: any } = {
   "aws.route_table.route.vpc_peering_connection_id": null,
   "aws.route_table.route.destination_prefix_list_id": null,
   "aws.route_table.route.carrier_gateway_id": null,
+  "aws.route_table.route.core_network_arn": null,
 
   "aws.default_security_group.ingress.cidr_blocks": null,
   "aws.default_security_group.ingress.description": null,

--- a/packages/@cdktf/provider-generator/lib/get/generator/custom-defaults.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/custom-defaults.ts
@@ -29,6 +29,7 @@ export const CUSTOM_DEFAULTS: { [fullName: string]: any } = {
   "aws.default_route_table.route.vpc_endpoint_id": null,
   "aws.default_route_table.route.vpc_peering_connection_id": null,
   "aws.default_route_table.route.destination_prefix_list_id": null,
+  "aws.default_route_table.route.core_network_arn": null,
 
   "aws.emr_cluster.step.action_on_failure": null,
   "aws.emr_cluster.step.hadoop_jar_step": null,


### PR DESCRIPTION
**Fixes**: [cdktf_cdktf_provider_aws.vpc.RouteTableRoute requires core_network_arn](https://github.com/hashicorp/terraform-cdk/issues/1748)

Followed the logic used to address a similar issue in this PR:
https://github.com/hashicorp/terraform-cdk/pull/821/files