### PR TITLE
feat(lib): add docstrings to gcs/http/local backend resources

### DIFF
--- a/packages/cdktf/lib/backends/gcs-backend.ts
+++ b/packages/cdktf/lib/backends/gcs-backend.ts
@@ -26,7 +26,7 @@ export class GcsBackend extends TerraformBackend {
     });
   }
 }
-
+ 
 export class DataTerraformRemoteStateGcs extends TerraformRemoteState {
   constructor(
     scope: Construct,
@@ -36,14 +36,58 @@ export class DataTerraformRemoteStateGcs extends TerraformRemoteState {
     super(scope, id, "gcs", config);
   }
 }
-
+/**
+ * Stores the state as an object in a configurable prefix in a pre-existing bucket 
+ * on Google Cloud Storage (GCS). The bucket must exist prior to configuring the backend.
+ * 
+ * This backend supports state locking.
+ * 
+ * Warning! It is highly recommended that you enable Object Versioning on the GCS bucket 
+ * to allow for state recovery in the case of accidental deletions and human error.
+ * 
+ * Read more about this backend in the Terraform docs:
+ * https://www.terraform.io/language/settings/backends/gcs
+ */
 export interface GcsBackendProps {
+  /**
+   * (Required) The name of the GCS bucket. This name must be globally unique.
+   */
   readonly bucket: string;
+  /**
+   * (Optional) Local path to Google Cloud Platform account credentials in JSON format. 
+   * If unset, Google Application Default Credentials are used. 
+   * The provided credentials must have Storage Object Admin role on the bucket. 
+   * 
+   * Warning: if using the Google Cloud Platform provider as well, 
+   * it will also pick up the GOOGLE_CREDENTIALS environment variable.
+   */
   readonly credentials?: string;
+  /**
+   * (Optional) A temporary [OAuth 2.0 access token] obtained from the Google Authorization server, 
+   * i.e. the Authorization: Bearer token used to authenticate HTTP requests to GCP APIs. 
+   * This is an alternative to credentials. 
+   * If both are specified, access_token will be used over the credentials field.
+   */
   readonly accessToken?: string;
+  /**
+   * (Optional) GCS prefix inside the bucket. 
+   * Named states for workspaces are stored in an object called <prefix>/<name>.tfstate.
+   */
   readonly prefix?: string;
+  /**
+   * (Optional) A 32 byte base64 encoded 'customer supplied encryption key' used to encrypt all state. 
+   */
   readonly encryptionKey?: string;
+  /**
+   * (Optional) The service account to impersonate for accessing the State Bucket. 
+   * You must have roles/iam.serviceAccountTokenCreator role on that account for the impersonation to succeed.
+   * If you are using a delegation chain, you can specify that using the impersonate_service_account_delegates field. 
+   * Alternatively, this can be specified using the GOOGLE_IMPERSONATE_SERVICE_ACCOUNT environment variable.
+   */
   readonly impersonateServiceAccount?: string;
+  /**
+   * (Optional) The delegation chain for an impersonating a service account
+   */
   readonly impersonateServiceAccountDelegates?: string[];
 }
 

--- a/packages/cdktf/lib/backends/http-backend.ts
+++ b/packages/cdktf/lib/backends/http-backend.ts
@@ -33,19 +33,69 @@ export class DataTerraformRemoteStateHttp extends TerraformRemoteState {
     super(scope, id, "http", config);
   }
 }
