### PR TITLE
chore: start linting for jsdoc strings in core library

### DIFF
--- a/packages/cdktf/bin/zipSync.ts
+++ b/packages/cdktf/bin/zipSync.ts
@@ -1,6 +1,7 @@
 import * as archiver from "archiver";
 import * as fs from "fs";
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 function zipFolder(inputPath: string, outputPath: string) {
   const output = fs.createWriteStream(outputPath);
 

--- a/packages/cdktf/lib/_tokens.ts
+++ b/packages/cdktf/lib/_tokens.ts
@@ -3,6 +3,7 @@ import { Construct } from "constructs";
 
 const TOKEN_RESOLVER = new DefaultTokenResolver(new StringConcat());
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function resolve<T>(scope: Construct, obj: T, preparing = false): T {
   return Tokenization.resolve(obj, {
     scope,

--- a/packages/cdktf/lib/app.ts
+++ b/packages/cdktf/lib/app.ts
@@ -91,6 +91,7 @@ export class App extends Construct {
   public static of(construct: IConstruct): App {
     return _lookup(construct);
 
+    // eslint-disable-next-line jsdoc/require-jsdoc
     function _lookup(c: IConstruct): App {
       if (App.isApp(c)) {
         return c;

--- a/packages/cdktf/lib/backends/artifactory-backend.ts
+++ b/packages/cdktf/lib/backends/artifactory-backend.ts
@@ -6,6 +6,7 @@ import {
   DataTerraformRemoteStateConfig,
 } from "../terraform-remote-state";
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class ArtifactoryBackend extends TerraformBackend {
   constructor(
     scope: Construct,
@@ -27,6 +28,7 @@ export class ArtifactoryBackend extends TerraformBackend {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class DataTerraformRemoteStateArtifactory extends TerraformRemoteState {
   constructor(
     scope: Construct,

--- a/packages/cdktf/lib/backends/azurerm-backend.ts
+++ b/packages/cdktf/lib/backends/azurerm-backend.ts
@@ -6,6 +6,7 @@ import {
   DataTerraformRemoteStateConfig,
 } from "../terraform-remote-state";
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class AzurermBackend extends TerraformBackend {
   constructor(scope: Construct, private readonly props: AzurermBackendProps) {
     super(scope, "backend", "azurerm");
@@ -27,6 +28,7 @@ export class AzurermBackend extends TerraformBackend {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class DataTerraformRemoteStateAzurerm extends TerraformRemoteState {
   constructor(
     scope: Construct,

--- a/packages/cdktf/lib/backends/consul-backend.ts
+++ b/packages/cdktf/lib/backends/consul-backend.ts
@@ -6,6 +6,7 @@ import {
   DataTerraformRemoteStateConfig,
 } from "../terraform-remote-state";
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class ConsulBackend extends TerraformBackend {
   constructor(scope: Construct, private readonly props: ConsulBackendProps) {
     super(scope, "backend", "consul");
@@ -27,6 +28,7 @@ export class ConsulBackend extends TerraformBackend {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class DataTerraformRemoteStateConsul extends TerraformRemoteState {
   constructor(
     scope: Construct,

--- a/packages/cdktf/lib/backends/cos-backend.ts
+++ b/packages/cdktf/lib/backends/cos-backend.ts
@@ -6,6 +6,7 @@ import {
   DataTerraformRemoteStateConfig,
 } from "../terraform-remote-state";
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class CosBackend extends TerraformBackend {
   constructor(scope: Construct, private readonly props: CosBackendProps) {
     super(scope, "backend", "cos");
@@ -27,6 +28,7 @@ export class CosBackend extends TerraformBackend {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class DataTerraformRemoteStateCos extends TerraformRemoteState {
   constructor(
     scope: Construct,

--- a/packages/cdktf/lib/backends/etcd-backend.ts
+++ b/packages/cdktf/lib/backends/etcd-backend.ts
@@ -6,6 +6,7 @@ import {
   DataTerraformRemoteStateConfig,
 } from "../terraform-remote-state";
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class EtcdBackend extends TerraformBackend {
   constructor(scope: Construct, private readonly props: EtcdBackendProps) {
     super(scope, "backend", "etcd");
@@ -24,6 +25,7 @@ export class EtcdBackend extends TerraformBackend {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class DataTerraformRemoteStateEtcd extends TerraformRemoteState {
   constructor(
     scope: Construct,

--- a/packages/cdktf/lib/backends/etcdv3-backend.ts
+++ b/packages/cdktf/lib/backends/etcdv3-backend.ts
@@ -6,6 +6,7 @@ import {
   DataTerraformRemoteStateConfig,
 } from "../terraform-remote-state";
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class EtcdV3Backend extends TerraformBackend {
   constructor(scope: Construct, private readonly props: EtcdV3BackendProps) {
     super(scope, "backend", "etcdv3");
@@ -27,6 +28,7 @@ export class EtcdV3Backend extends TerraformBackend {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class DataTerraformRemoteStateEtcdV3 extends TerraformRemoteState {
   constructor(
     scope: Construct,

--- a/packages/cdktf/lib/backends/gcs-backend.ts
+++ b/packages/cdktf/lib/backends/gcs-backend.ts
@@ -6,6 +6,7 @@ import {
   DataTerraformRemoteStateConfig,
 } from "../terraform-remote-state";
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class GcsBackend extends TerraformBackend {
   constructor(scope: Construct, private readonly props: GcsBackendProps) {
     super(scope, "backend", "gcs");
@@ -27,6 +28,7 @@ export class GcsBackend extends TerraformBackend {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class DataTerraformRemoteStateGcs extends TerraformRemoteState {
   constructor(
     scope: Construct,

--- a/packages/cdktf/lib/backends/http-backend.ts
+++ b/packages/cdktf/lib/backends/http-backend.ts
@@ -6,6 +6,7 @@ import {
   DataTerraformRemoteStateConfig,
 } from "../terraform-remote-state";
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class HttpBackend extends TerraformBackend {
   constructor(scope: Construct, private readonly props: HttpBackendProps) {
     super(scope, "backend", "http");
@@ -24,6 +25,7 @@ export class HttpBackend extends TerraformBackend {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class DataTerraformRemoteStateHttp extends TerraformRemoteState {
   constructor(
     scope: Construct,

--- a/packages/cdktf/lib/backends/local-backend.ts
+++ b/packages/cdktf/lib/backends/local-backend.ts
@@ -8,6 +8,7 @@ import {
 } from "../terraform-remote-state";
 import { TerraformStack } from "..";
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class LocalBackend extends TerraformBackend {
   private readonly props: LocalBackendProps;
   constructor(scope: Construct, props: LocalBackendProps = {}) {
@@ -40,6 +41,7 @@ export class LocalBackend extends TerraformBackend {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class DataTerraformRemoteStateLocal extends TerraformRemoteState {
   constructor(
     scope: Construct,

--- a/packages/cdktf/lib/backends/manta-backend.ts
+++ b/packages/cdktf/lib/backends/manta-backend.ts
@@ -6,6 +6,7 @@ import {
   DataTerraformRemoteStateConfig,
 } from "../terraform-remote-state";
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class MantaBackend extends TerraformBackend {
   constructor(scope: Construct, private readonly props: MantaBackendProps) {
     super(scope, "backend", "manta");
@@ -27,6 +28,7 @@ export class MantaBackend extends TerraformBackend {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class DataTerraformRemoteStateManta extends TerraformRemoteState {
   constructor(
     scope: Construct,

--- a/packages/cdktf/lib/backends/oss-backend.ts
+++ b/packages/cdktf/lib/backends/oss-backend.ts
@@ -6,6 +6,7 @@ import {
   DataTerraformRemoteStateConfig,
 } from "../terraform-remote-state";
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class OssBackend extends TerraformBackend {
   constructor(scope: Construct, private readonly props: OssBackendProps) {
     super(scope, "backend", "oss");
@@ -24,6 +25,7 @@ export class OssBackend extends TerraformBackend {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class DataTerraformRemoteStateOss extends TerraformRemoteState {
   constructor(
     scope: Construct,

--- a/packages/cdktf/lib/backends/pg-backend.ts
+++ b/packages/cdktf/lib/backends/pg-backend.ts
@@ -6,6 +6,7 @@ import {
   DataTerraformRemoteStateConfig,
 } from "../terraform-remote-state";
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class PgBackend extends TerraformBackend {
   constructor(scope: Construct, private readonly props: PgBackendProps) {
     super(scope, "backend", "pg");
@@ -27,6 +28,7 @@ export class PgBackend extends TerraformBackend {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class DataTerraformRemoteStatePg extends TerraformRemoteState {
   constructor(
     scope: Construct,

--- a/packages/cdktf/lib/backends/remote-backend.ts
+++ b/packages/cdktf/lib/backends/remote-backend.ts
@@ -6,6 +6,7 @@ import {
   DataTerraformRemoteStateConfig,
 } from "../terraform-remote-state";
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class RemoteBackend extends TerraformBackend {
   constructor(scope: Construct, private readonly props: RemoteBackendProps) {
     super(scope, "backend", "remote");
@@ -26,6 +27,7 @@ export class RemoteBackend extends TerraformBackend {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class DataTerraformRemoteState extends TerraformRemoteState {
   constructor(
     scope: Construct,
@@ -45,10 +47,12 @@ export interface RemoteBackendProps {
 
 export interface IRemoteWorkspace {}
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class NamedRemoteWorkspace implements IRemoteWorkspace {
   public constructor(public name: string) {}
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class PrefixedRemoteWorkspaces implements IRemoteWorkspace {
   public constructor(public prefix: string) {}
 }

--- a/packages/cdktf/lib/backends/s3-backend.ts
+++ b/packages/cdktf/lib/backends/s3-backend.ts
@@ -6,6 +6,7 @@ import {
   DataTerraformRemoteStateConfig,
 } from "../terraform-remote-state";
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class S3Backend extends TerraformBackend {
   constructor(scope: Construct, private readonly props: S3BackendProps) {
     super(scope, "backend", "s3");
@@ -27,6 +28,7 @@ export class S3Backend extends TerraformBackend {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class DataTerraformRemoteStateS3 extends TerraformRemoteState {
   constructor(
     scope: Construct,

--- a/packages/cdktf/lib/backends/swift-backend.ts
+++ b/packages/cdktf/lib/backends/swift-backend.ts
@@ -6,6 +6,7 @@ import {
   DataTerraformRemoteStateConfig,
 } from "../terraform-remote-state";
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class SwiftBackend extends TerraformBackend {
   constructor(scope: Construct, private readonly props: SwiftBackendProps) {
     super(scope, "backend", "swift");
@@ -24,6 +25,7 @@ export class SwiftBackend extends TerraformBackend {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class DataTerraformRemoteStateSwift extends TerraformRemoteState {
   constructor(
     scope: Construct,

--- a/packages/cdktf/lib/complex-computed-list.ts
+++ b/packages/cdktf/lib/complex-computed-list.ts
@@ -6,6 +6,7 @@ import {
 import { propertyAccess, Fn } from ".";
 import { captureStackTrace } from "./tokens/private/stack-trace";
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 abstract class ComplexResolvable implements IResolvable, ITerraformAddressable {
   public readonly creationStack: string[];
 
@@ -41,6 +42,7 @@ abstract class ComplexResolvable implements IResolvable, ITerraformAddressable {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 abstract class ComplexComputedAttribute
   extends ComplexResolvable
   implements IInterpolatingParent
@@ -99,6 +101,7 @@ abstract class ComplexComputedAttribute
   public abstract interpolationForAttribute(terraformAttribute: string): any;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class StringMap
   extends ComplexResolvable
   implements ITerraformAddressable
@@ -125,6 +128,7 @@ export class StringMap
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class NumberMap
   extends ComplexResolvable
   implements ITerraformAddressable
@@ -151,6 +155,7 @@ export class NumberMap
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class BooleanMap
   extends ComplexResolvable
   implements ITerraformAddressable
@@ -175,6 +180,7 @@ export class BooleanMap
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class AnyMap extends ComplexResolvable implements ITerraformAddressable {
   constructor(
     protected terraformResource: IInterpolatingParent,
@@ -254,6 +260,7 @@ export class ComplexComputedList extends ComplexComputedAttribute {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export abstract class ComplexList
   extends ComplexResolvable
   implements ITerraformAddressable
@@ -285,6 +292,7 @@ export abstract class ComplexList
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export abstract class ComplexMap
   extends ComplexResolvable
   implements ITerraformAddressable
@@ -303,6 +311,7 @@ export abstract class ComplexMap
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class ComplexObject extends ComplexComputedAttribute {
   /**
    * @param terraformResource
@@ -369,6 +378,7 @@ export class ComplexObject extends ComplexComputedAttribute {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 abstract class MapList
   extends ComplexResolvable
   implements ITerraformAddressable, IInterpolatingParent
@@ -420,6 +430,7 @@ abstract class MapList
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class StringMapList extends MapList {
   constructor(
     protected terraformResource: IInterpolatingParent,
@@ -434,6 +445,7 @@ export class StringMapList extends MapList {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class NumberMapList extends MapList {
   constructor(
     protected terraformResource: IInterpolatingParent,
@@ -448,6 +460,7 @@ export class NumberMapList extends MapList {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class BooleanMapList extends MapList {
   constructor(
     protected terraformResource: IInterpolatingParent,
@@ -462,6 +475,7 @@ export class BooleanMapList extends MapList {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class AnyMapList extends MapList {
   constructor(
     protected terraformResource: IInterpolatingParent,

--- a/packages/cdktf/lib/manifest.ts
+++ b/packages/cdktf/lib/manifest.ts
@@ -23,6 +23,7 @@ export interface IManifest {
   readonly version: string;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class Manifest implements IManifest {
   public static readonly fileName = "manifest.json";
   public static readonly stacksFolder = "stacks";

--- a/packages/cdktf/lib/private/fs.ts
+++ b/packages/cdktf/lib/private/fs.ts
@@ -5,8 +5,17 @@ import * as crypto from "crypto";
 
 const HASH_LEN = 32;
 
-// Full implementation at https://github.com/jprichardson/node-fs-extra/blob/master/lib/copy-sync/copy-sync.js
+// Full implementation at https://github.com/jprichardson/node-fs-extra/blob/master/lib/copy/copy-sync.js
+/**
+ * Copy a file or directory. The directory can have contents and subfolders.
+ * @param {string} src
+ * @param {string} dest
+ */
 export function copySync(src: string, dest: string) {
+  /**
+   * Copies file if present otherwise walks subfolder
+   * @param {string} p
+   */
   function copyItem(p: string) {
     const sourcePath = path.resolve(src, p);
     const stat = fs.statSync(sourcePath);
@@ -17,7 +26,10 @@ export function copySync(src: string, dest: string) {
       walkSubfolder(p);
     }
   }
-
+  /**
+   * Copies contents of subfolder
+   * @param {string} p
+   */
   function walkSubfolder(p: string) {
     const sourceDir = path.resolve(src, p);
     fs.mkdirSync(path.resolve(dest, p), { recursive: true });
@@ -27,6 +39,11 @@ export function copySync(src: string, dest: string) {
   walkSubfolder(".");
 }
 
+/**
+ * Zips contents at src and places zip archive at dest
+ * @param {string} src
+ * @param {string} dest
+ */
 export function archiveSync(src: string, dest: string) {
   const projectRoot = path.resolve(__dirname, "..", "..");
   const zipSyncPath = path.resolve(projectRoot, "bin", "zipSync.js");

--- a/packages/cdktf/lib/private/fs.ts
+++ b/packages/cdktf/lib/private/fs.ts
@@ -50,9 +50,11 @@ export function archiveSync(src: string, dest: string) {
   execSync(`node ${zipSyncPath} ${src} ${dest}`);
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function hashPath(src: string) {
   const hash = crypto.createHash("md5");
 
+  // eslint-disable-next-line jsdoc/require-jsdoc
   function hashRecursion(p: string) {
     const stat = fs.statSync(p);
     if (stat.isFile()) {
@@ -68,6 +70,7 @@ export function hashPath(src: string) {
   return hash.digest("hex").slice(0, HASH_LEN).toUpperCase();
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function findFileAboveCwd(
   file: string,
   rootPath = process.cwd()

--- a/packages/cdktf/lib/private/unique.ts
+++ b/packages/cdktf/lib/private/unique.ts
@@ -80,6 +80,7 @@ function pathHash(path: string[]): string {
   return md5.slice(0, HASH_LEN).toUpperCase();
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 function removeDisallowedCharacters(s: string, allowSepChars: boolean) {
   if (allowSepChars) {
     return removeNonAlphanumericSep(s);
@@ -95,6 +96,7 @@ function removeNonAlphanumeric(s: string) {
   return s.replace(/[^A-Za-z0-9]/g, "");
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 function removeNonAlphanumericSep(s: string) {
   return s.replace(/[^A-Za-z0-9_-]/g, "");
 }

--- a/packages/cdktf/lib/runtime.ts
+++ b/packages/cdktf/lib/runtime.ts
@@ -18,6 +18,7 @@ import { TerraformDynamicExpression } from "./terraform-dynamic-expression";
 // vs. complex types).
 export type Mapper = (x: any) => any;
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 function identity(x: any) {
   return x;
 }
@@ -62,6 +63,7 @@ export function listMapper(
   };
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function hashMapper(elementMapper: Mapper): Mapper {
   return (x: any) => {
     if (!canInspect(x)) {

--- a/packages/cdktf/lib/synthesize/synthesizer.ts
+++ b/packages/cdktf/lib/synthesize/synthesizer.ts
@@ -8,6 +8,7 @@ import { ConstructOrder, IConstruct, MetadataEntry } from "constructs";
 import { Aspects, IAspect } from "../aspect";
 import { StackAnnotation } from "../manifest";
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class StackSynthesizer implements IStackSynthesizer {
   /**
    * @param stack the stack to synthesize
@@ -109,6 +110,7 @@ export function invokeAspects(root: IConstruct) {
   let nestedAspectWarning = false;
   recurse(root, []);
 
+  // eslint-disable-next-line jsdoc/require-jsdoc
   function recurse(construct: IConstruct, inheritedAspects: IAspect[]) {
     const node = construct.node;
     const aspects = Aspects.of(construct);
@@ -151,10 +153,12 @@ const annotationMetadataEntryTypes = [
   AnnotationMetadataEntryType.ERROR,
 ] as string[];
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 function isAnnotationMetadata(metadata: MetadataEntry): boolean {
   return annotationMetadataEntryTypes.includes(metadata.type);
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 function isErrorAnnotation(annotation: StackAnnotation): boolean {
   return annotation.level === AnnotationMetadataEntryType.ERROR;
 }
@@ -175,6 +179,7 @@ export interface ICustomSynthesis {
   onSynthesize(session: ISynthesisSession): void;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function addCustomSynthesis(
   construct: IConstruct,
   synthesis: ICustomSynthesis
@@ -185,6 +190,7 @@ export function addCustomSynthesis(
   });
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 function getCustomSynthesis(
   construct: IConstruct
 ): ICustomSynthesis | undefined {

--- a/packages/cdktf/lib/terraform-asset.ts
+++ b/packages/cdktf/lib/terraform-asset.ts
@@ -29,6 +29,7 @@ export enum AssetType {
 const ARCHIVE_NAME = "archive.zip";
 const ASSETS_DIRECTORY = "assets";
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class TerraformAsset extends Resource {
   private sourcePath: string;
   // hash value of the asset that can be passed to consuming constructs (e.g. to not recreate a lambda function in case the underlying files did not change)

--- a/packages/cdktf/lib/terraform-backend.ts
+++ b/packages/cdktf/lib/terraform-backend.ts
@@ -5,6 +5,7 @@ import { deepMerge } from "./util";
 
 const BACKEND_SYMBOL = Symbol.for("cdktf/TerraformBackend");
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export abstract class TerraformBackend extends TerraformElement {
   constructor(scope: Construct, id: string, protected readonly name: string) {
     super(scope, id);

--- a/packages/cdktf/lib/terraform-data-source.ts
+++ b/packages/cdktf/lib/terraform-data-source.ts
@@ -15,6 +15,7 @@ import { IInterpolatingParent } from "./terraform-addressable";
 import { ITerraformIterator } from "./terraform-iterator";
 import assert = require("assert");
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class TerraformDataSource
   extends TerraformElement
   implements ITerraformResource, ITerraformDependable, IInterpolatingParent

--- a/packages/cdktf/lib/terraform-dynamic-block.ts
+++ b/packages/cdktf/lib/terraform-dynamic-block.ts
@@ -5,6 +5,7 @@ import { captureStackTrace } from "./tokens/private/stack-trace";
 
 const DYNAMIC_BLOCK_SYMBOL = Symbol.for("cdktf/TerraformDynamicBlock");
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class TerraformDynamicBlock implements IResolvable {
   public readonly creationStack: string[];
   public readonly forEach: ITerraformIterator;

--- a/packages/cdktf/lib/terraform-element.ts
+++ b/packages/cdktf/lib/terraform-element.ts
@@ -10,6 +10,7 @@ export interface TerraformElementMetadata {
   readonly stackTrace: string[];
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class TerraformElement extends Construct {
   public readonly cdktfStack: TerraformStack;
   protected readonly rawOverrides: any = {};

--- a/packages/cdktf/lib/terraform-functions.ts
+++ b/packages/cdktf/lib/terraform-functions.ts
@@ -12,7 +12,7 @@ type TFValueValidator = (value: any) => TFValue;
 type ExecutableTfFunction = (...args: any[]) => IResolvable;
 
 /**
- * Determines if given str had unescaped double quotes
+ * Determines if given str has unescaped double quotes
  * @param str String to test
  * @returns Boolean
  */

--- a/packages/cdktf/lib/terraform-functions.ts
+++ b/packages/cdktf/lib/terraform-functions.ts
@@ -21,14 +21,17 @@ function hasUnescapedDoubleQuotes(str: string) {
 }
 
 // Validators
+// eslint-disable-next-line jsdoc/require-jsdoc
 function anyValue(value: any): any {
   return value;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 function mapValue(value: any): any {
   return value;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 function stringValue(value: any): any {
   if (typeof value !== "string" && !Tokenization.isResolvable(value)) {
     throw new Error(`'${value}' is not a valid string nor a token`);
@@ -43,6 +46,7 @@ function stringValue(value: any): any {
   return value;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 function numericValue(value: any): any {
   if (typeof value !== "number" && !Tokenization.isResolvable(value)) {
     throw new Error(`${value} is not a valid number nor a token`);
@@ -50,6 +54,7 @@ function numericValue(value: any): any {
   return value;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 function listOf(type: TFValueValidator): TFValueValidator {
   return (value: any) => {
     if (Tokenization.isResolvable(value)) {
@@ -102,26 +107,32 @@ function listOf(type: TFValueValidator): TFValueValidator {
 }
 
 // Tokenization
+// eslint-disable-next-line jsdoc/require-jsdoc
 function asString(value: IResolvable) {
   return Token.asString(value);
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 function asNumber(value: IResolvable) {
   return Token.asNumber(value);
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 function asList(value: IResolvable) {
   return Token.asList(value);
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 function asStringMap(value: IResolvable) {
   return Token.asStringMap(value);
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 function asBoolean(value: IResolvable) {
   return value; // Booleans can not be represented as a token
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 function asAny(value: IResolvable) {
   // Ordinarily casting to any can cause issues, but
   // in this case it makes using functions a bit easier in TS
@@ -131,6 +142,7 @@ function asAny(value: IResolvable) {
   return asString(value) as any;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 function terraformFunction(
   name: string,
   argValidators: TFValueValidator | TFValueValidator[]
@@ -160,6 +172,7 @@ function terraformFunction(
   };
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class Fn {
   /**
    * {@link https://www.terraform.io/docs/language/functions/alltrue.html alltrue} returns true if all elements in a given collection are true or "true".

--- a/packages/cdktf/lib/terraform-functions.ts
+++ b/packages/cdktf/lib/terraform-functions.ts
@@ -11,6 +11,11 @@ type TFValueValidator = (value: any) => TFValue;
 
 type ExecutableTfFunction = (...args: any[]) => IResolvable;
 
+/**
+ * Determines if given str had unescaped double quotes
+ * @param str String to test
+ * @returns Boolean
+ */
 function hasUnescapedDoubleQuotes(str: string) {
   return /(^|[^\\])([\\]{2})*"/.test(str);
 }

--- a/packages/cdktf/lib/terraform-hcl-module.ts
+++ b/packages/cdktf/lib/terraform-hcl-module.ts
@@ -6,6 +6,7 @@ export interface TerraformHclModuleOptions extends TerraformModuleOptions {
   readonly variables?: { [key: string]: any };
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class TerraformHclModule extends TerraformModule {
   private _variables?: { [key: string]: any };
 

--- a/packages/cdktf/lib/terraform-iterator.ts
+++ b/packages/cdktf/lib/terraform-iterator.ts
@@ -48,6 +48,7 @@ type MapType =
   | AnyMap
   | ComplexMap;
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export abstract class TerraformIterator implements ITerraformIterator {
   /**
    * @internal used by TerraformResource to set the for_each expression
@@ -221,6 +222,7 @@ export abstract class TerraformIterator implements ITerraformIterator {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class ListTerraformIterator extends TerraformIterator {
   constructor(private readonly list: ListType) {
     super();
@@ -252,6 +254,7 @@ export class ListTerraformIterator extends TerraformIterator {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class MapTerraformIterator extends TerraformIterator {
   constructor(private readonly map: MapType) {
     super();

--- a/packages/cdktf/lib/terraform-local.ts
+++ b/packages/cdktf/lib/terraform-local.ts
@@ -5,6 +5,7 @@ import { ref } from "./tfExpression";
 import { IResolvable } from "./tokens/resolvable";
 import { ITerraformAddressable } from "./terraform-addressable";
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class TerraformLocal
   extends TerraformElement
   implements ITerraformAddressable

--- a/packages/cdktf/lib/terraform-module.ts
+++ b/packages/cdktf/lib/terraform-module.ts
@@ -25,6 +25,7 @@ export interface TerraformModuleProvider {
   readonly moduleAlias: string;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export abstract class TerraformModule
   extends TerraformElement
   implements ITerraformDependable

--- a/packages/cdktf/lib/terraform-output.ts
+++ b/packages/cdktf/lib/terraform-output.ts
@@ -23,6 +23,7 @@ export interface TerraformOutputConfig {
   readonly staticId?: boolean;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class TerraformOutput extends TerraformElement {
   public value: Expression | ITerraformAddressable;
   public description?: string;

--- a/packages/cdktf/lib/terraform-provider.ts
+++ b/packages/cdktf/lib/terraform-provider.ts
@@ -10,6 +10,7 @@ export interface TerraformProviderConfig {
   readonly terraformProviderSource?: string;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export abstract class TerraformProvider extends TerraformElement {
   public readonly terraformResourceType: string;
   public readonly terraformGeneratorMetadata?: TerraformProviderGeneratorMetadata;

--- a/packages/cdktf/lib/terraform-remote-state.ts
+++ b/packages/cdktf/lib/terraform-remote-state.ts
@@ -11,6 +11,7 @@ export interface DataTerraformRemoteStateConfig {
   readonly defaults?: { [key: string]: any };
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export abstract class TerraformRemoteState
   extends TerraformElement
   implements ITerraformAddressable

--- a/packages/cdktf/lib/terraform-resource.ts
+++ b/packages/cdktf/lib/terraform-resource.ts
@@ -62,6 +62,7 @@ export interface TerraformResourceConfig extends TerraformMetaArguments {
   readonly terraformGeneratorMetadata?: TerraformProviderGeneratorMetadata;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class TerraformResource
   extends TerraformElement
   implements ITerraformResource, ITerraformDependable, IInterpolatingParent

--- a/packages/cdktf/lib/terraform-stack.ts
+++ b/packages/cdktf/lib/terraform-stack.ts
@@ -34,6 +34,7 @@ export interface TerraformStackMetadata {
   readonly backend: string;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 function throwIfIdIsGlobCharacter(str: string): void {
   const err = (char: string) =>
     `Can not create Terraform stack with id "${str}". It contains a glob character: "${char}"`;
@@ -45,6 +46,7 @@ function throwIfIdIsGlobCharacter(str: string): void {
   });
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 function throwIfIdContainsWhitespace(str: string): void {
   if (/\s/.test(str)) {
     throw new Error(
@@ -53,6 +55,7 @@ function throwIfIdContainsWhitespace(str: string): void {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class TerraformStack extends Construct {
   private readonly rawOverrides: any = {};
   private readonly cdktfVersion: string;
@@ -83,6 +86,9 @@ export class TerraformStack extends Construct {
   public static of(construct: IConstruct): TerraformStack {
     return _lookup(construct);
 
+    /**
+     *
+     */
     function _lookup(c: IConstruct): TerraformStack {
       if (TerraformStack.isStack(c)) {
         return c;
@@ -331,6 +337,7 @@ export class TerraformStack extends Construct {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 function terraformElements(
   node: IConstruct,
   into: TerraformElement[] = []

--- a/packages/cdktf/lib/terraform-stack.ts
+++ b/packages/cdktf/lib/terraform-stack.ts
@@ -86,9 +86,7 @@ export class TerraformStack extends Construct {
   public static of(construct: IConstruct): TerraformStack {
     return _lookup(construct);
 
-    /**
-     *
-     */
+    // eslint-disable-next-line jsdoc/require-jsdoc
     function _lookup(c: IConstruct): TerraformStack {
       if (TerraformStack.isStack(c)) {
         return c;

--- a/packages/cdktf/lib/terraform-variable.ts
+++ b/packages/cdktf/lib/terraform-variable.ts
@@ -6,6 +6,7 @@ import { Expression, ref } from "./tfExpression";
 import { IResolvable } from "./tokens/resolvable";
 import { ITerraformAddressable } from "./terraform-addressable";
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export abstract class VariableType {
   public static readonly STRING = "string";
   public static readonly NUMBER = "number";
@@ -98,6 +99,7 @@ export interface TerraformVariableConfig {
   readonly validation?: TerraformVariableValidationConfig[];
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class TerraformVariable
   extends TerraformElement
   implements ITerraformAddressable

--- a/packages/cdktf/lib/testing/__tests__/matchers.test.ts
+++ b/packages/cdktf/lib/testing/__tests__/matchers.test.ts
@@ -13,6 +13,7 @@ import { DockerProvider } from "../../../test/helper/provider";
 import * as fs from "fs";
 import * as path from "path";
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 function corruptSynthesizedStack(stackPath: string) {
   const manifest = JSON.parse(
     fs.readFileSync(path.resolve(stackPath, "manifest.json"), "utf8")

--- a/packages/cdktf/lib/testing/__tests__/matchers.test.ts
+++ b/packages/cdktf/lib/testing/__tests__/matchers.test.ts
@@ -13,7 +13,6 @@ import { DockerProvider } from "../../../test/helper/provider";
 import * as fs from "fs";
 import * as path from "path";
 
-// eslint-disable-next-line jsdoc/require-jsdoc
 function corruptSynthesizedStack(stackPath: string) {
   const manifest = JSON.parse(
     fs.readFileSync(path.resolve(stackPath, "manifest.json"), "utf8")

--- a/packages/cdktf/lib/testing/adapters/__tests__/index.test.ts
+++ b/packages/cdktf/lib/testing/adapters/__tests__/index.test.ts
@@ -37,6 +37,9 @@ describe("#synthScope", () => {
   });
 
   test("using resource", () => {
+    /**
+     *
+     */
     class MyResource extends Resource {
       public resource: TestResource;
 

--- a/packages/cdktf/lib/testing/adapters/__tests__/index.test.ts
+++ b/packages/cdktf/lib/testing/adapters/__tests__/index.test.ts
@@ -37,9 +37,6 @@ describe("#synthScope", () => {
   });
 
   test("using resource", () => {
-    /**
-     *
-     */
     class MyResource extends Resource {
       public resource: TestResource;
 

--- a/packages/cdktf/lib/testing/index.ts
+++ b/packages/cdktf/lib/testing/index.ts
@@ -99,6 +99,9 @@ export class Testing {
     invokeAspects(stack);
     const tfConfig = stack.toTerraform();
 
+    /**
+     *
+     */
     function removeMetadata(item: any): any {
       if (item !== null && typeof item === "object") {
         if (Array.isArray(item)) {
@@ -143,6 +146,9 @@ export class Testing {
   public static renderConstructTree(construct: IConstruct): string {
     return render(construct, 0, false);
 
+    /**
+     *
+     */
     function render(
       construct: IConstruct,
       level: number,

--- a/packages/cdktf/lib/testing/index.ts
+++ b/packages/cdktf/lib/testing/index.ts
@@ -99,9 +99,7 @@ export class Testing {
     invokeAspects(stack);
     const tfConfig = stack.toTerraform();
 
-    /**
-     *
-     */
+    // eslint-disable-next-line jsdoc/require-jsdoc
     function removeMetadata(item: any): any {
       if (item !== null && typeof item === "object") {
         if (Array.isArray(item)) {
@@ -146,9 +144,7 @@ export class Testing {
   public static renderConstructTree(construct: IConstruct): string {
     return render(construct, 0, false);
 
-    /**
-     *
-     */
+    // eslint-disable-next-line jsdoc/require-jsdoc
     function render(
       construct: IConstruct,
       level: number,

--- a/packages/cdktf/lib/testing/matchers.ts
+++ b/packages/cdktf/lib/testing/matchers.ts
@@ -32,8 +32,8 @@ export function returnMatcherToJest(
 }
 
 /**
- * Compares expected and received. All expected properties are matched and considered equal if
- * there can be more properties in the received object than in the expected object while still returning true.
+ * Compares expected and received. All expected properties are matched and considered equal even if
+ * there are more properties in the received object than in the expected object in which case it will still return true.
  * @param expected
  * @param received
  * @returns {boolean}

--- a/packages/cdktf/lib/testing/matchers.ts
+++ b/packages/cdktf/lib/testing/matchers.ts
@@ -15,11 +15,13 @@ export type SynthesizedStack = {
   data: Record<string, any>;
 };
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class AssertionReturn {
   constructor(public readonly message: string, public readonly pass: boolean) {}
 }
 
 export type MatcherReturnJest = { message: () => string; pass: boolean };
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function returnMatcherToJest(
   toReturn: AssertionReturn
 ): MatcherReturnJest {
@@ -93,14 +95,17 @@ const defaultPassEvaluation = (
   );
 };
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 function isAsymmetric(obj: any) {
   return !!obj && typeof obj === "object" && "asymmetricMatch" in obj;
 }
 // You can use expect.Anything(), expect.ObjectContaining, etc in jest, this makes it nicer to read
 // when we print error mesages
+// eslint-disable-next-line jsdoc/require-jsdoc
 function jestAsymetricMatcherStringifyReplacer(_key: string, value: any) {
   return isAsymmetric(value) ? `expect.${value.toString()}` : value;
 }
+// eslint-disable-next-line jsdoc/require-jsdoc
 function getAssertElementWithProperties(
   // We have the evaluation function configurable so we can make use of the specific testing frameworks capabilities
   // This makes the resulting tests more native to the testing framework
@@ -165,6 +170,7 @@ Found ${items.length === 0 ? "no" : items.length} ${
   };
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function getToHaveDataSourceWithProperties(
   customPassEvaluation?: (
     items: any,
@@ -185,6 +191,7 @@ export function getToHaveDataSourceWithProperties(
   };
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function getToHaveResourceWithProperties(
   customPassEvaluation?: (
     items: any,
@@ -204,6 +211,7 @@ export function getToHaveResourceWithProperties(
     );
   };
 }
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function toBeValidTerraform(received: string): AssertionReturn {
   try {
     if (!fs.statSync(received).isDirectory()) {
@@ -253,6 +261,7 @@ export function toBeValidTerraform(received: string): AssertionReturn {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function toPlanSuccessfully(received: string): AssertionReturn {
   try {
     if (!fs.statSync(received).isDirectory()) {

--- a/packages/cdktf/lib/testing/matchers.ts
+++ b/packages/cdktf/lib/testing/matchers.ts
@@ -32,7 +32,7 @@ export function returnMatcherToJest(
 }
 
 /**
- * Compares expected and recieved. All expected properties are matched and considered equal if
+ * Compares expected and received. All expected properties are matched and considered equal if
  * there can be more properties in the received object than in the expected object while still returning true.
  * @param expected
  * @param received

--- a/packages/cdktf/lib/testing/matchers.ts
+++ b/packages/cdktf/lib/testing/matchers.ts
@@ -29,8 +29,13 @@ export function returnMatcherToJest(
   };
 }
 
-// All expected properties are matched and considered equal if
-// There can be more properties in the received object than in the expected object while still returning true
+/**
+ * Compares expected and recieved. All expected properties are matched and considered equal if
+ * there can be more properties in the received object than in the expected object while still returning true.
+ * @param expected
+ * @param received
+ * @returns {boolean}
+ */
 export function asymetricDeepEqualIgnoringObjectCasing(
   expected: unknown,
   received: unknown

--- a/packages/cdktf/lib/tfExpression.ts
+++ b/packages/cdktf/lib/tfExpression.ts
@@ -5,6 +5,7 @@ import { App } from "./app";
 import { TerraformStack } from "./terraform-stack";
 import { ITerraformDependable } from "./terraform-dependable";
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 class TFExpression extends Intrinsic implements IResolvable {
   protected resolveArg(context: IResolveContext, arg: any): string {
     const resolvedArg = context.resolve(arg);
@@ -100,6 +101,7 @@ class TFExpression extends Intrinsic implements IResolvable {
 }
 
 // A string that represents an input value to be escaped
+// eslint-disable-next-line jsdoc/require-jsdoc
 class RawString extends TFExpression {
   constructor(private readonly str: string) {
     super(str);
@@ -115,10 +117,12 @@ class RawString extends TFExpression {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function rawString(str: string): IResolvable {
   return new RawString(str);
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 class Reference extends TFExpression {
   /**
    * A single reference could be used in multiple stacks,
@@ -166,6 +170,7 @@ class Reference extends TFExpression {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function ref(identifier: string, stack?: TerraformStack): IResolvable {
   return new Reference(identifier, stack);
 }
@@ -178,6 +183,7 @@ export function insideTfExpression(arg: any) {
   return arg;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 class PropertyAccess extends TFExpression {
   constructor(private target: Expression, private args: Expression[]) {
     super({ target, args });
@@ -198,10 +204,12 @@ class PropertyAccess extends TFExpression {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function propertyAccess(target: Expression, args: Expression[]) {
   return new PropertyAccess(target, args) as IResolvable;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 class ConditionalExpression extends TFExpression {
   constructor(
     private condition: Expression,
@@ -252,6 +260,7 @@ export type Operator =
   | "!="
   | "&&"
   | "||";
+// eslint-disable-next-line jsdoc/require-jsdoc
 class OperatorExpression extends TFExpression {
   constructor(
     private operator: Operator,
@@ -293,65 +302,81 @@ class OperatorExpression extends TFExpression {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function notOperation(expression: Expression) {
   return new OperatorExpression("!", expression) as IResolvable;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function negateOperation(expression: Expression) {
   return new OperatorExpression("-", expression) as IResolvable;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function mulOperation(left: Expression, right: Expression) {
   return new OperatorExpression("*", left, right) as IResolvable;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function divOperation(left: Expression, right: Expression) {
   return new OperatorExpression("/", left, right) as IResolvable;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function modOperation(left: Expression, right: Expression) {
   return new OperatorExpression("%", left, right) as IResolvable;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function addOperation(left: Expression, right: Expression) {
   return new OperatorExpression("+", left, right) as IResolvable;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function subOperation(left: Expression, right: Expression) {
   return new OperatorExpression("-", left, right) as IResolvable;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function gtOperation(left: Expression, right: Expression) {
   return new OperatorExpression(">", left, right) as IResolvable;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function gteOperation(left: Expression, right: Expression) {
   return new OperatorExpression(">=", left, right) as IResolvable;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function ltOperation(left: Expression, right: Expression) {
   return new OperatorExpression("<", left, right) as IResolvable;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function lteOperation(left: Expression, right: Expression) {
   return new OperatorExpression("<=", left, right) as IResolvable;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function eqOperation(left: Expression, right: Expression) {
   return new OperatorExpression("==", left, right) as IResolvable;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function neqOperation(left: Expression, right: Expression) {
   return new OperatorExpression("!=", left, right) as IResolvable;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function andOperation(left: Expression, right: Expression) {
   return new OperatorExpression("&&", left, right) as IResolvable;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function orOperation(left: Expression, right: Expression) {
   return new OperatorExpression("||", left, right) as IResolvable;
 }
+// eslint-disable-next-line jsdoc/require-jsdoc
 class FunctionCall extends TFExpression {
   constructor(private name: string, private args: Expression[]) {
     super({ name, args });
@@ -370,6 +395,7 @@ class FunctionCall extends TFExpression {
     return suppressBraces ? expr : `\${${expr}}`;
   }
 }
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function call(name: string, args: Expression[]) {
   return new FunctionCall(name, args) as IResolvable;
 }
@@ -438,6 +464,7 @@ export function forExpression(
   ) as IResolvable;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 class Dependable extends TFExpression {
   constructor(private dependable: ITerraformDependable) {
     super(dependable);
@@ -449,6 +476,7 @@ class Dependable extends TFExpression {
     return this.dependable.fqn;
   }
 }
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function dependable(dependable: ITerraformDependable): string {
   return Token.asString(new Dependable(dependable));
 }

--- a/packages/cdktf/lib/tokens/lazy.ts
+++ b/packages/cdktf/lib/tokens/lazy.ts
@@ -145,6 +145,7 @@ export class Lazy {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export abstract class LazyBase implements IResolvable {
   public readonly creationStack: string[];
   private postProcessors: IPostProcessor[] = [];
@@ -181,6 +182,7 @@ export abstract class LazyBase implements IResolvable {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 class LazyString extends LazyBase {
   constructor(private readonly producer: IStringProducer) {
     super();
@@ -191,6 +193,7 @@ class LazyString extends LazyBase {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 class LazyNumber extends LazyBase {
   constructor(private readonly producer: INumberProducer) {
     super();
@@ -201,6 +204,7 @@ class LazyNumber extends LazyBase {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 class LazyList extends LazyBase {
   constructor(
     private readonly producer: IListProducer,
@@ -218,6 +222,7 @@ class LazyList extends LazyBase {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 class LazyAny extends LazyBase {
   constructor(
     private readonly producer: IAnyProducer,

--- a/packages/cdktf/lib/tokens/private/encoding.ts
+++ b/packages/cdktf/lib/tokens/private/encoding.ts
@@ -136,24 +136,36 @@ export class NullConcat implements IFragmentConcatenator {
   }
 }
 
+/**
+ * Returns true if argument contains a string list token
+ */
 export function containsStringListTokenElement(xs: any[]) {
   return xs.some(
     (x) => typeof x === "string" && TokenString.forListToken(x).test()
   );
 }
 
+/**
+ * Returns true if argument contains a number list token
+ */
 export function containsNumberListTokenElement(xs: any[]) {
   return xs.some(
     (x) => typeof x === "number" && extractTokenDouble(x, true) !== undefined
   );
 }
 
+/**
+ * Returns true if argument contains a string map token
+ */
 export function containsMapToken(xs: { [key: string]: any }) {
   return Object.keys(xs).some(
     (x) => typeof x === "string" && TokenString.forMapToken(x).test()
   );
 }
 
+/**
+ * Returns true if argument is a complex element
+ */
 export function isComplexElement(xs: any) {
   return (
     typeof xs === "object" &&
@@ -163,6 +175,9 @@ export function isComplexElement(xs: any) {
   );
 }
 
+/**
+ * Returns true if list contains a complex element
+ */
 export function containsComplexElement(xs: any) {
   return xs.length > 0 && isComplexElement(xs[0]);
 }

--- a/packages/cdktf/lib/tokens/private/intrinsic.ts
+++ b/packages/cdktf/lib/tokens/private/intrinsic.ts
@@ -80,6 +80,9 @@ export class Intrinsic implements IResolvable {
   }
 }
 
+/**
+ * Returns true if x is a function
+ */
 function isFunction(x: any) {
   return typeof x === "function";
 }

--- a/packages/cdktf/lib/tokens/private/resolve.ts
+++ b/packages/cdktf/lib/tokens/private/resolve.ts
@@ -301,6 +301,9 @@ function isConstruct(x: any): boolean {
   return x._children !== undefined && x._metadata !== undefined;
 }
 
+/**
+ * Resolves a number token
+ */
 function resolveNumberToken(x: number, context: IResolveContext): any {
   const token = TokenMap.instance().lookupNumberToken(x);
   if (token === undefined) {

--- a/packages/cdktf/lib/tokens/private/stack-trace.ts
+++ b/packages/cdktf/lib/tokens/private/stack-trace.ts
@@ -1,5 +1,8 @@
 // copied from https://github.com/aws/constructs/blob/e01e47f78ef1e9b600efcd23ff7705aa8d384017/lib/private/stack-trace.ts
 // eslint-disable-next-line @typescript-eslint/ban-types
+/**
+ * Captures a complete stack trace at the point of invocation.
+ */
 export function captureStackTrace(below?: Function): string[] {
   below = below || captureStackTrace; // hide myself if nothing else
   const object = { stack: "" };

--- a/packages/cdktf/lib/tokens/private/stack-trace.ts
+++ b/packages/cdktf/lib/tokens/private/stack-trace.ts
@@ -1,8 +1,9 @@
 // copied from https://github.com/aws/constructs/blob/e01e47f78ef1e9b600efcd23ff7705aa8d384017/lib/private/stack-trace.ts
-// eslint-disable-next-line @typescript-eslint/ban-types
+
 /**
  * Captures a complete stack trace at the point of invocation.
  */
+// eslint-disable-next-line @typescript-eslint/ban-types
 export function captureStackTrace(below?: Function): string[] {
   below = below || captureStackTrace; // hide myself if nothing else
   const object = { stack: "" };

--- a/packages/cdktf/lib/tokens/resolvable.ts
+++ b/packages/cdktf/lib/tokens/resolvable.ts
@@ -155,7 +155,7 @@ export class StringConcat implements IFragmentConcatenator {
  */
 export class DefaultTokenResolver implements ITokenResolver {
   /**
-   * Resolves token
+   * Resolves tokens
    */
   constructor(private readonly concat: IFragmentConcatenator) {}
 

--- a/packages/cdktf/lib/tokens/resolvable.ts
+++ b/packages/cdktf/lib/tokens/resolvable.ts
@@ -134,6 +134,9 @@ export interface IFragmentConcatenator {
  * Drops 'undefined's.
  */
 export class StringConcat implements IFragmentConcatenator {
+  /**
+   * Concatenates string fragments
+   */
   public join(left: any | undefined, right: any | undefined): any {
     if (left === undefined) {
       return right !== undefined ? `${right}` : undefined;
@@ -151,6 +154,9 @@ export class StringConcat implements IFragmentConcatenator {
  * @experimental
  */
 export class DefaultTokenResolver implements ITokenResolver {
+  /**
+   * Resolves token
+   */
   constructor(private readonly concat: IFragmentConcatenator) {}
 
   /**
@@ -194,6 +200,9 @@ export class DefaultTokenResolver implements ITokenResolver {
     return fragments.mapTokens({ mapToken: context.resolve }).join(this.concat);
   }
 
+  /**
+   * Resolves a list of string
+   */
   public resolveList(xs: string[], context: IResolveContext) {
     // Must be a singleton list token, because concatenation is not allowed.
     if (xs.length !== 1) {
@@ -214,6 +223,9 @@ export class DefaultTokenResolver implements ITokenResolver {
     return fragments.mapTokens({ mapToken: context.resolve }).firstValue;
   }
 
+  /**
+   * Resolves a list of numbers
+   */
   public resolveNumberList(xs: number[], context: IResolveContext) {
     // Must be a singleton list token, because concatenation is not allowed.
     if (xs.length !== 1) {
@@ -229,6 +241,9 @@ export class DefaultTokenResolver implements ITokenResolver {
     return context.resolve(token);
   }
 
+  /**
+   * Resolves a map token
+   */
   public resolveMap(xs: { [key: string]: any }, context: IResolveContext) {
     const keys = Object.keys(xs);
     if (keys.length !== 1) {

--- a/packages/cdktf/lib/tokens/string-fragments.ts
+++ b/packages/cdktf/lib/tokens/string-fragments.ts
@@ -17,6 +17,9 @@ type Fragment = LiteralFragment | TokenFragment | IntrinsicFragment;
  * @experimental
  */
 export class TokenizedStringFragments {
+  /**
+   * Fragments in the tokenized string
+   */
   private readonly fragments = new Array<Fragment>();
 
   /**

--- a/packages/cdktf/lib/tokens/token.ts
+++ b/packages/cdktf/lib/tokens/token.ts
@@ -108,6 +108,9 @@ export class Token {
     );
   }
 
+  /**
+   * String Map token value representation
+   */
   public static readonly STRING_MAP_TOKEN_VALUE = "String Map Token Value";
 
   /**
@@ -120,6 +123,9 @@ export class Token {
     return this.asMap(value, Token.STRING_MAP_TOKEN_VALUE, options);
   }
 
+  /**
+   * Number Map token value representation
+   */
   public static readonly NUMBER_MAP_TOKEN_VALUE = -123456789;
 
   /**
@@ -142,6 +148,9 @@ export class Token {
     return this.asMap(value, true, options);
   }
 
+  /**
+   * Any map token representation
+   */
   public static readonly ANY_MAP_TOKEN_VALUE = "Any Map Token Value";
 
   /**

--- a/packages/cdktf/lib/util.ts
+++ b/packages/cdktf/lib/util.ts
@@ -1,10 +1,10 @@
 import { TerraformDynamicBlock } from "./terraform-dynamic-block";
 import { Tokenization } from "./tokens/token";
+
 /**
  * Merges `source` into `target`, overriding any existing values.
  * `undefined` will cause a value to be deleted.
  */
-
 export function deepMerge(target: any, ...sources: any[]) {
   if (Tokenization.isResolvable(target) && sources.length > 0) {
     throw new Error(
@@ -58,6 +58,9 @@ export function deepMerge(target: any, ...sources: any[]) {
   return target;
 }
 
+/**
+ * Transforms a string to snake case
+ */
 export function snakeCase(str: string): string {
   if (!str) return "";
 
@@ -68,6 +71,9 @@ export function snakeCase(str: string): string {
     .toLowerCase();
 }
 
+/**
+ * Transforms all keys in a object to snake case
+ */
 export function keysToSnakeCase(object: any): any {
   if (Tokenization.isResolvable(object)) {
     return object;

--- a/packages/cdktf/lib/validateEnvironment.ts
+++ b/packages/cdktf/lib/validateEnvironment.ts
@@ -1,10 +1,16 @@
 import { Construct } from "constructs";
 
-// fails early if the environment contains e.g. invalid version combinations
+/**
+ * fails early if the environment contains e.g. invalid version combinations
+ */
 export function validateEnvironment() {
   validateConstructsIsV10();
 }
 
+/**
+ * fails early if the environment contains e.g. invalid version combinations
+ * for constructs
+ */
 function validateConstructsIsV10() {
   const construct = new Construct(null as any, "test");
   // construct.node was added in v10

--- a/packages/cdktf/lib/validations/validate-provider-presence.ts
+++ b/packages/cdktf/lib/validations/validate-provider-presence.ts
@@ -3,12 +3,28 @@ import { TerraformProvider } from "../terraform-provider";
 import { TerraformResource } from "../terraform-resource";
 import { TerraformDataSource } from "../terraform-data-source";
 
+/**
+ * A validation that is added by default, ensuring that all providers
+ * used are defined via Constructs.
+ */
 export class ValidateProviderPresence implements IValidation {
+  /**
+   * All provider names found in the construct tree.
+   */
   public providerNames: Set<string> = new Set();
+  /**
+   * All TerraformProviders found in the construct tree.
+   */
   public foundProviders: TerraformProvider[] = [];
 
+  /**
+   * Creates a ValidateProviderPresence
+   */
   constructor(protected host: IConstruct) {}
 
+  /**
+   * Checks the construct tree recursively
+   */
   public check(node: IConstruct) {
     if (
       node instanceof TerraformResource ||
@@ -28,6 +44,9 @@ export class ValidateProviderPresence implements IValidation {
     }
   }
 
+  /**
+   * Run the validation
+   */
   public validate() {
     this.check(this.host);
 

--- a/packages/cdktf/package.json
+++ b/packages/cdktf/package.json
@@ -79,7 +79,8 @@
       "node_modules",
       "dist",
       "coverage",
-      "test"
+      "test",
+      "*.test*.ts"
     ]
   },
   "license": "MPL-2.0",

--- a/packages/cdktf/package.json
+++ b/packages/cdktf/package.json
@@ -58,7 +58,8 @@
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",
     "plugins": [
-      "@typescript-eslint"
+      "@typescript-eslint",
+      "jsdoc"
     ],
     "extends": [
       "eslint:recommended",
@@ -71,12 +72,14 @@
       "@typescript-eslint/no-use-before-define": 0,
       "@typescript-eslint/no-empty-interface": 0,
       "@typescript-eslint/explicit-module-boundary-types": 0,
-      "no-sequences": "error"
+      "no-sequences": "error",
+      "jsdoc/require-jsdoc": [2, { "contexts": ["ClassDeclaration"] }]
     },
     "ignorePatterns": [
       "node_modules",
       "dist",
-      "coverage"
+      "coverage",
+      "test"
     ]
   },
   "license": "MPL-2.0",
@@ -88,6 +91,7 @@
     "@typescript-eslint/parser": "^4.33.0",
     "constructs": "^10.0.25",
     "eslint": "^7.32.0",
+    "eslint-plugin-jsdoc": "^39.3.3",
     "jest": "^26.6.3",
     "jsii": "^1.63.2",
     "jsii-docgen": "^7.0.66",

--- a/packages/cdktf/package.json
+++ b/packages/cdktf/package.json
@@ -73,7 +73,7 @@
       "@typescript-eslint/no-empty-interface": 0,
       "@typescript-eslint/explicit-module-boundary-types": 0,
       "no-sequences": "error",
-      "jsdoc/require-jsdoc": [2, { "contexts": ["ClassDeclaration"] }]
+      "jsdoc/require-jsdoc": ["error", { "contexts": ["ClassDeclaration"] }]
     },
     "ignorePatterns": [
       "node_modules",

--- a/website/docs/cdktf/api-reference/csharp.mdx
+++ b/website/docs/cdktf/api-reference/csharp.mdx
@@ -20857,9 +20857,9 @@ new DefaultTokenResolver(IFragmentConcatenator Concat);
 
 | **Name**                                                                                   | **Description**                     |
 | ------------------------------------------------------------------------------------------ | ----------------------------------- |
-| <code><a href="#cdktf.DefaultTokenResolver.resolveList">ResolveList</a></code>             | Resolve a tokenized list.           |
-| <code><a href="#cdktf.DefaultTokenResolver.resolveMap">ResolveMap</a></code>               | Resolve a tokenized map.            |
-| <code><a href="#cdktf.DefaultTokenResolver.resolveNumberList">ResolveNumberList</a></code> | Resolve a tokenized number list.    |
+| <code><a href="#cdktf.DefaultTokenResolver.resolveList">ResolveList</a></code>             | Resolves a list of string.          |
+| <code><a href="#cdktf.DefaultTokenResolver.resolveMap">ResolveMap</a></code>               | Resolves a map token.               |
+| <code><a href="#cdktf.DefaultTokenResolver.resolveNumberList">ResolveNumberList</a></code> | Resolves a list of numbers.         |
 | <code><a href="#cdktf.DefaultTokenResolver.resolveString">ResolveString</a></code>         | Resolve string fragments to Tokens. |
 | <code><a href="#cdktf.DefaultTokenResolver.resolveToken">ResolveToken</a></code>           | Default Token resolution.           |
 
@@ -20871,7 +20871,7 @@ new DefaultTokenResolver(IFragmentConcatenator Concat);
 private object ResolveList(string[] Xs, IResolveContext Context)
 ```
 
-Resolve a tokenized list.
+Resolves a list of string.
 
 ###### `Xs`<sup>Required</sup> <a name="Xs" id="cdktf.DefaultTokenResolver.resolveList.parameter.xs"></a>
 
@@ -20891,7 +20891,7 @@ Resolve a tokenized list.
 private object ResolveMap(System.Collections.Generic.IDictionary< string, object > Xs, IResolveContext Context)
 ```
 
-Resolve a tokenized map.
+Resolves a map token.
 
 ###### `Xs`<sup>Required</sup> <a name="Xs" id="cdktf.DefaultTokenResolver.resolveMap.parameter.xs"></a>
 
@@ -20911,7 +20911,7 @@ Resolve a tokenized map.
 private object ResolveNumberList(double[] Xs, IResolveContext Context)
 ```
 
-Resolve a tokenized number list.
+Resolves a list of numbers.
 
 ###### `Xs`<sup>Required</sup> <a name="Xs" id="cdktf.DefaultTokenResolver.resolveNumberList.parameter.xs"></a>
 
@@ -24457,9 +24457,9 @@ new StringConcat();
 
 #### Methods <a name="Methods" id="Methods"></a>
 
-| **Name**                                                 | **Description**                                 |
-| -------------------------------------------------------- | ----------------------------------------------- |
-| <code><a href="#cdktf.StringConcat.join">Join</a></code> | Join the fragment on the left and on the right. |
+| **Name**                                                 | **Description**                |
+| -------------------------------------------------------- | ------------------------------ |
+| <code><a href="#cdktf.StringConcat.join">Join</a></code> | Concatenates string fragments. |
 
 ---
 
@@ -24469,7 +24469,7 @@ new StringConcat();
 private object Join(object Left, object Right)
 ```
 
-Join the fragment on the left and on the right.
+Concatenates string fragments.
 
 ###### `Left`<sup>Required</sup> <a name="Left" id="cdktf.StringConcat.join.parameter.left"></a>
 
@@ -25620,11 +25620,11 @@ The object to test.
 
 #### Constants <a name="Constants" id="Constants"></a>
 
-| **Name**                                                                                    | **Type**            | **Description**   |
-| ------------------------------------------------------------------------------------------- | ------------------- | ----------------- |
-| <code><a href="#cdktf.Token.property.ANY_MAP_TOKEN_VALUE">AnyMapTokenValue</a></code>       | <code>string</code> | _No description._ |
-| <code><a href="#cdktf.Token.property.NUMBER_MAP_TOKEN_VALUE">NumberMapTokenValue</a></code> | <code>double</code> | _No description._ |
-| <code><a href="#cdktf.Token.property.STRING_MAP_TOKEN_VALUE">StringMapTokenValue</a></code> | <code>string</code> | _No description._ |
+| **Name**                                                                                    | **Type**            | **Description**                        |
+| ------------------------------------------------------------------------------------------- | ------------------- | -------------------------------------- |
+| <code><a href="#cdktf.Token.property.ANY_MAP_TOKEN_VALUE">AnyMapTokenValue</a></code>       | <code>string</code> | Any map token representation.          |
+| <code><a href="#cdktf.Token.property.NUMBER_MAP_TOKEN_VALUE">NumberMapTokenValue</a></code> | <code>double</code> | Number Map token value representation. |
+| <code><a href="#cdktf.Token.property.STRING_MAP_TOKEN_VALUE">StringMapTokenValue</a></code> | <code>string</code> | String Map token value representation. |
 
 ---
 
@@ -25636,6 +25636,8 @@ public string AnyMapTokenValue { get; }
 
 - _Type:_ string
 
+Any map token representation.
+
 ---
 
 ##### `NumberMapTokenValue`<sup>Required</sup> <a name="NumberMapTokenValue" id="cdktf.Token.property.NUMBER_MAP_TOKEN_VALUE"></a>
@@ -25646,6 +25648,8 @@ public double NumberMapTokenValue { get; }
 
 - _Type:_ double
 
+Number Map token value representation.
+
 ---
 
 ##### `StringMapTokenValue`<sup>Required</sup> <a name="StringMapTokenValue" id="cdktf.Token.property.STRING_MAP_TOKEN_VALUE"></a>
@@ -25655,6 +25659,8 @@ public string StringMapTokenValue { get; }
 ```
 
 - _Type:_ string
+
+String Map token value representation.
 
 ---
 

--- a/website/docs/cdktf/api-reference/go.mdx
+++ b/website/docs/cdktf/api-reference/go.mdx
@@ -20857,9 +20857,9 @@ cdktf.NewDefaultTokenResolver(concat IFragmentConcatenator) DefaultTokenResolver
 
 | **Name**                                                                                   | **Description**                     |
 | ------------------------------------------------------------------------------------------ | ----------------------------------- |
-| <code><a href="#cdktf.DefaultTokenResolver.resolveList">ResolveList</a></code>             | Resolve a tokenized list.           |
-| <code><a href="#cdktf.DefaultTokenResolver.resolveMap">ResolveMap</a></code>               | Resolve a tokenized map.            |
-| <code><a href="#cdktf.DefaultTokenResolver.resolveNumberList">ResolveNumberList</a></code> | Resolve a tokenized number list.    |
+| <code><a href="#cdktf.DefaultTokenResolver.resolveList">ResolveList</a></code>             | Resolves a list of string.          |
+| <code><a href="#cdktf.DefaultTokenResolver.resolveMap">ResolveMap</a></code>               | Resolves a map token.               |
+| <code><a href="#cdktf.DefaultTokenResolver.resolveNumberList">ResolveNumberList</a></code> | Resolves a list of numbers.         |
 | <code><a href="#cdktf.DefaultTokenResolver.resolveString">ResolveString</a></code>         | Resolve string fragments to Tokens. |
 | <code><a href="#cdktf.DefaultTokenResolver.resolveToken">ResolveToken</a></code>           | Default Token resolution.           |
 
@@ -20871,7 +20871,7 @@ cdktf.NewDefaultTokenResolver(concat IFragmentConcatenator) DefaultTokenResolver
 func ResolveList(xs *[]*string, context IResolveContext) interface{}
 ```
 
-Resolve a tokenized list.
+Resolves a list of string.
 
 ###### `xs`<sup>Required</sup> <a name="xs" id="cdktf.DefaultTokenResolver.resolveList.parameter.xs"></a>
 
@@ -20891,7 +20891,7 @@ Resolve a tokenized list.
 func ResolveMap(xs *map[string]interface{}, context IResolveContext) interface{}
 ```
 
-Resolve a tokenized map.
+Resolves a map token.
 
 ###### `xs`<sup>Required</sup> <a name="xs" id="cdktf.DefaultTokenResolver.resolveMap.parameter.xs"></a>
 
@@ -20911,7 +20911,7 @@ Resolve a tokenized map.
 func ResolveNumberList(xs *[]*f64, context IResolveContext) interface{}
 ```
 
-Resolve a tokenized number list.
+Resolves a list of numbers.
 
 ###### `xs`<sup>Required</sup> <a name="xs" id="cdktf.DefaultTokenResolver.resolveNumberList.parameter.xs"></a>
 
@@ -24457,9 +24457,9 @@ cdktf.NewStringConcat() StringConcat
 
 #### Methods <a name="Methods" id="Methods"></a>
 
-| **Name**                                                 | **Description**                                 |
-| -------------------------------------------------------- | ----------------------------------------------- |
-| <code><a href="#cdktf.StringConcat.join">Join</a></code> | Join the fragment on the left and on the right. |
+| **Name**                                                 | **Description**                |
+| -------------------------------------------------------- | ------------------------------ |
+| <code><a href="#cdktf.StringConcat.join">Join</a></code> | Concatenates string fragments. |
 
 ---
 
@@ -24469,7 +24469,7 @@ cdktf.NewStringConcat() StringConcat
 func Join(left interface{}, right interface{}) interface{}
 ```
 
-Join the fragment on the left and on the right.
+Concatenates string fragments.
 
 ###### `left`<sup>Required</sup> <a name="left" id="cdktf.StringConcat.join.parameter.left"></a>
 
@@ -25620,11 +25620,11 @@ The object to test.
 
 #### Constants <a name="Constants" id="Constants"></a>
 
-| **Name**                                                                                    | **Type**              | **Description**   |
-| ------------------------------------------------------------------------------------------- | --------------------- | ----------------- |
-| <code><a href="#cdktf.Token.property.ANY_MAP_TOKEN_VALUE">AnyMapTokenValue</a></code>       | <code>\*string</code> | _No description._ |
-| <code><a href="#cdktf.Token.property.NUMBER_MAP_TOKEN_VALUE">NumberMapTokenValue</a></code> | <code>\*f64</code>    | _No description._ |
-| <code><a href="#cdktf.Token.property.STRING_MAP_TOKEN_VALUE">StringMapTokenValue</a></code> | <code>\*string</code> | _No description._ |
+| **Name**                                                                                    | **Type**              | **Description**                        |
+| ------------------------------------------------------------------------------------------- | --------------------- | -------------------------------------- |
+| <code><a href="#cdktf.Token.property.ANY_MAP_TOKEN_VALUE">AnyMapTokenValue</a></code>       | <code>\*string</code> | Any map token representation.          |
+| <code><a href="#cdktf.Token.property.NUMBER_MAP_TOKEN_VALUE">NumberMapTokenValue</a></code> | <code>\*f64</code>    | Number Map token value representation. |
+| <code><a href="#cdktf.Token.property.STRING_MAP_TOKEN_VALUE">StringMapTokenValue</a></code> | <code>\*string</code> | String Map token value representation. |
 
 ---
 
@@ -25636,6 +25636,8 @@ func AnyMapTokenValue() *string
 
 - _Type:_ \*string
 
+Any map token representation.
+
 ---
 
 ##### `NumberMapTokenValue`<sup>Required</sup> <a name="NumberMapTokenValue" id="cdktf.Token.property.NUMBER_MAP_TOKEN_VALUE"></a>
@@ -25646,6 +25648,8 @@ func NumberMapTokenValue() *f64
 
 - _Type:_ \*f64
 
+Number Map token value representation.
+
 ---
 
 ##### `StringMapTokenValue`<sup>Required</sup> <a name="StringMapTokenValue" id="cdktf.Token.property.STRING_MAP_TOKEN_VALUE"></a>
@@ -25655,6 +25659,8 @@ func StringMapTokenValue() *string
 ```
 
 - _Type:_ \*string
+
+String Map token value representation.
 
 ---
 

--- a/website/docs/cdktf/api-reference/java.mdx
+++ b/website/docs/cdktf/api-reference/java.mdx
@@ -24479,9 +24479,9 @@ new DefaultTokenResolver(IFragmentConcatenator concat);
 
 | **Name**                                                                                   | **Description**                     |
 | ------------------------------------------------------------------------------------------ | ----------------------------------- |
-| <code><a href="#cdktf.DefaultTokenResolver.resolveList">resolveList</a></code>             | Resolve a tokenized list.           |
-| <code><a href="#cdktf.DefaultTokenResolver.resolveMap">resolveMap</a></code>               | Resolve a tokenized map.            |
-| <code><a href="#cdktf.DefaultTokenResolver.resolveNumberList">resolveNumberList</a></code> | Resolve a tokenized number list.    |
+| <code><a href="#cdktf.DefaultTokenResolver.resolveList">resolveList</a></code>             | Resolves a list of string.          |
+| <code><a href="#cdktf.DefaultTokenResolver.resolveMap">resolveMap</a></code>               | Resolves a map token.               |
+| <code><a href="#cdktf.DefaultTokenResolver.resolveNumberList">resolveNumberList</a></code> | Resolves a list of numbers.         |
 | <code><a href="#cdktf.DefaultTokenResolver.resolveString">resolveString</a></code>         | Resolve string fragments to Tokens. |
 | <code><a href="#cdktf.DefaultTokenResolver.resolveToken">resolveToken</a></code>           | Default Token resolution.           |
 
@@ -24493,7 +24493,7 @@ new DefaultTokenResolver(IFragmentConcatenator concat);
 public java.lang.Object resolveList(java.util.List< java.lang.String > xs, IResolveContext context)
 ```
 
-Resolve a tokenized list.
+Resolves a list of string.
 
 ###### `xs`<sup>Required</sup> <a name="xs" id="cdktf.DefaultTokenResolver.resolveList.parameter.xs"></a>
 
@@ -24513,7 +24513,7 @@ Resolve a tokenized list.
 public java.lang.Object resolveMap(java.util.Map< java.lang.String, java.lang.Object > xs, IResolveContext context)
 ```
 
-Resolve a tokenized map.
+Resolves a map token.
 
 ###### `xs`<sup>Required</sup> <a name="xs" id="cdktf.DefaultTokenResolver.resolveMap.parameter.xs"></a>
 
@@ -24533,7 +24533,7 @@ Resolve a tokenized map.
 public java.lang.Object resolveNumberList(java.util.List< java.lang.Number > xs, IResolveContext context)
 ```
 
-Resolve a tokenized number list.
+Resolves a list of numbers.
 
 ###### `xs`<sup>Required</sup> <a name="xs" id="cdktf.DefaultTokenResolver.resolveNumberList.parameter.xs"></a>
 
@@ -28079,9 +28079,9 @@ new StringConcat();
 
 #### Methods <a name="Methods" id="Methods"></a>
 
-| **Name**                                                 | **Description**                                 |
-| -------------------------------------------------------- | ----------------------------------------------- |
-| <code><a href="#cdktf.StringConcat.join">join</a></code> | Join the fragment on the left and on the right. |
+| **Name**                                                 | **Description**                |
+| -------------------------------------------------------- | ------------------------------ |
+| <code><a href="#cdktf.StringConcat.join">join</a></code> | Concatenates string fragments. |
 
 ---
 
@@ -28091,7 +28091,7 @@ new StringConcat();
 public java.lang.Object join(java.lang.Object left, java.lang.Object right)
 ```
 
-Join the fragment on the left and on the right.
+Concatenates string fragments.
 
 ###### `left`<sup>Required</sup> <a name="left" id="cdktf.StringConcat.join.parameter.left"></a>
 
@@ -29242,11 +29242,11 @@ The object to test.
 
 #### Constants <a name="Constants" id="Constants"></a>
 
-| **Name**                                                                                       | **Type**                      | **Description**   |
-| ---------------------------------------------------------------------------------------------- | ----------------------------- | ----------------- |
-| <code><a href="#cdktf.Token.property.ANY_MAP_TOKEN_VALUE">ANY_MAP_TOKEN_VALUE</a></code>       | <code>java.lang.String</code> | _No description._ |
-| <code><a href="#cdktf.Token.property.NUMBER_MAP_TOKEN_VALUE">NUMBER_MAP_TOKEN_VALUE</a></code> | <code>java.lang.Number</code> | _No description._ |
-| <code><a href="#cdktf.Token.property.STRING_MAP_TOKEN_VALUE">STRING_MAP_TOKEN_VALUE</a></code> | <code>java.lang.String</code> | _No description._ |
+| **Name**                                                                                       | **Type**                      | **Description**                        |
+| ---------------------------------------------------------------------------------------------- | ----------------------------- | -------------------------------------- |
+| <code><a href="#cdktf.Token.property.ANY_MAP_TOKEN_VALUE">ANY_MAP_TOKEN_VALUE</a></code>       | <code>java.lang.String</code> | Any map token representation.          |
+| <code><a href="#cdktf.Token.property.NUMBER_MAP_TOKEN_VALUE">NUMBER_MAP_TOKEN_VALUE</a></code> | <code>java.lang.Number</code> | Number Map token value representation. |
+| <code><a href="#cdktf.Token.property.STRING_MAP_TOKEN_VALUE">STRING_MAP_TOKEN_VALUE</a></code> | <code>java.lang.String</code> | String Map token value representation. |
 
 ---
 
@@ -29258,6 +29258,8 @@ public java.lang.String getAnyMapTokenValue();
 
 - _Type:_ java.lang.String
 
+Any map token representation.
+
 ---
 
 ##### `NUMBER_MAP_TOKEN_VALUE`<sup>Required</sup> <a name="NUMBER_MAP_TOKEN_VALUE" id="cdktf.Token.property.NUMBER_MAP_TOKEN_VALUE"></a>
@@ -29268,6 +29270,8 @@ public java.lang.Number getNumberMapTokenValue();
 
 - _Type:_ java.lang.Number
 
+Number Map token value representation.
+
 ---
 
 ##### `STRING_MAP_TOKEN_VALUE`<sup>Required</sup> <a name="STRING_MAP_TOKEN_VALUE" id="cdktf.Token.property.STRING_MAP_TOKEN_VALUE"></a>
@@ -29277,6 +29281,8 @@ public java.lang.String getStringMapTokenValue();
 ```
 
 - _Type:_ java.lang.String
+
+String Map token value representation.
 
 ---
 

--- a/website/docs/cdktf/api-reference/python.mdx
+++ b/website/docs/cdktf/api-reference/python.mdx
@@ -25309,9 +25309,9 @@ cdktf.DefaultTokenResolver(
 
 | **Name**                                                                                     | **Description**                     |
 | -------------------------------------------------------------------------------------------- | ----------------------------------- |
-| <code><a href="#cdktf.DefaultTokenResolver.resolveList">resolve_list</a></code>              | Resolve a tokenized list.           |
-| <code><a href="#cdktf.DefaultTokenResolver.resolveMap">resolve_map</a></code>                | Resolve a tokenized map.            |
-| <code><a href="#cdktf.DefaultTokenResolver.resolveNumberList">resolve_number_list</a></code> | Resolve a tokenized number list.    |
+| <code><a href="#cdktf.DefaultTokenResolver.resolveList">resolve_list</a></code>              | Resolves a list of string.          |
+| <code><a href="#cdktf.DefaultTokenResolver.resolveMap">resolve_map</a></code>                | Resolves a map token.               |
+| <code><a href="#cdktf.DefaultTokenResolver.resolveNumberList">resolve_number_list</a></code> | Resolves a list of numbers.         |
 | <code><a href="#cdktf.DefaultTokenResolver.resolveString">resolve_string</a></code>          | Resolve string fragments to Tokens. |
 | <code><a href="#cdktf.DefaultTokenResolver.resolveToken">resolve_token</a></code>            | Default Token resolution.           |
 
@@ -25326,7 +25326,7 @@ def resolve_list(
 ) - > typing.Any
 ```
 
-Resolve a tokenized list.
+Resolves a list of string.
 
 ###### `xs`<sup>Required</sup> <a name="xs" id="cdktf.DefaultTokenResolver.resolveList.parameter.xs"></a>
 
@@ -25349,7 +25349,7 @@ def resolve_map(
 ) - > typing.Any
 ```
 
-Resolve a tokenized map.
+Resolves a map token.
 
 ###### `xs`<sup>Required</sup> <a name="xs" id="cdktf.DefaultTokenResolver.resolveMap.parameter.xs"></a>
 
@@ -25372,7 +25372,7 @@ def resolve_number_list(
 ) - > typing.Any
 ```
 
-Resolve a tokenized number list.
+Resolves a list of numbers.
 
 ###### `xs`<sup>Required</sup> <a name="xs" id="cdktf.DefaultTokenResolver.resolveNumberList.parameter.xs"></a>
 
@@ -29313,9 +29313,9 @@ cdktf.StringConcat()
 
 #### Methods <a name="Methods" id="Methods"></a>
 
-| **Name**                                                 | **Description**                                 |
-| -------------------------------------------------------- | ----------------------------------------------- |
-| <code><a href="#cdktf.StringConcat.join">join</a></code> | Join the fragment on the left and on the right. |
+| **Name**                                                 | **Description**                |
+| -------------------------------------------------------- | ------------------------------ |
+| <code><a href="#cdktf.StringConcat.join">join</a></code> | Concatenates string fragments. |
 
 ---
 
@@ -29328,7 +29328,7 @@ def join(
 ) - > typing.Any
 ```
 
-Join the fragment on the left and on the right.
+Concatenates string fragments.
 
 ###### `left`<sup>Required</sup> <a name="left" id="cdktf.StringConcat.join.parameter.left"></a>
 
@@ -30641,11 +30641,11 @@ The object to test.
 
 #### Constants <a name="Constants" id="Constants"></a>
 
-| **Name**                                                                                       | **Type**                              | **Description**   |
-| ---------------------------------------------------------------------------------------------- | ------------------------------------- | ----------------- |
-| <code><a href="#cdktf.Token.property.ANY_MAP_TOKEN_VALUE">ANY_MAP_TOKEN_VALUE</a></code>       | <code>str</code>                      | _No description._ |
-| <code><a href="#cdktf.Token.property.NUMBER_MAP_TOKEN_VALUE">NUMBER_MAP_TOKEN_VALUE</a></code> | <code>typing.Union[int, float]</code> | _No description._ |
-| <code><a href="#cdktf.Token.property.STRING_MAP_TOKEN_VALUE">STRING_MAP_TOKEN_VALUE</a></code> | <code>str</code>                      | _No description._ |
+| **Name**                                                                                       | **Type**                              | **Description**                        |
+| ---------------------------------------------------------------------------------------------- | ------------------------------------- | -------------------------------------- |
+| <code><a href="#cdktf.Token.property.ANY_MAP_TOKEN_VALUE">ANY_MAP_TOKEN_VALUE</a></code>       | <code>str</code>                      | Any map token representation.          |
+| <code><a href="#cdktf.Token.property.NUMBER_MAP_TOKEN_VALUE">NUMBER_MAP_TOKEN_VALUE</a></code> | <code>typing.Union[int, float]</code> | Number Map token value representation. |
+| <code><a href="#cdktf.Token.property.STRING_MAP_TOKEN_VALUE">STRING_MAP_TOKEN_VALUE</a></code> | <code>str</code>                      | String Map token value representation. |
 
 ---
 
@@ -30657,6 +30657,8 @@ ANY_MAP_TOKEN_VALUE: str
 
 - _Type:_ str
 
+Any map token representation.
+
 ---
 
 ##### `NUMBER_MAP_TOKEN_VALUE`<sup>Required</sup> <a name="NUMBER_MAP_TOKEN_VALUE" id="cdktf.Token.property.NUMBER_MAP_TOKEN_VALUE"></a>
@@ -30667,6 +30669,8 @@ NUMBER_MAP_TOKEN_VALUE: typing.Union[int, float]
 
 - _Type:_ typing.Union[int, float]
 
+Number Map token value representation.
+
 ---
 
 ##### `STRING_MAP_TOKEN_VALUE`<sup>Required</sup> <a name="STRING_MAP_TOKEN_VALUE" id="cdktf.Token.property.STRING_MAP_TOKEN_VALUE"></a>
@@ -30676,6 +30680,8 @@ STRING_MAP_TOKEN_VALUE: str
 ```
 
 - _Type:_ str
+
+String Map token value representation.
 
 ---
 

--- a/website/docs/cdktf/api-reference/typescript.mdx
+++ b/website/docs/cdktf/api-reference/typescript.mdx
@@ -20359,9 +20359,9 @@ new DefaultTokenResolver(concat: IFragmentConcatenator)
 
 | **Name**                                                                                   | **Description**                     |
 | ------------------------------------------------------------------------------------------ | ----------------------------------- |
-| <code><a href="#cdktf.DefaultTokenResolver.resolveList">resolveList</a></code>             | Resolve a tokenized list.           |
-| <code><a href="#cdktf.DefaultTokenResolver.resolveMap">resolveMap</a></code>               | Resolve a tokenized map.            |
-| <code><a href="#cdktf.DefaultTokenResolver.resolveNumberList">resolveNumberList</a></code> | Resolve a tokenized number list.    |
+| <code><a href="#cdktf.DefaultTokenResolver.resolveList">resolveList</a></code>             | Resolves a list of string.          |
+| <code><a href="#cdktf.DefaultTokenResolver.resolveMap">resolveMap</a></code>               | Resolves a map token.               |
+| <code><a href="#cdktf.DefaultTokenResolver.resolveNumberList">resolveNumberList</a></code> | Resolves a list of numbers.         |
 | <code><a href="#cdktf.DefaultTokenResolver.resolveString">resolveString</a></code>         | Resolve string fragments to Tokens. |
 | <code><a href="#cdktf.DefaultTokenResolver.resolveToken">resolveToken</a></code>           | Default Token resolution.           |
 
@@ -20373,7 +20373,7 @@ new DefaultTokenResolver(concat: IFragmentConcatenator)
 public resolveList(xs: string[], context: IResolveContext): any
 ```
 
-Resolve a tokenized list.
+Resolves a list of string.
 
 ###### `xs`<sup>Required</sup> <a name="xs" id="cdktf.DefaultTokenResolver.resolveList.parameter.xs"></a>
 
@@ -20393,7 +20393,7 @@ Resolve a tokenized list.
 public resolveMap(xs: {[ key: string ]: any}, context: IResolveContext): any
 ```
 
-Resolve a tokenized map.
+Resolves a map token.
 
 ###### `xs`<sup>Required</sup> <a name="xs" id="cdktf.DefaultTokenResolver.resolveMap.parameter.xs"></a>
 
@@ -20413,7 +20413,7 @@ Resolve a tokenized map.
 public resolveNumberList(xs: number[], context: IResolveContext): any
 ```
 
-Resolve a tokenized number list.
+Resolves a list of numbers.
 
 ###### `xs`<sup>Required</sup> <a name="xs" id="cdktf.DefaultTokenResolver.resolveNumberList.parameter.xs"></a>
 
@@ -23959,9 +23959,9 @@ new StringConcat();
 
 #### Methods <a name="Methods" id="Methods"></a>
 
-| **Name**                                                 | **Description**                                 |
-| -------------------------------------------------------- | ----------------------------------------------- |
-| <code><a href="#cdktf.StringConcat.join">join</a></code> | Join the fragment on the left and on the right. |
+| **Name**                                                 | **Description**                |
+| -------------------------------------------------------- | ------------------------------ |
+| <code><a href="#cdktf.StringConcat.join">join</a></code> | Concatenates string fragments. |
 
 ---
 
@@ -23971,7 +23971,7 @@ new StringConcat();
 public join(left: any, right: any): any
 ```
 
-Join the fragment on the left and on the right.
+Concatenates string fragments.
 
 ###### `left`<sup>Required</sup> <a name="left" id="cdktf.StringConcat.join.parameter.left"></a>
 
@@ -25122,11 +25122,11 @@ The object to test.
 
 #### Constants <a name="Constants" id="Constants"></a>
 
-| **Name**                                                                                       | **Type**            | **Description**   |
-| ---------------------------------------------------------------------------------------------- | ------------------- | ----------------- |
-| <code><a href="#cdktf.Token.property.ANY_MAP_TOKEN_VALUE">ANY_MAP_TOKEN_VALUE</a></code>       | <code>string</code> | _No description._ |
-| <code><a href="#cdktf.Token.property.NUMBER_MAP_TOKEN_VALUE">NUMBER_MAP_TOKEN_VALUE</a></code> | <code>number</code> | _No description._ |
-| <code><a href="#cdktf.Token.property.STRING_MAP_TOKEN_VALUE">STRING_MAP_TOKEN_VALUE</a></code> | <code>string</code> | _No description._ |
+| **Name**                                                                                       | **Type**            | **Description**                        |
+| ---------------------------------------------------------------------------------------------- | ------------------- | -------------------------------------- |
+| <code><a href="#cdktf.Token.property.ANY_MAP_TOKEN_VALUE">ANY_MAP_TOKEN_VALUE</a></code>       | <code>string</code> | Any map token representation.          |
+| <code><a href="#cdktf.Token.property.NUMBER_MAP_TOKEN_VALUE">NUMBER_MAP_TOKEN_VALUE</a></code> | <code>number</code> | Number Map token value representation. |
+| <code><a href="#cdktf.Token.property.STRING_MAP_TOKEN_VALUE">STRING_MAP_TOKEN_VALUE</a></code> | <code>string</code> | String Map token value representation. |
 
 ---
 
@@ -25138,6 +25138,8 @@ public readonly ANY_MAP_TOKEN_VALUE: string;
 
 - _Type:_ string
 
+Any map token representation.
+
 ---
 
 ##### `NUMBER_MAP_TOKEN_VALUE`<sup>Required</sup> <a name="NUMBER_MAP_TOKEN_VALUE" id="cdktf.Token.property.NUMBER_MAP_TOKEN_VALUE"></a>
@@ -25148,6 +25150,8 @@ public readonly NUMBER_MAP_TOKEN_VALUE: number;
 
 - _Type:_ number
 
+Number Map token value representation.
+
 ---
 
 ##### `STRING_MAP_TOKEN_VALUE`<sup>Required</sup> <a name="STRING_MAP_TOKEN_VALUE" id="cdktf.Token.property.STRING_MAP_TOKEN_VALUE"></a>
@@ -25157,6 +25161,8 @@ public readonly STRING_MAP_TOKEN_VALUE: string;
 ```
 
 - _Type:_ string
+
+String Map token value representation.
 
 ---
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -322,6 +322,15 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@es-joy/jsdoccomment@~0.31.0":
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/@es-joy/jsdoccomment/-/jsdoccomment-0.31.0.tgz#dbc342cc38eb6878c12727985e693eaef34302bc"
+  integrity sha512-tc1/iuQcnaiSIUVad72PBierDFpsxdUHtEF/OrfqvM1CBAsIoMP51j52jTMb3dXriwhieTo289InzZj72jL3EQ==
+  dependencies:
+    comment-parser "1.3.1"
+    esquery "^1.4.0"
+    jsdoc-type-pratt-parser "~3.1.0"
+
 "@esbuild/linux-loong64@0.14.53":
   version "0.14.53"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.14.53.tgz#251b4cd6760fadb4d68a05815e6dc5e432d69cd6"
@@ -3230,6 +3239,11 @@ commander@^9.3.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.0.tgz#bc4a40918fefe52e22450c111ecd6b7acce6f11c"
   integrity sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==
 
+comment-parser@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.3.1.tgz#3d7ea3adaf9345594aedee6563f422348f165c1b"
+  integrity sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==
+
 commonmark@^0.30.0:
   version "0.30.0"
   resolved "https://registry.yarnpkg.com/commonmark/-/commonmark-0.30.0.tgz#38811dc7bbf0f59d277ae09054d4d73a332f2e45"
@@ -4183,6 +4197,19 @@ eslint-plugin-import@^2.26.0:
     object.values "^1.1.5"
     resolve "^1.22.0"
     tsconfig-paths "^3.14.1"
+
+eslint-plugin-jsdoc@^39.3.3:
+  version "39.3.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.3.3.tgz#75dd67ce581e7527a69f27800138cc0f9c388236"
+  integrity sha512-K/DAjKRUNaUTf0KQhI9PvsF+Y3mGDx/j0pofXsJCQe/tmRsRweBIXR353c8nAro0lytZYEf7l0PluBpzKDiHxw==
+  dependencies:
+    "@es-joy/jsdoccomment" "~0.31.0"
+    comment-parser "1.3.1"
+    debug "^4.3.4"
+    escape-string-regexp "^4.0.0"
+    esquery "^1.4.0"
+    semver "^7.3.7"
+    spdx-expression-parse "^3.0.1"
 
 eslint-plugin-monorepo@^0.3.2:
   version "0.3.2"
@@ -6610,6 +6637,11 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==
+
+jsdoc-type-pratt-parser@~3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz#a4a56bdc6e82e5865ffd9febc5b1a227ff28e67e"
+  integrity sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==
 
 jsdom@^16.4.0, jsdom@^16.6.0:
   version "16.7.0"
@@ -9224,7 +9256,7 @@ spdx-exceptions@^2.1.0:
   resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz#3f28ce1a77a00372683eade4a433183527a2163d"
   integrity sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==
 
-spdx-expression-parse@^3.0.0:
+spdx-expression-parse@^3.0.0, spdx-expression-parse@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz#cf70f50482eefdc98e3ce0a6833e4a53ceeba679"
   integrity sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==


### PR DESCRIPTION
This approach will help us document new parts directly, while we can gradually improve our documentation step by step.

Successor of #1946 (instead of trying to do it in one step, we can do it incrementally)