### PR TITLE
chore(docs): Check whether links work :) 

### DIFF
--- a/cdk.tf/vercel.json
+++ b/cdk.tf/vercel.json
@@ -185,7 +185,7 @@
     },
     {
       "source": "/crash-reporting",
-      "destination": "https://developer.hashicorp.com/cdktf/telemetry#crash-reporting"
+      "destination": "https://www.terraform.io/cdktf/telemetry#crash-reporting"
     }
   ]
 }

--- a/cdk.tf/vercel.json
+++ b/cdk.tf/vercel.json
@@ -182,6 +182,10 @@
     {
       "source": "/cdk-day-2022-hybrid-modules",
       "destination": "https://www.youtube.com/watch?v=7Dt_zJbDmso"
+    },
+    {
+      "source": "/crash-reporting",
+      "destination": "https://developer.hashicorp.com/cdktf/telemetry#crash-reporting"
     }
   ]
 }

--- a/packages/cdktf-cli/bin/cmds/init.ts
+++ b/packages/cdktf-cli/bin/cmds/init.ts
@@ -49,7 +49,7 @@ class Command extends BaseCommand {
       })
       .option("enable-crash-reporting", {
         type: "boolean",
-        desc: "Enable crash reporting for the CLI, see https://www.terraform.io/cdktf/telemetry#crash-reporting for more details",
+        desc: "Enable crash reporting for the CLI, refer to https://cdk.tf/crash-reporting for more details",
       })
       .strict();
 

--- a/website/docs/cdktf/cli-reference/commands.mdx
+++ b/website/docs/cdktf/cli-reference/commands.mdx
@@ -363,7 +363,7 @@ Options:
       --local                     Use local state storage for generated Terraform.                                                                    [boolean] [default: false]
       --cdktf-version             The cdktf version to use while creating a new project.                                                             [string] [default: "0.0.0"]
       --from-terraform-project    Use a terraform project as the basis, CDK constructs will be generated based on the .tf files in the path                             [string]
-      --enable-crash-reporting    Enable crash reporting for the CLI, refer to https://www.developer.hashicorp.com/cdktf/telemetry#crash-reporting for more details                    [boolean]
+      --enable-crash-reporting    Enable crash reporting for the CLI, refer to https://cdk.tf/crash-reporting for more details                    [boolean]
   -h, --help                      Show help                                                                                                                            [boolean]
 ```
 

--- a/website/docs/cdktf/cli-reference/commands.mdx
+++ b/website/docs/cdktf/cli-reference/commands.mdx
@@ -363,7 +363,7 @@ Options:
       --local                     Use local state storage for generated Terraform.                                                                    [boolean] [default: false]
       --cdktf-version             The cdktf version to use while creating a new project.                                                             [string] [default: "0.0.0"]
       --from-terraform-project    Use a terraform project as the basis, CDK constructs will be generated based on the .tf files in the path                             [string]
-      --enable-crash-reporting    Enable crash reporting for the CLI, see https://www.terraform.io/cdktf/telemetry#crash-reporting for more details                    [boolean]
+      --enable-crash-reporting    Enable crash reporting for the CLI, refer to https://www.developer.hashicorp.com/cdktf/telemetry#crash-reporting for more details                    [boolean]
   -h, --help                      Show help                                                                                                                            [boolean]
 ```
 

--- a/website/docs/cdktf/concepts/assets.mdx
+++ b/website/docs/cdktf/concepts/assets.mdx
@@ -16,7 +16,7 @@ Assets are especially useful for:
 
 ## Usage Example
 
