### PR TITLE
fix(cli): get in java should not create an empty .gen folder

### DIFF
--- a/packages/cdktf-cli/templates/java/cdktf.json
+++ b/packages/cdktf-cli/templates/java/cdktf.json
@@ -3,6 +3,7 @@
   "app": "mvn -e -q compile exec:java",
   "projectId": "{{projectId}}",
   "sendCrashReports": "{{sendCrashReports}}",
+  "codeMakerOutput": "src/main/java/imports",
   "terraformProviders": [],
   "terraformModules": [],
   "context": {


### PR DESCRIPTION
Closes #519
