### PR TITLE
fix(provider-generator): replace dashes with underscores in module names for Go when generating bindings for Terraform modules

### DIFF
--- a/packages/@cdktf/provider-generator/lib/get/__tests__/constructs-maker.test.ts
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/constructs-maker.test.ts
@@ -2,6 +2,7 @@ import * as fs from "fs-extra";
 import * as os from "os";
 import * as path from "path";
 import {
+  ConstructsMakerModuleTarget,
   ConstructsMakerProviderTarget,
   determineGoModuleName,
   Language,
@@ -95,6 +96,21 @@ describe("constructsMaker", () => {
         Language.GO
       );
       expect(target.srcMakName).toEqual("google_beta");
+    });
+  });
+  describe("ConstructsMakerModuleTarget", () => {
+    it("returns valid package name for Go", () => {
+      const target = new ConstructsMakerModuleTarget(
+        {
+          name: "security-group",
+          source: "terraform-aws-modules/security-group/aws",
+          fqn: "terraform-aws-modules/security-group/aws",
+          version: "4.9.0",
+          namespace: "terraform-aws-modules/aws",
+        },
+        Language.GO
+      );
+      expect(target.srcMakName).toEqual("security_group");
     });
   });
 });

--- a/packages/@cdktf/provider-generator/lib/get/constructs-maker.ts
+++ b/packages/@cdktf/provider-generator/lib/get/constructs-maker.ts
@@ -125,7 +125,7 @@ export class ConstructsMakerModuleTarget extends ConstructsMakerTarget {
   public get srcMakName(): string {
     switch (this.targetLanguage) {
       case Language.GO:
-        return this.name;
+        return this.name.replace(/-/gi, "_");
       case Language.JAVA:
       case Language.CSHARP:
       case Language.PYTHON:


### PR DESCRIPTION
Closes #1927
