### PR TITLE
fix(hcl2json): add fs-extra to dependencies

### DIFF
--- a/packages/@cdktf/hcl2json/package.json
+++ b/packages/@cdktf/hcl2json/package.json
@@ -30,6 +30,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "@types/node-fetch": "^2.6.2",
+    "fs-extra": "^8.1.0",
     "node-fetch": "^2.6.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently, fs-extra is not defined in the `dependencies` block of `hcl2json`: https://github.com/hashicorp/terraform-cdk/blob/ae0d4901e0260d88752e364f246a82ce70af4e8f/packages/%40cdktf/hcl2json/package.json#L31-L42

This causes a runtime error with the default `yarn` berry PnP linker:

```
 /tmp  mkdir tfcdk-demo
 /tmp  cd tfcdk-demo
 /tmp/tfcdk-demo  yarn set version berry
➤ YN0000: Retrieving https://repo.yarnpkg.com/3.2.2/packages/yarnpkg-cli/bin/yarn.js
➤ YN0000: Saving the new release in .yarn/releases/yarn-3.2.2.cjs
➤ YN0000: Done in 0s 357ms
 /tmp/tfcdk-demo  yarn init
{
  name: 'tfcdk-demo',
  packageManager: 'yarn@3.2.2'
}
 /tmp/tfcdk-demo   main  yarn add -D cdktf-cli@next
➤ YN0000: ┌ Resolution step
➤ YN0060: │ @cdktf/hcl2cdk@npm:0.13.0-pre.19 provides graphology-types (pb9009) with version 0.21.2, which doesn't satisfy what graphology requests
➤ YN0002: │ cdktf-cli@npm:0.13.0-pre.19 doesn't provide ink (pfc5b2), requested by ink-select-input
➤ YN0002: │ cdktf-cli@npm:0.13.0-pre.19 doesn't provide react (pf61fd), requested by ink-select-input
➤ YN0000: │ Some peer dependencies are incorrectly met; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code
➤ YN0000: └ Completed in 3s 619ms
➤ YN0000: ┌ Fetch step
➤ YN0013: │ yargs@npm:16.2.0 can't be found in the cache and will be fetched from the remote registry
➤ YN0013: │ yargs@npm:17.5.1 can't be found in the cache and will be fetched from the remote registry
➤ YN0013: │ yoga-layout-prebuilt@npm:1.10.0 can't be found in the cache and will be fetched from the r
➤ YN0013: │ zip-stream@npm:4.1.0 can't be found in the cache and will be fetched from the remote regis
➤ YN0013: │ zod@npm:1.11.17 can't be found in the cache and will be fetched from the remote registry
➤ YN0000: └ Completed in 0s 491ms
➤ YN0000: ┌ Link step
➤ YN0000: │ ESM support for PnP uses the experimental loader API and is therefore experimental
➤ YN0000: └ Completed in 0s 230ms
➤ YN0000: Done with warnings in 4s 361ms
 /tmp/tfcdk-demo   main  yarn cdktf
/private/tmp/tfcdk-demo/.pnp.cjs:11196
      Error.captureStackTrace(firstError);
            ^

Error: @cdktf/hcl2json tried to access fs-extra, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: fs-extra
Required by: @cdktf/hcl2json@npm:0.13.0-pre.19 (via /private/tmp/tfcdk-demo/.yarn/cache/@cdktf-hcl2json-npm-0.13.0-pre.19-5727ef21f1-e3e733207e.zip/node_modules/@cdktf/hcl2json/lib/)

Require stack:
- /private/tmp/tfcdk-demo/.yarn/cache/@cdktf-hcl2json-npm-0.13.0-pre.19-5727ef21f1-e3e733207e.zip/node_modules/@cdktf/hcl2json/lib/index.js
- /private/tmp/tfcdk-demo/.yarn/unplugged/cdktf-cli-npm-0.13.0-pre.19-99a43dc70f/node_modules/cdktf-cli/bundle/bin/cdktf.js
- /private/tmp/tfcdk-demo/.yarn/unplugged/cdktf-cli-npm-0.13.0-pre.19-99a43dc70f/node_modules/cdktf-cli/bundle/bin/cdktf
    at Function.require$$0.Module._resolveFilename (/private/tmp/tfcdk-demo/.pnp.cjs:11196:13)
    at Function.require$$0.Module._load (/private/tmp/tfcdk-demo/.pnp.cjs:11050:42)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/private/tmp/tfcdk-demo/.yarn/cache/@cdktf-hcl2json-npm-0.13.0-pre.19-5727ef21f1-e3e733207e.zip/node_modules/@cdktf/hcl2json/lib/index.js:31:36)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Object.require$$0.Module._extensions..js (/private/tmp/tfcdk-demo/.pnp.cjs:11240:33)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.require$$0.Module._load (/private/tmp/tfcdk-demo/.pnp.cjs:11080:14)
```

Version: `0.13.0-pre.19`

To fix this issue, I copied the version of `fs-extra` used by the existing packages in the monorepo:

![Screen Shot 2022-08-22 at 13 16 50](https://user-images.githubusercontent.com/630449/186001945-b6c276e6-6eca-4345-9798-90be5d758ac8.png)

In the meantime, using the `node-modules` yarn linker works around the problem ([docs](https://yarnpkg.com/configuration/yarnrc/#nodeLinker)).