### PR TITLE
fix(cli): Fix package version check on Windows

### DIFF
--- a/packages/cdktf-cli/lib/debug.ts
+++ b/packages/cdktf-cli/lib/debug.ts
@@ -133,7 +133,7 @@ async function getPythonPackageVersion(
   }
 
   const versionInfo = output
-    .split("\n")
+    .split(/\r\n|\r|\n/)
     .find((line) => line.startsWith("Version:"));
 
   if (!versionInfo) {
@@ -169,7 +169,7 @@ async function getCSharpPackageVersion(packageName: string) {
   }
 
   const versionLine = output
-    .split("\n")
+    .split(/\r\n|\r|\n/)
     .find((line) => line.includes(`> ${cSharpPackageName}`));
 
   if (!versionLine) {
@@ -208,7 +208,7 @@ async function getGoPackageVersion(packageName: string) {
   }
 
   let versionLine = output
-    .split("\n")
+    .split(/\r\n|\r|\n/)
     .find((line) => line.includes(goPackageName));
 
   if (!versionLine) {
@@ -254,7 +254,7 @@ async function getJavaPackageVersion(packageName: string) {
   }
 
   const versionLine = resolutionPart
-    .split("\n")
+    .split(/\r\n|\r|\n/)
     .find((line) => line.includes(javaPackageName));
 
   if (!versionLine) {

--- a/packages/cdktf-cli/lib/dependencies/dependency-manager.ts
+++ b/packages/cdktf-cli/lib/dependencies/dependency-manager.ts
@@ -116,17 +116,17 @@ export class ProviderConstraint {
  * manages dependencies of a CDKTF project (e.g. terraform providers)
  */
 export class DependencyManager {
-  private packageManager: PackageManager;
+  private packageManager?: PackageManager;
 
   constructor(
     private readonly targetLanguage: Language,
     private cdktfVersion: string,
     private readonly projectDirectory: string
   ) {
-    this.packageManager = PackageManager.forLanguage(
-      targetLanguage,
-      this.projectDirectory
-    );
+    this.packageManager =
+      targetLanguage !== Language.GO
+        ? PackageManager.forLanguage(targetLanguage, this.projectDirectory)
+        : undefined;
   }
 
   async addProvider(
@@ -182,6 +182,12 @@ export class DependencyManager {
     if (this.targetLanguage === Language.GO) {
       throw Errors.Usage(
         "There are no pre-built providers published for Go at the moment. See https://github.com/hashicorp/terraform-cdk/issues/723"
+      );
+    }
+
+    if (!this.packageManager) {
+      throw Errors.Internal(
+        "Package manager not initialized. Please report this issue."
       );
     }
 

--- a/test/csharp/provider-add-command/test.ts
+++ b/test/csharp/provider-add-command/test.ts
@@ -13,6 +13,11 @@ describe("provider add command", () => {
       });
     }, 500_000);
 
+    it("detects correct cdktf version", async () => {
+      const res = await driver.exec("cdktf", ["debug"]);
+      expect(res.stdout).toContain("cdktf: 0.10.4");
+    });
+
     onPosix(
       "installs pre-built provider using nuget",
       async () => {
@@ -22,20 +27,20 @@ describe("provider add command", () => {
           "random@=3.1.3", // this is not the latest version, but theres v0.2.55 of the pre-built provider resulting in exactly this package
         ]);
         expect(res.stdout).toMatchInlineSnapshot(`
-        "Checking whether pre-built provider exists for the following constraints:
-          provider: random
-          version : =3.1.3
-          language: csharp
-          cdktf   : 0.10.4
+                  "Checking whether pre-built provider exists for the following constraints:
+                    provider: random
+                    version : =3.1.3
+                    language: csharp
+                    cdktf   : 0.10.4
 
 
-        Found pre-built provider.
+                  Found pre-built provider.
 
-        Installing package HashiCorp.Cdktf.Providers.Random @ 0.2.55 using \\"dotnet add package HashiCorp.Cdktf.Providers.Random --version 0.2.55\\".
+                  Installing package HashiCorp.Cdktf.Providers.Random @ 0.2.55 using \\"dotnet add package HashiCorp.Cdktf.Providers.Random --version 0.2.55\\".
 
-        Package installed.
-        "
-      `);
+                  Package installed.
+                  "
+              `);
         expect(res.stderr).toBe("");
 
         const proj = driver.readLocalFile("MyTerraformStack.csproj");

--- a/test/go/edge/test.ts
+++ b/test/go/edge/test.ts
@@ -7,19 +7,21 @@ describe("Golang edge provider test", () => {
 
   beforeAll(async () => {
     driver = new TestDriver(__dirname);
-    await driver.setupGoProject((dir) => {
-      // use generated custom bindings
-      fs.copySync(
-        path.resolve(
-          __dirname,
-          "..",
-          "..",
-          "edge-provider-bindings",
-          "go",
-          "edge"
-        ),
-        path.resolve(dir, "generated", "hashicorp", "edge")
-      );
+    await driver.setupGoProject({
+      cb: (dir) => {
+        // use generated custom bindings
+        fs.copySync(
+          path.resolve(
+            __dirname,
+            "..",
+            "..",
+            "edge-provider-bindings",
+            "go",
+            "edge"
+          ),
+          path.resolve(dir, "generated", "hashicorp", "edge")
+        );
+      },
     });
 
     console.log(driver.workingDirectory);

--- a/test/go/provider-add-command/cdktf.json
+++ b/test/go/provider-add-command/cdktf.json
@@ -1,0 +1,9 @@
+{
+  "language": "go",
+  "app": "go run main.go",
+  "terraformProviders": ["hashicorp/null@~> 3.1.0"],
+  "codeMakerOutput": "generated",
+  "context": {
+    "excludeStackIdFromLogicalIds": "true"
+  }
+}

--- a/test/go/provider-add-command/main.go
+++ b/test/go/provider-add-command/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"github.com/aws/constructs-go/constructs/v10"
+	"github.com/aws/jsii-runtime-go"
+	"github.com/hashicorp/terraform-cdk-go/cdktf"
+)
+
+func NewMyStack(scope constructs.Construct, id string) cdktf.TerraformStack {
+	stack := cdktf.NewTerraformStack(scope, &id)
+	return stack
+}
+
+func main() {
+	app := cdktf.Testing_StubVersion(cdktf.NewApp(&cdktf.AppOptions{StackTraces: jsii.Bool(false)}))
+
+	NewMyStack(app, "go-simple")
+
+	app.Synth()
+}

--- a/test/go/provider-add-command/test.ts
+++ b/test/go/provider-add-command/test.ts
@@ -8,11 +8,6 @@ describe("provider add command", () => {
       await driver.setupGoProject();
     }, 500_000);
 
-    it("detects correct cdktf version", async () => {
-      const res = await driver.exec("cdktf", ["debug"]);
-      expect(res.stdout).toContain("cdktf: v0.0.0");
-    });
-
     onPosix(
       "adds local provider on posix", // Don't have pre-built providers for go
       async () => {

--- a/test/go/provider-add-command/test.ts
+++ b/test/go/provider-add-command/test.ts
@@ -1,0 +1,85 @@
+import { onPosix, onWindows, TestDriver } from "../../test-helper";
+
+describe("provider add command", () => {
+  describe("pre-built", () => {
+    let driver: TestDriver;
+    beforeEach(async () => {
+      driver = new TestDriver(__dirname, {
+        CDKTF_DIST: "",
+        DISABLE_VERSION_CHECK: "true",
+      }); // reset CDKTF_DIST set by run-against-dist script & disable version check as we have to use an older version of cdktf-cli
+      await driver.setupGoProject({
+        init: { additionalOptions: "--cdktf-version 0.10.4" },
+      });
+    }, 500_000);
+
+    it("detects correct cdktf version", async () => {
+      const res = await driver.exec("cdktf", ["debug"]);
+      expect(res.stdout).toContain("cdktf: 0.10.4");
+    });
+
+    onPosix(
+      "adds local provider on posix", // Don't have pre-built providers for go
+      async () => {
+        const res = await driver.exec("cdktf", [
+          "provider",
+          "add",
+          "local@=2.2.3",
+        ]);
+        const config = JSON.parse(driver.readLocalFile("cdktf.json"));
+        expect(config.terraformProviders).toMatchInlineSnapshot(`
+        Array [
+          "hashicorp/null@ ~> 3.1.0",
+          "hashicorp/local@=2.2.3",
+        ]
+      `);
+
+        expect(res.stdout).toContain(
+          `Local providers have been updated. Running cdktf get to update...`
+        );
+
+        await new Promise((r) => setTimeout(r, 10000));
+
+        const genVersionsFile = JSON.parse(
+          driver.readLocalFile(".gen/versions.json")
+        );
+
+        expect(
+          genVersionsFile["registry.terraform.io/hashicorp/local"]
+        ).toEqual("2.2.3");
+      },
+      240_000
+    );
+
+    onWindows(
+      "adds local provider on windows",
+      async () => {
+        const res = await driver.exec("cdktf", [
+          "provider",
+          "add",
+          "local@=2.2.3",
+        ]);
+        const config = JSON.parse(driver.readLocalFile("cdktf.json"));
+        expect(config.terraformProviders).toMatchInlineSnapshot(`
+        Array [
+          "hashicorp/null@ ~> 3.1.0",
+          "hashicorp/local@=2.2.3",
+        ]
+      `);
+
+        expect(res.stdout).toContain(
+          `Local providers have been updated. Running cdktf get to update...`
+        );
+
+        const genVersionsFile = JSON.parse(
+          driver.readLocalFile(".gen/versions.json")
+        );
+
+        expect(
+          genVersionsFile["registry.terraform.io/hashicorp/local"]
+        ).toEqual("2.2.3");
+      },
+      120_000
+    );
+  });
+});

--- a/test/go/provider-add-command/test.ts
+++ b/test/go/provider-add-command/test.ts
@@ -61,13 +61,15 @@ describe("provider add command", () => {
           `Local providers have been updated. Running cdktf get to update...`
         );
 
-        const genVersionsFile = JSON.parse(
-          driver.readLocalFile(".gen/versions.json")
-        );
-
-        expect(
-          genVersionsFile["registry.terraform.io/hashicorp/local"]
-        ).toEqual("2.2.3");
+        // This file currently is only created for TypeScript targets
+        // we need to make "generateJsiiLanguage" copy that file to
+        // the target directory for this to work
+        // const genVersionsFile = JSON.parse(
+        //   driver.readLocalFile("generated/versions.json")
+        // );
+        // expect(
+        //   genVersionsFile["registry.terraform.io/hashicorp/local"]
+        // ).toEqual("2.2.3");
       },
       120_000
     );

--- a/test/go/provider-add-command/test.ts
+++ b/test/go/provider-add-command/test.ts
@@ -1,21 +1,16 @@
 import { onPosix, onWindows, TestDriver } from "../../test-helper";
 
 describe("provider add command", () => {
-  describe("pre-built", () => {
+  describe("local", () => {
     let driver: TestDriver;
     beforeEach(async () => {
-      driver = new TestDriver(__dirname, {
-        CDKTF_DIST: "",
-        DISABLE_VERSION_CHECK: "true",
-      }); // reset CDKTF_DIST set by run-against-dist script & disable version check as we have to use an older version of cdktf-cli
-      await driver.setupGoProject({
-        init: { additionalOptions: "--cdktf-version 0.10.4" },
-      });
+      driver = new TestDriver(__dirname);
+      await driver.setupGoProject();
     }, 500_000);
 
     it("detects correct cdktf version", async () => {
       const res = await driver.exec("cdktf", ["debug"]);
-      expect(res.stdout).toContain("cdktf: 0.10.4");
+      expect(res.stdout).toContain("cdktf: v0.0.0");
     });
 
     onPosix(
@@ -29,7 +24,7 @@ describe("provider add command", () => {
         const config = JSON.parse(driver.readLocalFile("cdktf.json"));
         expect(config.terraformProviders).toMatchInlineSnapshot(`
         Array [
-          "hashicorp/null@ ~> 3.1.0",
+          "hashicorp/null@~> 3.1.0",
           "hashicorp/local@=2.2.3",
         ]
       `);
@@ -38,15 +33,15 @@ describe("provider add command", () => {
           `Local providers have been updated. Running cdktf get to update...`
         );
 
-        await new Promise((r) => setTimeout(r, 10000));
-
-        const genVersionsFile = JSON.parse(
-          driver.readLocalFile(".gen/versions.json")
-        );
-
-        expect(
-          genVersionsFile["registry.terraform.io/hashicorp/local"]
-        ).toEqual("2.2.3");
+        // This file currently is only created for TypeScript targets
+        // we need to make "generateJsiiLanguage" copy that file to
+        // the target directory for this to work
+        // const genVersionsFile = JSON.parse(
+        //   driver.readLocalFile("generated/versions.json")
+        // );
+        // expect(
+        //   genVersionsFile["registry.terraform.io/hashicorp/local"]
+        // ).toEqual("2.2.3");
       },
       240_000
     );
@@ -62,7 +57,7 @@ describe("provider add command", () => {
         const config = JSON.parse(driver.readLocalFile("cdktf.json"));
         expect(config.terraformProviders).toMatchInlineSnapshot(`
         Array [
-          "hashicorp/null@ ~> 3.1.0",
+          "hashicorp/null@~> 3.1.0",
           "hashicorp/local@=2.2.3",
         ]
       `);

--- a/test/java/provider-add-command/test.ts
+++ b/test/java/provider-add-command/test.ts
@@ -14,6 +14,11 @@ describe("provider add command", () => {
       });
     });
 
+    it("detects correct cdktf version", async () => {
+      const res = await driver.exec("cdktf", ["debug"]);
+      expect(res.stdout).toContain("cdktf: 0.10.4");
+    });
+
     test("installs pre-built provider using maven", async () => {
       const res = await driver.exec("cdktf", [
         "provider",

--- a/test/python/provider-add-command/test.ts
+++ b/test/python/provider-add-command/test.ts
@@ -15,6 +15,11 @@ describe("provider add command", () => {
         });
       });
 
+      it("detects correct cdktf version", async () => {
+        const res = await driver.exec("cdktf", ["debug"]);
+        expect(res.stdout).toContain("cdktf: 0.10.4");
+      });
+
       test("installs pre-built provider using pipenb", async () => {
         const res = await driver.exec("cdktf", [
           "provider",
@@ -44,6 +49,11 @@ describe("provider add command", () => {
 
         driver.copyFile("cdktf-pip.json", "cdktf.json");
         driver.copyFiles("requirements.txt");
+      });
+
+      it("detects correct cdktf version", async () => {
+        const res = await driver.exec("cdktf", ["debug"]);
+        expect(res.stdout).toContain("cdktf: 0.10.4");
       });
 
       test("installs pre-built provider using pipenb", async () => {

--- a/test/test-helper.ts
+++ b/test/test-helper.ts
@@ -294,15 +294,18 @@ export class TestDriver {
     await this.get();
   };
 
-  setupGoProject = async (cb?: (workingDirectory) => void) => {
+  setupGoProject = async (options?: {
+    init?: { additionalOptions?: string };
+    cb?: (workingDirectory) => void;
+  }) => {
     this.switchToTempDir();
     console.log(this.workingDirectory);
-    await this.init("go");
+    await this.init("go", options?.init?.additionalOptions);
     this.copyFiles("cdktf.json");
     this.copyFile("main.go", "main.go");
 
     await this.get();
-    cb && cb(this.workingDirectory);
+    options?.cb && options.cb(this.workingDirectory);
 
     // automatically retrieves required jsii-runtime module (used in generated providers)
     await this.exec("go mod tidy");

--- a/test/typescript/provider-add-command/test.ts
+++ b/test/typescript/provider-add-command/test.ts
@@ -13,6 +13,11 @@ describe("provider add command", () => {
       });
     }, 500_000);
 
+    it("detects correct cdktf version", async () => {
+      const res = await driver.exec("cdktf", ["debug"]);
+      expect(res.stdout).toContain("cdktf: 0.10.4");
+    });
+
     test("installs pre-built provider using npm", async () => {
       const res = await driver.exec("cdktf", [
         "provider",

--- a/test/typescript/provider-add-command/test.ts
+++ b/test/typescript/provider-add-command/test.ts
@@ -78,8 +78,6 @@ describe("provider add command", () => {
           `Local providers have been updated. Running cdktf get to update...`
         );
 
-        await new Promise((r) => setTimeout(r, 10000));
-
         const genVersionsFile = JSON.parse(
           driver.readLocalFile(".gen/versions.json")
         );


### PR DESCRIPTION
For at least c#, the package version lookup is failing on Windows due to line endings. I went ahead and change the other languages as well.
I believe this is at least partially contributing to #1816.