### PR TITLE
chore: add notes for how to clean the local dotnet cache

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,8 @@ For Java [examples](./examples/java), packages are referenced from `./dist`, the
 
 For C# [examples](./examples/csharp), packages are referenced from `./dist`, there's no symlinking possible for live code updates. You'll have to explictly run `yarn package` to create new packages to be referenced in the project.
 
+Sometimes, after re-packaging the cdktf package for C#, an already initialized example might not update that package even when running yarn reinstall. In that case you can clear your local cache by running `dotnet nuget locals all --clear` and after a `yarn reinstall` it should all be updated.
+
 ### Outside of this Monorepo
 
 If you want to use the libraries and cli from the repo for local development, you can make use of `yarn link`.


### PR DESCRIPTION
Useful if c# examples don't use the latest locally built cdktf package