### PR TITLE
fix: Allow "all" as ignoreChanges lifecycle value

### DIFF
--- a/packages/cdktf/lib/terraform-resource.ts
+++ b/packages/cdktf/lib/terraform-resource.ts
@@ -24,7 +24,7 @@ export interface ITerraformResource {
 export interface TerraformResourceLifecycle {
   readonly createBeforeDestroy?: boolean;
   readonly preventDestroy?: boolean;
-  readonly ignoreChanges?: string[];
+  readonly ignoreChanges?: string[] | "all";
 }
 
 export interface TerraformMetaArguments {


### PR DESCRIPTION
ignoreChanges can be "all" ignoring all changes. This has to be reflected by the type (if that's true for all resources?).

Closes #1425