### PR TITLE
feat(cli): Automatically Update Locked Providers

### DIFF
--- a/packages/cdktf-cli/src/lib/cdktf-stack.ts
+++ b/packages/cdktf-cli/src/lib/cdktf-stack.ts
@@ -9,6 +9,9 @@ import { TerraformJson } from "./terraform-json";
 import { TerraformCloud } from "./models/terraform-cloud";
 import { TerraformCli } from "./models/terraform-cli";
 import { Errors } from "./errors";
+import * as fs from "fs";
+import * as path from "path";
+import { ProviderConstraint } from "./dependencies/dependency-manager";
 
 export type StackUpdate =
   | {
@@ -140,9 +143,11 @@ export class CdktfStack {
   public stopped = false;
   public currentWorkPromise: Promise<void> | undefined;
   public readonly currentState: CdktfStackStates = "idle";
+  private readonly parsedContent: any;
 
   constructor(public options: CdktfStackOptions) {
     this.stack = options.stack;
+    this.parsedContent = JSON.parse(this.stack.content);
   }
 
   public get isPending(): boolean {
@@ -236,6 +241,50 @@ export class CdktfStack {
     await terraform.init();
 
     return terraform;
+  }
+
+  private async checkLockFile() {
+    const lockFilePath = path.join(
+      this.stack.workingDirectory,
+      ".terraform.lock.hcl"
+    );
+    try {
+      const lockFile = (await fs.promises.readFile(lockFilePath)).toString();
+
+      let currentProvider: string | undefined;
+      const lockedProviders: ProviderConstraint[] = [];
+
+      lockFile.split(/\r\n|\r|\n/).forEach((line) => {
+        if (currentProvider) {
+          // const versionMatch = line.match(/version\s= "(.*)"/); // TODO should this be used instead / in addition to?
+          const constraintMatch = line.match(/constraints\s= "(.*)"/);
+          if (constraintMatch) {
+            lockedProviders.push(
+              new ProviderConstraint(currentProvider, constraintMatch[1])
+            );
+            currentProvider = undefined;
+          }
+        } else {
+          const providerMatch = line.match(/provider "(.*)"/);
+          if (providerMatch) {
+            currentProvider = providerMatch[1];
+          }
+        }
+      });
+
+      const requiredProviders = this.parsedContent.terraform.required_providers;
+      const providers = Object.values(requiredProviders).map((value) => {
+        return new ProviderConstraint(
+          (value as any).source,
+          (value as any).version
+        );
+      });
+
+      // TODO check if any provider contained in `providers` violates constraints in `lockedProviders`
+    } catch (err) {
+      // ignore as this most likely means the file doesn't exist
+      // if it is some other error, Terraform will mentiond later
+    }
   }
 
   private async run(cb: () => Promise<void>) {

--- a/packages/cdktf-cli/src/lib/cdktf-stack.ts
+++ b/packages/cdktf-cli/src/lib/cdktf-stack.ts
@@ -258,7 +258,6 @@ export class CdktfStack {
 
       lockFile.split(/\r\n|\r|\n/).forEach((line) => {
         if (currentProvider) {
-          // const versionMatch = line.match(/version\s= "(.*)"/); // TODO should this be used instead / in addition to?
           const constraintMatch = line.match(/constraints\s= "(.*)"/);
           if (constraintMatch) {
             lockedProviders.push(
@@ -290,7 +289,7 @@ export class CdktfStack {
       const providerMatches = lockedProviders.map((lockedProvider) => {
         const provider = providers[lockedProvider.source];
         if (provider) {
-          return lockedProvider.matchesVersion(provider.version ?? "*"); //TODO check if correct fallback for no version
+          return lockedProvider.matchesVersion(provider.version ?? ">0");
         }
         // else no longer using this provider, so won't cause problems
 

--- a/packages/cdktf-cli/src/lib/models/terraform-cli.ts
+++ b/packages/cdktf-cli/src/lib/models/terraform-cli.ts
@@ -42,11 +42,17 @@ export class TerraformCli implements Terraform {
       createTerraformLogHandler(phase)(stderr.toString(), true);
   }
 
-  public async init(): Promise<void> {
+  public async init(needsUpgrade: boolean): Promise<void> {
     await this.setUserAgent();
+
+    const args = ["init", "-input=false"];
+    if (needsUpgrade) {
+      args.push("-upgrade");
+    }
+
     await exec(
       terraformBinaryName,
-      ["init", "-input=false"],
+      args,
       {
         cwd: this.workdir,
         env: process.env,

--- a/packages/cdktf-cli/src/lib/models/terraform-cloud.ts
+++ b/packages/cdktf-cli/src/lib/models/terraform-cloud.ts
@@ -218,7 +218,8 @@ export class TerraformCloud implements Terraform {
   }
 
   @BeautifyErrors("Init")
-  public async init(): Promise<void> {
+  public async init(_needsUpgrade: boolean): Promise<void> {
+    //TODO not sure if the needsUpgrade flag is relevant in tf cloud or how to use it
     const sendLog = this.createTerraformLogHandler("init");
     if (
       fs.existsSync(

--- a/packages/cdktf-cli/src/lib/models/terraform-cloud.ts
+++ b/packages/cdktf-cli/src/lib/models/terraform-cloud.ts
@@ -218,8 +218,7 @@ export class TerraformCloud implements Terraform {
   }
 
   @BeautifyErrors("Init")
-  public async init(_needsUpgrade: boolean): Promise<void> {
-    //TODO not sure if the needsUpgrade flag is relevant in tf cloud or how to use it
+  public async init(needsUpgrade: boolean): Promise<void> {
     const sendLog = this.createTerraformLogHandler("init");
     if (
       fs.existsSync(
@@ -251,6 +250,11 @@ export class TerraformCloud implements Terraform {
     );
 
     this.removeLocalTerraformDirectory();
+
+    if (needsUpgrade) {
+      // Most likely this file doesn't exist, but try removing since init upgrade isn't possible in TFC/E
+      this.removeLocalLockFile();
+    }
 
     sendLog(`Zipping up the directory ${this.workDir}`);
     const zipBuffer = await zipDirectory(this.workDir);
@@ -590,6 +594,16 @@ export class TerraformCloud implements Terraform {
       });
     } catch (error) {
       logger.debug(`Could not remove .terraform folder`, error);
+    }
+  }
+
+  private removeLocalLockFile() {
+    try {
+      fs.rmSync(
+        path.resolve(this.stack.workingDirectory, ".terraform.lock.hcl")
+      );
+    } catch (error) {
+      logger.debug(`Could not remove ".terraform.lock.hcl" file`, error);
     }
   }
 }

--- a/packages/cdktf-cli/src/lib/models/terraform.ts
+++ b/packages/cdktf-cli/src/lib/models/terraform.ts
@@ -114,7 +114,7 @@ export abstract class AbstractTerraformPlan implements TerraformPlan {
 }
 
 export interface Terraform {
-  init: () => Promise<void>;
+  init: (upgrade: boolean) => Promise<void>;
   plan: (
     destroy: boolean,
     refreshOnly?: boolean,

--- a/test/typescript/provider-upgrade/cdktf.json
+++ b/test/typescript/provider-upgrade/cdktf.json
@@ -1,0 +1,9 @@
+{
+  "language": "typescript",
+  "app": "npm run --silent compile && node main.js",
+  "terraformProviders": [],
+  "terraformModules": [],
+  "context": {
+    "excludeStackIdFromLogicalIds": "true"
+  }
+}

--- a/test/typescript/provider-upgrade/main.ts
+++ b/test/typescript/provider-upgrade/main.ts
@@ -1,0 +1,17 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { Construct } from "constructs";
+import { App, TerraformStack, Testing } from "cdktf";
+import { AzureadProvider } from "@cdktf/provider-azuread";
+
+export class HelloTerra extends TerraformStack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new AzureadProvider(this, "provider", {});
+  }
+}
+
+const app = Testing.stubVersion(new App({ stackTraces: false }));
+new HelloTerra(app, "dummy");
+app.synth();

--- a/test/typescript/provider-upgrade/test.ts
+++ b/test/typescript/provider-upgrade/test.ts
@@ -11,12 +11,20 @@ describe("upgrade pre-built provider", () => {
   });
 
   test("initial add", async () => {
-    await driver.exec("npm", ["install", "@cdktf/provider-azuread@0.4.7"]);
+    await driver.exec("npm", [
+      "install",
+      "@cdktf/provider-azuread@0.4.7",
+      "--force",
+    ]);
     await driver.diff();
   });
 
   test("update version", async () => {
-    await driver.exec("npm", ["install", "@cdktf/provider-azuread@0.5.17"]);
+    await driver.exec("npm", [
+      "install",
+      "@cdktf/provider-azuread@0.5.17",
+      "--force",
+    ]);
     await driver.diff();
   });
 });

--- a/test/typescript/provider-upgrade/test.ts
+++ b/test/typescript/provider-upgrade/test.ts
@@ -1,0 +1,22 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { TestDriver } from "../../test-helper";
+
+describe("upgrade pre-built provider", () => {
+  let driver: TestDriver;
+
+  beforeAll(async () => {
+    driver = new TestDriver(__dirname);
+    await driver.setupTypescriptProject();
+  });
+
+  test("initial add", async () => {
+    await driver.exec("npm", ["install", "@cdktf/provider-azuread@0.4.7"]);
+    await driver.diff();
+  });
+
+  test("update version", async () => {
+    await driver.exec("npm", ["install", "@cdktf/provider-azuread@0.5.17"]);
+    await driver.diff();
+  });
+});


### PR DESCRIPTION
Fixes #1863

When [locked providers](https://www.terraform.io/language/files/dependency-lock) aren't compatible with currently specified providers, automatically update the locked version.
Users are likely to run into this situation when updating a pre-built provider package.

Still todo:
* Possibly exposing behavior as an option