### PR TITLE
fix: don't lock state in tests

### DIFF
--- a/packages/cdktf/lib/testing/matchers.ts
+++ b/packages/cdktf/lib/testing/matchers.ts
@@ -276,7 +276,7 @@ export function toPlanSuccessfully(received: string): AssertionReturn {
       execSync(`${terraformBinaryName} init`, opts);
 
       // Throws on a non-zero exit code
-      execSync(`${terraformBinaryName} plan -input=false `, opts);
+      execSync(`${terraformBinaryName} plan -input=false -lock=false `, opts);
     });
 
     return new AssertionReturn(


### PR DESCRIPTION
The test matcher `toPlanSuccessfully` executes a full Terraform plan which needs to look at potentially locked remote state.
This locks the state and interferes with tests running in parallel etc.

On the other hand, disabling the locking in tests should have no negative affect.
Hence the PR.