### PR TITLE
fix(cli): Stop pinning jest in TS init template

### DIFF
--- a/packages/cdktf-cli/templates/typescript/.hooks.sscaff.js
+++ b/packages/cdktf-cli/templates/typescript/.hooks.sscaff.js
@@ -12,8 +12,7 @@ exports.post = ctx => {
   if (!npm_cdktf) { throw new Error(`missing context "npm_cdktf"`); }
 
   installDeps([npm_cdktf, `constructs@10`]);
-  // make sure we have at least https://github.com/facebook/jest/releases/tag/v27.4.3 due to https://github.com/facebook/jest/issues/12098
-  installDeps(['@types/node', 'typescript', 'jest@^27.4.3', '@types/jest', "ts-jest", "ts-node"], true);
+  installDeps(['@types/node', 'typescript', 'jest', '@types/jest', "ts-jest", "ts-node"], true);
 
   console.log(readFileSync('./help', 'utf-8'));
 };


### PR DESCRIPTION
upstream issue has been resolved by now and the fixed version currently fails initializing a cdktf project as ts-node requires a newer version

Related to #1766