### PR TITLE
chore: add redirects to forum & support in GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ❓ Question
+    url: https://discuss.hashicorp.com/c/terraform-core/cdk-for-terraform/47
+    about: 🙋 For usage questions that may not require a core maintainer to answer, post in our community forum
+  - name: Terraform Cloud/Enterprise Troubleshooting
+    url: https://support.hashicorp.com/hc/en-us/requests/new
+    about: For issues related to the Terraform Cloud/Enterprise platform, please submit a HashiCorp support request or email tf-cloud@hashicorp.support


### PR DESCRIPTION
One of the issues I triaged earlier made me think that we can make it a little easier for users to find a place to ask usage questions other than by posting to GitHub. I looked to see how TF-Core does this and it looks like this YAML config file allows you to add these extra links: https://github.com/hashicorp/terraform/blob/main/.github/ISSUE_TEMPLATE/config.yml

I also copied over the TFC/E support option now that we're gearing up to provide full commercial support.

Open question: are we okay with disabling blank issues? (Seems like a good thing to me, but let me know if y'all disagree.)