### PR TITLE
chore: use retry action

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -50,7 +50,12 @@ jobs:
       - name: create bundle
         run: yarn package
       - name: examples integration tests
-        run: test/run-against-dist tools/build-examples.sh ${TEST_TARGET}
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 2
+          retry_on: error
+          command: test/run-against-dist tools/build-examples.sh ${TEST_TARGET}
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           TEST_TARGET: "${{ matrix.target }}"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -84,8 +84,13 @@ jobs:
           path: test/edge-provider-bindings
       - name: install test dependencies
         run: cd test && yarn
-      - name: integration tests
-        run: cd test && ./run-against-dist npx jest ${TEST_TARGET}
+      - name: integration test
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 2
+          retry_on: error
+          command: cd test && ./run-against-dist npx jest ${TEST_TARGET}
         env:
           TEST_TARGET: ${{ matrix.target }}
           TERRAFORM_CLOUD_TOKEN: ${{ secrets.TERRAFORM_CLOUD_TOKEN }}
@@ -131,8 +136,15 @@ jobs:
         run: npm install -g npm@8.12.1
       - name: install test dependencies
         run: cd test && yarn
-      - name: integration tests
-        run: cd test && ./run-against-dist.bat "npx jest --ci ${env:TEST_TARGET}"
+      - name: integration test
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 2
+          retry_on: error
+          command: |
+            cd test
+            ./run-against-dist.bat "npx jest --ci ${env:TEST_TARGET}"
         env:
           TEST_TARGET: ${{ matrix.target }}
           TERRAFORM_CLOUD_TOKEN: ${{ secrets.TERRAFORM_CLOUD_TOKEN }}

--- a/.github/workflows/provider-integration.yml
+++ b/.github/workflows/provider-integration.yml
@@ -69,8 +69,13 @@ jobs:
           path: dist
       - name: install test dependencies
         run: cd test && yarn
-      - name: integration tests
-        run: cd test && npm run test:provider -- ${TEST_TARGET}
+      - name: integration test
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 2
+          retry_on: error
+          command: cd test && npm run test:provider -- ${TEST_TARGET}
         env:
           TEST_TARGET: ${{ matrix.target }}
           NODE_OPTIONS: "--max-old-space-size=7168"
@@ -109,8 +114,15 @@ jobs:
         run: npm install -g npm@8.12.1
       - name: install test dependencies
         run: cd test && yarn
-      - name: integration tests
-        run: cd test && ./provider-tests/test-provider.bat ${env:TEST_TARGET}
+      - name: integration test
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 2
+          retry_on: error
+          command: |
+            cd test
+            ./provider-tests/test-provider.bat ${env:TEST_TARGET}
         env:
           TEST_TARGET: ${{ matrix.target }}
           NODE_OPTIONS: "--max-old-space-size=7168"

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -6,5 +6,3 @@ let originalBeforeAll = global.beforeAll;
 global.beforeAll = function beforeAllWithDefaultTimeout(setup, timeout = DEFAULT_TIMEOUT) {
     return originalBeforeAll(setup, timeout);
 };
-
-jest.retryTimes(1)


### PR DESCRIPTION
This should help combat infrastructure flake. Most of the errors happen not inside a test but in a beforeAll so jest did not really help in this case. Retrying the entire step a second time should help