### PR TITLE
fix(cli): Make provider add command case insensitive for provider names

### DIFF
--- a/packages/cdktf-cli/lib/dependencies/prebuilt-providers.ts
+++ b/packages/cdktf-cli/lib/dependencies/prebuilt-providers.ts
@@ -31,7 +31,8 @@ export async function getNpmPackageName(
 
   const entry = Object.entries(providers).find(
     ([, p]) =>
-      ProviderConstraint.fromConfigEntry(p).source === constraint.source
+      ProviderConstraint.fromConfigEntry(p).source.toLowerCase() ===
+      constraint.source.toLowerCase()
   );
   if (!entry) {
     return undefined; // no pre-built provider found for this constraint


### PR DESCRIPTION
fixes 'datadog/datadog' not working (only 'DataDog/datadog' worked previously)
