### PR TITLE
chore: update prerequisites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,11 @@
 # Contributing
 
+## Prerequisites
+
 To build and install `terraform-cdk` locally you need to install:
 
 - Node version 14.0+
-- Go 1.16+
+- Go 1.16
 - dotnet (v3.1.0)
 - mvn
 - pipenv

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ The development team would love your feedback to help guide the project.
 
 ## Build
 
+About prerequisites, refer the [followings](https://github.com/kination/terraform-cdk/blob/main/CONTRIBUTING.md#prerequisites).
+
 Clone the project repository.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The development team would love your feedback to help guide the project.
 
 ## Build
 
-About prerequisites, refer the [followings](https://github.com/kination/terraform-cdk/blob/main/CONTRIBUTING.md#prerequisites).
+About prerequisites, refer the [followings](./CONTRIBUTING.md#prerequisites).
 
 Clone the project repository.
 


### PR DESCRIPTION
Update prerequisites (go version 1.18 is not working)