### PR TITLE
feat(docs): update website README for versioning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -346,3 +346,7 @@ Here are GitHub links that help this process:
 ## Reproducing Bugs on Windows
 
 A good way to tackle windows related things is to use an AWS EC2 instance running Windows. Here's a Terraform repo with a bit of guideline on how to connect via Remote Desktop or VS Code Remote SSH https://github.com/skorfmann/windows-test-machine
+
+## Documentation
+
+The markdown files containing the documentation for CDK for Terraform are in the [`/website`](./website) directory. Refer to the [website README](./website/README.md) for more information.

--- a/website/README.md
+++ b/website/README.md
@@ -26,9 +26,13 @@ You should preview all of your changes locally before creating a pull request. T
 1. Open `http://localhost:3000` in your web browser. While the preview is running, you can edit pages and Next.js will automatically rebuild them.
 1. When you're done with the preview, press `ctrl-C` in your terminal to stop the server.
 
-### Deployment
+## Deployment
 
-New commits to the `stable-website` branch of `hashicorp/terraform-cdk` will be reflected on [terraform.io] within an hour.
+The website reads content from release tags to generate documentation for previous versions of CDK for Terraform. Changes merged into `main` will be included in the documentation for the next product release.
+
+The website reads the latest version of documentation from the `stable-website` branch. To immediately update the latest version of the documentation, [cherry-pick](https://git-scm.com/docs/git-cherry-pick) your changes to `stable-website`. Changes pushed to `stable-website` will be reflected on [terraform.io] within an hour.
+
+You cannot edit documentation for past versions of CDK for Terraform. Documentation is an artifact of a product release. We push docs fixes forward for the next release, rather than retroactively fixing older versions.
 
 [nav-data]: https://github.com/hashicorp/terraform-cdk/blob/main/website/data/cdktf-nav-data.json
 [terraform.io]: https://www.terraform.io/


### PR DESCRIPTION
Adjusts the website README in preparation for the versioning rollout. Also adds a link to the website README in the `CONTRIBUTING.md` file.