### PR TITLE
fix(lib): Delay complex object fqn so that override id can still be used

### DIFF
--- a/test/typescript/providers/cdktf.json
+++ b/test/typescript/providers/cdktf.json
@@ -12,7 +12,7 @@
     "nomad",
     "external",
     "terraform-providers/openstack",
-    "oci",
+    "hashicorp/oci@= 4.75.0",
     "DataDog/datadog@~> 3.0",
     "awscc@= 0.17.0"
   ],


### PR DESCRIPTION
Closes #1656

#1779 introduced changes to fix #1656; however, #1725 made those fixes no longer work in all cases. This fixes that by applying a similar technique as the original fix.