### PR TITLE
feat(cli): support custom Terraform Enterprise instances

### DIFF
--- a/packages/cdktf-cli/bin/cmds/handlers.ts
+++ b/packages/cdktf-cli/bin/cmds/handlers.ts
@@ -1,7 +1,6 @@
 import chalk from "chalk";
 import * as fs from "fs-extra";
 import React from "react";
-import yargs from "yargs";
 import { convert as hcl2cdkConvert } from "@cdktf/hcl2cdk";
 import {
   readSchema,
@@ -237,13 +236,16 @@ export async function list(argv: any) {
   await renderInk(React.createElement(List, { outDir, synthCommand: command }));
 }
 
-export async function login(argv: any) {
+export async function login(argv: { tfeHostname: string }) {
   await terraformCheck();
   await displayVersionMessage();
 
   async function showUserDetails(authToken: string) {
     // Get user details if token is set
-    const userAccount = await terraformCloudClient.getAccountDetails(authToken);
+    const userAccount = await terraformCloudClient.getAccountDetails(
+      argv.tfeHostname,
+      authToken
+    );
     if (userAccount) {
       const username = userAccount.data.attributes.username;
       console.log(
@@ -255,16 +257,7 @@ export async function login(argv: any) {
     }
   }
 
-  const args = argv as yargs.Arguments;
-  if (args["_"].length > 1) {
-    console.error(
-      chalkColour`{redBright ERROR: 'cdktf login' command cannot have more than one argument.}\n`
-    );
-    yargs.showHelp();
-    process.exit(1);
-  }
-
-  const terraformLogin = new TerraformLogin();
+  const terraformLogin = new TerraformLogin(argv.tfeHostname);
   let token = "";
   try {
     token = await readStreamAsString(process.stdin, "No stdin was passed");

--- a/packages/cdktf-cli/bin/cmds/helper/init.ts
+++ b/packages/cdktf-cli/bin/cmds/helper/init.ts
@@ -49,7 +49,7 @@ export function checkForEmptyDirectory(dir: string) {
     process.exit(1);
   }
 }
-
+const tfeHostname = "app.terraform.io";
 type Options = {
   local?: boolean;
   template?: string;
@@ -69,7 +69,8 @@ export async function runInit(argv: Options) {
     // We ask the user to login to Terraform Cloud and set a token
     // If the user chooses not to use Terraform Cloud, we continue
     // without a token and set up the project.
-    const terraformLogin = new TerraformLogin();
+
+    const terraformLogin = new TerraformLogin(tfeHostname);
     token = await terraformLogin.askToLogin();
   } else {
     console.log(chalkColour`{yellow Note: By supplying '--local' option you have chosen local storage mode for storing the state of your stack.
@@ -112,6 +113,7 @@ This means that your Terraform state file will be stored locally on disk in a fi
       );
       try {
         await terraformCloudClient.createWorkspace(
+          tfeHostname,
           projectInfo.OrganizationName,
           projectInfo.WorkspaceName,
           token
@@ -267,6 +269,7 @@ async function gatherInfo(
       chalkColour`\nWe will now set up {blueBright Terraform Cloud} for your project.\n`
     );
     const organizationNames = await terraformCloudClient.getOrganizationNames(
+      tfeHostname,
       token
     );
     const organizationData = organizationNames.data;

--- a/packages/cdktf-cli/bin/cmds/helper/terraform-cloud-client.ts
+++ b/packages/cdktf-cli/bin/cmds/helper/terraform-cloud-client.ts
@@ -1,8 +1,6 @@
 import https = require("https");
 import { format } from "url";
 
-const BASE_URL = `https://app.terraform.io/api/v2/`;
-
 const SUCCESS_STATUS_CODES = [200, 201];
 
 export interface Attributes {
@@ -102,17 +100,21 @@ async function post(url: string, token: string, data: string) {
   });
 }
 
-export async function getAccountDetails(token: string) {
-  return (await get(`${BASE_URL}/account/details`, token)) as Account;
+export async function getAccountDetails(tfeHostname: string, token: string) {
+  return (await get(
+    `https://${tfeHostname}/api/v2//account/details`,
+    token
+  )) as Account;
 }
 
 export async function createWorkspace(
+  tfeHostname: string,
   organizationName: string,
   workspaceName: string,
   token: string
 ) {
   await post(
-    `${BASE_URL}/organizations/${organizationName}/workspaces`,
+    `https://${tfeHostname}/api/v2//organizations/${organizationName}/workspaces`,
     token,
     JSON.stringify({
       data: {
@@ -126,6 +128,9 @@ export async function createWorkspace(
   );
 }
 
-export async function getOrganizationNames(token: string) {
-  return (await get(`${BASE_URL}/organizations`, token)) as Organization;
+export async function getOrganizationNames(tfeHostname: string, token: string) {
+  return (await get(
+    `https://${tfeHostname}/api/v2//organizations`,
+    token
+  )) as Organization;
 }

--- a/packages/cdktf-cli/bin/cmds/helper/utilities.ts
+++ b/packages/cdktf-cli/bin/cmds/helper/utilities.ts
@@ -38,13 +38,12 @@ export const requireHandlers = () => {
 };
 
 export function readStreamAsString(
-  stream: typeof process.stdin
+  stream: typeof process.stdin,
+  noTTYErrorMessage: string
 ): Promise<string> {
   return new Promise((ok, ko) => {
     if (stream.isTTY) {
-      ko(
-        "No stdin was passed, please use it like this: cat main.tf | cdktf convert > imported.ts"
-      );
+      ko(noTTYErrorMessage);
     } else {
       let string = "";
       stream.on("data", (data) => (string += data.toString()));

--- a/packages/cdktf-cli/bin/cmds/login.ts
+++ b/packages/cdktf-cli/bin/cmds/login.ts
@@ -7,7 +7,15 @@ class Command extends BaseCommand {
   public readonly command = "login";
   public readonly describe =
     "Retrieves an API token to connect to Terraform Cloud.";
-  public readonly builder = (args: yargs.Argv) => args.showHelpOnFail(true);
+  public readonly builder = (args: yargs.Argv) =>
+    args
+      .showHelpOnFail(true)
+      .example("cdktf login", "Takes you through the interactive login process")
+      .example(
+        "cat my-token.txt | cdktf login",
+        "Uses a locally stored token directly, instead of going through the interactive login process"
+      )
+      .strict();
 
   public async handleCommand(argv: any) {
     Errors.setScope("login");

--- a/packages/cdktf-cli/bin/cmds/login.ts
+++ b/packages/cdktf-cli/bin/cmds/login.ts
@@ -6,11 +6,22 @@ import { BaseCommand } from "./helper/base-command";
 class Command extends BaseCommand {
   public readonly command = "login";
   public readonly describe =
-    "Retrieves an API token to connect to Terraform Cloud.";
+    "Retrieves an API token to connect to Terraform Cloud or Terraform Enterprise.";
   public readonly builder = (args: yargs.Argv) =>
     args
       .showHelpOnFail(true)
+      .option("tfe-hostname", {
+        string: true,
+        requiresArg: true,
+        describe:
+          "The Terraform Enterprise hostname to authenticate against. If you use Terraform Cloud you can leave this on the default.",
+        default: "app.terraform.io",
+      })
       .example("cdktf login", "Takes you through the interactive login process")
+      .example(
+        "cdktf login --tfe-hostname tfe.my-company.com",
+        "Takes you through the interactive login process on your companies Terraform Enterprise instance."
+      )
       .example(
         "cat my-token.txt | cdktf login",
         "Uses a locally stored token directly, instead of going through the interactive login process"

--- a/packages/cdktf-cli/lib/models/terraform-cloud.ts
+++ b/packages/cdktf-cli/lib/models/terraform-cloud.ts
@@ -149,7 +149,10 @@ export class TerraformCloud implements Terraform {
       this.token = configFile.credentials[this.hostname].token;
     }
 
-    this.client = new TerraformCloudClient.TerraformCloud(this.token);
+    this.client = new TerraformCloudClient.TerraformCloud(
+      this.token,
+      this.hostname
+    );
 
     this.abortSignal.addEventListener("abort", () => {
       this.removeRun("cancel");
@@ -231,7 +234,7 @@ export class TerraformCloud implements Terraform {
       throw new Error("Please create a ConfigurationVersion before planning");
     const sendLog = this.createTerraformLogHandler("plan");
     const workspace = await this.workspace();
-    const workspaceUrl = `https://app.terraform.io/app/${this.organizationName}/workspaces/${this.workspaceName}`;
+    const workspaceUrl = `https://${this.hostname}/app/${this.organizationName}/workspaces/${this.workspaceName}`;
 
     if (
       workspace.attributes.locked &&
@@ -284,7 +287,7 @@ export class TerraformCloud implements Terraform {
         },
       },
     });
-    const url = `https://app.terraform.io/app/${this.organizationName}/workspaces/${this.workspaceName}/runs/${result.id}`;
+    const url = `https://${this.hostname}/app/${this.organizationName}/workspaces/${this.workspaceName}/runs/${result.id}`;
     sendLog(`Created speculative Terraform Cloud run: ${url}`);
 
     const pendingStates = ["pending", "plan_queued", "planning"];
@@ -494,7 +497,7 @@ export class TerraformCloud implements Terraform {
       return;
     }
 
-    const url = `https://app.terraform.io/app/${this.organizationName}/workspaces/${this.workspaceName}/runs/${this.run.id}`;
+    const url = `https://${this.hostname}/app/${this.organizationName}/workspaces/${this.workspaceName}/runs/${this.run.id}`;
     logger.info(`${action}ing run ${url}`);
     this.client.Runs.action(action, this.run.id)
       .then(() => {

--- a/packages/cdktf-cli/package.json
+++ b/packages/cdktf-cli/package.json
@@ -93,7 +93,7 @@
     "@cdktf/provider-generator": "0.0.0",
     "@npmcli/ci-detect": "^1.4.0",
     "@skorfmann/ink-confirm-input": "^3.0.0",
-    "@skorfmann/terraform-cloud": "^1.12.0",
+    "@skorfmann/terraform-cloud": "^1.14.0",
     "@types/archiver": "^5.3.1",
     "@types/cross-spawn": "^6.0.2",
     "@types/detect-port": "^1.3.2",

--- a/website/docs/cdktf/cli-reference/commands.mdx
+++ b/website/docs/cdktf/cli-reference/commands.mdx
@@ -390,19 +390,23 @@ $ cdktf login --help
 ```
 cdktf login
 
-Retrieves an API token to connect to Terraform Cloud.
+Retrieves an API token to connect to Terraform Cloud or Terraform Enterprise.
 
 Options:
       --version                   Show version number                                                                                                                                                    [boolean]
       --disable-plugin-cache-env  Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env CDKTF_DISABLE_PLUGIN_CACHE_ENV.
                                                                                                                                                                                         [boolean] [default: false]
       --log-level                 Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL                                                                                   [string]
+      --tfe-hostname              The Terraform Enterprise hostname to authenticate against. If you use Terraform Cloud you can leave this on the default.                  [string] [default: "app.terraform.io"]
   -h, --help                      Show help                                                                                                                                                              [boolean]
 
 Examples:
-  cdktf login                     Takes you through the interactive login process
-  cat my-token.txt | cdktf login  Uses a locally stored token directly, instead of going through the interactive login process                                                                                                                                  [boolean]
+  cdktf login                                    Takes you through the interactive login process
+  cdktf login --tfe-hostname tfe.my-company.com  Takes you through the interactive login process on your companies Terraform Enterprise instance.
+  cat my-token.txt | cdktf login                 Uses a locally stored token directly, instead of going through the interactive login process
 ```
+
+Please note that we currently expect custom TFE instances to be using the `https` protocol.
 
 **Examples**
 

--- a/website/docs/cdktf/cli-reference/commands.mdx
+++ b/website/docs/cdktf/cli-reference/commands.mdx
@@ -393,9 +393,15 @@ cdktf login
 Retrieves an API token to connect to Terraform Cloud.
 
 Options:
-  --version          Show version number                                                                                                                                           [boolean]
-  --log-level        Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL                                                                          [string]
-  -h, --help         Show help                                                                                                                                                     [boolean]
+      --version                   Show version number                                                                                                                                                    [boolean]
+      --disable-plugin-cache-env  Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env CDKTF_DISABLE_PLUGIN_CACHE_ENV.
+                                                                                                                                                                                        [boolean] [default: false]
+      --log-level                 Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL                                                                                   [string]
+  -h, --help                      Show help                                                                                                                                                              [boolean]
+
+Examples:
+  cdktf login                     Takes you through the interactive login process
+  cat my-token.txt | cdktf login  Uses a locally stored token directly, instead of going through the interactive login process                                                                                                                                  [boolean]
 ```
 
 **Examples**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,10 +1718,10 @@
     prop-types "^15.5.10"
     yn "^3.1.1"
 
-"@skorfmann/terraform-cloud@^1.12.0":
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/@skorfmann/terraform-cloud/-/terraform-cloud-1.12.0.tgz#883db4e2ae9629c424ee230f96a87331bea97cff"
-  integrity sha512-XG4gi/TWJv39UGqfeoAffOP6izWRsKG9fgl3FTjyiCsF3hnZi5vhxg4k74ydaxq29lxsc6p/gPTufG7MTqqL1w==
+"@skorfmann/terraform-cloud@^1.14.0":
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/@skorfmann/terraform-cloud/-/terraform-cloud-1.14.0.tgz#463b637a5d0973d69f10ec2a1d650dea040c2cfc"
+  integrity sha512-9SVGwp0/dORB8y69SWrYqro9qrcWMP340+pJIa92JxPUQeSRhwOLFqhrn/5MsJ75AA8kNj4ZD4YZ4TTqu4B0Hw==
   dependencies:
     axios "^0.21.1"
     camelcase-keys "^6.2.2"


### PR DESCRIPTION
This PR also ships support for logging into terraform enterprise instances as well as logging in by passing a token through stdin.

Closes #1854

