### PR TITLE
chore(docs): Remove positional language + fix style nits

### DIFF
--- a/examples/python/provisioner/Pipfile.lock
+++ b/examples/python/provisioner/Pipfile.lock
@@ -1,107 +1,107 @@
 {
-    "_meta": {
-        "hash": {
-            "sha256": "4d795221fae1915a3c9346d1137bbd6adb709356a0278af165e98d47c32e6ded"
-        },
-        "pipfile-spec": 6,
-        "requires": {
-            "python_version": "3.7"
-        },
-        "sources": [
-            {
-                "name": "pypi",
-                "url": "https://pypi.org/simple",
-                "verify_ssl": true
-            }
-        ]
+  "_meta": {
+    "hash": {
+      "sha256": "4d795221fae1915a3c9346d1137bbd6adb709356a0278af165e98d47c32e6ded"
     },
-    "default": {
-        "attrs": {
-            "hashes": [
-                "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6",
-                "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==22.1.0"
-        },
-        "cattrs": {
-            "hashes": [
-                "sha256:94b67b64cf92c994f8784c40c082177dc916e0489a73a9a36b24eb18a9db40c6",
-                "sha256:d55c477b4672f93606e992049f15d526dc7867e6c756cd6256d4af92e2b1e364"
-            ],
-            "markers": "python_version >= '3.7' and python_version < '4.0'",
-            "version": "==22.1.0"
-        },
-        "cdktf": {
-            "hashes": [
-                "sha256:f90f042026e1d9dc44933c1001ec6e9fd00db3551aa7b91b1ec4a8cd25ce9596"
-            ],
-            "path": "./../../../dist/python/cdktf-0.0.0-py3-none-any.whl",
-            "version": "==0.0.0"
-        },
-        "constructs": {
-            "hashes": [
-                "sha256:1b491afce3e73884faa42f32e94ed15fda6a70c91f700ea552ebe0ea3a0d9a0f",
-                "sha256:8bc6047134f21ceea12753f5d3bfd439a4db01507ca727a3b1d4bc2bde077be7"
-            ],
-            "markers": "python_version ~= '3.7'",
-            "version": "==10.1.84"
-        },
-        "exceptiongroup": {
-            "hashes": [
-                "sha256:6990c24f06b8d33c8065cfe43e5e8a4bfa384e0358be036af9cc60b6321bd11a",
-                "sha256:ab0a968e1ef769e55d9a596f4a89f7be9ffedbc9fdefdb77cc68cf5c33ce1035"
-            ],
-            "markers": "python_version <= '3.10'",
-            "version": "==1.0.0rc8"
-        },
-        "jsii": {
-            "hashes": [
-                "sha256:47b939259ec465bc044aed6d3288b9b27a8edef2af21f1a8448e297b8429f154",
-                "sha256:a09ef1f9864fe27457ba4233b3a0744a76d2562077d5b8b3a7f2242edc4a8293"
-            ],
-            "markers": "python_version ~= '3.7'",
-            "version": "==1.65.0"
-        },
-        "publication": {
-            "hashes": [
-                "sha256:0248885351febc11d8a1098d5c8e3ab2dabcf3e8c0c96db1e17ecd12b53afbe6",
-                "sha256:68416a0de76dddcdd2930d1c8ef853a743cc96c82416c4e4d3b5d901c6276dc4"
-            ],
-            "version": "==0.0.3"
-        },
-        "python-dateutil": {
-            "hashes": [
-                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
-                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
-            "version": "==2.8.2"
-        },
-        "six": {
-            "hashes": [
-                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
-                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
-            "version": "==1.16.0"
-        },
-        "typeguard": {
-            "hashes": [
-                "sha256:00edaa8da3a133674796cf5ea87d9f4b4c367d77476e185e80251cc13dfbb8c4",
-                "sha256:5e3e3be01e887e7eafae5af63d1f36c849aaa94e3a0112097312aabfa16284f1"
-            ],
-            "markers": "python_full_version >= '3.5.3'",
-            "version": "==2.13.3"
-        },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02",
-                "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==4.3.0"
-        }
+    "pipfile-spec": 6,
+    "requires": {
+      "python_version": "3.7"
     },
-    "develop": {}
+    "sources": [
+      {
+        "name": "pypi",
+        "url": "https://pypi.org/simple",
+        "verify_ssl": true
+      }
+    ]
+  },
+  "default": {
+    "attrs": {
+      "hashes": [
+        "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6",
+        "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"
+      ],
+      "markers": "python_version >= '3.5'",
+      "version": "==22.1.0"
+    },
+    "cattrs": {
+      "hashes": [
+        "sha256:94b67b64cf92c994f8784c40c082177dc916e0489a73a9a36b24eb18a9db40c6",
+        "sha256:d55c477b4672f93606e992049f15d526dc7867e6c756cd6256d4af92e2b1e364"
+      ],
+      "markers": "python_version >= '3.7' and python_version < '4.0'",
+      "version": "==22.1.0"
+    },
+    "cdktf": {
+      "hashes": [
+        "sha256:f90f042026e1d9dc44933c1001ec6e9fd00db3551aa7b91b1ec4a8cd25ce9596"
+      ],
+      "path": "./../../../dist/python/cdktf-0.0.0-py3-none-any.whl",
+      "version": "==0.0.0"
+    },
+    "constructs": {
+      "hashes": [
+        "sha256:1b491afce3e73884faa42f32e94ed15fda6a70c91f700ea552ebe0ea3a0d9a0f",
+        "sha256:8bc6047134f21ceea12753f5d3bfd439a4db01507ca727a3b1d4bc2bde077be7"
+      ],
+      "markers": "python_version ~= '3.7'",
+      "version": "==10.1.84"
+    },
+    "exceptiongroup": {
+      "hashes": [
+        "sha256:6990c24f06b8d33c8065cfe43e5e8a4bfa384e0358be036af9cc60b6321bd11a",
+        "sha256:ab0a968e1ef769e55d9a596f4a89f7be9ffedbc9fdefdb77cc68cf5c33ce1035"
+      ],
+      "markers": "python_version <= '3.10'",
+      "version": "==1.0.0rc8"
+    },
+    "jsii": {
+      "hashes": [
+        "sha256:47b939259ec465bc044aed6d3288b9b27a8edef2af21f1a8448e297b8429f154",
+        "sha256:a09ef1f9864fe27457ba4233b3a0744a76d2562077d5b8b3a7f2242edc4a8293"
+      ],
+      "markers": "python_version ~= '3.7'",
+      "version": "==1.65.0"
+    },
+    "publication": {
+      "hashes": [
+        "sha256:0248885351febc11d8a1098d5c8e3ab2dabcf3e8c0c96db1e17ecd12b53afbe6",
+        "sha256:68416a0de76dddcdd2930d1c8ef853a743cc96c82416c4e4d3b5d901c6276dc4"
+      ],
+      "version": "==0.0.3"
+    },
+    "python-dateutil": {
+      "hashes": [
+        "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+        "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+      ],
+      "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+      "version": "==2.8.2"
+    },
+    "six": {
+      "hashes": [
+        "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+        "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+      ],
+      "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+      "version": "==1.16.0"
+    },
+    "typeguard": {
+      "hashes": [
+        "sha256:00edaa8da3a133674796cf5ea87d9f4b4c367d77476e185e80251cc13dfbb8c4",
+        "sha256:5e3e3be01e887e7eafae5af63d1f36c849aaa94e3a0112097312aabfa16284f1"
+      ],
+      "markers": "python_full_version >= '3.5.3'",
+      "version": "==2.13.3"
+    },
+    "typing-extensions": {
+      "hashes": [
+        "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02",
+        "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"
+      ],
+      "markers": "python_version >= '3.7'",
+      "version": "==4.3.0"
+    }
+  },
+  "develop": {}
 }

--- a/packages/cdktf-cli/lib/synth-stack.ts
+++ b/packages/cdktf-cli/lib/synth-stack.ts
@@ -58,8 +58,8 @@ export class SynthStack {
     );
 
     // Increases the default memory available to Node.js when synthesizing a TypeScript CDK project.
-    const nodeOptsSwitch = "--max-old-space-size"
-    const nodeOptsSetting = `${nodeOptsSwitch}=4096`
+    const nodeOptsSwitch = "--max-old-space-size";
+    const nodeOptsSetting = `${nodeOptsSwitch}=4096`;
     if (env.NODE_OPTIONS && !env.NODE_OPTIONS.includes(nodeOptsSwitch)) {
       logger.warn(`WARNING: Found NODE_OPTIONS environment variable without a setting for ${nodeOptsSwitch}
 The synthesizing step for TypeScript may need an increased amount of memory if multiple large providers

--- a/website/docs/cdktf/api-reference/csharp.mdx
+++ b/website/docs/cdktf/api-reference/csharp.mdx
@@ -26458,7 +26458,7 @@ public string Content { get; }
 
 The destination path to write to on the remote system.
 
-See Destination Paths below for more information.
+Refer to Destination Paths for more information.
 
 ---
 
@@ -27406,7 +27406,7 @@ public string ScriptPath { get; }
 
 The path used to copy scripts meant for remote execution.
 
-Refer to {@link https://www.terraform.io/language/resources/provisioners/connection#how-provisioners-execute-remote-scripts How Provisioners Execute Remote Scripts below for more details}
+Refer to {@link https://www.terraform.io/language/resources/provisioners/connection#how-provisioners-execute-remote-scripts How Provisioners Execute Remote Scripts for more details}
 
 ---
 
@@ -28012,7 +28012,7 @@ public string ScriptPath { get; }
 
 The path used to copy scripts meant for remote execution.
 
-Refer to {@link https://www.terraform.io/language/resources/provisioners/connection#how-provisioners-execute-remote-scripts How Provisioners Execute Remote Scripts below for more details}
+Refer to {@link https://www.terraform.io/language/resources/provisioners/connection#how-provisioners-execute-remote-scripts How Provisioners Execute Remote Scripts for more details}
 
 ---
 

--- a/website/docs/cdktf/api-reference/go.mdx
+++ b/website/docs/cdktf/api-reference/go.mdx
@@ -26458,7 +26458,7 @@ func Content() *string
 
 The destination path to write to on the remote system.
 
-See Destination Paths below for more information.
+Refer to Destination Paths for more information.
 
 ---
 
@@ -27406,7 +27406,7 @@ func ScriptPath() *string
 
 The path used to copy scripts meant for remote execution.
 
-Refer to {@link https://www.terraform.io/language/resources/provisioners/connection#how-provisioners-execute-remote-scripts How Provisioners Execute Remote Scripts below for more details}
+Refer to {@link https://www.terraform.io/language/resources/provisioners/connection#how-provisioners-execute-remote-scripts How Provisioners Execute Remote Scripts for more details}
 
 ---
 
@@ -28012,7 +28012,7 @@ func ScriptPath() *string
 
 The path used to copy scripts meant for remote execution.
 
-Refer to {@link https://www.terraform.io/language/resources/provisioners/connection#how-provisioners-execute-remote-scripts How Provisioners Execute Remote Scripts below for more details}
+Refer to {@link https://www.terraform.io/language/resources/provisioners/connection#how-provisioners-execute-remote-scripts How Provisioners Execute Remote Scripts for more details}
 
 ---
 

--- a/website/docs/cdktf/api-reference/java.mdx
+++ b/website/docs/cdktf/api-reference/java.mdx
@@ -30080,7 +30080,7 @@ public java.lang.String getContent();
 
 The destination path to write to on the remote system.
 
-See Destination Paths below for more information.
+Refer to Destination Paths for more information.
 
 ---
 
@@ -31028,7 +31028,7 @@ public java.lang.String getScriptPath();
 
 The path used to copy scripts meant for remote execution.
 
-Refer to {@link https://www.terraform.io/language/resources/provisioners/connection#how-provisioners-execute-remote-scripts How Provisioners Execute Remote Scripts below for more details}
+Refer to {@link https://www.terraform.io/language/resources/provisioners/connection#how-provisioners-execute-remote-scripts How Provisioners Execute Remote Scripts for more details}
 
 ---
 
@@ -31634,7 +31634,7 @@ public java.lang.String getScriptPath();
 
 The path used to copy scripts meant for remote execution.
 
-Refer to {@link https://www.terraform.io/language/resources/provisioners/connection#how-provisioners-execute-remote-scripts How Provisioners Execute Remote Scripts below for more details}
+Refer to {@link https://www.terraform.io/language/resources/provisioners/connection#how-provisioners-execute-remote-scripts How Provisioners Execute Remote Scripts for more details}
 
 ---
 

--- a/website/docs/cdktf/api-reference/python.mdx
+++ b/website/docs/cdktf/api-reference/python.mdx
@@ -31541,7 +31541,7 @@ content: str
 
 The destination path to write to on the remote system.
 
-See Destination Paths below for more information.
+Refer to Destination Paths for more information.
 
 ---
 
@@ -32507,7 +32507,7 @@ script_path: str
 
 The path used to copy scripts meant for remote execution.
 
-Refer to {@link https://www.terraform.io/language/resources/provisioners/connection#how-provisioners-execute-remote-scripts How Provisioners Execute Remote Scripts below for more details}
+Refer to {@link https://www.terraform.io/language/resources/provisioners/connection#how-provisioners-execute-remote-scripts How Provisioners Execute Remote Scripts for more details}
 
 ---
 
@@ -33137,7 +33137,7 @@ script_path: str
 
 The path used to copy scripts meant for remote execution.
 
-Refer to {@link https://www.terraform.io/language/resources/provisioners/connection#how-provisioners-execute-remote-scripts How Provisioners Execute Remote Scripts below for more details}
+Refer to {@link https://www.terraform.io/language/resources/provisioners/connection#how-provisioners-execute-remote-scripts How Provisioners Execute Remote Scripts for more details}
 
 ---
 

--- a/website/docs/cdktf/api-reference/typescript.mdx
+++ b/website/docs/cdktf/api-reference/typescript.mdx
@@ -25960,7 +25960,7 @@ public readonly content: string;
 
 The destination path to write to on the remote system.
 
-See Destination Paths below for more information.
+Refer to Destination Paths for more information.
 
 ---
 
@@ -26908,7 +26908,7 @@ public readonly scriptPath: string;
 
 The path used to copy scripts meant for remote execution.
 
-Refer to {@link https://www.terraform.io/language/resources/provisioners/connection#how-provisioners-execute-remote-scripts How Provisioners Execute Remote Scripts below for more details}
+Refer to {@link https://www.terraform.io/language/resources/provisioners/connection#how-provisioners-execute-remote-scripts How Provisioners Execute Remote Scripts for more details}
 
 ---
 
@@ -27514,7 +27514,7 @@ public readonly scriptPath: string;
 
 The path used to copy scripts meant for remote execution.
 
-Refer to {@link https://www.terraform.io/language/resources/provisioners/connection#how-provisioners-execute-remote-scripts How Provisioners Execute Remote Scripts below for more details}
+Refer to {@link https://www.terraform.io/language/resources/provisioners/connection#how-provisioners-execute-remote-scripts How Provisioners Execute Remote Scripts for more details}
 
 ---
 

--- a/website/docs/cdktf/cli-reference/commands.mdx
+++ b/website/docs/cdktf/cli-reference/commands.mdx
@@ -186,7 +186,7 @@ $ cdktf deploy '*-production'
 
 If the stacks have dependencies (through cross stack references or by calling `myStack.addDependency(otherStack)`) deploy will figure out the right order to run.
 
-For more info on the `--outputs-file` option, [see the `output` command below](/cdktf/cli-reference/commands#output).
+For more info on the `--outputs-file` option, refer to the [`output` command](/cdktf/cli-reference/commands#output).
 
 ## destroy
 

--- a/website/docs/cdktf/concepts/aspects.mdx
+++ b/website/docs/cdktf/concepts/aspects.mdx
@@ -16,7 +16,7 @@ To create an aspect, you must import the `Aspects` class and the `IAspect` inter
 
 Everything within a CDKTF application descends from the `Construct` class, so you could call the construct on any instantiated element. This includes the entire application, a particular [stack](/cdktf/concepts/stacks), or all of the resources for a specific [provider](/cdktf/concepts/providers). When you call the aspect, CDKTF applies its methods to all of the the constructs that fall within the specified scope.
 
-The TypeScript example below defines an aspect to add tags to resources.
+The following TypeScript example defines an aspect to add tags to resources.
 
 ```ts
 import { IConstruct } from "constructs";
@@ -48,7 +48,7 @@ export class TagsAddingAspect implements IAspect {
 Aspects.of(myStack).add(new TagsAddingAspect({ createdBy: "cdktf" }));
 ```
 
-You can also use aspects for validation. The TypeScript example below defines an aspect that checks whether all S3 Buckets start with the correct prefix.
+You can also use aspects for validation. The following TypeScript example defines an aspect that checks whether all S3 Buckets start with the correct prefix.
 
 ```ts
 import { IConstruct } from "constructs";

--- a/website/docs/cdktf/concepts/assets.mdx
+++ b/website/docs/cdktf/concepts/assets.mdx
@@ -18,7 +18,7 @@ Assets are especially useful for:
 
 > **Hands-on:** Try the [Deploy Multiple Lambda Functions with TypeScript](https://learn.hashicorp.com/tutorials/terraform/cdktf-assets-stacks-lambda?in=terraform/cdktf) tutorial on HashiCorp Learn. This tutorial guides you through using a `TerraformAsset` to archive a Lambda function, uploading the archive to an S3 bucket, then deploying the Lambda function.
 
-The TypeScript example below uses `TerraformAsset` to upload the contents of the specified directory into an S3 Bucket. The `TerraformAsset` is responsible for making sure the directory ends up in the correct output folder as a zip file that the `S3BucketObject` can reference.
+The following TypeScript example uses `TerraformAsset` to upload the contents of the specified directory into an S3 Bucket. The `TerraformAsset` is responsible for making sure the directory ends up in the correct output folder as a zip file that the `S3BucketObject` can reference.
 
 The stack output directory in `cdktf.out` contains all of the assets that `TerraformAsset` needs. This is important for workflows where you use synthesized configurations with Terraform directly. For example, you would only need to upload the contents of the stack output folder to Terraform Cloud or Terraform Enterprise.
 

--- a/website/docs/cdktf/concepts/cdktf-architecture.mdx
+++ b/website/docs/cdktf/concepts/cdktf-architecture.mdx
@@ -23,7 +23,7 @@ The [`jsii` tool](https://aws.github.io/jsii/) enables publishing polyglot libra
 
 CDKTF [synthesizes](/cdktf/cli-reference/commands#synth) infrastructure that you define in a supported programming language into [JSON configuration files](/language/syntax/json) that Terraform can use to manage infrastructure.
 
-The diagram below shows how synthesizing a CDKTF application produces a series of artifacts in a designated output folder. You can then either use the JSON file with Terraform directly or provision your infrastructure using CDKTF CLI commands. All CDKTF CLI operations like `diff`, `deploy`, and `destroy` communicate with Terraform for execution.
+The following diagram shows how synthesizing a CDKTF application produces a series of artifacts in a designated output folder. You can then either use the JSON file with Terraform directly or provision your infrastructure using CDKTF CLI commands. All CDKTF CLI operations like `diff`, `deploy`, and `destroy` communicate with Terraform for execution.
 
 ![cdktf-terraform](./images/cdktf-terraform-workflow.png)
 

--- a/website/docs/cdktf/concepts/constructs.mdx
+++ b/website/docs/cdktf/concepts/constructs.mdx
@@ -44,11 +44,11 @@ Constructs also provide a way to logically structure a set of resources, but you
 
 ## Use Constructs
 
-> **Hands On:** Try [Deploy Applications with CDK for Terraform](https://learn.hashicorp.com/tutorials/terraform/cdktf-applications?in=terraform/cdktf) tutorial on HashiCorp Learn to use a custom construct. It includes the example code below.
+> **Hands On:** Try [Deploy Applications with CDK for Terraform](https://learn.hashicorp.com/tutorials/terraform/cdktf-applications?in=terraform/cdktf) tutorial on HashiCorp Learn to use a custom construct.
 
 You can import any [CDKTF-compatible](#available-constructs) construct that is available in your project’s programming language. Then, you can create new instances of the construct and use any exposed properties to customize the construct configuration.
 
-The TypeScript example below instantiates a construct called `KubernetesWebAppDeployment` and uses the available arguments to specify that the deployment will have two replicas.
+The following TypeScript example instantiates a construct called `KubernetesWebAppDeployment` and uses the available arguments to specify that the deployment will have two replicas.
 
 ```typescript
 import { Construct } from "constructs";
@@ -85,7 +85,7 @@ app.synth();
 
 You can instantiate a construct multiple times throughout your infrastructure. For example, you may want to create multiple S3 Buckets with different configurations. CDKTF infers a unique `name` for each instance from its `Construct#id` and parent construct. Instances that share the same parent element are considered to be part of the same scope. If you instantiate multiple constructs within the same scope, you must set a different `name` for each instance to avoid naming conflicts.
 
-The example below creates three different S3 buckets, two of which are in the same scope. When CDKTF synthesizes this configuration, the Terraform IDs for these resources will be the construct names prefixed by the stack name and suffixed with a hash for each Construct instance.
+The following example creates three different S3 buckets, two of which are in the same scope. When CDKTF synthesizes this configuration, the Terraform IDs for these resources will be the construct names prefixed by the stack name and suffixed with a hash for each Construct instance.
 
 ```ts
 import { Construct } from "constructs";
@@ -95,7 +95,7 @@ class PublicS3Bucket extends Construct {
     super(scope, name); // This creates a new scope since we extend from resource
 
     // This bucket is in a different scope than the buckets
-    // defined in `MyStack` below. Therefore, it does not need a unique name.
+    // defined in `MyStack`. Therefore, it does not need a unique name.
     this.bucket = new S3Bucket(this, "bucket", {
       bucketPrefix: name,
       website: [

--- a/website/docs/cdktf/concepts/data-sources.mdx
+++ b/website/docs/cdktf/concepts/data-sources.mdx
@@ -19,7 +19,7 @@ When data is static or you know the values before [synthesizing your code](/cdkt
 
 Data Sources are part of a [Terraform provider](/cdktf/concepts/providers). All classes representing Data Sources are prefixed with `Data`.
 
-In the TypeScript example below, a Terraform data source fetches the AWS region `DataAwsRegion` from the AWS provider.
+In the following TypeScript example, a Terraform data source fetches the AWS region `DataAwsRegion` from the AWS provider.
 
 ```typescript
 .....
@@ -39,7 +39,7 @@ export class HelloTerraform extends TerraformStack {
 
 The [`terraform_remote_state` data source](/language/state/remote-state-data) retrieves state data from a remote [Terraform backend](/language/settings/backends). This allows you to use the root-level outputs of one or more Terraform configurations as input data for another configuration. For example, a core infrastructure team can handle building the core machines, networking, etc. and then expose some information to other teams that allows them to run their own infrastructure. Refer to the [Remote Backends page](/cdktf/concepts/remote-backends) for more details.
 
-The TypeScript example below uses the global `DataTerraformRemoteState` to reference a Terraform Output of another Terraform configuration.
+The following TypeScript example uses the global `DataTerraformRemoteState` to reference a Terraform Output of another Terraform configuration.
 
 ```typescript
 .....

--- a/website/docs/cdktf/concepts/functions.mdx
+++ b/website/docs/cdktf/concepts/functions.mdx
@@ -17,7 +17,7 @@ When inputs are available before [synthesizing your code](/cdktf/cli-reference/c
 
 ## Usage Example
 
-The TypeScript example below uses a Data Source from the AWS Provider to fetch the Availability Zones of the given region. As this data is unknown until Terraform applies the configuration, this CDKTF application uses both [Terraform Outputs](/cdktf/concepts/variables-and-outputs#output-values) and the Terraform [`element`](/language/functions/element) function.
+The following TypeScript example uses a Data Source from the AWS Provider to fetch the Availability Zones of the given region. As this data is unknown until Terraform applies the configuration, this CDKTF application uses both [Terraform Outputs](/cdktf/concepts/variables-and-outputs#output-values) and the Terraform [`element`](/language/functions/element) function.
 
 The `element` function gets the first element from the list of Availability Zone names.
 

--- a/website/docs/cdktf/concepts/hcl-interoperability.mdx
+++ b/website/docs/cdktf/concepts/hcl-interoperability.mdx
@@ -18,7 +18,7 @@ This page shows how you can interoperate HCL and CDK for Terraform configuration
 
 ## CDKTF to HCL
 
-The TypeScript example below is a CDKTF application that uses the `hashicorp/random` provider to generate a random name.
+The following TypeScript example is a CDKTF application that uses the `hashicorp/random` provider to generate a random name.
 
 ```typescript
 import { Construct } from "constructs";

--- a/website/docs/cdktf/concepts/iterators.mdx
+++ b/website/docs/cdktf/concepts/iterators.mdx
@@ -18,7 +18,7 @@ When data is static or you know the values before [synthesizing your code](/cdkt
 
 Import the `TerraformIterator` class and call the `.fromList()` or `.fromMap()` static method. Then use the `forEach` property to pass the iterator to a resource, data source, or module. This lets you use the iterator in attributes.
 
-The example below uses an iterator to create a unique name for each new S3 bucket.
+The following example uses an iterator to create a unique name for each new S3 bucket.
 
 ```ts
 import { s3 } from "@cdktf/provider-aws";
@@ -40,7 +40,7 @@ You cannot access the index of items when iterating over lists. This is because 
 
 ## Using Iterators on Complex Types
 
-The iterator also exposes methods to access nested attributes. The example below uses the `getString` and `getStringMap` methods to access the `name` and `tags` attributes of each list item.
+The iterator also exposes methods to access nested attributes. The following example uses the `getString` and `getStringMap` methods to access the `name` and `tags` attributes of each list item.
 
 ```ts
 const iterator = TerraformIterator.fromList([
@@ -67,7 +67,7 @@ You can also use iterators to create a list of objects based on each item in a l
 
 Use iterators for list attributes if the length of the list is not known before deploying. Otherwise, use native functions that are available in your language (e.g., `Array.map` in TypeScript).
 
-The examples below use an iterator to create a team containing each member of an organization.
+The following examples use an iterator to create a team containing each member of an organization.
 
 <CodeTabs>
 

--- a/website/docs/cdktf/concepts/modules.mdx
+++ b/website/docs/cdktf/concepts/modules.mdx
@@ -15,7 +15,7 @@ You can specify any existing public or private module in your `cdktf.json` file,
 
 ## Install Modules
 
-You can use modules from the [Terraform Registry](https://registry.terraform.io/) and other sources like GitHub in your application. For example, the TypeScript project below has a `main.ts` file that defines AWS resources and uses the [AWS VPC module](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest).
+You can use modules from the [Terraform Registry](https://registry.terraform.io/) and other sources like GitHub in your application. For example, the following TypeScript project has a `main.ts` file that defines AWS resources and uses the [AWS VPC module](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest).
 
 ```typescript
 import { Construct } from "constructs";
@@ -103,7 +103,7 @@ Modules often return data that you can use as inputs to other modules or resourc
 
 ### Examples
 
-The TypeScript example below uses a local module and references its output as a Terraform output.
+The following TypeScript example uses a local module and references its output as a Terraform output.
 
 ```typescript
 import { Construct } from "constructs";
@@ -126,7 +126,7 @@ class MyStack extends TerraformStack {
 }
 ```
 
-The Python example below uses a local module and references its output as a Terraform output.
+The following Python example uses a local module and references its output as a Terraform output.
 
 ```python
 #!/usr/bin/env python
@@ -149,7 +149,7 @@ class MyStack(TerraformStack):
 
 While we generally recommend generating code bindings for modules, you can also use the `TerraformHclModule` class to reference any module that Terraform supports. Both methods create identical synthesized Terraform configuration files, but using `TerraformHclModule` does not generate any types or type-safe inputs or outputs.
 
-The TypeScript example below uses `TerraformHclModule` to import an AWS module.
+The following TypeScript example uses `TerraformHclModule` to import an AWS module.
 
 ```typescript
 const provider = new AwsProvider(stack, "provider", {

--- a/website/docs/cdktf/concepts/providers.mdx
+++ b/website/docs/cdktf/concepts/providers.mdx
@@ -54,7 +54,7 @@ app.synth();
 
 To use a new provider, first add it to the `"terraformProviders"` array in the [`cdktf.json` file](/cdktf/create-and-deploy/configuration-file).
 
-The example below adds the [DNS Simple](https://registry.terraform.io/providers/dnsimple/dnsimple/latest/docs) provider:
+The following example adds the [DNS Simple](https://registry.terraform.io/providers/dnsimple/dnsimple/latest/docs) provider.
 
 ```json
 {
@@ -79,7 +79,7 @@ Generated typescript constructs in the output directory: .gen
 
 #### Import Classes
 
-Import and use the generated classes in your application. The TypeScript example below imports the `DnsimpleProvider` and `Record` resources from `./.gen/providers/dnsimple` and defines them.
+Import and use the generated classes in your application. The following TypeScript example imports the `DnsimpleProvider` and `Record` resources from `./.gen/providers/dnsimple` and defines them.
 
 ```typescript
 import { Construct } from "constructs";
@@ -202,7 +202,7 @@ It can take several minutes to generate the code bindings for providers with ver
 - [Github Provider](https://github.com/terraform-cdk-providers/cdktf-provider-github)
 - [Null Provider](https://github.com/terraform-cdk-providers/cdktf-provider-null)
 
-These packages are regularly published to NPM / PyPi, and you can treat them as you would any other dependency. The example below shows how to install the AWS provider in TypeScript / Node.
+These packages are regularly published to NPM / PyPi, and you can treat them as you would any other dependency. The following example shows how to install the AWS provider in TypeScript / Node.
 
 ```
 npm install @cdktf/provider-aws

--- a/website/docs/cdktf/concepts/remote-backends.mdx
+++ b/website/docs/cdktf/concepts/remote-backends.mdx
@@ -24,7 +24,7 @@ Consider using a remote backend when multiple individuals or teams need access t
 You can define a [JSON configuration for a remote backend](/language/syntax/json#terraform-blocks)
 with a `TerraformBackend` subclass or a JSON configuration file.
 
-The TypeScript example below uses the `TerraformBackend` subclass `RemoteBackend`.
+The following TypeScript example uses the `TerraformBackend` subclass `RemoteBackend`.
 
 ```typescript
 import { Construct } from "constructs";
@@ -54,7 +54,7 @@ new Mystack(app, "hello-terraform");
 
 When you call `cdktf synth`, CDKTF generates a JSON file called `remote.tf.json` in the `cdktf.out` stack sub-directory containing the synthesized CDKTF code. For example, CDKTF creates the output for a stack called `hello-terraform` in `cdktf.out/stacks/hello-terraform`.
 
-Below is the stack output directory.
+The following example shows the stack output directory.
 
 ```bash
 tree .
@@ -63,7 +63,7 @@ tree .
 └── remote.tf.json
 ```
 
-Below is the generated `remote.tf.json` file.
+The following example shows the generated `remote.tf.json` file.
 
 ```json
 {
@@ -226,7 +226,7 @@ In addition to Terraform Cloud, Terraform and CDKTF support the following backen
 
 Escape hatches can add to or override existing resources, and you can use them for backends or backend constructs that CDKTF does not natively support. Escape hatch methods have an `Override` suffix (e.g., `addOverride`).
 
-The example below uses an escape hatch to add an unsupported remote backend on a `Stack` object.
+The following example uses an escape hatch to add an unsupported remote backend on a `Stack` object.
 
 ```typescript
 stack.addOverride("terraform.backend", {

--- a/website/docs/cdktf/concepts/resources.mdx
+++ b/website/docs/cdktf/concepts/resources.mdx
@@ -14,7 +14,7 @@ In your CDK for Terraform (CDKTF) application, you will use your preferred progr
 
 Resource definitions and properties vary depending on the type of resource and the provider. Consult your provider's documentation for a full list of available resources and their configuration options.
 
-The TypeScript example below defines a [DynamoDB table](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) resource on the AWS provider.
+The following TypeScript example defines a [DynamoDB table](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) resource on the AWS provider.
 
 ```typescript
 export class HelloTerra extends TerraformStack {
@@ -51,7 +51,7 @@ You can reference resource properties throughout your configuration. For example
 
 To create references, call `myResource.<propertyName>` on the resource instance. For example, you could use `myResource.name` to retrieve the `name` property from `myResource`. Terraform does not support passing an entire block (e.g. `exampleNamespace.metadata`) into a resource or data source, so you must create a reference for each individual property.
 
-References are also useful when you need to track logical dependencies. For example, Kubernetes resources live in a namespace, so a namespace must exist before Terraform can provision the associated resources. The TypeScript example below uses a reference for the namespace property in the the deployment. This reference tells Terraform that it needs to create the namespace before creating the resources.
+References are also useful when you need to track logical dependencies. For example, Kubernetes resources live in a namespace, so a namespace must exist before Terraform can provision the associated resources. The following TypeScript example uses a reference for the namespace property in the the deployment. This reference tells Terraform that it needs to create the namespace before creating the resources.
 
 ```ts
 
@@ -81,7 +81,7 @@ If you need to use the special [`self` object](https://www.terraform.io/language
 
 Terraform provides [meta-arguments](/language/resources/syntax#meta-arguments) to change resource behavior. For example, the `for_each` meta-argument creates multiple resource instances according to a map, or set of strings. The escape hatch allows you to use these meta-arguments to your CDKTF application and to override attributes that CDKTF cannot yet fully express.
 
-The TypeScript example below defines a provisioner for a resource using the `addOverride` method.
+The following TypeScript example defines a provisioner for a resource using the `addOverride` method.
 
 ```typescript
 const tableName = "my-table";
@@ -166,7 +166,7 @@ To use an escape hatch to loop over dynamic data, you must:
 - Create a `for_each` value for the second argument and set it to the list you want to iterate over.
 - Take the attribute as base for the reference when you reference values from the list. For example, use `"${<attribute_name>.value.nested_value}"`.
 
-The TypeScript example below adds ingress values by looping through the ports passed as `TerraformVariable`.
+The following TypeScript example adds ingress values by looping through the ports passed as `TerraformVariable`.
 
 ```ts
 const ports = new TerraformVariable(this, "ports", {
@@ -199,7 +199,7 @@ sg.addOverride("dynamic.ingress", {
 
 You should only use escape hatches when you need to work with dynamic values that are unknown until after Terraform provisions your infrastructure. If you are working with static values, we recommend using the functionality available in your preferred programming language to iterate through the array.
 
-The TypeScript example below loops through the ports without using an escape hatch.
+The following TypeScript example loops through the ports without using an escape hatch.
 
 ```ts
 const ports = [22, 80, 443, 5432];

--- a/website/docs/cdktf/concepts/stacks.mdx
+++ b/website/docs/cdktf/concepts/stacks.mdx
@@ -19,7 +19,7 @@ Refer to the [constructs documentation](/cdktf/concepts/constructs#scope) for mo
 
 ## Single Stack
 
-The example below generates a single Terraform configuration in the configured output folder. When you run `cdktf synth`, the synthesized Terraform configuration will be in the folder `cdktf.out/stacks/a-single-stack`
+The following example generates a single Terraform configuration in the configured output folder. When you run `cdktf synth`, the synthesized Terraform configuration will be in the folder `cdktf.out/stacks/a-single-stack`
 
 ```typescript
 import { Construct } from "constructs";
@@ -52,7 +52,7 @@ app.synth();
 
 You can specify multiple stacks in your application. For example, you may want a separate configuration for development, testing, and production environments.
 
-The example below synthesizes multiple Terraform configurations in the configured output folder.
+The following example synthesizes multiple Terraform configurations in the configured output folder.
 
 ```typescript
 import { Construct } from "constructs";
@@ -203,7 +203,9 @@ Until version `0.2`, CDKTF only supported a single stack. For local state handli
 
 For anything on the top-level `terraform` block that is not natively implemented, use the **stack escape hatch** to define a configuration. For example, define remote backend using the `addOverride` method in TypeScript.
 
-~> **Important**: Escape hatches **must not** have empty arguments or objects, as they will be removed from the synthesized JSON configuration.
+~> **Important**: Escape hatches **must not** have empty arguments or objects, because CDKTF removes them from the synthesized JSON configuration.
+
+The following example synthesizes a Terraform configuration with the `remote` backend included in the `terraform` block.
 
 ```typescript
 stack.addOverride("terraform.backend", {
@@ -216,7 +218,7 @@ stack.addOverride("terraform.backend", {
 });
 ```
 
-The example above synthesizes a Terraform configuration with the remote backend included in the `terraform` block.
+The following configuration snippet shows the `remote` backend configuration.
 
 ```json
 {

--- a/website/docs/cdktf/concepts/variables-and-outputs.mdx
+++ b/website/docs/cdktf/concepts/variables-and-outputs.mdx
@@ -31,7 +31,7 @@ If you plan to use CDKTF to manage your infrastructure, we recommend using your 
 
 You must specify values in exactly the same way as you would in an HCL configuration file. Refer to the [Terraform variables documentation](/language/values/variables#variables-on-the-command-line) for details. The CDKTF CLI currently also supports configuration via [environment variables](/language/values/variables#environment-variables).
 
-The TypeScript example below uses `TerraformVariable` to provide inputs to resources.
+The following TypeScript example uses `TerraformVariable` to provide inputs to resources.
 
 ```typescript
 const imageId = new TerraformVariable(this, "imageId", {
@@ -57,7 +57,7 @@ When values are available before [synthesizing your code](/cdktf/cli-reference/c
 
 ### Define Local Values
 
-The TypeScript example below uses `TerraformLocal` to create a local value.
+The following TypeScript example uses `TerraformLocal` to create a local value.
 
 ```typescript
 const commonTags = new TerraformLocal(this, "common_tags", {
@@ -70,7 +70,7 @@ new EC2.Instance(this, "example", {
 });
 ```
 
-When you run `cdktf synth` the `TerraformLocal` above synthesizes to the following JSON.
+When you run `cdktf synth` the `TerraformLocal` synthesizes to the following JSON.
 
 ```json
 "locals": {
@@ -99,7 +99,7 @@ Use outputs to make data from [Terraform resources](/cdktf/concepts/resources) a
 
 When values are available before [synthesizing your code](/cdktf/cli-reference/commands#synth), we recommend using the functionality in your preferred programming language to supply this data as direct inputs.
 
-The TypeScript example below uses a `TerraformOutput` to create an output.
+The following TypeScript example uses a `TerraformOutput` to create an output.
 
 ```ts
 import { Construct } from "constructs";
@@ -134,7 +134,7 @@ To access outputs, use the `_output` suffix for Python and the `Output` suffix f
 
 Outputs return an HCL expression representing the underlying Terraform resource, so the return type must always be `string`. When `TerraformOutput` is any other type than string, you must add a typecast to compile the application (e.g. `mod.numberOutput as number`). If a module returns a list, you must use an escape hatch to access items or loop over it. Refer to the [Resources page](/cdktf/concepts/resources) for more information about how to use escape hatches.
 
-The Typescript example below uses `TerraformOutput` to create an output for a Random provider resource.
+The following Typescript example uses `TerraformOutput` to create an output for a Random provider resource.
 
 ```typescript
 import * as random from "@cdktf/provider-random";
@@ -160,7 +160,7 @@ new MyStack(app, "cdktf-demo");
 app.synth();
 ```
 
-When you run `cdktf synth`, CDKTF synthesizes the code above to the following JSON configuration.
+When you run `cdktf synth`, CDKTF synthesizes the code to the following JSON configuration.
 
 ```json
 "output": {
@@ -184,7 +184,7 @@ Output: random-pet = choice-haddock
 
 ### Define & Reference Outputs via Remote State
 
-The TypeScript example below uses outputs to share data between stacks, each of which has a [remote backend](/cdktf/concepts/remote-backends) to store the Terraform state files remotely.
+The following TypeScript example uses outputs to share data between stacks, each of which has a [remote backend](/cdktf/concepts/remote-backends) to store the Terraform state files remotely.
 
 ```ts
 import * as random from "@cdktf/provider-random";

--- a/website/docs/cdktf/create-and-deploy/aws-adapter.mdx
+++ b/website/docs/cdktf/create-and-deploy/aws-adapter.mdx
@@ -93,13 +93,13 @@ export class MyStack extends TerraformStack {
 
 The `AwsTerraformAdapter` adds an Aspect to `MyStack` that is invoked when the stack is synthesized. That Aspect then iterates over all AWS CDK constructs that have been added to the adapter, converts them to CDK for Terraform constructs, and adds them to the stack. It does not add the AWS CDK constructs themselves.
 
-The [full code of the example above](https://github.com/hashicorp/cdktf-aws-cdk/tree/main/examples/typescript-cron-lambda) is available in the cdktf-aws-cdk repository.
+The [full example code](https://github.com/hashicorp/cdktf-aws-cdk/tree/main/examples/typescript-cron-lambda) is available in the cdktf-aws-cdk repository.
 
 ## Write Manual Mappings
 
 While some mappings are already included, you need to manually map most resources that the AWS Cloud Control API does not yet support ([supported resources](https://docs.aws.amazon.com/cloudcontrolapi/latest/userguide/supported-resources.html)).
 
-The example below shows how to write and register a mapping for an `AWS::DynamoDB::Table` CloudFormation resource.
+The following example shows how to write and register a mapping for an `AWS::DynamoDB::Table` CloudFormation resource.
 
 Consider the following code:
 
@@ -210,7 +210,7 @@ Error: cannot map some properties of AWS::DynamoDB::Table: {
 }
 ```
 
-The example below adds mapping for missing values in the error message. First, it maps the `AttributeDefinitions` array to make sure it fits the schema of the Terraform resource. It also looks up the `hashKey` in the `KeySchema array`. Finally, it deletes the properties that have been handled and returns a new `DynamodbTable` resource.
+The following example adds mapping for missing values in the error message. First, it maps the `AttributeDefinitions` array to make sure it fits the schema of the Terraform resource. It also looks up the `hashKey` in the `KeySchema array`. Finally, it deletes the properties that have been handled and returns a new `DynamodbTable` resource.
 
 ```ts
 import { DynamoDB } from "@cdktf/aws-cdk";
@@ -256,7 +256,7 @@ Error: cannot map some properties of AWS::DynamoDB::Table: {
 }
 ```
 
-The error indicates that the `ProvisionedThroughput` property has not yet been mapped or deleted. The example below shows a complete mapping for the DynamoDB table.
+The error indicates that the `ProvisionedThroughput` property has not yet been mapped or deleted. The following example shows a complete mapping for the DynamoDB table.
 
 ```ts
 import { DynamoDB } from "@cdktf/aws-cdk";
@@ -325,7 +325,7 @@ This code synthesizes without error and produces the following `aws_dynamodb_tab
 
 You should also map the `attributes` argument. When AWS CDK constructs reference each other's properties, they do so via the CloudFormation property name of the resource.
 
-The example below maps the `Arn` CloudFormation property to the `.arn` of the Terraform resource. While this example might look like something that could be handled automatically, there are cases where this cannot map directly. For example, there are some resources that do not have a direct representation in Terraform but do in CloudFormation (and vice versa).
+The follwing example maps the `Arn` CloudFormation property to the `.arn` of the Terraform resource. While this example might look like something that could be handled automatically, there are cases where this cannot map directly. For example, there are some resources that do not have a direct representation in Terraform but do in CloudFormation (and vice versa).
 
 ```ts
 import { aws_dynamodb, CfnOutput } from "aws-cdk-lib";
@@ -345,7 +345,7 @@ Synthesizing this code produces the following error.
 Error: Resolution error: no "Arn" attribute mapping for resource of type AWS::DynamoDB::Table.
 ```
 
-To fix the resolution error, the example below adds an `Arn` property to the empty `attributes` object in the mapping.
+To fix the resolution error, the following example adds an `Arn` property to the empty `attributes` object in the mapping.
 
 ```ts
 registerMapping("AWS::DynamoDB::Table", {

--- a/website/docs/cdktf/create-and-deploy/configuration-file.mdx
+++ b/website/docs/cdktf/create-and-deploy/configuration-file.mdx
@@ -104,7 +104,7 @@ When you declare providers in JSON, add the constraint in the `version` property
 
 CDKTF uses feature flags to enable potentially breaking behaviors in a release. Flags are stored as runtime context values in `cdktf.json`. Feature flags are disabled by default, so existing projects that do not specify the flag will continue to work as expected with later CDKTF releases. New projects created using `cdktf init` include flags enabling all features available in the release that created the project.
 
-Edit `cdktf.json` to disable flags for which you prefer the old behavior, or to add flags to enable new behaviors after upgrading (example below).
+Edit `cdktf.json` to disable flags for which you prefer the old behavior, or to add flags to enable new behaviors after upgrading. The following example adds a feature flag.
 
 ```json
 {
@@ -120,15 +120,15 @@ The [CHANGELOG on Github](https://github.com/hashicorp/terraform-cdk/blob/main/C
 
 ## Configure Files to Watch
 
-When using `cdktf watch` we inspect the `cdktf.json`s `watchPattern` property to determine which files to watch. If you do not specify a `watchPattern` property, we will add the default watch pattern for your language on the first run. The `watchPattern` expects an array of glob patterns, e.g. `["main.ts", "../constructs/**/*.ts", "lib/*.ts"]`.
+When using `cdktf watch`, CDKTF inspects the `cdktf.json`s `watchPattern` property to determine which files to watch. If you do not specify a `watchPattern` property, CDKTF adds the default watch pattern for your language on the first run. The `watchPattern` expects an array of glob patterns, e.g. `["main.ts", "../constructs/**/*.ts", "lib/*.ts"]`.
 
 ## Configuration Examples
 
 ### Change the Output Directory
 
-Defining `output` changes the directory where `cdktf` will put your generated Terraform configuration file. All Terraform operations will be performed from this directory.
+Defining `output` changes the directory where `cdktf` stores your generated Terraform configuration file. Terraform performs all operations within this directory.
 
-The example below synthesizes the JSON Terraform configuration into `my-workdir`:
+The following example synthesizes the JSON Terraform configuration into `my-workdir`:
 
 ```json
 {
@@ -139,7 +139,7 @@ The example below synthesizes the JSON Terraform configuration into `my-workdir`
 
 ### Build Providers
 
-With the `terraformProviders` configuration below, a `cdktf get` will build the latest AWS provider within the 2.X version range. The generated code will be saved into `.gen` by default. This can be adjusted with `codeMakerOutput`, see other examples below.
+With the following `terraformProviders` configuration, a `cdktf get` builds the latest AWS provider within the 2.X version range. CDKTF saves the generated code in in `.gen` by default. You can adjust this behavior with `codeMakerOutput`. Refer to the other examples on this page.
 
 ```json
 {
@@ -151,7 +151,7 @@ With the `terraformProviders` configuration below, a `cdktf get` will build the 
 
 ### Build Modules
 
-With this `terraformModules` configuration, a `cdktf get` will build the latest `terraform-aws-modules/vpc/aws` module from the Terraform Registry. The generated code will be saved into `.gen` by default. This can be adjusted with `codeMakerOutput` - see other examples below.
+With the following `terraformModules` configuration, a `cdktf get` builds the latest `terraform-aws-modules/vpc/aws` module from the Terraform Registry. The generated code will be saved into `.gen` by default. You can adjust this behavior with `codeMakerOutput`. Refer to the other examples on this page.
 
 ```json
 {
@@ -163,7 +163,7 @@ With this `terraformModules` configuration, a `cdktf get` will build the latest 
 
 ### Build Providers & Modules
 
-This combines the two examples above. A `cdktf get` will build both the AWS provider and the latest `terraform-aws-modules/vpc/aws` module from the Terraform Registry.
+With the following example configuration, a `cdktf get` builds both the AWS provider and the latest `terraform-aws-modules/vpc/aws` module from the Terraform Registry.
 
 ```json
 {
@@ -176,7 +176,7 @@ This combines the two examples above. A `cdktf get` will build both the AWS prov
 
 ### Build Multiple Providers
 
-It's possible to build multiple providers or modules as well.
+You can also build multiple providers or modules. The following example builds multiple providers.
 
 ```json
 {
@@ -197,7 +197,7 @@ It's possible to build multiple providers or modules as well.
 
 ### Build Providers in Custom Directory
 
-This generates the `aws` provider bindings in the folder `./imports`. This is used in the Python template to make it easier to reference the generated classes.
+The following configuration generates the `aws` provider bindings in the folder `./imports`. The Python template uses this method to make it easier to reference the generated classes.
 
 ```json
 {
@@ -210,7 +210,7 @@ This generates the `aws` provider bindings in the folder `./imports`. This is us
 
 ### Enable Crash Reporting for the CLI
 
-You can enable or disable crash reporting by setting the `sendCrashReports` property to `true` or `false`. Sending crash reports helps our team improve the CLI faster, you can learn more about what we track on our [telemetry page](/cdktf/telemetry#crash-reporting).
+You can enable or disable crash reporting by setting the `sendCrashReports` property to `true` or `false`. Sending crash reports helps our team improve the CLI faster. Refer to [Telemetry](/cdktf/telemetry#crash-reporting) for more information about what we track.
 
 ```json
 {

--- a/website/docs/cdktf/create-and-deploy/project-setup.mdx
+++ b/website/docs/cdktf/create-and-deploy/project-setup.mdx
@@ -70,7 +70,7 @@ You can also provide context when instantiating the `App` class.
 const app = new App({ context: { myConfig: "value" } });
 ```
 
-The TypeScript example below uses `App` context to provide a custom tag value to an AWS EC2 instance.
+The following TypeScript example uses `App` context to provide a custom tag value to an AWS EC2 instance.
 
 ```typescript
 import { Construct } from "constructs";
@@ -118,7 +118,7 @@ $ cdktf init --template=typescript --from-terraform-project /path/to/my/tf-hcl-p
 
 ### Usage Example
 
-Consider the HCL configuration below.
+The following HCL configuration defines the `random` provider.
 
 ```hcl
 # File: /tmp/demo/main.tf

--- a/website/docs/cdktf/create-and-deploy/remote-templates.mdx
+++ b/website/docs/cdktf/create-and-deploy/remote-templates.mdx
@@ -17,13 +17,13 @@ You can use the library [`sscaff`](https://github.com/awslabs/node-sscaff) to sc
 
 ### Substitutions
 
-A template can use substitutions for filenames and file content. To specify your own variables, use Hooks (details below). In addition to the [built-in substitutions of](https://github.com/awslabs/node-sscaff#built-in-substitutions) `sccaff`, CDKTF supplies variables that you can use in templates.
+A template can use substitutions for filenames and file content. To specify your own variables, use [Hooks](#pre-and-post-hooks). In addition to the [built-in substitutions of](https://github.com/awslabs/node-sscaff#built-in-substitutions) `sccaff`, CDKTF supplies variables that you can use in templates.
 
 #### User Input
 
 These variables hold user input. For example, you can use them in project files like `package.json`. CDKTF collects the required data from users when they run `cdktf init` with the template.
 
-The TypeScript example below specifies that `Name` and `Description` are mandatory, but `OrganizationName` and `WorkspaceName` will only be required for projects that are set up to use a Terraform Cloud [remote backend](/cdktf/concepts/remote-backends).
+The following TypeScript example specifies that `Name` and `Description` are mandatory, but `OrganizationName` and `WorkspaceName` will only be required for projects that are set up to use a Terraform Cloud [remote backend](/cdktf/concepts/remote-backends).
 
 ```typescript
 Name: string;
@@ -38,7 +38,7 @@ There is no way to collect custom user input for templates at the moment.
 
 These variables contain correct versions of the packages that are depending on the CDKTF CLI. The package names are provided in the correct format for the given platform. We recommend using these variables as they are provided without adding any custom logic, since the package name and their version schema follow specific conventions.
 
-Reference the [built-in templates](https://github.com/hashicorp/terraform-cdk/tree/main/packages/cdktf-cli/templates) for examples of how you can use version variables. Below are some of the variables in TypeScript.
+Reference the [built-in templates](https://github.com/hashicorp/terraform-cdk/tree/main/packages/cdktf-cli/templates) for examples of how you can use version variables. The following example shows some of the variables in TypeScript.
 
 ```typescript
 cdktf_version: string;
@@ -64,11 +64,11 @@ You can also set the environment variable `CDKTF_LOG_LEVEL` to `debug` before in
 
 You can host your remote template anywhere, as long as it is formatted as a zip archive. GitHub allows users to fetch the repository contents as zip archive, so you do not have to create one manually. You can only specify urls to zip archives, so only url-based authentication mechanisms are supported. If you need support for private packages, please [file an issue](https://github.com/hashicorp/terraform-cdk/issues/new?labels=enhancement%2C+new&template=feature-request.md).
 
-Below is an example for the `main` branch for a remote template GitHub repository.
+The following example shows the URL for the `main` branch for a remote template GitHub repository.
 
 `https://github.com/<user or organization>/<repo>/archive/refs/heads/main.zip`
 
-If you prefer to use a Git tag, the URL format would look like this
+The following example shows a URL that uses a Git tag.
 
 `https://github.com/<user or organization>/<repo>/archive/refs/tags/v0.0.1.zip`
 
@@ -78,7 +78,7 @@ The CDKTF community maintains the following remote templates that you can use to
 
 - [python-poetry](https://github.com/johnfraney/cdktf-remote-template-python-poetry) (by [@johnfraney](https://github.com/johnfraney))
 
-The example below initializes a new CDKTF project with a remote template.
+The following example initializes a new CDKTF project with a remote template.
 
 ```
 $ cdktf init --template https://github.com/<user or organization>/<repo>/archive/refs/tags/v0.0.1.zip

--- a/website/docs/cdktf/examples.mdx
+++ b/website/docs/cdktf/examples.mdx
@@ -22,7 +22,7 @@ Follow these hands-on tutorials from HashiCorp Learn:
 
 ## Example Projects
 
--> **Note**: You can find more information about all of the providers in the examples below on the [Terraform Registry](https://registry.terraform.io/).
+-> **Note**: The [Terraform Registry](https://registry.terraform.io/) has more information about all of the providers in following examples.
 
 ### Typescript
 

--- a/website/docs/cdktf/release/upgrade-guide-v0-10.mdx
+++ b/website/docs/cdktf/release/upgrade-guide-v0-10.mdx
@@ -74,7 +74,7 @@ firstItem := resource.ListAttribute().Get(jsii.Number(0)); // now possible
 
 ### Referencing computed string map entries via function call [#1630](https://github.com/hashicorp/terraform-cdk/pull/1630)
 
-In preparation for a similar change as to the computed lists (section above), string map entries can now be accessed via a function call instead of using `Fn.lookup`. Accessing the whole map at once now requires a different function call in the meantime.
+In preparation for a similar change as to the computed lists, string map entries can now be accessed via a function call instead of using `Fn.lookup`. Accessing the whole map at once now requires a different function call in the meantime.
 
 #### Example
 

--- a/website/docs/cdktf/test/unit-tests.mdx
+++ b/website/docs/cdktf/test/unit-tests.mdx
@@ -27,7 +27,7 @@ If you would like to add testing to an existing project, refer the following res
 
 ### Write Assertions
 
-The Typescript example below uses `Testing.synthScope` to test a part of the application. This creates a scope to test a subset of the application and returns a JSON string representing the synthesized HCL-JSON. Then it uses custom matchers to verify the code acts as intended.
+The following Typescript example uses `Testing.synthScope` to test a part of the application. This creates a scope to test a subset of the application and returns a JSON string representing the synthesized HCL-JSON. Then it uses custom matchers to verify the code acts as intended.
 
 The other examples use `Testing.synth` to test a part of the application. Given the desired scope to test, a JSON string representing the synthesized HCL-JSON is returned. Then the custom assertions under `Testing` in the cdktf package can be used to verify the code acts as intended.
 


### PR DESCRIPTION
We should not use positional language (above, below, etc.) in our documentation. This is something we did frequently early on, but that we should fix now for consistency with other documentation. This PR removes positional language and fixes a few other tiny style nits (like passive voice) that I found along the way.

The preferred way to introduce code examples is:

"The following example..."

This is good as long as the code immediately follows this explanatory sentence. We should do this in the future instead of saying "the example below." 