-
+/**
+ * Stores the state using a simple REST client.
+ * 
+ * State will be fetched via GET, updated via POST, and purged with DELETE. 
+ * The method used for updating is configurable.
+ * 
+ * This backend optionally supports state locking. 
+ * When locking support is enabled it will use LOCK and UNLOCK requests providing the lock info in the body. 
+ * The endpoint should return a 423: Locked or 409: Conflict with the holding lock info when 
+ * it's already taken, 200: OK for success. Any other status will be considered an error. 
+ * The ID of the holding lock info will be added as a query parameter to state updates requests.
+ * 
+ * Read more about this backend in the Terraform docs:
+ * https://www.terraform.io/language/settings/backends/http
+ */
 export interface HttpBackendProps {
+  /**
+   * (Required) The address of the REST endpoint
+   */
   readonly address: string;
+  /**
+   * (Optional) HTTP method to use when updating state. Defaults to POST.
+   */
   readonly updateMethod?: string;
+  /**
+   * (Optional) The address of the lock REST endpoint. Defaults to disabled.
+   */
   readonly lockAddress?: string;
+  /**
+   * (Optional) The HTTP method to use when locking. Defaults to LOCK.
+   */
   readonly lockMethod?: string;
+  /**
+   * (Optional) The address of the unlock REST endpoint. Defaults to disabled.
+   */
   readonly unlockAddress?: string;
+  /**
+   * (Optional) The HTTP method to use when unlocking. Defaults to UNLOCK.
+   */
   readonly unlockMethod?: string;
+  /**
+   * (Optional) The username for HTTP basic authentication
+   */
   readonly username?: string;
+  /**
+   * (Optional) The password for HTTP basic authentication
+   */
   readonly password?: string;
+  /**
+   * (Optional) Whether to skip TLS verification. Defaults to false.
+   */
   readonly skipCertVerification?: boolean;
+  /**
+   * (Optional) The number of HTTP request retries. Defaults to 2.
+   */
   readonly retryMax?: number;
+  /**
+   * (Optional) The minimum time in seconds to wait between HTTP request attempts. Defaults to 1.
+   */
   readonly retryWaitMin?: number;
+  /**
+   * (Optional) The maximum time in seconds to wait between HTTP request attempts. Defaults to 30.
+   */
   readonly retryWaitMax?: number;
 }
 

--- a/packages/cdktf/lib/backends/local-backend.ts
+++ b/packages/cdktf/lib/backends/local-backend.ts
@@ -49,13 +49,22 @@ export class DataTerraformRemoteStateLocal extends TerraformRemoteState {
     super(scope, id, "local", config);
   }
 }
-
+/**
+ * The local backend stores state on the local filesystem, 
+ * locks that state using system APIs, and performs operations locally.
+ * 
+ * Read more about this backend in the Terraform docs:
+ * https://www.terraform.io/language/settings/backends/http
+ */
 export interface LocalBackendProps {
   /**
-   * Path where the state file is stored.
-   * @default - defaults to terraform.${stackId}.tfstate
+   * (Optional) The path to the tfstate file. 
+   * This defaults to "terraform.tfstate" relative to the root module by default.
    */
   readonly path?: string;
+  /**
+   * (Optional) The path to non-default workspaces.
+   */
   readonly workspaceDir?: string;
 }
 

--- a/packages/cdktf/lib/backends/local-backend.ts
+++ b/packages/cdktf/lib/backends/local-backend.ts
@@ -60,9 +60,6 @@ export interface LocalBackendProps {
   /**
    * Path where the state file is stored.
    * @default - defaults to terraform.${stackId}.tfstate
-   * 
-   * (Optional) The path to the tfstate file. 
-   * This defaults to "terraform.tfstate" relative to the root module by default.
    */
   readonly path?: string;
   /**

--- a/packages/cdktf/lib/backends/local-backend.ts
+++ b/packages/cdktf/lib/backends/local-backend.ts
@@ -54,10 +54,13 @@ export class DataTerraformRemoteStateLocal extends TerraformRemoteState {
  * locks that state using system APIs, and performs operations locally.
  * 
  * Read more about this backend in the Terraform docs:
- * https://www.terraform.io/language/settings/backends/http
+ * https://www.terraform.io/language/settings/backends/local
  */
 export interface LocalBackendProps {
   /**
+   * Path where the state file is stored.
+   * @default - defaults to terraform.${stackId}.tfstate
+   * 
    * (Optional) The path to the tfstate file. 
    * This defaults to "terraform.tfstate" relative to the root module by default.
    */


### PR DESCRIPTION
Have added doc-string to gcs,http,local backend resources.

Working on issue - https://github.com/hashicorp/terraform-cdk/issues/1268