### PR TITLE
fix: Avoid unstable fqn for TerraformElements

### DIFF
--- a/packages/cdktf/lib/terraform-data-source.ts
+++ b/packages/cdktf/lib/terraform-data-source.ts
@@ -26,10 +26,9 @@ export class TerraformDataSource
   public count?: number;
   public provider?: TerraformProvider;
   public lifecycle?: TerraformResourceLifecycle;
-  public readonly fqn: string;
 
   constructor(scope: Construct, id: string, config: TerraformResourceConfig) {
-    super(scope, id);
+    super(scope, id, `data.${config.terraformResourceType}`);
 
     this.terraformResourceType = config.terraformResourceType;
     this.terraformGeneratorMetadata = config.terraformGeneratorMetadata;
@@ -41,12 +40,6 @@ export class TerraformDataSource
     this.count = config.count;
     this.provider = config.provider;
     this.lifecycle = config.lifecycle;
-    this.fqn = Token.asString(
-      ref(
-        `data.${this.terraformResourceType}.${this.friendlyUniqueId}`,
-        this.cdktfStack
-      )
-    );
   }
 
   public getStringAttribute(terraformAttribute: string) {

--- a/packages/cdktf/lib/terraform-element.ts
+++ b/packages/cdktf/lib/terraform-element.ts
@@ -78,7 +78,7 @@ export class TerraformElement extends Construct {
   public overrideLogicalId(newLogicalId: string) {
     ok(
       !this._fqnToken,
-      "Logical ID may not be overriden once .fqn has been requested"
+      "Logical ID may not be overriden once .fqn has been requested. Make sure to override the id before passing the construct to other constructs."
     );
     this._logicalIdOverride = newLogicalId;
   }

--- a/packages/cdktf/lib/terraform-element.ts
+++ b/packages/cdktf/lib/terraform-element.ts
@@ -92,7 +92,7 @@ export class TerraformElement extends Construct {
   public resetOverrideLogicalId() {
     ok(
       !this._fqnToken,
-      "Logical ID may not be overriden once .fqn has been requested"
+      "Logical ID may not be overriden once .fqn has been requested. You can only reset the override before you pass the construct to other constructs."
     );
     this._logicalIdOverride = undefined;
   }

--- a/packages/cdktf/lib/terraform-element.ts
+++ b/packages/cdktf/lib/terraform-element.ts
@@ -20,7 +20,10 @@ export class TerraformElement extends Construct {
   private _logicalIdOverride?: string;
 
   /**
-   * Type of this element, used for fqn
+   * Type of this element, used for fqn.
+   * This is undefined for
+   * - elements not referable, like TerraformOutput
+   * - elements using their own fqn implementation, like TerraformProvider
    */
   private readonly _elementType?: string;
 

--- a/packages/cdktf/lib/terraform-local.ts
+++ b/packages/cdktf/lib/terraform-local.ts
@@ -10,15 +10,11 @@ export class TerraformLocal
   implements ITerraformAddressable
 {
   private _expression: any;
-  public readonly fqn: string;
 
   constructor(scope: Construct, id: string, expression: any) {
-    super(scope, id);
+    super(scope, id, "local");
 
     this._expression = expression;
-    this.fqn = Token.asString(
-      ref(`local.${this.friendlyUniqueId}`, this.cdktfStack)
-    );
   }
 
   public set expression(value: any) {

--- a/packages/cdktf/lib/terraform-module.ts
+++ b/packages/cdktf/lib/terraform-module.ts
@@ -27,10 +27,9 @@ export abstract class TerraformModule
   public readonly version?: string;
   private _providers?: (TerraformProvider | TerraformModuleProvider)[];
   public dependsOn?: string[];
-  public readonly fqn: string;
 
   constructor(scope: Construct, id: string, options: TerraformModuleOptions) {
-    super(scope, id);
+    super(scope, id, "module");
 
     if (options.source.startsWith("./") || options.source.startsWith("../")) {
       // Create an asset for the local module for better TFC support
@@ -51,10 +50,6 @@ export abstract class TerraformModule
         insideTfExpression(dependency.fqn)
       );
     }
-
-    this.fqn = Token.asString(
-      ref(`module.${this.friendlyUniqueId}`, this.cdktfStack)
-    );
   }
 
   // jsii can't handle abstract classes?

--- a/packages/cdktf/lib/terraform-remote-state.ts
+++ b/packages/cdktf/lib/terraform-remote-state.ts
@@ -16,7 +16,6 @@ export abstract class TerraformRemoteState
   implements ITerraformAddressable
 {
   public static readonly tfResourceType = "terraform_remote_state";
-  public readonly fqn: string;
 
   constructor(
     scope: Construct,
@@ -24,13 +23,7 @@ export abstract class TerraformRemoteState
     private readonly backend: string,
     private readonly config: DataTerraformRemoteStateConfig
   ) {
-    super(scope, id);
-    this.fqn = Token.asString(
-      ref(
-        `data.terraform_remote_state.${this.friendlyUniqueId}`,
-        this.cdktfStack
-      )
-    );
+    super(scope, id, "data.terraform_remote_state");
   }
 
   public getString(output: string): string {

--- a/packages/cdktf/lib/terraform-resource.ts
+++ b/packages/cdktf/lib/terraform-resource.ts
@@ -58,10 +58,9 @@ export class TerraformResource
   public count?: number;
   public provider?: TerraformProvider;
   public lifecycle?: TerraformResourceLifecycle;
-  public readonly fqn: string;
 
   constructor(scope: Construct, id: string, config: TerraformResourceConfig) {
-    super(scope, id);
+    super(scope, id, config.terraformResourceType);
 
     this.terraformResourceType = config.terraformResourceType;
     this.terraformGeneratorMetadata = config.terraformGeneratorMetadata;
@@ -73,12 +72,6 @@ export class TerraformResource
     this.count = config.count;
     this.provider = config.provider;
     this.lifecycle = config.lifecycle;
-    this.fqn = Token.asString(
-      ref(
-        `${this.terraformResourceType}.${this.friendlyUniqueId}`,
-        this.cdktfStack
-      )
-    );
   }
 
   public getStringAttribute(terraformAttribute: string) {

--- a/packages/cdktf/lib/terraform-variable.ts
+++ b/packages/cdktf/lib/terraform-variable.ts
@@ -98,17 +98,14 @@ export class TerraformVariable
   public readonly sensitive?: boolean;
   public readonly nullable?: boolean;
 
-  public readonly fqn: string;
-
   constructor(scope: Construct, id: string, config: TerraformVariableConfig) {
-    super(scope, id);
+    super(scope, id, "var");
 
     this.default = config.default;
     this.description = config.description;
     this.type = config.type;
     this.sensitive = config.sensitive;
     this.nullable = config.nullable;
-    this.fqn = Token.asString(this.interpolation());
   }
 
   public get stringValue(): string {

--- a/packages/cdktf/test/resource.test.ts
+++ b/packages/cdktf/test/resource.test.ts
@@ -1,4 +1,4 @@
-import { Testing, TerraformStack } from "../lib";
+import { Testing, TerraformStack, TerraformElement } from "../lib";
 import { TestProvider, TestResource, OtherTestResource } from "./helper";
 import { TestDataSource } from "./helper/data-source";
 import { TerraformOutput } from "../lib/terraform-output";
@@ -67,6 +67,22 @@ test("resource fqn", () => {
   expect(JSON.parse(Testing.synth(stack) as any).output.result.value).toEqual(
     "${test_resource.test}"
   );
+});
+
+test("fqn is stable", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+
+  const elementWithFQN = new TerraformElement(stack, "test", "valid_type");
+  const fqn = elementWithFQN.fqn;
+  expect(elementWithFQN.fqn).toBe(fqn);
+
+  // May not override logical id after fqn has been requested
+  expect(() => elementWithFQN.overrideLogicalId("new-id")).toThrow();
+
+  const elementWithoutFQN = new TerraformElement(stack, "test2");
+  // May not request fqn on element without element type
+  expect(() => elementWithoutFQN.fqn).toThrow();
 });
 
 test("serialize list interpolation", () => {


### PR DESCRIPTION
Hi,

when using `dependsOn` to depend on a resource with overwritten logical id, the fqn does not fit the resource anymore, as it is generated within the constructor. I took an approach to stabilizing the fqn and also avoiding potential problems when using the fqn before changing the id.

This change might be a breaking change.

Let me know if you need any more infos!