### PR TITLE
fix(docs): fix code blocks in "create and deploy" documentation

### DIFF
--- a/website/docs/cdktf/create-and-deploy/best-practices.mdx
+++ b/website/docs/cdktf/create-and-deploy/best-practices.mdx
@@ -13,7 +13,7 @@ Secrets appear in your synthesized CDKTF code when you read them directly from e
 
 The following example uses a Terraform variable to read the sensitive admin password instead of reading it directly from an environment variable.
 
-````ts
+```ts
 const adminPassword = new TerraformVariable(this, "adminPassword", {
   type: "string",
   description: "Admin password for the instance",
@@ -22,6 +22,7 @@ const adminPassword = new TerraformVariable(this, "adminPassword", {
 new MyResource(this, "hello", {
   adminPassword: adminPassword.value, // use this instead of process.env.ADMIN_PASSWORD
 });
+```
 
 To pass a [Terraform variable through environment variables](/cli/config/environment-variables#tf_var_name), name the environment variable `TF_VAR_NAME`. For example, set `TF_VAR_adminPasword='<your password>'` in the execution environment.
 
@@ -91,7 +92,7 @@ new Blog(this, "ecommerce-staging", {
   subnets: stageNetworking.subnets,
   region: "us-west-1",
 });
-````
+```
 
 ### Create Extensible Constructs
 


### PR DESCRIPTION
This PR fixes code blocks in the `Create and Deploy > Best Practices > Read Secrets with Terraform Variables` [documentation](https://www.terraform.io/cdktf/create-and-deploy/best-practices#read-secrets-with-terraform-variables). Below is an image of the current documentation.

![image](https://user-images.githubusercontent.com/10817843/170557273-26ed2234-2d2b-4798-9028-ad2a9c67584c.png)
