### PR TITLE
fix(cli): Wait for other stacks to complete if one of them failed

### DIFF
--- a/packages/cdktf-cli/lib/cdktf-project.ts
+++ b/packages/cdktf-cli/lib/cdktf-project.ts
@@ -550,11 +550,15 @@ export class CdktfProject {
             "Encountered an error while awaiting stack to finish",
             e
           );
-          logger.debug("Waiting for still running stacks to finish");
+          const openStacks = this.stacksToRun.filter(
+            (ex) => ex.currentWorkPromise
+          );
+          logger.debug(
+            "Waiting for still running stacks to finish:",
+            openStacks
+          );
           await Promise.allSettled(
-            this.stacksToRun
-              .filter((ex) => ex.currentWorkPromise)
-              .map((ex) => ex.currentWorkPromise)
+            openStacks.map((ex) => ex.currentWorkPromise)
           );
           logger.debug(
             "Done waiting for still running stacks. All pending work finished"

--- a/packages/cdktf-cli/lib/util.ts
+++ b/packages/cdktf-cli/lib/util.ts
@@ -189,3 +189,23 @@ export async function downloadFile(
     request.end();
   });
 }
+
+/**
+ * Awaits a promise and makes sure it's error (if any) is only thrown after all other promises are settled
+ * if the promise does not throw an error, the other promises won't be awaited
+ * @param p promise to await
+ * @param promises promises to await to be all settled if p failed before throwing error that p failed with
+ */
+export async function ensureAllSettledBeforeThrowing(
+  p: Promise<any>,
+  promises: (Promise<any> | undefined)[]
+) {
+  try {
+    await p;
+  } catch (e) {
+    // if an error happened, we still need to wait for all other promises that
+    // are currently in progress to complete to allow them to properly wrap up
+    await Promise.allSettled(promises);
+    throw e;
+  }
+}

--- a/packages/cdktf-cli/test/lib/fixtures/parallel-error/main.ts.fixture
+++ b/packages/cdktf-cli/test/lib/fixtures/parallel-error/main.ts.fixture
@@ -1,0 +1,40 @@
+import { Construct } from "constructs";
+import {
+  App,
+  TerraformStack,
+  Testing,
+  LocalBackend,
+} from "cdktf";
+import * as NullProvider from "./.gen/providers/null";
+
+export class HelloTerra extends TerraformStack {
+  constructor(scope: Construct, id: string, timeout: number, shouldThrowError=false) {
+    super(scope, id);
+    new NullProvider.NullProvider(this, "null", {});
+    new LocalBackend(this);
+
+    const nullResouce = new NullProvider.Resource(this, "test", {});
+
+    const command = shouldThrowError ? "exit 1" : `echo "hello deploy"`;
+    nullResouce.addOverride("provisioner", [
+      {
+        "local-exec": {
+          command: `sleep ${timeout} && ${command}`,
+        },
+      },
+    ]);
+  }
+}
+
+
+// This is how the deployment should work timing wise
+// | denotes when the plan happens
+// stack1 ---|-----> (passed)
+// stack2 ---|-----------------> (failed)
+// stack3 ---|--------------------------> (passed)
+
+const app = Testing.stubVersion(new App({ stackTraces: false }));
+new HelloTerra(app, "stack1", 1);
+new HelloTerra(app, "stack2", 5, true);
+new HelloTerra(app, "stack3", 10);
+app.synth();

--- a/packages/cdktf-cli/test/lib/fixtures/parallel-error/main.ts.fixture
+++ b/packages/cdktf-cli/test/lib/fixtures/parallel-error/main.ts.fixture
@@ -35,6 +35,6 @@ export class HelloTerra extends TerraformStack {
 
 const app = Testing.stubVersion(new App({ stackTraces: false }));
 new HelloTerra(app, "stack1", 1);
-new HelloTerra(app, "stack2", 5, true);
-new HelloTerra(app, "stack3", 10);
+new HelloTerra(app, "stack2", 20, true);
+new HelloTerra(app, "stack3", 40);
 app.synth();


### PR DESCRIPTION
- chore: replicate deployment bug
- fix(cli): fix test as planning steps have no ensured order
- fix(cli): Wait for other work promises to complete even if one of them failed, which causes .race and .all to short circuit

Closes #1836