### PR TITLE
fix: provider add uses local provider for google in go

### DIFF
--- a/packages/cdktf-cli/lib/dependencies/dependency-manager.ts
+++ b/packages/cdktf-cli/lib/dependencies/dependency-manager.ts
@@ -168,6 +168,15 @@ export class DependencyManager {
       return false;
     }
 
+    // google and google-beta can not build go bindings yet
+    // the GH Action runners don't have enough RAM to support this
+    if (
+      this.targetLanguage === Language.GO &&
+      constraint.simplifiedName.includes("google")
+    ) {
+      return false;
+    }
+
     const v = await getPrebuiltProviderVersion(constraint, this.cdktfVersion);
     const exists = v !== null;
 


### PR DESCRIPTION
google and google-beta can not build go bindings yet
the GH Action runners don't have enough RAM to support this
