### PR TITLE
fix(cli): add major versions greater 1 to package name when installing pre-built providers for go

### DIFF
--- a/packages/cdktf-cli/lib/debug.ts
+++ b/packages/cdktf-cli/lib/debug.ts
@@ -224,7 +224,7 @@ async function getGoPackageVersion(packageName: string) {
     versionLine = versionLine.split("=>")[0].trim();
   }
 
-  return versionLine.split(" ").pop();
+  return versionLine.split(" ").pop()?.replace("v", "");
 }
 
 async function getJavaPackageVersion(packageName: string) {

--- a/packages/cdktf-cli/lib/dependencies/package-manager.ts
+++ b/packages/cdktf-cli/lib/dependencies/package-manager.ts
@@ -5,6 +5,7 @@ import { exec } from "../util";
 import { xml2js, js2xml, Element } from "xml-js";
 import { Errors } from "../errors";
 import * as fs from "fs-extra";
+import * as semver from "semver";
 
 /**
  * manages installing, updating, and removing dependencies
@@ -223,8 +224,23 @@ class GoPackageManager extends PackageManager {
   ): Promise<void> {
     console.log(`Adding package ${packageName} @ ${packageVersion}`);
 
+    const majorVersion: number | undefined = packageVersion
+      ? semver.major(packageVersion)
+      : undefined;
+
+    let versionPackageSuffix = "";
+    if (typeof majorVersion === "number" && majorVersion > 1) {
+      versionPackageSuffix = `/v${majorVersion}`;
+    }
+
     // Install
-    await exec("go", ["get", packageName], { cwd: this.workingDirectory });
+    await exec(
+      "go",
+      ["get", `${packageName}${versionPackageSuffix}@v${packageVersion}`],
+      {
+        cwd: this.workingDirectory,
+      }
+    );
 
     console.log("Package installed.");
   }

--- a/test/go/provider-add-command/test.ts
+++ b/test/go/provider-add-command/test.ts
@@ -104,6 +104,11 @@ describe("provider add command", () => {
         "add",
         "random@=3.3.2", // this won't always be the latest version, but theres v2.0.12 of the pre-built provider resulting in exactly this package
       ]);
+      // TODO: this will fail as soon as we release a new pre-built provider version for that exact version of the TF provider
+      // until there is a newer version of that TF provider, cdktf provider add will always pick the latest and hence v2.0.12 will change
+      // this will settle as soon as we release cdktf 0.13 or a "random@>3.3.2" comes out and no newer pre-built provider versions will
+      // be published for v3.3.2. We could skip this test in the meantime. Unfortunately we can't test against an older version as Go pre-built
+      // providers where only supported as of cdktf 0.12 🙈
 
       // no snapshot, as the output also contains logs from Go upgrading JSII dependencies which might
       // change in the future and would break this test
@@ -112,7 +117,7 @@ describe("provider add command", () => {
   provider: random
   version : =3.3.2
   language: go
-  cdktf   : v0.12.0
+  cdktf   : 0.12.0
 
 
 Found pre-built provider.

--- a/test/test-helper.ts
+++ b/test/test-helper.ts
@@ -333,3 +333,17 @@ export class TestDriver {
 
 export const onWindows = process.platform === "win32" ? it : it.skip;
 export const onPosix = process.platform !== "win32" ? it : it.skip;
+
+/**
+ * replaces all occurences like
+ * [2022-08-05T15:51:40.093] [ERROR]
+ * with
+ * [<TIMESTAMP>] [ERROR]
+ * to allow snapshot tests on output that produces errors which are logged with timestamps
+ */
+export function sanitizeTimestamps(output: string): string {
+  return output.replace(
+    /\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}\]/m,
+    "[<TIMESTAMP>]"
+  );
+}


### PR DESCRIPTION
Resolves #1998