-> **Hands-on:** Try the [Deploy Multiple Lambda Functions with TypeScript](https://learn.hashicorp.com/tutorials/terraform/cdktf-assets-stacks-lambda?in=terraform/cdktf) tutorial on HashiCorp Learn. This tutorial guides you through using a `TerraformAsset` to archive a Lambda function, uploading the archive to an S3 bucket, then deploying the Lambda function.
+> **Hands-on:** Try the [Deploy Multiple Lambda Functions with TypeScript](https://learn.hashicorp.com/tutorials/terraform/cdktf-assets-stacks-lambda?in=terraform/cdktf) tutorial. This tutorial guides you through using a `TerraformAsset` to archive a Lambda function, uploading the archive to an S3 bucket, then deploying the Lambda function.
 
 The following TypeScript example uses `TerraformAsset` to upload the contents of the specified directory into an S3 Bucket. The `TerraformAsset` is responsible for making sure the directory ends up in the correct output folder as a zip file that the `S3BucketObject` can reference.
 

--- a/website/docs/cdktf/concepts/constructs.mdx
+++ b/website/docs/cdktf/concepts/constructs.mdx
@@ -44,7 +44,7 @@ Constructs also provide a way to logically structure a set of resources, but you
 
 ## Use Constructs
 
-> **Hands On:** Try [Deploy Applications with CDK for Terraform](https://learn.hashicorp.com/tutorials/terraform/cdktf-applications?in=terraform/cdktf) tutorial on HashiCorp Learn to use a custom construct.  It includes the example code below.
+> **Hands On:** Try [Deploy Applications with CDK for Terraform](https://learn.hashicorp.com/tutorials/terraform/cdktf-applications?in=terraform/cdktf) tutorial to use a custom construct.  It includes the example code below.
 
 You can import any [CDKTF-compatible](#available-constructs) construct that is available in your project’s programming language. Then, you can create new instances of the construct and use any exposed properties to customize the construct configuration.
 

--- a/website/docs/cdktf/concepts/constructs.mdx
+++ b/website/docs/cdktf/concepts/constructs.mdx
@@ -44,7 +44,7 @@ Constructs also provide a way to logically structure a set of resources, but you
 
 ## Use Constructs
 
-> **Hands On:** Try [Deploy Applications with CDK for Terraform](https://learn.hashicorp.com/tutorials/terraform/cdktf-applications?in=terraform/cdktf) tutorial to use a custom construct.  It includes the example code below.
+> **Hands On:** Try [Deploy Applications with CDK for Terraform](https://learn.hashicorp.com/tutorials/terraform/cdktf-applications?in=terraform/cdktf) tutorial to use a custom construct. It includes the example code below.
 
 You can import any [CDKTF-compatible](#available-constructs) construct that is available in your project’s programming language. Then, you can create new instances of the construct and use any exposed properties to customize the construct configuration.
 

--- a/website/docs/cdktf/concepts/constructs.mdx
+++ b/website/docs/cdktf/concepts/constructs.mdx
@@ -44,7 +44,7 @@ Constructs also provide a way to logically structure a set of resources, but you
 
 ## Use Constructs
 
-> **Hands On:** Try [Deploy Applications with CDK for Terraform](https://learn.hashicorp.com/tutorials/terraform/cdktf-applications?in=terraform/cdktf) tutorial on HashiCorp Learn to use a custom construct.
+> **Hands On:** Try [Deploy Applications with CDK for Terraform](https://learn.hashicorp.com/tutorials/terraform/cdktf-applications?in=terraform/cdktf) tutorial on HashiCorp Learn to use a custom construct.  It includes the example code below.
 
 You can import any [CDKTF-compatible](#available-constructs) construct that is available in your project’s programming language. Then, you can create new instances of the construct and use any exposed properties to customize the construct configuration.
 

--- a/website/docs/cdktf/concepts/stacks.mdx
+++ b/website/docs/cdktf/concepts/stacks.mdx
@@ -9,7 +9,7 @@ description: >-
 
 A stack represents a collection of infrastructure that CDK for Terraform (CDKTF) synthesizes as a dedicated Terraform configuration. Stacks allow you to separate the state management for multiple environments within an application.
 
-> **Hands-on:** Try the [Deploy Applications with CDK for Terraform](https://learn.hashicorp.com/tutorials/terraform/cdktf-applications?in=terraform/cdktf&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial on HashiCorp Learn.
+> **Hands-on:** Try the [Deploy Applications with CDK for Terraform](https://learn.hashicorp.com/tutorials/terraform/cdktf-applications?in=terraform/cdktf&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial.
 
 ## Scope
 
@@ -48,7 +48,7 @@ app.synth();
 
 ## Multiple Stacks
 
-> **Hands-on:** Try the [Deploy Multiple Lambda Functions with TypeScript](https://learn.hashicorp.com/tutorials/terraform/cdktf-assets-stacks-lambda?in=terraform/cdktf) tutorial on HashiCorp Learn. This tutorial guides you through a multi-stack application.
+> **Hands-on:** Try the [Deploy Multiple Lambda Functions with TypeScript](https://learn.hashicorp.com/tutorials/terraform/cdktf-assets-stacks-lambda?in=terraform/cdktf) tutorial. This tutorial guides you through a multi-stack application.
 
 You can specify multiple stacks in your application. For example, you may want a separate configuration for development, testing, and production environments.
 

--- a/website/docs/cdktf/create-and-deploy/project-setup.mdx
+++ b/website/docs/cdktf/create-and-deploy/project-setup.mdx
@@ -9,7 +9,7 @@ description: >-
 
 There are several ways to create a new CDK for Terraform (CDKTF) project. You can create a new application from a pre-built or a custom template, and you can also convert an existing HCL project. When you create a new project, you can store Terraform state locally or use a [remote backend](/cdktf/concepts/remote-backends). This page discusses these setup options in more detail.
 
-> **Hands On**: Try the [CDK for Terraform Quick Start Demo](https://learn.hashicorp.com/tutorials/terraform/cdktf-install?in=terraform/cdktf) and language-specific [Get Started Tutorials](https://learn.hashicorp.com/collections/terraform/cdktf) on HashiCorp Learn.
+> **Hands On**: Try the [CDK for Terraform Quick Start Demo](https://learn.hashicorp.com/tutorials/terraform/cdktf-install?in=terraform/cdktf) and language-specific [Get Started tutorials](https://learn.hashicorp.com/collections/terraform/cdktf).
 
 ## Initialize Project from a Template
 

--- a/website/docs/cdktf/examples.mdx
+++ b/website/docs/cdktf/examples.mdx
@@ -11,7 +11,7 @@ This page contains links to tutorials, example projects in every supported langu
 
 ## Tutorials
 
-Follow these hands-on tutorials from HashiCorp Learn:
+Follow these hands-on tutorials:
 
 | Tutorial                                                                                                                                          | Description                                                                                                           |
 | ------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |

--- a/website/docs/cdktf/index.mdx
+++ b/website/docs/cdktf/index.mdx
@@ -43,6 +43,6 @@ If you plan to create and package your own constructs, we recommend choosing Typ
 
 ## Get Started
 
-- [Install CDKTF](https://learn.hashicorp.com/tutorials/terraform/cdktf-install?in=terraform/cdktf) and set up your first project on HashiCorp Learn.
+- [Install CDKTF](https://learn.hashicorp.com/tutorials/terraform/cdktf-install?in=terraform/cdktf) and set up your first project.
 - Learn about [CDKTF application architecture](/cdktf/concepts/cdktf-architecture).
 - Learn how to use key CDKTF concepts like [providers](/cdktf/concepts/providers), [modules](/cdktf/concepts/modules), and [resources](/cdktf/concepts/resources) to define infrastructure.


### PR DESCRIPTION
We need to migrate the links to exclude the terraform.io part --> that will no longer exist with the devdot migration. This PR is where we can test to make sure the new links we merged into the `dev-portal` branch will work!