### PR TITLE
chore: release 0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.12.2 (unreleased)
+## 0.12.2
 
 **Breaking Changes**
 
@@ -12,10 +12,38 @@ A very minor change in the interface names for provisioners occured [to support 
 
 Another very minor change is that we now use the `CloudBackend` by default when running cdktf init. This requires Terraform >=1.1, therefore an error is thrown on `cdktf init` if you want to use Terraform Cloud and are on an older version. Already existing projects are not affected and you can use `cdktf init --local` and configure the `RemoteBackend` if you need to use an older version.
 
+### feat
+
+- feat(cli): throw an error if a user tries to create a new project with TFC on an old TF version [\#2062](https://github.com/hashicorp/terraform-cdk/pull/2062)
+- feat: install time tool in Docker container to be able to use it for memory consumption tracking in tests [\#2059](https://github.com/hashicorp/terraform-cdk/pull/2059)
+- feat: add Go port of TypeScript Google CloudRun example [\#2035](https://github.com/hashicorp/terraform-cdk/pull/2035)
+- feat(lib): add support for cloud backend [\#1924](https://github.com/hashicorp/terraform-cdk/pull/1924)
+
 ### fix
 
+- fix(provider-generator): use terraform get instead of init to download modules [\#2057](https://github.com/hashicorp/terraform-cdk/pull/2057)
+- fix(lib): Add missing config options for S3Backend: skipRegionValidation, assumeRolePolicyArns, assumeRoleTags, and assumeRoleTransitiveTagKeys [\#2050](https://github.com/hashicorp/terraform-cdk/pull/2050)
+- fix: support provisioners in JSII languages [\#2042](https://github.com/hashicorp/terraform-cdk/pull/2042)
 - fix(hcl2json): add fs-extra to dependencies [\#2040](https://github.com/hashicorp/terraform-cdk/pull/2040)
-- fix(lib): support provisioners in JSII languages [\#2042](https://github.com/hashicorp/terraform-cdk/pull/2042)
+- fix(lib): Improve error message when provider constructs are missing [\#2039](https://github.com/hashicorp/terraform-cdk/pull/2039)
+- fix(cli): Make provider add command case insensitive for provider names [\#2038](https://github.com/hashicorp/terraform-cdk/pull/2038)
+- fix(cli): run a speculative plan on diff [\#2033](https://github.com/hashicorp/terraform-cdk/pull/2033)
+
+### chore
+
+- chore(cli): remove red and magenta from colors for stack names [\#2064](https://github.com/hashicorp/terraform-cdk/pull/2064)
+- chore: add link to hybrid module talk [\#2054](https://github.com/hashicorp/terraform-cdk/pull/2054)
+- chore: make Terraform 1.2.8 available in Docker image [\#2051](https://github.com/hashicorp/terraform-cdk/pull/2051)
+- chore: document updating the API documentation [\#2046](https://github.com/hashicorp/terraform-cdk/pull/2046)
+- chore(docs): Remove positional language + fix style nits [\#2045](https://github.com/hashicorp/terraform-cdk/pull/2045)
+- chore(lib): deprecate Resource in favor of Construct [\#2044](https://github.com/hashicorp/terraform-cdk/pull/2044)
+- chore: update links in our youtube playlist examples [\#2043](https://github.com/hashicorp/terraform-cdk/pull/2043)
+- chore: npm-check-updates && yarn upgrade [\#2025](https://github.com/hashicorp/terraform-cdk/pull/2025)
+- chore: translate parts of the documentation [\#2011](https://github.com/hashicorp/terraform-cdk/pull/2011)
+
+### refactor
+
+- refactor: port example script to JS [\#2047](https://github.com/hashicorp/terraform-cdk/pull/2047)
 
 ## 0.12.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "scripts": {
     "build": "lerna run --scope 'cdktf*' --scope @cdktf/* build",

--- a/website/docs/cdktf/api-reference/csharp.mdx
+++ b/website/docs/cdktf/api-reference/csharp.mdx
@@ -712,6 +712,249 @@ public string FriendlyUniqueId { get; }
 
 ---
 
+### CloudBackend <a name="CloudBackend" id="cdktf.CloudBackend"></a>
+
+The Cloud Backend synthesizes a {@link https://www.terraform.io/cli/cloud/settings#the-cloud-block cloud block}. The cloud block is a nested block within the top-level terraform settings block. It specifies which Terraform Cloud workspaces to use for the current working directory. The cloud block only affects Terraform CLI's behavior. When Terraform Cloud uses a configuration that contains a cloud block - for example, when a workspace is configured to use a VCS provider directly - it ignores the block and behaves according to its own workspace settings.
+
+#### Initializers <a name="Initializers" id="cdktf.CloudBackend.Initializer"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+new CloudBackend(Construct Scope, CloudBackendProps Props);
+```
+
+| **Name**                                                                         | **Type**                                                              | **Description**   |
+| -------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ----------------- |
+| <code><a href="#cdktf.CloudBackend.Initializer.parameter.scope">Scope</a></code> | <code>Constructs.Construct</code>                                     | _No description._ |
+| <code><a href="#cdktf.CloudBackend.Initializer.parameter.props">Props</a></code> | <code><a href="#cdktf.CloudBackendProps">CloudBackendProps</a></code> | _No description._ |
+
+---
+
+##### `Scope`<sup>Required</sup> <a name="Scope" id="cdktf.CloudBackend.Initializer.parameter.scope"></a>
+
+- _Type:_ Constructs.Construct
+
+---
+
+##### `Props`<sup>Required</sup> <a name="Props" id="cdktf.CloudBackend.Initializer.parameter.props"></a>
+
+- _Type:_ <a href="#cdktf.CloudBackendProps">CloudBackendProps</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name**                                                                                         | **Description**                                                                   |
+| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.CloudBackend.toString">ToString</a></code>                                 | Returns a string representation of this construct.                                |
+| <code><a href="#cdktf.CloudBackend.addOverride">AddOverride</a></code>                           | _No description._                                                                 |
+| <code><a href="#cdktf.CloudBackend.overrideLogicalId">OverrideLogicalId</a></code>               | Overrides the auto-generated logical ID with a specific ID.                       |
+| <code><a href="#cdktf.CloudBackend.resetOverrideLogicalId">ResetOverrideLogicalId</a></code>     | Resets a previously passed logical Id to use the auto-generated logical id again. |
+| <code><a href="#cdktf.CloudBackend.toMetadata">ToMetadata</a></code>                             | _No description._                                                                 |
+| <code><a href="#cdktf.CloudBackend.toTerraform">ToTerraform</a></code>                           | Adds this resource to the terraform JSON output.                                  |
+| <code><a href="#cdktf.CloudBackend.getRemoteStateDataSource">GetRemoteStateDataSource</a></code> | Creates a TerraformRemoteState resource that accesses this backend.               |
+
+---
+
+##### `ToString` <a name="ToString" id="cdktf.CloudBackend.toString"></a>
+
+```csharp
+private string ToString()
+```
+
+Returns a string representation of this construct.
+
+##### `AddOverride` <a name="AddOverride" id="cdktf.CloudBackend.addOverride"></a>
+
+```csharp
+private void AddOverride(string Path, object Value)
+```
+
+###### `Path`<sup>Required</sup> <a name="Path" id="cdktf.CloudBackend.addOverride.parameter.path"></a>
+
+- _Type:_ string
+
+---
+
+###### `Value`<sup>Required</sup> <a name="Value" id="cdktf.CloudBackend.addOverride.parameter.value"></a>
+
+- _Type:_ object
+
+---
+
+##### `OverrideLogicalId` <a name="OverrideLogicalId" id="cdktf.CloudBackend.overrideLogicalId"></a>
+
+```csharp
+private void OverrideLogicalId(string NewLogicalId)
+```
+
+Overrides the auto-generated logical ID with a specific ID.
+
+###### `NewLogicalId`<sup>Required</sup> <a name="NewLogicalId" id="cdktf.CloudBackend.overrideLogicalId.parameter.newLogicalId"></a>
+
+- _Type:_ string
+
+The new logical ID to use for this stack element.
+
+---
+
+##### `ResetOverrideLogicalId` <a name="ResetOverrideLogicalId" id="cdktf.CloudBackend.resetOverrideLogicalId"></a>
+
+```csharp
+private void ResetOverrideLogicalId()
+```
+
+Resets a previously passed logical Id to use the auto-generated logical id again.
+
+##### `ToMetadata` <a name="ToMetadata" id="cdktf.CloudBackend.toMetadata"></a>
+
+```csharp
+private object ToMetadata()
+```
+
+##### `ToTerraform` <a name="ToTerraform" id="cdktf.CloudBackend.toTerraform"></a>
+
+```csharp
+private object ToTerraform()
+```
+
+Adds this resource to the terraform JSON output.
+
+##### `GetRemoteStateDataSource` <a name="GetRemoteStateDataSource" id="cdktf.CloudBackend.getRemoteStateDataSource"></a>
+
+```csharp
+private TerraformRemoteState GetRemoteStateDataSource(Construct Scope, string Name, string FromStack)
+```
+
+Creates a TerraformRemoteState resource that accesses this backend.
+
+###### `Scope`<sup>Required</sup> <a name="Scope" id="cdktf.CloudBackend.getRemoteStateDataSource.parameter.scope"></a>
+
+- _Type:_ Constructs.Construct
+
+---
+
+###### `Name`<sup>Required</sup> <a name="Name" id="cdktf.CloudBackend.getRemoteStateDataSource.parameter.name"></a>
+
+- _Type:_ string
+
+---
+
+###### `FromStack`<sup>Required</sup> <a name="FromStack" id="cdktf.CloudBackend.getRemoteStateDataSource.parameter._fromStack"></a>
+
+- _Type:_ string
+
+---
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name**                                                               | **Description**               |
+| ---------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.CloudBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#cdktf.CloudBackend.isBackend">IsBackend</a></code>     | _No description._             |
+
+---
+
+##### `IsConstruct` <a name="IsConstruct" id="cdktf.CloudBackend.isConstruct"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+CloudBackend.IsConstruct(object X);
+```
+
+Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.CloudBackend.isConstruct.parameter.x"></a>
+
+- _Type:_ object
+
+Any object.
+
+---
+
+##### `IsBackend` <a name="IsBackend" id="cdktf.CloudBackend.isBackend"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+CloudBackend.IsBackend(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.CloudBackend.isBackend.parameter.x"></a>
+
+- _Type:_ object
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name**                                                                                  | **Type**                                                        | **Description**   |
+| ----------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ----------------- |
+| <code><a href="#cdktf.CloudBackend.property.node">Node</a></code>                         | <code>Constructs.Node</code>                                    | The tree node.    |
+| <code><a href="#cdktf.CloudBackend.property.cdktfStack">CdktfStack</a></code>             | <code><a href="#cdktf.TerraformStack">TerraformStack</a></code> | _No description._ |
+| <code><a href="#cdktf.CloudBackend.property.fqn">Fqn</a></code>                           | <code>string</code>                                             | _No description._ |
+| <code><a href="#cdktf.CloudBackend.property.friendlyUniqueId">FriendlyUniqueId</a></code> | <code>string</code>                                             | _No description._ |
+
+---
+
+##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.CloudBackend.property.node"></a>
+
+```csharp
+public Node Node { get; }
+```
+
+- _Type:_ Constructs.Node
+
+The tree node.
+
+---
+
+##### `CdktfStack`<sup>Required</sup> <a name="CdktfStack" id="cdktf.CloudBackend.property.cdktfStack"></a>
+
+```csharp
+public TerraformStack CdktfStack { get; }
+```
+
+- _Type:_ <a href="#cdktf.TerraformStack">TerraformStack</a>
+
+---
+
+##### `Fqn`<sup>Required</sup> <a name="Fqn" id="cdktf.CloudBackend.property.fqn"></a>
+
+```csharp
+public string Fqn { get; }
+```
+
+- _Type:_ string
+
+---
+
+##### `FriendlyUniqueId`<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.CloudBackend.property.friendlyUniqueId"></a>
+
+```csharp
+public string FriendlyUniqueId { get; }
+```
+
+- _Type:_ string
+
+---
+
 ### ConsulBackend <a name="ConsulBackend" id="cdktf.ConsulBackend"></a>
 
 #### Initializers <a name="Initializers" id="cdktf.ConsulBackend.Initializer"></a>
@@ -7739,7 +7982,7 @@ new Resource(Construct Scope, string Id);
 
 ---
 
-##### `ToString` <a name="ToString" id="cdktf.Resource.toString"></a>
+##### ~~`ToString`~~ <a name="ToString" id="cdktf.Resource.toString"></a>
 
 ```csharp
 private string ToString()
@@ -7755,7 +7998,7 @@ Returns a string representation of this construct.
 
 ---
 
-##### `IsConstruct` <a name="IsConstruct" id="cdktf.Resource.isConstruct"></a>
+##### ~~`IsConstruct`~~ <a name="IsConstruct" id="cdktf.Resource.isConstruct"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -7796,7 +8039,9 @@ Any object.
 
 ---
 
-##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.Resource.property.node"></a>
+##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.Resource.property.node"></a>
+
+- _Deprecated:_ - Please use Construct from the constructs package instead.
 
 ```csharp
 public Node Node { get; }
@@ -7808,7 +8053,9 @@ The tree node.
 
 ---
 
-##### `Stack`<sup>Required</sup> <a name="Stack" id="cdktf.Resource.property.stack"></a>
+##### ~~`Stack`~~<sup>Required</sup> <a name="Stack" id="cdktf.Resource.property.stack"></a>
+
+- _Deprecated:_ - Please use Construct from the constructs package instead.
 
 ```csharp
 public TerraformStack Stack { get; }
@@ -8396,14 +8643,13 @@ Any object.
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                      | **Type**                                                        | **Description**                                                                                                    |
-| ----------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| <code><a href="#cdktf.TerraformAsset.property.node">Node</a></code>           | <code>Constructs.Node</code>                                    | The tree node.                                                                                                     |
-| <code><a href="#cdktf.TerraformAsset.property.stack">Stack</a></code>         | <code><a href="#cdktf.TerraformStack">TerraformStack</a></code> | The stack in which this resource is defined.                                                                       |
-| <code><a href="#cdktf.TerraformAsset.property.fileName">FileName</a></code>   | <code>string</code>                                             | Name of the asset.                                                                                                 |
-| <code><a href="#cdktf.TerraformAsset.property.path">Path</a></code>           | <code>string</code>                                             | The path relative to the root of the terraform directory in posix format Use this property to reference the asset. |
-| <code><a href="#cdktf.TerraformAsset.property.assetHash">AssetHash</a></code> | <code>string</code>                                             | _No description._                                                                                                  |
-| <code><a href="#cdktf.TerraformAsset.property.type">Type</a></code>           | <code><a href="#cdktf.AssetType">AssetType</a></code>           | _No description._                                                                                                  |
+| **Name**                                                                      | **Type**                                              | **Description**                                                                                                    |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| <code><a href="#cdktf.TerraformAsset.property.node">Node</a></code>           | <code>Constructs.Node</code>                          | The tree node.                                                                                                     |
+| <code><a href="#cdktf.TerraformAsset.property.fileName">FileName</a></code>   | <code>string</code>                                   | Name of the asset.                                                                                                 |
+| <code><a href="#cdktf.TerraformAsset.property.path">Path</a></code>           | <code>string</code>                                   | The path relative to the root of the terraform directory in posix format Use this property to reference the asset. |
+| <code><a href="#cdktf.TerraformAsset.property.assetHash">AssetHash</a></code> | <code>string</code>                                   | _No description._                                                                                                  |
+| <code><a href="#cdktf.TerraformAsset.property.type">Type</a></code>           | <code><a href="#cdktf.AssetType">AssetType</a></code> | _No description._                                                                                                  |
 
 ---
 
@@ -8416,18 +8662,6 @@ public Node Node { get; }
 - _Type:_ Constructs.Node
 
 The tree node.
-
----
-
-##### `Stack`<sup>Required</sup> <a name="Stack" id="cdktf.TerraformAsset.property.stack"></a>
-
-```csharp
-public TerraformStack Stack { get; }
-```
-
-- _Type:_ <a href="#cdktf.TerraformStack">TerraformStack</a>
-
-The stack in which this resource is defined.
 
 ---
 
@@ -11640,6 +11874,7 @@ new TerraformStack(Construct Scope, string Id);
 | <code><a href="#cdktf.TerraformStack.prepareStack">PrepareStack</a></code>                                               | _No description._                                  |
 | <code><a href="#cdktf.TerraformStack.registerIncomingCrossStackReference">RegisterIncomingCrossStackReference</a></code> | _No description._                                  |
 | <code><a href="#cdktf.TerraformStack.registerOutgoingCrossStackReference">RegisterOutgoingCrossStackReference</a></code> | _No description._                                  |
+| <code><a href="#cdktf.TerraformStack.runAllValidations">RunAllValidations</a></code>                                     | Run all validations on the stack.                  |
 | <code><a href="#cdktf.TerraformStack.toTerraform">ToTerraform</a></code>                                                 | _No description._                                  |
 
 ---
@@ -11747,6 +11982,14 @@ private TerraformOutput RegisterOutgoingCrossStackReference(string Identifier)
 - _Type:_ string
 
 ---
+
+##### `RunAllValidations` <a name="RunAllValidations" id="cdktf.TerraformStack.runAllValidations"></a>
+
+```csharp
+private void RunAllValidations()
+```
+
+Run all validations on the stack.
 
 ##### `ToTerraform` <a name="ToTerraform" id="cdktf.TerraformStack.toTerraform"></a>
 
@@ -12642,6 +12885,89 @@ public bool UseMsi { get; set; }
 (Optional) Should Managed Service Identity authentication be used?
 
 This can also be sourced from the ARM_USE_MSI environment variable.
+
+---
+
+### CloudBackendProps <a name="CloudBackendProps" id="cdktf.CloudBackendProps"></a>
+
+The Cloud Backend synthesizes a {@link https://www.terraform.io/cli/cloud/settings#the-cloud-block cloud block}. The cloud block is a nested block within the top-level terraform settings block. It specifies which Terraform Cloud workspaces to use for the current working directory. The cloud block only affects Terraform CLI's behavior. When Terraform Cloud uses a configuration that contains a cloud block - for example, when a workspace is configured to use a VCS provider directly - it ignores the block and behaves according to its own workspace settings.
+
+https://www.terraform.io/cli/cloud/settings#arguments
+
+#### Initializer <a name="Initializer" id="cdktf.CloudBackendProps.Initializer"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+new CloudBackendProps {
+    string Organization,
+    object Workspaces,
+    string Hostname = null,
+    string Token = null
+};
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name**                                                                               | **Type**            | **Description**                                                                                             |
+| -------------------------------------------------------------------------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.CloudBackendProps.property.organization">Organization</a></code> | <code>string</code> | The name of the organization containing the workspace(s) the current configuration should use.              |
+| <code><a href="#cdktf.CloudBackendProps.property.workspaces">Workspaces</a></code>     | <code>object</code> | A nested block that specifies which remote Terraform Cloud workspaces to use for the current configuration. |
+| <code><a href="#cdktf.CloudBackendProps.property.hostname">Hostname</a></code>         | <code>string</code> | The hostname of a Terraform Enterprise installation, if using Terraform Enterprise.                         |
+| <code><a href="#cdktf.CloudBackendProps.property.token">Token</a></code>               | <code>string</code> | The token used to authenticate with Terraform Cloud.                                                        |
+
+---
+
+##### `Organization`<sup>Required</sup> <a name="Organization" id="cdktf.CloudBackendProps.property.organization"></a>
+
+```csharp
+public string Organization { get; set; }
+```
+
+- _Type:_ string
+
+The name of the organization containing the workspace(s) the current configuration should use.
+
+---
+
+##### `Workspaces`<sup>Required</sup> <a name="Workspaces" id="cdktf.CloudBackendProps.property.workspaces"></a>
+
+```csharp
+public object Workspaces { get; set; }
+```
+
+- _Type:_ object
+
+A nested block that specifies which remote Terraform Cloud workspaces to use for the current configuration.
+
+The workspaces block must contain exactly one of the following arguments, each denoting a strategy for how workspaces should be mapped:
+
+---
+
+##### `Hostname`<sup>Optional</sup> <a name="Hostname" id="cdktf.CloudBackendProps.property.hostname"></a>
+
+```csharp
+public string Hostname { get; set; }
+```
+
+- _Type:_ string
+- _Default:_ app.terraform.io
+
+The hostname of a Terraform Enterprise installation, if using Terraform Enterprise.
+
+---
+
+##### `Token`<sup>Optional</sup> <a name="Token" id="cdktf.CloudBackendProps.property.token"></a>
+
+```csharp
+public string Token { get; set; }
+```
+
+- _Type:_ string
+
+The token used to authenticate with Terraform Cloud.
+
+We recommend omitting the token from the configuration, and instead using terraform login or manually configuring credentials in the CLI config file.
 
 ---
 
@@ -15044,6 +15370,9 @@ new DataTerraformRemoteStateS3Config {
     string AccessKey = null,
     string Acl = null,
     string AssumeRolePolicy = null,
+    string[] AssumeRolePolicyArns = null,
+    System.Collections.Generic.IDictionary< string, string > AssumeRoleTags = null,
+    string[] AssumeRoleTransitiveTagKeys = null,
     string DynamodbEndpoint = null,
     string DynamodbTable = null,
     bool Encrypt = null,
@@ -15061,6 +15390,7 @@ new DataTerraformRemoteStateS3Config {
     string SharedCredentialsFile = null,
     bool SkipCredentialsValidation = null,
     bool SkipMetadataApiCheck = null,
+    bool SkipRegionValidation = null,
     string SseCustomerKey = null,
     string StsEndpoint = null,
     string Token = null,
@@ -15070,36 +15400,40 @@ new DataTerraformRemoteStateS3Config {
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                                                        | **Type**                                                              | **Description**                                                                                                                                                                                                                                                |
-| ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.defaults">Defaults</a></code>                                   | <code>System.Collections.Generic.IDictionary< string, object ></code> | _No description._                                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.workspace">Workspace</a></code>                                 | <code>string</code>                                                   | _No description._                                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.bucket">Bucket</a></code>                                       | <code>string</code>                                                   | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.key">Key</a></code>                                             | <code>string</code>                                                   | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.accessKey">AccessKey</a></code>                                 | <code>string</code>                                                   | (Optional) AWS access key.                                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.acl">Acl</a></code>                                             | <code>string</code>                                                   | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRolePolicy">AssumeRolePolicy</a></code>                   | <code>string</code>                                                   | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.dynamodbEndpoint">DynamodbEndpoint</a></code>                   | <code>string</code>                                                   | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.dynamodbTable">DynamodbTable</a></code>                         | <code>string</code>                                                   | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.encrypt">Encrypt</a></code>                                     | <code>bool</code>                                                     | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.endpoint">Endpoint</a></code>                                   | <code>string</code>                                                   | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.externalId">ExternalId</a></code>                               | <code>string</code>                                                   | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.forcePathStyle">ForcePathStyle</a></code>                       | <code>bool</code>                                                     | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.iamEndpoint">IamEndpoint</a></code>                             | <code>string</code>                                                   | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.kmsKeyId">KmsKeyId</a></code>                                   | <code>string</code>                                                   | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.maxRetries">MaxRetries</a></code>                               | <code>double</code>                                                   | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.profile">Profile</a></code>                                     | <code>string</code>                                                   | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.region">Region</a></code>                                       | <code>string</code>                                                   | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.roleArn">RoleArn</a></code>                                     | <code>string</code>                                                   | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.secretKey">SecretKey</a></code>                                 | <code>string</code>                                                   | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sessionName">SessionName</a></code>                             | <code>string</code>                                                   | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sharedCredentialsFile">SharedCredentialsFile</a></code>         | <code>string</code>                                                   | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipCredentialsValidation">SkipCredentialsValidation</a></code> | <code>bool</code>                                                     | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipMetadataApiCheck">SkipMetadataApiCheck</a></code>           | <code>bool</code>                                                     | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sseCustomerKey">SseCustomerKey</a></code>                       | <code>string</code>                                                   | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.stsEndpoint">StsEndpoint</a></code>                             | <code>string</code>                                                   | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.token">Token</a></code>                                         | <code>string</code>                                                   | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.workspaceKeyPrefix">WorkspaceKeyPrefix</a></code>               | <code>string</code>                                                   | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
+| **Name**                                                                                                                            | **Type**                                                              | **Description**                                                                                                                                                                                                                                                |
+| ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.defaults">Defaults</a></code>                                       | <code>System.Collections.Generic.IDictionary< string, object ></code> | _No description._                                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.workspace">Workspace</a></code>                                     | <code>string</code>                                                   | _No description._                                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.bucket">Bucket</a></code>                                           | <code>string</code>                                                   | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.key">Key</a></code>                                                 | <code>string</code>                                                   | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.accessKey">AccessKey</a></code>                                     | <code>string</code>                                                   | (Optional) AWS access key.                                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.acl">Acl</a></code>                                                 | <code>string</code>                                                   | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRolePolicy">AssumeRolePolicy</a></code>                       | <code>string</code>                                                   | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRolePolicyArns">AssumeRolePolicyArns</a></code>               | <code>string[]</code>                                                 | (Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.                                                                                                                      |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRoleTags">AssumeRoleTags</a></code>                           | <code>System.Collections.Generic.IDictionary< string, string ></code> | (Optional) Map of assume role session tags.                                                                                                                                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRoleTransitiveTagKeys">AssumeRoleTransitiveTagKeys</a></code> | <code>string[]</code>                                                 | (Optional) Set of assume role session tag keys to pass to any subsequent sessions.                                                                                                                                                                             |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.dynamodbEndpoint">DynamodbEndpoint</a></code>                       | <code>string</code>                                                   | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.dynamodbTable">DynamodbTable</a></code>                             | <code>string</code>                                                   | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.encrypt">Encrypt</a></code>                                         | <code>bool</code>                                                     | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.endpoint">Endpoint</a></code>                                       | <code>string</code>                                                   | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.externalId">ExternalId</a></code>                                   | <code>string</code>                                                   | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.forcePathStyle">ForcePathStyle</a></code>                           | <code>bool</code>                                                     | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.iamEndpoint">IamEndpoint</a></code>                                 | <code>string</code>                                                   | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.kmsKeyId">KmsKeyId</a></code>                                       | <code>string</code>                                                   | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.maxRetries">MaxRetries</a></code>                                   | <code>double</code>                                                   | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.profile">Profile</a></code>                                         | <code>string</code>                                                   | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.region">Region</a></code>                                           | <code>string</code>                                                   | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.roleArn">RoleArn</a></code>                                         | <code>string</code>                                                   | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.secretKey">SecretKey</a></code>                                     | <code>string</code>                                                   | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sessionName">SessionName</a></code>                                 | <code>string</code>                                                   | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sharedCredentialsFile">SharedCredentialsFile</a></code>             | <code>string</code>                                                   | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipCredentialsValidation">SkipCredentialsValidation</a></code>     | <code>bool</code>                                                     | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipMetadataApiCheck">SkipMetadataApiCheck</a></code>               | <code>bool</code>                                                     | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipRegionValidation">SkipRegionValidation</a></code>               | <code>bool</code>                                                     | (Optional) Skip validation of provided region name.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sseCustomerKey">SseCustomerKey</a></code>                           | <code>string</code>                                                   | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.stsEndpoint">StsEndpoint</a></code>                                 | <code>string</code>                                                   | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.token">Token</a></code>                                             | <code>string</code>                                                   | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.workspaceKeyPrefix">WorkspaceKeyPrefix</a></code>                   | <code>string</code>                                                   | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
 
 ---
 
@@ -15188,6 +15522,42 @@ public string AssumeRolePolicy { get; set; }
 - _Type:_ string
 
 (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `AssumeRolePolicyArns`<sup>Optional</sup> <a name="AssumeRolePolicyArns" id="cdktf.DataTerraformRemoteStateS3Config.property.assumeRolePolicyArns"></a>
+
+```csharp
+public string[] AssumeRolePolicyArns { get; set; }
+```
+
+- _Type:_ string[]
+
+(Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `AssumeRoleTags`<sup>Optional</sup> <a name="AssumeRoleTags" id="cdktf.DataTerraformRemoteStateS3Config.property.assumeRoleTags"></a>
+
+```csharp
+public System.Collections.Generic.IDictionary< string, string > AssumeRoleTags { get; set; }
+```
+
+- _Type:_ System.Collections.Generic.IDictionary< string, string >
+
+(Optional) Map of assume role session tags.
+
+---
+
+##### `AssumeRoleTransitiveTagKeys`<sup>Optional</sup> <a name="AssumeRoleTransitiveTagKeys" id="cdktf.DataTerraformRemoteStateS3Config.property.assumeRoleTransitiveTagKeys"></a>
+
+```csharp
+public string[] AssumeRoleTransitiveTagKeys { get; set; }
+```
+
+- _Type:_ string[]
+
+(Optional) Set of assume role session tag keys to pass to any subsequent sessions.
 
 ---
 
@@ -15418,6 +15788,18 @@ public bool SkipMetadataApiCheck { get; set; }
 - _Type:_ bool
 
 (Optional) Skip usage of EC2 Metadata API.
+
+---
+
+##### `SkipRegionValidation`<sup>Optional</sup> <a name="SkipRegionValidation" id="cdktf.DataTerraformRemoteStateS3Config.property.skipRegionValidation"></a>
+
+```csharp
+public bool SkipRegionValidation { get; set; }
+```
+
+- _Type:_ bool
+
+(Optional) Skip validation of provided region name.
 
 ---
 
@@ -17584,6 +17966,9 @@ new S3BackendProps {
     string AccessKey = null,
     string Acl = null,
     string AssumeRolePolicy = null,
+    string[] AssumeRolePolicyArns = null,
+    System.Collections.Generic.IDictionary< string, string > AssumeRoleTags = null,
+    string[] AssumeRoleTransitiveTagKeys = null,
     string DynamodbEndpoint = null,
     string DynamodbTable = null,
     bool Encrypt = null,
@@ -17601,6 +17986,7 @@ new S3BackendProps {
     string SharedCredentialsFile = null,
     bool SkipCredentialsValidation = null,
     bool SkipMetadataApiCheck = null,
+    bool SkipRegionValidation = null,
     string SseCustomerKey = null,
     string StsEndpoint = null,
     string Token = null,
@@ -17610,34 +17996,38 @@ new S3BackendProps {
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                                      | **Type**            | **Description**                                                                                                                                                                                                                                                |
-| ------------------------------------------------------------------------------------------------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.S3BackendProps.property.bucket">Bucket</a></code>                                       | <code>string</code> | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
-| <code><a href="#cdktf.S3BackendProps.property.key">Key</a></code>                                             | <code>string</code> | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
-| <code><a href="#cdktf.S3BackendProps.property.accessKey">AccessKey</a></code>                                 | <code>string</code> | (Optional) AWS access key.                                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.S3BackendProps.property.acl">Acl</a></code>                                             | <code>string</code> | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.S3BackendProps.property.assumeRolePolicy">AssumeRolePolicy</a></code>                   | <code>string</code> | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
-| <code><a href="#cdktf.S3BackendProps.property.dynamodbEndpoint">DynamodbEndpoint</a></code>                   | <code>string</code> | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
-| <code><a href="#cdktf.S3BackendProps.property.dynamodbTable">DynamodbTable</a></code>                         | <code>string</code> | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
-| <code><a href="#cdktf.S3BackendProps.property.encrypt">Encrypt</a></code>                                     | <code>bool</code>   | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
-| <code><a href="#cdktf.S3BackendProps.property.endpoint">Endpoint</a></code>                                   | <code>string</code> | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
-| <code><a href="#cdktf.S3BackendProps.property.externalId">ExternalId</a></code>                               | <code>string</code> | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
-| <code><a href="#cdktf.S3BackendProps.property.forcePathStyle">ForcePathStyle</a></code>                       | <code>bool</code>   | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
-| <code><a href="#cdktf.S3BackendProps.property.iamEndpoint">IamEndpoint</a></code>                             | <code>string</code> | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
-| <code><a href="#cdktf.S3BackendProps.property.kmsKeyId">KmsKeyId</a></code>                                   | <code>string</code> | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
-| <code><a href="#cdktf.S3BackendProps.property.maxRetries">MaxRetries</a></code>                               | <code>double</code> | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
-| <code><a href="#cdktf.S3BackendProps.property.profile">Profile</a></code>                                     | <code>string</code> | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
-| <code><a href="#cdktf.S3BackendProps.property.region">Region</a></code>                                       | <code>string</code> | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
-| <code><a href="#cdktf.S3BackendProps.property.roleArn">RoleArn</a></code>                                     | <code>string</code> | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
-| <code><a href="#cdktf.S3BackendProps.property.secretKey">SecretKey</a></code>                                 | <code>string</code> | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.S3BackendProps.property.sessionName">SessionName</a></code>                             | <code>string</code> | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.S3BackendProps.property.sharedCredentialsFile">SharedCredentialsFile</a></code>         | <code>string</code> | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.S3BackendProps.property.skipCredentialsValidation">SkipCredentialsValidation</a></code> | <code>bool</code>   | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
-| <code><a href="#cdktf.S3BackendProps.property.skipMetadataApiCheck">SkipMetadataApiCheck</a></code>           | <code>bool</code>   | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.S3BackendProps.property.sseCustomerKey">SseCustomerKey</a></code>                       | <code>string</code> | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
-| <code><a href="#cdktf.S3BackendProps.property.stsEndpoint">StsEndpoint</a></code>                             | <code>string</code> | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
-| <code><a href="#cdktf.S3BackendProps.property.token">Token</a></code>                                         | <code>string</code> | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.S3BackendProps.property.workspaceKeyPrefix">WorkspaceKeyPrefix</a></code>               | <code>string</code> | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
+| **Name**                                                                                                          | **Type**                                                              | **Description**                                                                                                                                                                                                                                                |
+| ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.S3BackendProps.property.bucket">Bucket</a></code>                                           | <code>string</code>                                                   | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
+| <code><a href="#cdktf.S3BackendProps.property.key">Key</a></code>                                                 | <code>string</code>                                                   | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
+| <code><a href="#cdktf.S3BackendProps.property.accessKey">AccessKey</a></code>                                     | <code>string</code>                                                   | (Optional) AWS access key.                                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.S3BackendProps.property.acl">Acl</a></code>                                                 | <code>string</code>                                                   | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.S3BackendProps.property.assumeRolePolicy">AssumeRolePolicy</a></code>                       | <code>string</code>                                                   | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
+| <code><a href="#cdktf.S3BackendProps.property.assumeRolePolicyArns">AssumeRolePolicyArns</a></code>               | <code>string[]</code>                                                 | (Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.                                                                                                                      |
+| <code><a href="#cdktf.S3BackendProps.property.assumeRoleTags">AssumeRoleTags</a></code>                           | <code>System.Collections.Generic.IDictionary< string, string ></code> | (Optional) Map of assume role session tags.                                                                                                                                                                                                                    |
+| <code><a href="#cdktf.S3BackendProps.property.assumeRoleTransitiveTagKeys">AssumeRoleTransitiveTagKeys</a></code> | <code>string[]</code>                                                 | (Optional) Set of assume role session tag keys to pass to any subsequent sessions.                                                                                                                                                                             |
+| <code><a href="#cdktf.S3BackendProps.property.dynamodbEndpoint">DynamodbEndpoint</a></code>                       | <code>string</code>                                                   | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
+| <code><a href="#cdktf.S3BackendProps.property.dynamodbTable">DynamodbTable</a></code>                             | <code>string</code>                                                   | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
+| <code><a href="#cdktf.S3BackendProps.property.encrypt">Encrypt</a></code>                                         | <code>bool</code>                                                     | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
+| <code><a href="#cdktf.S3BackendProps.property.endpoint">Endpoint</a></code>                                       | <code>string</code>                                                   | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
+| <code><a href="#cdktf.S3BackendProps.property.externalId">ExternalId</a></code>                                   | <code>string</code>                                                   | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
+| <code><a href="#cdktf.S3BackendProps.property.forcePathStyle">ForcePathStyle</a></code>                           | <code>bool</code>                                                     | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
+| <code><a href="#cdktf.S3BackendProps.property.iamEndpoint">IamEndpoint</a></code>                                 | <code>string</code>                                                   | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
+| <code><a href="#cdktf.S3BackendProps.property.kmsKeyId">KmsKeyId</a></code>                                       | <code>string</code>                                                   | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
+| <code><a href="#cdktf.S3BackendProps.property.maxRetries">MaxRetries</a></code>                                   | <code>double</code>                                                   | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
+| <code><a href="#cdktf.S3BackendProps.property.profile">Profile</a></code>                                         | <code>string</code>                                                   | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
+| <code><a href="#cdktf.S3BackendProps.property.region">Region</a></code>                                           | <code>string</code>                                                   | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
+| <code><a href="#cdktf.S3BackendProps.property.roleArn">RoleArn</a></code>                                         | <code>string</code>                                                   | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
+| <code><a href="#cdktf.S3BackendProps.property.secretKey">SecretKey</a></code>                                     | <code>string</code>                                                   | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.S3BackendProps.property.sessionName">SessionName</a></code>                                 | <code>string</code>                                                   | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.S3BackendProps.property.sharedCredentialsFile">SharedCredentialsFile</a></code>             | <code>string</code>                                                   | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.S3BackendProps.property.skipCredentialsValidation">SkipCredentialsValidation</a></code>     | <code>bool</code>                                                     | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
+| <code><a href="#cdktf.S3BackendProps.property.skipMetadataApiCheck">SkipMetadataApiCheck</a></code>               | <code>bool</code>                                                     | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.S3BackendProps.property.skipRegionValidation">SkipRegionValidation</a></code>               | <code>bool</code>                                                     | (Optional) Skip validation of provided region name.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.S3BackendProps.property.sseCustomerKey">SseCustomerKey</a></code>                           | <code>string</code>                                                   | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
+| <code><a href="#cdktf.S3BackendProps.property.stsEndpoint">StsEndpoint</a></code>                                 | <code>string</code>                                                   | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
+| <code><a href="#cdktf.S3BackendProps.property.token">Token</a></code>                                             | <code>string</code>                                                   | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.S3BackendProps.property.workspaceKeyPrefix">WorkspaceKeyPrefix</a></code>                   | <code>string</code>                                                   | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
 
 ---
 
@@ -17706,6 +18096,42 @@ public string AssumeRolePolicy { get; set; }
 - _Type:_ string
 
 (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `AssumeRolePolicyArns`<sup>Optional</sup> <a name="AssumeRolePolicyArns" id="cdktf.S3BackendProps.property.assumeRolePolicyArns"></a>
+
+```csharp
+public string[] AssumeRolePolicyArns { get; set; }
+```
+
+- _Type:_ string[]
+
+(Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `AssumeRoleTags`<sup>Optional</sup> <a name="AssumeRoleTags" id="cdktf.S3BackendProps.property.assumeRoleTags"></a>
+
+```csharp
+public System.Collections.Generic.IDictionary< string, string > AssumeRoleTags { get; set; }
+```
+
+- _Type:_ System.Collections.Generic.IDictionary< string, string >
+
+(Optional) Map of assume role session tags.
+
+---
+
+##### `AssumeRoleTransitiveTagKeys`<sup>Optional</sup> <a name="AssumeRoleTransitiveTagKeys" id="cdktf.S3BackendProps.property.assumeRoleTransitiveTagKeys"></a>
+
+```csharp
+public string[] AssumeRoleTransitiveTagKeys { get; set; }
+```
+
+- _Type:_ string[]
+
+(Optional) Set of assume role session tag keys to pass to any subsequent sessions.
 
 ---
 
@@ -17936,6 +18362,18 @@ public bool SkipMetadataApiCheck { get; set; }
 - _Type:_ bool
 
 (Optional) Skip usage of EC2 Metadata API.
+
+---
+
+##### `SkipRegionValidation`<sup>Optional</sup> <a name="SkipRegionValidation" id="cdktf.S3BackendProps.property.skipRegionValidation"></a>
+
+```csharp
+public bool SkipRegionValidation { get; set; }
+```
+
+- _Type:_ bool
+
+(Optional) Skip validation of provided region name.
 
 ---
 
@@ -21030,6 +21468,37 @@ public string Fqn { get; }
 - _Type:_ string
 
 ---
+
+### CloudWorkspace <a name="CloudWorkspace" id="cdktf.CloudWorkspace"></a>
+
+A cloud workspace can either be a single named workspace, or a list of tagged workspaces.
+
+#### Initializers <a name="Initializers" id="cdktf.CloudWorkspace.Initializer"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+new CloudWorkspace();
+```
+
+| **Name** | **Type** | **Description** |
+| -------- | -------- | --------------- |
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name**                                                                 | **Description**   |
+| ------------------------------------------------------------------------ | ----------------- |
+| <code><a href="#cdktf.CloudWorkspace.toTerraform">ToTerraform</a></code> | _No description._ |
+
+---
+
+##### `ToTerraform` <a name="ToTerraform" id="cdktf.CloudWorkspace.toTerraform"></a>
+
+```csharp
+private object ToTerraform()
+```
 
 ### ComplexComputedList <a name="ComplexComputedList" id="cdktf.ComplexComputedList"></a>
 
@@ -25021,6 +25490,64 @@ Returns the value of the current item iterated over.
 
 ---
 
+### NamedCloudWorkspace <a name="NamedCloudWorkspace" id="cdktf.NamedCloudWorkspace"></a>
+
+The name of a single Terraform Cloud workspace.
+
+You will only be able to use the workspace specified in the configuration with this working directory, and cannot manage workspaces from the CLI (e.g. terraform workspace select or terraform workspace new).
+
+#### Initializers <a name="Initializers" id="cdktf.NamedCloudWorkspace.Initializer"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+new NamedCloudWorkspace(string Name);
+```
+
+| **Name**                                                                              | **Type**            | **Description**   |
+| ------------------------------------------------------------------------------------- | ------------------- | ----------------- |
+| <code><a href="#cdktf.NamedCloudWorkspace.Initializer.parameter.name">Name</a></code> | <code>string</code> | _No description._ |
+
+---
+
+##### `Name`<sup>Required</sup> <a name="Name" id="cdktf.NamedCloudWorkspace.Initializer.parameter.name"></a>
+
+- _Type:_ string
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name**                                                                      | **Description**   |
+| ----------------------------------------------------------------------------- | ----------------- |
+| <code><a href="#cdktf.NamedCloudWorkspace.toTerraform">ToTerraform</a></code> | _No description._ |
+
+---
+
+##### `ToTerraform` <a name="ToTerraform" id="cdktf.NamedCloudWorkspace.toTerraform"></a>
+
+```csharp
+private object ToTerraform()
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name**                                                                 | **Type**            | **Description**   |
+| ------------------------------------------------------------------------ | ------------------- | ----------------- |
+| <code><a href="#cdktf.NamedCloudWorkspace.property.name">Name</a></code> | <code>string</code> | _No description._ |
+
+---
+
+##### `Name`<sup>Required</sup> <a name="Name" id="cdktf.NamedCloudWorkspace.property.name"></a>
+
+```csharp
+public string Name { get; }
+```
+
+- _Type:_ string
+
+---
+
 ### NamedRemoteWorkspace <a name="NamedRemoteWorkspace" id="cdktf.NamedRemoteWorkspace"></a>
 
 - _Implements:_ <a href="#cdktf.IRemoteWorkspace">IRemoteWorkspace</a>
@@ -25662,6 +26189,64 @@ public string Fqn { get; }
 
 ---
 
+### TaggedCloudWorkspaces <a name="TaggedCloudWorkspaces" id="cdktf.TaggedCloudWorkspaces"></a>
+
+A set of Terraform Cloud workspace tags.
+
+You will be able to use this working directory with any workspaces that have all of the specified tags, and can use the terraform workspace commands to switch between them or create new workspaces. New workspaces will automatically have the specified tags. This option conflicts with name.
+
+#### Initializers <a name="Initializers" id="cdktf.TaggedCloudWorkspaces.Initializer"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+new TaggedCloudWorkspaces(string[] Tags);
+```
+
+| **Name**                                                                                | **Type**              | **Description**   |
+| --------------------------------------------------------------------------------------- | --------------------- | ----------------- |
+| <code><a href="#cdktf.TaggedCloudWorkspaces.Initializer.parameter.tags">Tags</a></code> | <code>string[]</code> | _No description._ |
+
+---
+
+##### `Tags`<sup>Required</sup> <a name="Tags" id="cdktf.TaggedCloudWorkspaces.Initializer.parameter.tags"></a>
+
+- _Type:_ string[]
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name**                                                                        | **Description**   |
+| ------------------------------------------------------------------------------- | ----------------- |
+| <code><a href="#cdktf.TaggedCloudWorkspaces.toTerraform">ToTerraform</a></code> | _No description._ |
+
+---
+
+##### `ToTerraform` <a name="ToTerraform" id="cdktf.TaggedCloudWorkspaces.toTerraform"></a>
+
+```csharp
+private object ToTerraform()
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name**                                                                   | **Type**              | **Description**   |
+| -------------------------------------------------------------------------- | --------------------- | ----------------- |
+| <code><a href="#cdktf.TaggedCloudWorkspaces.property.tags">Tags</a></code> | <code>string[]</code> | _No description._ |
+
+---
+
+##### `Tags`<sup>Required</sup> <a name="Tags" id="cdktf.TaggedCloudWorkspaces.property.tags"></a>
+
+```csharp
+public string[] Tags { get; }
+```
+
+- _Type:_ string[]
+
+---
+
 ### TerraformIterator <a name="TerraformIterator" id="cdktf.TerraformIterator"></a>
 
 - _Implements:_ <a href="#cdktf.ITerraformIterator">ITerraformIterator</a>
@@ -26127,7 +26712,7 @@ Testing.StubVersion(App App);
 ```csharp
 using HashiCorp.Cdktf;
 
-Testing.Synth(TerraformStack Stack);
+Testing.Synth(TerraformStack Stack, bool RunValidations = null);
 ```
 
 Returns the Terraform synthesized JSON.
@@ -26135,6 +26720,12 @@ Returns the Terraform synthesized JSON.
 ###### `Stack`<sup>Required</sup> <a name="Stack" id="cdktf.Testing.synth.parameter.stack"></a>
 
 - _Type:_ <a href="#cdktf.TerraformStack">TerraformStack</a>
+
+---
+
+###### `RunValidations`<sup>Optional</sup> <a name="RunValidations" id="cdktf.Testing.synth.parameter.runValidations"></a>
+
+- _Type:_ bool
 
 ---
 
@@ -27670,7 +28261,7 @@ True when ${} should be ommitted (because already inside them), false otherwise.
 
 - _Extends:_ Constructs.IConstruct
 
-- _Implemented By:_ <a href="#cdktf.Resource">Resource</a>, <a href="#cdktf.TerraformAsset">TerraformAsset</a>, <a href="#cdktf.IResource">IResource</a>
+- _Implemented By:_ <a href="#cdktf.Resource">Resource</a>, <a href="#cdktf.IResource">IResource</a>
 
 #### Properties <a name="Properties" id="Properties"></a>
 

--- a/website/docs/cdktf/api-reference/go.mdx
+++ b/website/docs/cdktf/api-reference/go.mdx
@@ -712,6 +712,249 @@ func FriendlyUniqueId() *string
 
 ---
 
+### CloudBackend <a name="CloudBackend" id="cdktf.CloudBackend"></a>
+
+The Cloud Backend synthesizes a {@link https://www.terraform.io/cli/cloud/settings#the-cloud-block cloud block}. The cloud block is a nested block within the top-level terraform settings block. It specifies which Terraform Cloud workspaces to use for the current working directory. The cloud block only affects Terraform CLI's behavior. When Terraform Cloud uses a configuration that contains a cloud block - for example, when a workspace is configured to use a VCS provider directly - it ignores the block and behaves according to its own workspace settings.
+
+#### Initializers <a name="Initializers" id="cdktf.CloudBackend.Initializer"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.NewCloudBackend(scope Construct, props CloudBackendProps) CloudBackend
+```
+
+| **Name**                                                                         | **Type**                                                              | **Description**   |
+| -------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ----------------- |
+| <code><a href="#cdktf.CloudBackend.Initializer.parameter.scope">scope</a></code> | <code>github.com/aws/constructs-go/constructs/v10.Construct</code>    | _No description._ |
+| <code><a href="#cdktf.CloudBackend.Initializer.parameter.props">props</a></code> | <code><a href="#cdktf.CloudBackendProps">CloudBackendProps</a></code> | _No description._ |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="cdktf.CloudBackend.Initializer.parameter.scope"></a>
+
+- _Type:_ github.com/aws/constructs-go/constructs/v10.Construct
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="cdktf.CloudBackend.Initializer.parameter.props"></a>
+
+- _Type:_ <a href="#cdktf.CloudBackendProps">CloudBackendProps</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name**                                                                                         | **Description**                                                                   |
+| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.CloudBackend.toString">ToString</a></code>                                 | Returns a string representation of this construct.                                |
+| <code><a href="#cdktf.CloudBackend.addOverride">AddOverride</a></code>                           | _No description._                                                                 |
+| <code><a href="#cdktf.CloudBackend.overrideLogicalId">OverrideLogicalId</a></code>               | Overrides the auto-generated logical ID with a specific ID.                       |
+| <code><a href="#cdktf.CloudBackend.resetOverrideLogicalId">ResetOverrideLogicalId</a></code>     | Resets a previously passed logical Id to use the auto-generated logical id again. |
+| <code><a href="#cdktf.CloudBackend.toMetadata">ToMetadata</a></code>                             | _No description._                                                                 |
+| <code><a href="#cdktf.CloudBackend.toTerraform">ToTerraform</a></code>                           | Adds this resource to the terraform JSON output.                                  |
+| <code><a href="#cdktf.CloudBackend.getRemoteStateDataSource">GetRemoteStateDataSource</a></code> | Creates a TerraformRemoteState resource that accesses this backend.               |
+
+---
+
+##### `ToString` <a name="ToString" id="cdktf.CloudBackend.toString"></a>
+
+```go
+func ToString() *string
+```
+
+Returns a string representation of this construct.
+
+##### `AddOverride` <a name="AddOverride" id="cdktf.CloudBackend.addOverride"></a>
+
+```go
+func AddOverride(path *string, value interface{})
+```
+
+###### `path`<sup>Required</sup> <a name="path" id="cdktf.CloudBackend.addOverride.parameter.path"></a>
+
+- _Type:_ \*string
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="cdktf.CloudBackend.addOverride.parameter.value"></a>
+
+- _Type:_ interface{}
+
+---
+
+##### `OverrideLogicalId` <a name="OverrideLogicalId" id="cdktf.CloudBackend.overrideLogicalId"></a>
+
+```go
+func OverrideLogicalId(newLogicalId *string)
+```
+
+Overrides the auto-generated logical ID with a specific ID.
+
+###### `newLogicalId`<sup>Required</sup> <a name="newLogicalId" id="cdktf.CloudBackend.overrideLogicalId.parameter.newLogicalId"></a>
+
+- _Type:_ \*string
+
+The new logical ID to use for this stack element.
+
+---
+
+##### `ResetOverrideLogicalId` <a name="ResetOverrideLogicalId" id="cdktf.CloudBackend.resetOverrideLogicalId"></a>
+
+```go
+func ResetOverrideLogicalId()
+```
+
+Resets a previously passed logical Id to use the auto-generated logical id again.
+
+##### `ToMetadata` <a name="ToMetadata" id="cdktf.CloudBackend.toMetadata"></a>
+
+```go
+func ToMetadata() interface{}
+```
+
+##### `ToTerraform` <a name="ToTerraform" id="cdktf.CloudBackend.toTerraform"></a>
+
+```go
+func ToTerraform() interface{}
+```
+
+Adds this resource to the terraform JSON output.
+
+##### `GetRemoteStateDataSource` <a name="GetRemoteStateDataSource" id="cdktf.CloudBackend.getRemoteStateDataSource"></a>
+
+```go
+func GetRemoteStateDataSource(scope Construct, name *string, _fromStack *string) TerraformRemoteState
+```
+
+Creates a TerraformRemoteState resource that accesses this backend.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="cdktf.CloudBackend.getRemoteStateDataSource.parameter.scope"></a>
+
+- _Type:_ github.com/aws/constructs-go/constructs/v10.Construct
+
+---
+
+###### `name`<sup>Required</sup> <a name="name" id="cdktf.CloudBackend.getRemoteStateDataSource.parameter.name"></a>
+
+- _Type:_ \*string
+
+---
+
+###### `_fromStack`<sup>Required</sup> <a name="_fromStack" id="cdktf.CloudBackend.getRemoteStateDataSource.parameter._fromStack"></a>
+
+- _Type:_ \*string
+
+---
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name**                                                               | **Description**               |
+| ---------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.CloudBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#cdktf.CloudBackend.isBackend">IsBackend</a></code>     | _No description._             |
+
+---
+
+##### `IsConstruct` <a name="IsConstruct" id="cdktf.CloudBackend.isConstruct"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.CloudBackend_IsConstruct(x interface{}) *bool
+```
+
+Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.CloudBackend.isConstruct.parameter.x"></a>
+
+- _Type:_ interface{}
+
+Any object.
+
+---
+
+##### `IsBackend` <a name="IsBackend" id="cdktf.CloudBackend.isBackend"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.CloudBackend_IsBackend(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.CloudBackend.isBackend.parameter.x"></a>
+
+- _Type:_ interface{}
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name**                                                                                  | **Type**                                                        | **Description**   |
+| ----------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ----------------- |
+| <code><a href="#cdktf.CloudBackend.property.node">Node</a></code>                         | <code>github.com/aws/constructs-go/constructs/v10.Node</code>   | The tree node.    |
+| <code><a href="#cdktf.CloudBackend.property.cdktfStack">CdktfStack</a></code>             | <code><a href="#cdktf.TerraformStack">TerraformStack</a></code> | _No description._ |
+| <code><a href="#cdktf.CloudBackend.property.fqn">Fqn</a></code>                           | <code>\*string</code>                                           | _No description._ |
+| <code><a href="#cdktf.CloudBackend.property.friendlyUniqueId">FriendlyUniqueId</a></code> | <code>\*string</code>                                           | _No description._ |
+
+---
+
+##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.CloudBackend.property.node"></a>
+
+```go
+func Node() Node
+```
+
+- _Type:_ github.com/aws/constructs-go/constructs/v10.Node
+
+The tree node.
+
+---
+
+##### `CdktfStack`<sup>Required</sup> <a name="CdktfStack" id="cdktf.CloudBackend.property.cdktfStack"></a>
+
+```go
+func CdktfStack() TerraformStack
+```
+
+- _Type:_ <a href="#cdktf.TerraformStack">TerraformStack</a>
+
+---
+
+##### `Fqn`<sup>Required</sup> <a name="Fqn" id="cdktf.CloudBackend.property.fqn"></a>
+
+```go
+func Fqn() *string
+```
+
+- _Type:_ \*string
+
+---
+
+##### `FriendlyUniqueId`<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.CloudBackend.property.friendlyUniqueId"></a>
+
+```go
+func FriendlyUniqueId() *string
+```
+
+- _Type:_ \*string
+
+---
+
 ### ConsulBackend <a name="ConsulBackend" id="cdktf.ConsulBackend"></a>
 
 #### Initializers <a name="Initializers" id="cdktf.ConsulBackend.Initializer"></a>
@@ -7739,7 +7982,7 @@ cdktf.NewResource(scope Construct, id *string) Resource
 
 ---
 
-##### `ToString` <a name="ToString" id="cdktf.Resource.toString"></a>
+##### ~~`ToString`~~ <a name="ToString" id="cdktf.Resource.toString"></a>
 
 ```go
 func ToString() *string
@@ -7755,7 +7998,7 @@ Returns a string representation of this construct.
 
 ---
 
-##### `IsConstruct` <a name="IsConstruct" id="cdktf.Resource.isConstruct"></a>
+##### ~~`IsConstruct`~~ <a name="IsConstruct" id="cdktf.Resource.isConstruct"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -7796,7 +8039,9 @@ Any object.
 
 ---
 
-##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.Resource.property.node"></a>
+##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.Resource.property.node"></a>
+
+- _Deprecated:_ - Please use Construct from the constructs package instead.
 
 ```go
 func Node() Node
@@ -7808,7 +8053,9 @@ The tree node.
 
 ---
 
-##### `Stack`<sup>Required</sup> <a name="Stack" id="cdktf.Resource.property.stack"></a>
+##### ~~`Stack`~~<sup>Required</sup> <a name="Stack" id="cdktf.Resource.property.stack"></a>
+
+- _Deprecated:_ - Please use Construct from the constructs package instead.
 
 ```go
 func Stack() TerraformStack
@@ -8396,14 +8643,13 @@ Any object.
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                      | **Type**                                                        | **Description**                                                                                                    |
-| ----------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| <code><a href="#cdktf.TerraformAsset.property.node">Node</a></code>           | <code>github.com/aws/constructs-go/constructs/v10.Node</code>   | The tree node.                                                                                                     |
-| <code><a href="#cdktf.TerraformAsset.property.stack">Stack</a></code>         | <code><a href="#cdktf.TerraformStack">TerraformStack</a></code> | The stack in which this resource is defined.                                                                       |
-| <code><a href="#cdktf.TerraformAsset.property.fileName">FileName</a></code>   | <code>\*string</code>                                           | Name of the asset.                                                                                                 |
-| <code><a href="#cdktf.TerraformAsset.property.path">Path</a></code>           | <code>\*string</code>                                           | The path relative to the root of the terraform directory in posix format Use this property to reference the asset. |
-| <code><a href="#cdktf.TerraformAsset.property.assetHash">AssetHash</a></code> | <code>\*string</code>                                           | _No description._                                                                                                  |
-| <code><a href="#cdktf.TerraformAsset.property.type">Type</a></code>           | <code><a href="#cdktf.AssetType">AssetType</a></code>           | _No description._                                                                                                  |
+| **Name**                                                                      | **Type**                                                      | **Description**                                                                                                    |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| <code><a href="#cdktf.TerraformAsset.property.node">Node</a></code>           | <code>github.com/aws/constructs-go/constructs/v10.Node</code> | The tree node.                                                                                                     |
+| <code><a href="#cdktf.TerraformAsset.property.fileName">FileName</a></code>   | <code>\*string</code>                                         | Name of the asset.                                                                                                 |
+| <code><a href="#cdktf.TerraformAsset.property.path">Path</a></code>           | <code>\*string</code>                                         | The path relative to the root of the terraform directory in posix format Use this property to reference the asset. |
+| <code><a href="#cdktf.TerraformAsset.property.assetHash">AssetHash</a></code> | <code>\*string</code>                                         | _No description._                                                                                                  |
+| <code><a href="#cdktf.TerraformAsset.property.type">Type</a></code>           | <code><a href="#cdktf.AssetType">AssetType</a></code>         | _No description._                                                                                                  |
 
 ---
 
@@ -8416,18 +8662,6 @@ func Node() Node
 - _Type:_ github.com/aws/constructs-go/constructs/v10.Node
 
 The tree node.
-
----
-
-##### `Stack`<sup>Required</sup> <a name="Stack" id="cdktf.TerraformAsset.property.stack"></a>
-
-```go
-func Stack() TerraformStack
-```
-
-- _Type:_ <a href="#cdktf.TerraformStack">TerraformStack</a>
-
-The stack in which this resource is defined.
 
 ---
 
@@ -11640,6 +11874,7 @@ cdktf.NewTerraformStack(scope Construct, id *string) TerraformStack
 | <code><a href="#cdktf.TerraformStack.prepareStack">PrepareStack</a></code>                                               | _No description._                                  |
 | <code><a href="#cdktf.TerraformStack.registerIncomingCrossStackReference">RegisterIncomingCrossStackReference</a></code> | _No description._                                  |
 | <code><a href="#cdktf.TerraformStack.registerOutgoingCrossStackReference">RegisterOutgoingCrossStackReference</a></code> | _No description._                                  |
+| <code><a href="#cdktf.TerraformStack.runAllValidations">RunAllValidations</a></code>                                     | Run all validations on the stack.                  |
 | <code><a href="#cdktf.TerraformStack.toTerraform">ToTerraform</a></code>                                                 | _No description._                                  |
 
 ---
@@ -11747,6 +11982,14 @@ func RegisterOutgoingCrossStackReference(identifier *string) TerraformOutput
 - _Type:_ \*string
 
 ---
+
+##### `RunAllValidations` <a name="RunAllValidations" id="cdktf.TerraformStack.runAllValidations"></a>
+
+```go
+func RunAllValidations()
+```
+
+Run all validations on the stack.
 
 ##### `ToTerraform` <a name="ToTerraform" id="cdktf.TerraformStack.toTerraform"></a>
 
@@ -12642,6 +12885,89 @@ UseMsi *bool
 (Optional) Should Managed Service Identity authentication be used?
 
 This can also be sourced from the ARM_USE_MSI environment variable.
+
+---
+
+### CloudBackendProps <a name="CloudBackendProps" id="cdktf.CloudBackendProps"></a>
+
+The Cloud Backend synthesizes a {@link https://www.terraform.io/cli/cloud/settings#the-cloud-block cloud block}. The cloud block is a nested block within the top-level terraform settings block. It specifies which Terraform Cloud workspaces to use for the current working directory. The cloud block only affects Terraform CLI's behavior. When Terraform Cloud uses a configuration that contains a cloud block - for example, when a workspace is configured to use a VCS provider directly - it ignores the block and behaves according to its own workspace settings.
+
+https://www.terraform.io/cli/cloud/settings#arguments
+
+#### Initializer <a name="Initializer" id="cdktf.CloudBackendProps.Initializer"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+&cdktf.CloudBackendProps {
+	Organization: *string,
+	Workspaces: interface{},
+	Hostname: *string,
+	Token: *string,
+}
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name**                                                                               | **Type**                 | **Description**                                                                                             |
+| -------------------------------------------------------------------------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.CloudBackendProps.property.organization">Organization</a></code> | <code>\*string</code>    | The name of the organization containing the workspace(s) the current configuration should use.              |
+| <code><a href="#cdktf.CloudBackendProps.property.workspaces">Workspaces</a></code>     | <code>interface{}</code> | A nested block that specifies which remote Terraform Cloud workspaces to use for the current configuration. |
+| <code><a href="#cdktf.CloudBackendProps.property.hostname">Hostname</a></code>         | <code>\*string</code>    | The hostname of a Terraform Enterprise installation, if using Terraform Enterprise.                         |
+| <code><a href="#cdktf.CloudBackendProps.property.token">Token</a></code>               | <code>\*string</code>    | The token used to authenticate with Terraform Cloud.                                                        |
+
+---
+
+##### `Organization`<sup>Required</sup> <a name="Organization" id="cdktf.CloudBackendProps.property.organization"></a>
+
+```go
+Organization *string
+```
+
+- _Type:_ \*string
+
+The name of the organization containing the workspace(s) the current configuration should use.
+
+---
+
+##### `Workspaces`<sup>Required</sup> <a name="Workspaces" id="cdktf.CloudBackendProps.property.workspaces"></a>
+
+```go
+Workspaces interface{}
+```
+
+- _Type:_ interface{}
+
+A nested block that specifies which remote Terraform Cloud workspaces to use for the current configuration.
+
+The workspaces block must contain exactly one of the following arguments, each denoting a strategy for how workspaces should be mapped:
+
+---
+
+##### `Hostname`<sup>Optional</sup> <a name="Hostname" id="cdktf.CloudBackendProps.property.hostname"></a>
+
+```go
+Hostname *string
+```
+
+- _Type:_ \*string
+- _Default:_ app.terraform.io
+
+The hostname of a Terraform Enterprise installation, if using Terraform Enterprise.
+
+---
+
+##### `Token`<sup>Optional</sup> <a name="Token" id="cdktf.CloudBackendProps.property.token"></a>
+
+```go
+Token *string
+```
+
+- _Type:_ \*string
+
+The token used to authenticate with Terraform Cloud.
+
+We recommend omitting the token from the configuration, and instead using terraform login or manually configuring credentials in the CLI config file.
 
 ---
 
@@ -15044,6 +15370,9 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 	AccessKey: *string,
 	Acl: *string,
 	AssumeRolePolicy: *string,
+	AssumeRolePolicyArns: *[]*string,
+	AssumeRoleTags: *map[string]*string,
+	AssumeRoleTransitiveTagKeys: *[]*string,
 	DynamodbEndpoint: *string,
 	DynamodbTable: *string,
 	Encrypt: *bool,
@@ -15061,6 +15390,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 	SharedCredentialsFile: *string,
 	SkipCredentialsValidation: *bool,
 	SkipMetadataApiCheck: *bool,
+	SkipRegionValidation: *bool,
 	SseCustomerKey: *string,
 	StsEndpoint: *string,
 	Token: *string,
@@ -15070,36 +15400,40 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                                                        | **Type**                              | **Description**                                                                                                                                                                                                                                                |
-| ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.defaults">Defaults</a></code>                                   | <code>\*map[string]interface{}</code> | _No description._                                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.workspace">Workspace</a></code>                                 | <code>\*string</code>                 | _No description._                                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.bucket">Bucket</a></code>                                       | <code>\*string</code>                 | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.key">Key</a></code>                                             | <code>\*string</code>                 | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.accessKey">AccessKey</a></code>                                 | <code>\*string</code>                 | (Optional) AWS access key.                                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.acl">Acl</a></code>                                             | <code>\*string</code>                 | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRolePolicy">AssumeRolePolicy</a></code>                   | <code>\*string</code>                 | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.dynamodbEndpoint">DynamodbEndpoint</a></code>                   | <code>\*string</code>                 | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.dynamodbTable">DynamodbTable</a></code>                         | <code>\*string</code>                 | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.encrypt">Encrypt</a></code>                                     | <code>\*bool</code>                   | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.endpoint">Endpoint</a></code>                                   | <code>\*string</code>                 | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.externalId">ExternalId</a></code>                               | <code>\*string</code>                 | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.forcePathStyle">ForcePathStyle</a></code>                       | <code>\*bool</code>                   | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.iamEndpoint">IamEndpoint</a></code>                             | <code>\*string</code>                 | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.kmsKeyId">KmsKeyId</a></code>                                   | <code>\*string</code>                 | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.maxRetries">MaxRetries</a></code>                               | <code>\*f64</code>                    | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.profile">Profile</a></code>                                     | <code>\*string</code>                 | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.region">Region</a></code>                                       | <code>\*string</code>                 | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.roleArn">RoleArn</a></code>                                     | <code>\*string</code>                 | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.secretKey">SecretKey</a></code>                                 | <code>\*string</code>                 | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sessionName">SessionName</a></code>                             | <code>\*string</code>                 | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sharedCredentialsFile">SharedCredentialsFile</a></code>         | <code>\*string</code>                 | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipCredentialsValidation">SkipCredentialsValidation</a></code> | <code>\*bool</code>                   | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipMetadataApiCheck">SkipMetadataApiCheck</a></code>           | <code>\*bool</code>                   | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sseCustomerKey">SseCustomerKey</a></code>                       | <code>\*string</code>                 | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.stsEndpoint">StsEndpoint</a></code>                             | <code>\*string</code>                 | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.token">Token</a></code>                                         | <code>\*string</code>                 | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.workspaceKeyPrefix">WorkspaceKeyPrefix</a></code>               | <code>\*string</code>                 | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
+| **Name**                                                                                                                            | **Type**                              | **Description**                                                                                                                                                                                                                                                |
+| ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.defaults">Defaults</a></code>                                       | <code>\*map[string]interface{}</code> | _No description._                                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.workspace">Workspace</a></code>                                     | <code>\*string</code>                 | _No description._                                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.bucket">Bucket</a></code>                                           | <code>\*string</code>                 | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.key">Key</a></code>                                                 | <code>\*string</code>                 | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.accessKey">AccessKey</a></code>                                     | <code>\*string</code>                 | (Optional) AWS access key.                                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.acl">Acl</a></code>                                                 | <code>\*string</code>                 | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRolePolicy">AssumeRolePolicy</a></code>                       | <code>\*string</code>                 | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRolePolicyArns">AssumeRolePolicyArns</a></code>               | <code>*[]*string</code>               | (Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.                                                                                                                      |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRoleTags">AssumeRoleTags</a></code>                           | <code>*map[string]*string</code>      | (Optional) Map of assume role session tags.                                                                                                                                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRoleTransitiveTagKeys">AssumeRoleTransitiveTagKeys</a></code> | <code>*[]*string</code>               | (Optional) Set of assume role session tag keys to pass to any subsequent sessions.                                                                                                                                                                             |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.dynamodbEndpoint">DynamodbEndpoint</a></code>                       | <code>\*string</code>                 | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.dynamodbTable">DynamodbTable</a></code>                             | <code>\*string</code>                 | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.encrypt">Encrypt</a></code>                                         | <code>\*bool</code>                   | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.endpoint">Endpoint</a></code>                                       | <code>\*string</code>                 | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.externalId">ExternalId</a></code>                                   | <code>\*string</code>                 | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.forcePathStyle">ForcePathStyle</a></code>                           | <code>\*bool</code>                   | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.iamEndpoint">IamEndpoint</a></code>                                 | <code>\*string</code>                 | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.kmsKeyId">KmsKeyId</a></code>                                       | <code>\*string</code>                 | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.maxRetries">MaxRetries</a></code>                                   | <code>\*f64</code>                    | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.profile">Profile</a></code>                                         | <code>\*string</code>                 | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.region">Region</a></code>                                           | <code>\*string</code>                 | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.roleArn">RoleArn</a></code>                                         | <code>\*string</code>                 | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.secretKey">SecretKey</a></code>                                     | <code>\*string</code>                 | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sessionName">SessionName</a></code>                                 | <code>\*string</code>                 | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sharedCredentialsFile">SharedCredentialsFile</a></code>             | <code>\*string</code>                 | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipCredentialsValidation">SkipCredentialsValidation</a></code>     | <code>\*bool</code>                   | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipMetadataApiCheck">SkipMetadataApiCheck</a></code>               | <code>\*bool</code>                   | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipRegionValidation">SkipRegionValidation</a></code>               | <code>\*bool</code>                   | (Optional) Skip validation of provided region name.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sseCustomerKey">SseCustomerKey</a></code>                           | <code>\*string</code>                 | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.stsEndpoint">StsEndpoint</a></code>                                 | <code>\*string</code>                 | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.token">Token</a></code>                                             | <code>\*string</code>                 | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.workspaceKeyPrefix">WorkspaceKeyPrefix</a></code>                   | <code>\*string</code>                 | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
 
 ---
 
@@ -15188,6 +15522,42 @@ AssumeRolePolicy *string
 - _Type:_ \*string
 
 (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `AssumeRolePolicyArns`<sup>Optional</sup> <a name="AssumeRolePolicyArns" id="cdktf.DataTerraformRemoteStateS3Config.property.assumeRolePolicyArns"></a>
+
+```go
+AssumeRolePolicyArns *[]*string
+```
+
+- _Type:_ *[]*string
+
+(Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `AssumeRoleTags`<sup>Optional</sup> <a name="AssumeRoleTags" id="cdktf.DataTerraformRemoteStateS3Config.property.assumeRoleTags"></a>
+
+```go
+AssumeRoleTags *map[string]*string
+```
+
+- _Type:_ *map[string]*string
+
+(Optional) Map of assume role session tags.
+
+---
+
+##### `AssumeRoleTransitiveTagKeys`<sup>Optional</sup> <a name="AssumeRoleTransitiveTagKeys" id="cdktf.DataTerraformRemoteStateS3Config.property.assumeRoleTransitiveTagKeys"></a>
+
+```go
+AssumeRoleTransitiveTagKeys *[]*string
+```
+
+- _Type:_ *[]*string
+
+(Optional) Set of assume role session tag keys to pass to any subsequent sessions.
 
 ---
 
@@ -15418,6 +15788,18 @@ SkipMetadataApiCheck *bool
 - _Type:_ \*bool
 
 (Optional) Skip usage of EC2 Metadata API.
+
+---
+
+##### `SkipRegionValidation`<sup>Optional</sup> <a name="SkipRegionValidation" id="cdktf.DataTerraformRemoteStateS3Config.property.skipRegionValidation"></a>
+
+```go
+SkipRegionValidation *bool
+```
+
+- _Type:_ \*bool
+
+(Optional) Skip validation of provided region name.
 
 ---
 
@@ -17584,6 +17966,9 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 	AccessKey: *string,
 	Acl: *string,
 	AssumeRolePolicy: *string,
+	AssumeRolePolicyArns: *[]*string,
+	AssumeRoleTags: *map[string]*string,
+	AssumeRoleTransitiveTagKeys: *[]*string,
 	DynamodbEndpoint: *string,
 	DynamodbTable: *string,
 	Encrypt: *bool,
@@ -17601,6 +17986,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 	SharedCredentialsFile: *string,
 	SkipCredentialsValidation: *bool,
 	SkipMetadataApiCheck: *bool,
+	SkipRegionValidation: *bool,
 	SseCustomerKey: *string,
 	StsEndpoint: *string,
 	Token: *string,
@@ -17610,34 +17996,38 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                                      | **Type**              | **Description**                                                                                                                                                                                                                                                |
-| ------------------------------------------------------------------------------------------------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.S3BackendProps.property.bucket">Bucket</a></code>                                       | <code>\*string</code> | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
-| <code><a href="#cdktf.S3BackendProps.property.key">Key</a></code>                                             | <code>\*string</code> | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
-| <code><a href="#cdktf.S3BackendProps.property.accessKey">AccessKey</a></code>                                 | <code>\*string</code> | (Optional) AWS access key.                                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.S3BackendProps.property.acl">Acl</a></code>                                             | <code>\*string</code> | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.S3BackendProps.property.assumeRolePolicy">AssumeRolePolicy</a></code>                   | <code>\*string</code> | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
-| <code><a href="#cdktf.S3BackendProps.property.dynamodbEndpoint">DynamodbEndpoint</a></code>                   | <code>\*string</code> | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
-| <code><a href="#cdktf.S3BackendProps.property.dynamodbTable">DynamodbTable</a></code>                         | <code>\*string</code> | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
-| <code><a href="#cdktf.S3BackendProps.property.encrypt">Encrypt</a></code>                                     | <code>\*bool</code>   | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
-| <code><a href="#cdktf.S3BackendProps.property.endpoint">Endpoint</a></code>                                   | <code>\*string</code> | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
-| <code><a href="#cdktf.S3BackendProps.property.externalId">ExternalId</a></code>                               | <code>\*string</code> | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
-| <code><a href="#cdktf.S3BackendProps.property.forcePathStyle">ForcePathStyle</a></code>                       | <code>\*bool</code>   | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
-| <code><a href="#cdktf.S3BackendProps.property.iamEndpoint">IamEndpoint</a></code>                             | <code>\*string</code> | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
-| <code><a href="#cdktf.S3BackendProps.property.kmsKeyId">KmsKeyId</a></code>                                   | <code>\*string</code> | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
-| <code><a href="#cdktf.S3BackendProps.property.maxRetries">MaxRetries</a></code>                               | <code>\*f64</code>    | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
-| <code><a href="#cdktf.S3BackendProps.property.profile">Profile</a></code>                                     | <code>\*string</code> | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
-| <code><a href="#cdktf.S3BackendProps.property.region">Region</a></code>                                       | <code>\*string</code> | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
-| <code><a href="#cdktf.S3BackendProps.property.roleArn">RoleArn</a></code>                                     | <code>\*string</code> | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
-| <code><a href="#cdktf.S3BackendProps.property.secretKey">SecretKey</a></code>                                 | <code>\*string</code> | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.S3BackendProps.property.sessionName">SessionName</a></code>                             | <code>\*string</code> | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.S3BackendProps.property.sharedCredentialsFile">SharedCredentialsFile</a></code>         | <code>\*string</code> | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.S3BackendProps.property.skipCredentialsValidation">SkipCredentialsValidation</a></code> | <code>\*bool</code>   | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
-| <code><a href="#cdktf.S3BackendProps.property.skipMetadataApiCheck">SkipMetadataApiCheck</a></code>           | <code>\*bool</code>   | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.S3BackendProps.property.sseCustomerKey">SseCustomerKey</a></code>                       | <code>\*string</code> | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
-| <code><a href="#cdktf.S3BackendProps.property.stsEndpoint">StsEndpoint</a></code>                             | <code>\*string</code> | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
-| <code><a href="#cdktf.S3BackendProps.property.token">Token</a></code>                                         | <code>\*string</code> | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.S3BackendProps.property.workspaceKeyPrefix">WorkspaceKeyPrefix</a></code>               | <code>\*string</code> | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
+| **Name**                                                                                                          | **Type**                         | **Description**                                                                                                                                                                                                                                                |
+| ----------------------------------------------------------------------------------------------------------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.S3BackendProps.property.bucket">Bucket</a></code>                                           | <code>\*string</code>            | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
+| <code><a href="#cdktf.S3BackendProps.property.key">Key</a></code>                                                 | <code>\*string</code>            | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
+| <code><a href="#cdktf.S3BackendProps.property.accessKey">AccessKey</a></code>                                     | <code>\*string</code>            | (Optional) AWS access key.                                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.S3BackendProps.property.acl">Acl</a></code>                                                 | <code>\*string</code>            | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.S3BackendProps.property.assumeRolePolicy">AssumeRolePolicy</a></code>                       | <code>\*string</code>            | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
+| <code><a href="#cdktf.S3BackendProps.property.assumeRolePolicyArns">AssumeRolePolicyArns</a></code>               | <code>*[]*string</code>          | (Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.                                                                                                                      |
+| <code><a href="#cdktf.S3BackendProps.property.assumeRoleTags">AssumeRoleTags</a></code>                           | <code>*map[string]*string</code> | (Optional) Map of assume role session tags.                                                                                                                                                                                                                    |
+| <code><a href="#cdktf.S3BackendProps.property.assumeRoleTransitiveTagKeys">AssumeRoleTransitiveTagKeys</a></code> | <code>*[]*string</code>          | (Optional) Set of assume role session tag keys to pass to any subsequent sessions.                                                                                                                                                                             |
+| <code><a href="#cdktf.S3BackendProps.property.dynamodbEndpoint">DynamodbEndpoint</a></code>                       | <code>\*string</code>            | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
+| <code><a href="#cdktf.S3BackendProps.property.dynamodbTable">DynamodbTable</a></code>                             | <code>\*string</code>            | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
+| <code><a href="#cdktf.S3BackendProps.property.encrypt">Encrypt</a></code>                                         | <code>\*bool</code>              | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
+| <code><a href="#cdktf.S3BackendProps.property.endpoint">Endpoint</a></code>                                       | <code>\*string</code>            | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
+| <code><a href="#cdktf.S3BackendProps.property.externalId">ExternalId</a></code>                                   | <code>\*string</code>            | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
+| <code><a href="#cdktf.S3BackendProps.property.forcePathStyle">ForcePathStyle</a></code>                           | <code>\*bool</code>              | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
+| <code><a href="#cdktf.S3BackendProps.property.iamEndpoint">IamEndpoint</a></code>                                 | <code>\*string</code>            | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
+| <code><a href="#cdktf.S3BackendProps.property.kmsKeyId">KmsKeyId</a></code>                                       | <code>\*string</code>            | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
+| <code><a href="#cdktf.S3BackendProps.property.maxRetries">MaxRetries</a></code>                                   | <code>\*f64</code>               | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
+| <code><a href="#cdktf.S3BackendProps.property.profile">Profile</a></code>                                         | <code>\*string</code>            | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
+| <code><a href="#cdktf.S3BackendProps.property.region">Region</a></code>                                           | <code>\*string</code>            | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
+| <code><a href="#cdktf.S3BackendProps.property.roleArn">RoleArn</a></code>                                         | <code>\*string</code>            | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
+| <code><a href="#cdktf.S3BackendProps.property.secretKey">SecretKey</a></code>                                     | <code>\*string</code>            | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.S3BackendProps.property.sessionName">SessionName</a></code>                                 | <code>\*string</code>            | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.S3BackendProps.property.sharedCredentialsFile">SharedCredentialsFile</a></code>             | <code>\*string</code>            | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.S3BackendProps.property.skipCredentialsValidation">SkipCredentialsValidation</a></code>     | <code>\*bool</code>              | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
+| <code><a href="#cdktf.S3BackendProps.property.skipMetadataApiCheck">SkipMetadataApiCheck</a></code>               | <code>\*bool</code>              | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.S3BackendProps.property.skipRegionValidation">SkipRegionValidation</a></code>               | <code>\*bool</code>              | (Optional) Skip validation of provided region name.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.S3BackendProps.property.sseCustomerKey">SseCustomerKey</a></code>                           | <code>\*string</code>            | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
+| <code><a href="#cdktf.S3BackendProps.property.stsEndpoint">StsEndpoint</a></code>                                 | <code>\*string</code>            | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
+| <code><a href="#cdktf.S3BackendProps.property.token">Token</a></code>                                             | <code>\*string</code>            | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.S3BackendProps.property.workspaceKeyPrefix">WorkspaceKeyPrefix</a></code>                   | <code>\*string</code>            | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
 
 ---
 
@@ -17706,6 +18096,42 @@ AssumeRolePolicy *string
 - _Type:_ \*string
 
 (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `AssumeRolePolicyArns`<sup>Optional</sup> <a name="AssumeRolePolicyArns" id="cdktf.S3BackendProps.property.assumeRolePolicyArns"></a>
+
+```go
+AssumeRolePolicyArns *[]*string
+```
+
+- _Type:_ *[]*string
+
+(Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `AssumeRoleTags`<sup>Optional</sup> <a name="AssumeRoleTags" id="cdktf.S3BackendProps.property.assumeRoleTags"></a>
+
+```go
+AssumeRoleTags *map[string]*string
+```
+
+- _Type:_ *map[string]*string
+
+(Optional) Map of assume role session tags.
+
+---
+
+##### `AssumeRoleTransitiveTagKeys`<sup>Optional</sup> <a name="AssumeRoleTransitiveTagKeys" id="cdktf.S3BackendProps.property.assumeRoleTransitiveTagKeys"></a>
+
+```go
+AssumeRoleTransitiveTagKeys *[]*string
+```
+
+- _Type:_ *[]*string
+
+(Optional) Set of assume role session tag keys to pass to any subsequent sessions.
 
 ---
 
@@ -17936,6 +18362,18 @@ SkipMetadataApiCheck *bool
 - _Type:_ \*bool
 
 (Optional) Skip usage of EC2 Metadata API.
+
+---
+
+##### `SkipRegionValidation`<sup>Optional</sup> <a name="SkipRegionValidation" id="cdktf.S3BackendProps.property.skipRegionValidation"></a>
+
+```go
+SkipRegionValidation *bool
+```
+
+- _Type:_ \*bool
+
+(Optional) Skip validation of provided region name.
 
 ---
 
@@ -21030,6 +21468,37 @@ func Fqn() *string
 - _Type:_ \*string
 
 ---
+
+### CloudWorkspace <a name="CloudWorkspace" id="cdktf.CloudWorkspace"></a>
+
+A cloud workspace can either be a single named workspace, or a list of tagged workspaces.
+
+#### Initializers <a name="Initializers" id="cdktf.CloudWorkspace.Initializer"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.NewCloudWorkspace() CloudWorkspace
+```
+
+| **Name** | **Type** | **Description** |
+| -------- | -------- | --------------- |
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name**                                                                 | **Description**   |
+| ------------------------------------------------------------------------ | ----------------- |
+| <code><a href="#cdktf.CloudWorkspace.toTerraform">ToTerraform</a></code> | _No description._ |
+
+---
+
+##### `ToTerraform` <a name="ToTerraform" id="cdktf.CloudWorkspace.toTerraform"></a>
+
+```go
+func ToTerraform() interface{}
+```
 
 ### ComplexComputedList <a name="ComplexComputedList" id="cdktf.ComplexComputedList"></a>
 
@@ -25021,6 +25490,64 @@ Returns the value of the current item iterated over.
 
 ---
 
+### NamedCloudWorkspace <a name="NamedCloudWorkspace" id="cdktf.NamedCloudWorkspace"></a>
+
+The name of a single Terraform Cloud workspace.
+
+You will only be able to use the workspace specified in the configuration with this working directory, and cannot manage workspaces from the CLI (e.g. terraform workspace select or terraform workspace new).
+
+#### Initializers <a name="Initializers" id="cdktf.NamedCloudWorkspace.Initializer"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.NewNamedCloudWorkspace(name *string) NamedCloudWorkspace
+```
+
+| **Name**                                                                              | **Type**              | **Description**   |
+| ------------------------------------------------------------------------------------- | --------------------- | ----------------- |
+| <code><a href="#cdktf.NamedCloudWorkspace.Initializer.parameter.name">name</a></code> | <code>\*string</code> | _No description._ |
+
+---
+
+##### `name`<sup>Required</sup> <a name="name" id="cdktf.NamedCloudWorkspace.Initializer.parameter.name"></a>
+
+- _Type:_ \*string
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name**                                                                      | **Description**   |
+| ----------------------------------------------------------------------------- | ----------------- |
+| <code><a href="#cdktf.NamedCloudWorkspace.toTerraform">ToTerraform</a></code> | _No description._ |
+
+---
+
+##### `ToTerraform` <a name="ToTerraform" id="cdktf.NamedCloudWorkspace.toTerraform"></a>
+
+```go
+func ToTerraform() interface{}
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name**                                                                 | **Type**              | **Description**   |
+| ------------------------------------------------------------------------ | --------------------- | ----------------- |
+| <code><a href="#cdktf.NamedCloudWorkspace.property.name">Name</a></code> | <code>\*string</code> | _No description._ |
+
+---
+
+##### `Name`<sup>Required</sup> <a name="Name" id="cdktf.NamedCloudWorkspace.property.name"></a>
+
+```go
+func Name() *string
+```
+
+- _Type:_ \*string
+
+---
+
 ### NamedRemoteWorkspace <a name="NamedRemoteWorkspace" id="cdktf.NamedRemoteWorkspace"></a>
 
 - _Implements:_ <a href="#cdktf.IRemoteWorkspace">IRemoteWorkspace</a>
@@ -25662,6 +26189,64 @@ func Fqn() *string
 
 ---
 
+### TaggedCloudWorkspaces <a name="TaggedCloudWorkspaces" id="cdktf.TaggedCloudWorkspaces"></a>
+
+A set of Terraform Cloud workspace tags.
+
+You will be able to use this working directory with any workspaces that have all of the specified tags, and can use the terraform workspace commands to switch between them or create new workspaces. New workspaces will automatically have the specified tags. This option conflicts with name.
+
+#### Initializers <a name="Initializers" id="cdktf.TaggedCloudWorkspaces.Initializer"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.NewTaggedCloudWorkspaces(tags *[]*string) TaggedCloudWorkspaces
+```
+
+| **Name**                                                                                | **Type**                | **Description**   |
+| --------------------------------------------------------------------------------------- | ----------------------- | ----------------- |
+| <code><a href="#cdktf.TaggedCloudWorkspaces.Initializer.parameter.tags">tags</a></code> | <code>*[]*string</code> | _No description._ |
+
+---
+
+##### `tags`<sup>Required</sup> <a name="tags" id="cdktf.TaggedCloudWorkspaces.Initializer.parameter.tags"></a>
+
+- _Type:_ *[]*string
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name**                                                                        | **Description**   |
+| ------------------------------------------------------------------------------- | ----------------- |
+| <code><a href="#cdktf.TaggedCloudWorkspaces.toTerraform">ToTerraform</a></code> | _No description._ |
+
+---
+
+##### `ToTerraform` <a name="ToTerraform" id="cdktf.TaggedCloudWorkspaces.toTerraform"></a>
+
+```go
+func ToTerraform() interface{}
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name**                                                                   | **Type**                | **Description**   |
+| -------------------------------------------------------------------------- | ----------------------- | ----------------- |
+| <code><a href="#cdktf.TaggedCloudWorkspaces.property.tags">Tags</a></code> | <code>*[]*string</code> | _No description._ |
+
+---
+
+##### `Tags`<sup>Required</sup> <a name="Tags" id="cdktf.TaggedCloudWorkspaces.property.tags"></a>
+
+```go
+func Tags() *[]*string
+```
+
+- _Type:_ *[]*string
+
+---
+
 ### TerraformIterator <a name="TerraformIterator" id="cdktf.TerraformIterator"></a>
 
 - _Implements:_ <a href="#cdktf.ITerraformIterator">ITerraformIterator</a>
@@ -26127,7 +26712,7 @@ cdktf.Testing_StubVersion(app App) App
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
-cdktf.Testing_Synth(stack TerraformStack) *string
+cdktf.Testing_Synth(stack TerraformStack, runValidations *bool) *string
 ```
 
 Returns the Terraform synthesized JSON.
@@ -26135,6 +26720,12 @@ Returns the Terraform synthesized JSON.
 ###### `stack`<sup>Required</sup> <a name="stack" id="cdktf.Testing.synth.parameter.stack"></a>
 
 - _Type:_ <a href="#cdktf.TerraformStack">TerraformStack</a>
+
+---
+
+###### `runValidations`<sup>Optional</sup> <a name="runValidations" id="cdktf.Testing.synth.parameter.runValidations"></a>
+
+- _Type:_ \*bool
 
 ---
 
@@ -27670,7 +28261,7 @@ True when ${} should be ommitted (because already inside them), false otherwise.
 
 - _Extends:_ github.com/aws/constructs-go/constructs/v10.IConstruct
 
-- _Implemented By:_ <a href="#cdktf.Resource">Resource</a>, <a href="#cdktf.TerraformAsset">TerraformAsset</a>, <a href="#cdktf.IResource">IResource</a>
+- _Implemented By:_ <a href="#cdktf.Resource">Resource</a>, <a href="#cdktf.IResource">IResource</a>
 
 #### Properties <a name="Properties" id="Properties"></a>
 

--- a/website/docs/cdktf/api-reference/java.mdx
+++ b/website/docs/cdktf/api-reference/java.mdx
@@ -950,6 +950,289 @@ public java.lang.String getFriendlyUniqueId();
 
 ---
 
+### CloudBackend <a name="CloudBackend" id="cdktf.CloudBackend"></a>
+
+The Cloud Backend synthesizes a {@link https://www.terraform.io/cli/cloud/settings#the-cloud-block cloud block}. The cloud block is a nested block within the top-level terraform settings block. It specifies which Terraform Cloud workspaces to use for the current working directory. The cloud block only affects Terraform CLI's behavior. When Terraform Cloud uses a configuration that contains a cloud block - for example, when a workspace is configured to use a VCS provider directly - it ignores the block and behaves according to its own workspace settings.
+
+#### Initializers <a name="Initializers" id="cdktf.CloudBackend.Initializer"></a>
+
+```java
+import com.hashicorp.cdktf.CloudBackend;
+
+CloudBackend.Builder.create(Construct scope)
+    .organization(java.lang.String)
+    .workspaces(NamedCloudWorkspace)
+    .workspaces(TaggedCloudWorkspaces)
+//  .hostname(java.lang.String)
+//  .token(java.lang.String)
+    .build();
+```
+
+| **Name**                                                                                       | **Type**                                                                                                                                      | **Description**                                                                                             |
+| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.CloudBackend.Initializer.parameter.scope">scope</a></code>               | <code>software.constructs.Construct</code>                                                                                                    | _No description._                                                                                           |
+| <code><a href="#cdktf.CloudBackend.Initializer.parameter.organization">organization</a></code> | <code>java.lang.String</code>                                                                                                                 | The name of the organization containing the workspace(s) the current configuration should use.              |
+| <code><a href="#cdktf.CloudBackend.Initializer.parameter.workspaces">workspaces</a></code>     | <code><a href="#cdktf.NamedCloudWorkspace">NamedCloudWorkspace</a> OR <a href="#cdktf.TaggedCloudWorkspaces">TaggedCloudWorkspaces</a></code> | A nested block that specifies which remote Terraform Cloud workspaces to use for the current configuration. |
+| <code><a href="#cdktf.CloudBackend.Initializer.parameter.hostname">hostname</a></code>         | <code>java.lang.String</code>                                                                                                                 | The hostname of a Terraform Enterprise installation, if using Terraform Enterprise.                         |
+| <code><a href="#cdktf.CloudBackend.Initializer.parameter.token">token</a></code>               | <code>java.lang.String</code>                                                                                                                 | The token used to authenticate with Terraform Cloud.                                                        |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="cdktf.CloudBackend.Initializer.parameter.scope"></a>
+
+- _Type:_ software.constructs.Construct
+
+---
+
+##### `organization`<sup>Required</sup> <a name="organization" id="cdktf.CloudBackend.Initializer.parameter.organization"></a>
+
+- _Type:_ java.lang.String
+
+The name of the organization containing the workspace(s) the current configuration should use.
+
+---
+
+##### `workspaces`<sup>Required</sup> <a name="workspaces" id="cdktf.CloudBackend.Initializer.parameter.workspaces"></a>
+
+- _Type:_ <a href="#cdktf.NamedCloudWorkspace">NamedCloudWorkspace</a> OR <a href="#cdktf.TaggedCloudWorkspaces">TaggedCloudWorkspaces</a>
+
+A nested block that specifies which remote Terraform Cloud workspaces to use for the current configuration.
+
+The workspaces block must contain exactly one of the following arguments, each denoting a strategy for how workspaces should be mapped:
+
+---
+
+##### `hostname`<sup>Optional</sup> <a name="hostname" id="cdktf.CloudBackend.Initializer.parameter.hostname"></a>
+
+- _Type:_ java.lang.String
+- _Default:_ app.terraform.io
+
+The hostname of a Terraform Enterprise installation, if using Terraform Enterprise.
+
+---
+
+##### `token`<sup>Optional</sup> <a name="token" id="cdktf.CloudBackend.Initializer.parameter.token"></a>
+
+- _Type:_ java.lang.String
+
+The token used to authenticate with Terraform Cloud.
+
+We recommend omitting the token from the configuration, and instead using terraform login or manually configuring credentials in the CLI config file.
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name**                                                                                         | **Description**                                                                   |
+| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.CloudBackend.toString">toString</a></code>                                 | Returns a string representation of this construct.                                |
+| <code><a href="#cdktf.CloudBackend.addOverride">addOverride</a></code>                           | _No description._                                                                 |
+| <code><a href="#cdktf.CloudBackend.overrideLogicalId">overrideLogicalId</a></code>               | Overrides the auto-generated logical ID with a specific ID.                       |
+| <code><a href="#cdktf.CloudBackend.resetOverrideLogicalId">resetOverrideLogicalId</a></code>     | Resets a previously passed logical Id to use the auto-generated logical id again. |
+| <code><a href="#cdktf.CloudBackend.toMetadata">toMetadata</a></code>                             | _No description._                                                                 |
+| <code><a href="#cdktf.CloudBackend.toTerraform">toTerraform</a></code>                           | Adds this resource to the terraform JSON output.                                  |
+| <code><a href="#cdktf.CloudBackend.getRemoteStateDataSource">getRemoteStateDataSource</a></code> | Creates a TerraformRemoteState resource that accesses this backend.               |
+
+---
+
+##### `toString` <a name="toString" id="cdktf.CloudBackend.toString"></a>
+
+```java
+public java.lang.String toString()
+```
+
+Returns a string representation of this construct.
+
+##### `addOverride` <a name="addOverride" id="cdktf.CloudBackend.addOverride"></a>
+
+```java
+public void addOverride(java.lang.String path, java.lang.Object value)
+```
+
+###### `path`<sup>Required</sup> <a name="path" id="cdktf.CloudBackend.addOverride.parameter.path"></a>
+
+- _Type:_ java.lang.String
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="cdktf.CloudBackend.addOverride.parameter.value"></a>
+
+- _Type:_ java.lang.Object
+
+---
+
+##### `overrideLogicalId` <a name="overrideLogicalId" id="cdktf.CloudBackend.overrideLogicalId"></a>
+
+```java
+public void overrideLogicalId(java.lang.String newLogicalId)
+```
+
+Overrides the auto-generated logical ID with a specific ID.
+
+###### `newLogicalId`<sup>Required</sup> <a name="newLogicalId" id="cdktf.CloudBackend.overrideLogicalId.parameter.newLogicalId"></a>
+
+- _Type:_ java.lang.String
+
+The new logical ID to use for this stack element.
+
+---
+
+##### `resetOverrideLogicalId` <a name="resetOverrideLogicalId" id="cdktf.CloudBackend.resetOverrideLogicalId"></a>
+
+```java
+public void resetOverrideLogicalId()
+```
+
+Resets a previously passed logical Id to use the auto-generated logical id again.
+
+##### `toMetadata` <a name="toMetadata" id="cdktf.CloudBackend.toMetadata"></a>
+
+```java
+public java.lang.Object toMetadata()
+```
+
+##### `toTerraform` <a name="toTerraform" id="cdktf.CloudBackend.toTerraform"></a>
+
+```java
+public java.lang.Object toTerraform()
+```
+
+Adds this resource to the terraform JSON output.
+
+##### `getRemoteStateDataSource` <a name="getRemoteStateDataSource" id="cdktf.CloudBackend.getRemoteStateDataSource"></a>
+
+```java
+public TerraformRemoteState getRemoteStateDataSource(Construct scope, java.lang.String name, java.lang.String _fromStack)
+```
+
+Creates a TerraformRemoteState resource that accesses this backend.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="cdktf.CloudBackend.getRemoteStateDataSource.parameter.scope"></a>
+
+- _Type:_ software.constructs.Construct
+
+---
+
+###### `name`<sup>Required</sup> <a name="name" id="cdktf.CloudBackend.getRemoteStateDataSource.parameter.name"></a>
+
+- _Type:_ java.lang.String
+
+---
+
+###### `_fromStack`<sup>Required</sup> <a name="_fromStack" id="cdktf.CloudBackend.getRemoteStateDataSource.parameter._fromStack"></a>
+
+- _Type:_ java.lang.String
+
+---
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name**                                                               | **Description**               |
+| ---------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.CloudBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#cdktf.CloudBackend.isBackend">isBackend</a></code>     | _No description._             |
+
+---
+
+##### `isConstruct` <a name="isConstruct" id="cdktf.CloudBackend.isConstruct"></a>
+
+```java
+import com.hashicorp.cdktf.CloudBackend;
+
+CloudBackend.isConstruct(java.lang.Object x)
+```
+
+Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.CloudBackend.isConstruct.parameter.x"></a>
+
+- _Type:_ java.lang.Object
+
+Any object.
+
+---
+
+##### `isBackend` <a name="isBackend" id="cdktf.CloudBackend.isBackend"></a>
+
+```java
+import com.hashicorp.cdktf.CloudBackend;
+
+CloudBackend.isBackend(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.CloudBackend.isBackend.parameter.x"></a>
+
+- _Type:_ java.lang.Object
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name**                                                                                  | **Type**                                                        | **Description**   |
+| ----------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ----------------- |
+| <code><a href="#cdktf.CloudBackend.property.node">node</a></code>                         | <code>software.constructs.Node</code>                           | The tree node.    |
+| <code><a href="#cdktf.CloudBackend.property.cdktfStack">cdktfStack</a></code>             | <code><a href="#cdktf.TerraformStack">TerraformStack</a></code> | _No description._ |
+| <code><a href="#cdktf.CloudBackend.property.fqn">fqn</a></code>                           | <code>java.lang.String</code>                                   | _No description._ |
+| <code><a href="#cdktf.CloudBackend.property.friendlyUniqueId">friendlyUniqueId</a></code> | <code>java.lang.String</code>                                   | _No description._ |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="cdktf.CloudBackend.property.node"></a>
+
+```java
+public Node getNode();
+```
+
+- _Type:_ software.constructs.Node
+
+The tree node.
+
+---
+
+##### `cdktfStack`<sup>Required</sup> <a name="cdktfStack" id="cdktf.CloudBackend.property.cdktfStack"></a>
+
+```java
+public TerraformStack getCdktfStack();
+```
+
+- _Type:_ <a href="#cdktf.TerraformStack">TerraformStack</a>
+
+---
+
+##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.CloudBackend.property.fqn"></a>
+
+```java
+public java.lang.String getFqn();
+```
+
+- _Type:_ java.lang.String
+
+---
+
+##### `friendlyUniqueId`<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.CloudBackend.property.friendlyUniqueId"></a>
+
+```java
+public java.lang.String getFriendlyUniqueId();
+```
+
+- _Type:_ java.lang.String
+
+---
+
 ### ConsulBackend <a name="ConsulBackend" id="cdktf.ConsulBackend"></a>
 
 #### Initializers <a name="Initializers" id="cdktf.ConsulBackend.Initializer"></a>
@@ -6584,6 +6867,9 @@ DataTerraformRemoteStateS3.Builder.create(Construct scope, java.lang.String id)
 //  .accessKey(java.lang.String)
 //  .acl(java.lang.String)
 //  .assumeRolePolicy(java.lang.String)
+//  .assumeRolePolicyArns(java.util.List< java.lang.String >)
+//  .assumeRoleTags(java.util.Map< java.lang.String, java.lang.String >)
+//  .assumeRoleTransitiveTagKeys(java.util.List< java.lang.String >)
 //  .dynamodbEndpoint(java.lang.String)
 //  .dynamodbTable(java.lang.String)
 //  .encrypt(java.lang.Boolean)
@@ -6601,6 +6887,7 @@ DataTerraformRemoteStateS3.Builder.create(Construct scope, java.lang.String id)
 //  .sharedCredentialsFile(java.lang.String)
 //  .skipCredentialsValidation(java.lang.Boolean)
 //  .skipMetadataApiCheck(java.lang.Boolean)
+//  .skipRegionValidation(java.lang.Boolean)
 //  .sseCustomerKey(java.lang.String)
 //  .stsEndpoint(java.lang.String)
 //  .token(java.lang.String)
@@ -6608,38 +6895,42 @@ DataTerraformRemoteStateS3.Builder.create(Construct scope, java.lang.String id)
     .build();
 ```
 
-| **Name**                                                                                                                               | **Type**                                                         | **Description**                                                                                                                                                                                                                                                |
-| -------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.scope">scope</a></code>                                         | <code>software.constructs.Construct</code>                       | _No description._                                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.id">id</a></code>                                               | <code>java.lang.String</code>                                    | _No description._                                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.defaults">defaults</a></code>                                   | <code>java.util.Map< java.lang.String, java.lang.Object ></code> | _No description._                                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.workspace">workspace</a></code>                                 | <code>java.lang.String</code>                                    | _No description._                                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.bucket">bucket</a></code>                                       | <code>java.lang.String</code>                                    | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.key">key</a></code>                                             | <code>java.lang.String</code>                                    | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.accessKey">accessKey</a></code>                                 | <code>java.lang.String</code>                                    | (Optional) AWS access key.                                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.acl">acl</a></code>                                             | <code>java.lang.String</code>                                    | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.assumeRolePolicy">assumeRolePolicy</a></code>                   | <code>java.lang.String</code>                                    | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.dynamodbEndpoint">dynamodbEndpoint</a></code>                   | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.dynamodbTable">dynamodbTable</a></code>                         | <code>java.lang.String</code>                                    | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.encrypt">encrypt</a></code>                                     | <code>java.lang.Boolean</code>                                   | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.endpoint">endpoint</a></code>                                   | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.externalId">externalId</a></code>                               | <code>java.lang.String</code>                                    | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.forcePathStyle">forcePathStyle</a></code>                       | <code>java.lang.Boolean</code>                                   | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.iamEndpoint">iamEndpoint</a></code>                             | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.kmsKeyId">kmsKeyId</a></code>                                   | <code>java.lang.String</code>                                    | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.maxRetries">maxRetries</a></code>                               | <code>java.lang.Number</code>                                    | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.profile">profile</a></code>                                     | <code>java.lang.String</code>                                    | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.region">region</a></code>                                       | <code>java.lang.String</code>                                    | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.roleArn">roleArn</a></code>                                     | <code>java.lang.String</code>                                    | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.secretKey">secretKey</a></code>                                 | <code>java.lang.String</code>                                    | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.sessionName">sessionName</a></code>                             | <code>java.lang.String</code>                                    | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.sharedCredentialsFile">sharedCredentialsFile</a></code>         | <code>java.lang.String</code>                                    | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.skipCredentialsValidation">skipCredentialsValidation</a></code> | <code>java.lang.Boolean</code>                                   | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.skipMetadataApiCheck">skipMetadataApiCheck</a></code>           | <code>java.lang.Boolean</code>                                   | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.sseCustomerKey">sseCustomerKey</a></code>                       | <code>java.lang.String</code>                                    | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.stsEndpoint">stsEndpoint</a></code>                             | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.token">token</a></code>                                         | <code>java.lang.String</code>                                    | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.workspaceKeyPrefix">workspaceKeyPrefix</a></code>               | <code>java.lang.String</code>                                    | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
+| **Name**                                                                                                                                   | **Type**                                                         | **Description**                                                                                                                                                                                                                                                |
+| ------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.scope">scope</a></code>                                             | <code>software.constructs.Construct</code>                       | _No description._                                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.id">id</a></code>                                                   | <code>java.lang.String</code>                                    | _No description._                                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.defaults">defaults</a></code>                                       | <code>java.util.Map< java.lang.String, java.lang.Object ></code> | _No description._                                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.workspace">workspace</a></code>                                     | <code>java.lang.String</code>                                    | _No description._                                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.bucket">bucket</a></code>                                           | <code>java.lang.String</code>                                    | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.key">key</a></code>                                                 | <code>java.lang.String</code>                                    | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.accessKey">accessKey</a></code>                                     | <code>java.lang.String</code>                                    | (Optional) AWS access key.                                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.acl">acl</a></code>                                                 | <code>java.lang.String</code>                                    | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.assumeRolePolicy">assumeRolePolicy</a></code>                       | <code>java.lang.String</code>                                    | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.assumeRolePolicyArns">assumeRolePolicyArns</a></code>               | <code>java.util.List< java.lang.String ></code>                  | (Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.                                                                                                                      |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.assumeRoleTags">assumeRoleTags</a></code>                           | <code>java.util.Map< java.lang.String, java.lang.String ></code> | (Optional) Map of assume role session tags.                                                                                                                                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.assumeRoleTransitiveTagKeys">assumeRoleTransitiveTagKeys</a></code> | <code>java.util.List< java.lang.String ></code>                  | (Optional) Set of assume role session tag keys to pass to any subsequent sessions.                                                                                                                                                                             |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.dynamodbEndpoint">dynamodbEndpoint</a></code>                       | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.dynamodbTable">dynamodbTable</a></code>                             | <code>java.lang.String</code>                                    | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.encrypt">encrypt</a></code>                                         | <code>java.lang.Boolean</code>                                   | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.endpoint">endpoint</a></code>                                       | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.externalId">externalId</a></code>                                   | <code>java.lang.String</code>                                    | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.forcePathStyle">forcePathStyle</a></code>                           | <code>java.lang.Boolean</code>                                   | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.iamEndpoint">iamEndpoint</a></code>                                 | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.kmsKeyId">kmsKeyId</a></code>                                       | <code>java.lang.String</code>                                    | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.maxRetries">maxRetries</a></code>                                   | <code>java.lang.Number</code>                                    | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.profile">profile</a></code>                                         | <code>java.lang.String</code>                                    | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.region">region</a></code>                                           | <code>java.lang.String</code>                                    | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.roleArn">roleArn</a></code>                                         | <code>java.lang.String</code>                                    | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.secretKey">secretKey</a></code>                                     | <code>java.lang.String</code>                                    | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.sessionName">sessionName</a></code>                                 | <code>java.lang.String</code>                                    | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.sharedCredentialsFile">sharedCredentialsFile</a></code>             | <code>java.lang.String</code>                                    | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.skipCredentialsValidation">skipCredentialsValidation</a></code>     | <code>java.lang.Boolean</code>                                   | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.skipMetadataApiCheck">skipMetadataApiCheck</a></code>               | <code>java.lang.Boolean</code>                                   | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.skipRegionValidation">skipRegionValidation</a></code>               | <code>java.lang.Boolean</code>                                   | (Optional) Skip validation of provided region name.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.sseCustomerKey">sseCustomerKey</a></code>                           | <code>java.lang.String</code>                                    | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.stsEndpoint">stsEndpoint</a></code>                                 | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.token">token</a></code>                                             | <code>java.lang.String</code>                                    | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.workspaceKeyPrefix">workspaceKeyPrefix</a></code>                   | <code>java.lang.String</code>                                    | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
 
 ---
 
@@ -6712,6 +7003,30 @@ or AWS shared configuration file (e.g. ~/.aws/config).
 - _Type:_ java.lang.String
 
 (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `assumeRolePolicyArns`<sup>Optional</sup> <a name="assumeRolePolicyArns" id="cdktf.DataTerraformRemoteStateS3.Initializer.parameter.assumeRolePolicyArns"></a>
+
+- _Type:_ java.util.List< java.lang.String >
+
+(Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `assumeRoleTags`<sup>Optional</sup> <a name="assumeRoleTags" id="cdktf.DataTerraformRemoteStateS3.Initializer.parameter.assumeRoleTags"></a>
+
+- _Type:_ java.util.Map< java.lang.String, java.lang.String >
+
+(Optional) Map of assume role session tags.
+
+---
+
+##### `assumeRoleTransitiveTagKeys`<sup>Optional</sup> <a name="assumeRoleTransitiveTagKeys" id="cdktf.DataTerraformRemoteStateS3.Initializer.parameter.assumeRoleTransitiveTagKeys"></a>
+
+- _Type:_ java.util.List< java.lang.String >
+
+(Optional) Set of assume role session tag keys to pass to any subsequent sessions.
 
 ---
 
@@ -6874,6 +7189,14 @@ Defaults to ~/.aws/credentials.
 - _Type:_ java.lang.Boolean
 
 (Optional) Skip usage of EC2 Metadata API.
+
+---
+
+##### `skipRegionValidation`<sup>Optional</sup> <a name="skipRegionValidation" id="cdktf.DataTerraformRemoteStateS3.Initializer.parameter.skipRegionValidation"></a>
+
+- _Type:_ java.lang.Boolean
+
+(Optional) Skip validation of provided region name.
 
 ---
 
@@ -10459,7 +10782,7 @@ new Resource(Construct scope, java.lang.String id);
 
 ---
 
-##### `toString` <a name="toString" id="cdktf.Resource.toString"></a>
+##### ~~`toString`~~ <a name="toString" id="cdktf.Resource.toString"></a>
 
 ```java
 public java.lang.String toString()
@@ -10475,7 +10798,7 @@ Returns a string representation of this construct.
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdktf.Resource.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdktf.Resource.isConstruct"></a>
 
 ```java
 import com.hashicorp.cdktf.Resource;
@@ -10516,7 +10839,9 @@ Any object.
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.Resource.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.Resource.property.node"></a>
+
+- _Deprecated:_ - Please use Construct from the constructs package instead.
 
 ```java
 public Node getNode();
@@ -10528,7 +10853,9 @@ The tree node.
 
 ---
 
-##### `stack`<sup>Required</sup> <a name="stack" id="cdktf.Resource.property.stack"></a>
+##### ~~`stack`~~<sup>Required</sup> <a name="stack" id="cdktf.Resource.property.stack"></a>
+
+- _Deprecated:_ - Please use Construct from the constructs package instead.
 
 ```java
 public TerraformStack getStack();
@@ -10553,6 +10880,9 @@ S3Backend.Builder.create(Construct scope)
 //  .accessKey(java.lang.String)
 //  .acl(java.lang.String)
 //  .assumeRolePolicy(java.lang.String)
+//  .assumeRolePolicyArns(java.util.List< java.lang.String >)
+//  .assumeRoleTags(java.util.Map< java.lang.String, java.lang.String >)
+//  .assumeRoleTransitiveTagKeys(java.util.List< java.lang.String >)
 //  .dynamodbEndpoint(java.lang.String)
 //  .dynamodbTable(java.lang.String)
 //  .encrypt(java.lang.Boolean)
@@ -10570,6 +10900,7 @@ S3Backend.Builder.create(Construct scope)
 //  .sharedCredentialsFile(java.lang.String)
 //  .skipCredentialsValidation(java.lang.Boolean)
 //  .skipMetadataApiCheck(java.lang.Boolean)
+//  .skipRegionValidation(java.lang.Boolean)
 //  .sseCustomerKey(java.lang.String)
 //  .stsEndpoint(java.lang.String)
 //  .token(java.lang.String)
@@ -10577,35 +10908,39 @@ S3Backend.Builder.create(Construct scope)
     .build();
 ```
 
-| **Name**                                                                                                              | **Type**                                   | **Description**                                                                                                                                                                                                                                                |
-| --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.scope">scope</a></code>                                         | <code>software.constructs.Construct</code> | _No description._                                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.bucket">bucket</a></code>                                       | <code>java.lang.String</code>              | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.key">key</a></code>                                             | <code>java.lang.String</code>              | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.accessKey">accessKey</a></code>                                 | <code>java.lang.String</code>              | (Optional) AWS access key.                                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.acl">acl</a></code>                                             | <code>java.lang.String</code>              | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.assumeRolePolicy">assumeRolePolicy</a></code>                   | <code>java.lang.String</code>              | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.dynamodbEndpoint">dynamodbEndpoint</a></code>                   | <code>java.lang.String</code>              | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.dynamodbTable">dynamodbTable</a></code>                         | <code>java.lang.String</code>              | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.encrypt">encrypt</a></code>                                     | <code>java.lang.Boolean</code>             | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.endpoint">endpoint</a></code>                                   | <code>java.lang.String</code>              | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.externalId">externalId</a></code>                               | <code>java.lang.String</code>              | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.forcePathStyle">forcePathStyle</a></code>                       | <code>java.lang.Boolean</code>             | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.iamEndpoint">iamEndpoint</a></code>                             | <code>java.lang.String</code>              | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.kmsKeyId">kmsKeyId</a></code>                                   | <code>java.lang.String</code>              | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.maxRetries">maxRetries</a></code>                               | <code>java.lang.Number</code>              | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.profile">profile</a></code>                                     | <code>java.lang.String</code>              | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.region">region</a></code>                                       | <code>java.lang.String</code>              | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.roleArn">roleArn</a></code>                                     | <code>java.lang.String</code>              | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.secretKey">secretKey</a></code>                                 | <code>java.lang.String</code>              | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.sessionName">sessionName</a></code>                             | <code>java.lang.String</code>              | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.sharedCredentialsFile">sharedCredentialsFile</a></code>         | <code>java.lang.String</code>              | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.skipCredentialsValidation">skipCredentialsValidation</a></code> | <code>java.lang.Boolean</code>             | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.skipMetadataApiCheck">skipMetadataApiCheck</a></code>           | <code>java.lang.Boolean</code>             | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.sseCustomerKey">sseCustomerKey</a></code>                       | <code>java.lang.String</code>              | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.stsEndpoint">stsEndpoint</a></code>                             | <code>java.lang.String</code>              | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.token">token</a></code>                                         | <code>java.lang.String</code>              | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.workspaceKeyPrefix">workspaceKeyPrefix</a></code>               | <code>java.lang.String</code>              | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
+| **Name**                                                                                                                  | **Type**                                                         | **Description**                                                                                                                                                                                                                                                |
+| ------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.scope">scope</a></code>                                             | <code>software.constructs.Construct</code>                       | _No description._                                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.bucket">bucket</a></code>                                           | <code>java.lang.String</code>                                    | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.key">key</a></code>                                                 | <code>java.lang.String</code>                                    | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.accessKey">accessKey</a></code>                                     | <code>java.lang.String</code>                                    | (Optional) AWS access key.                                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.acl">acl</a></code>                                                 | <code>java.lang.String</code>                                    | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.assumeRolePolicy">assumeRolePolicy</a></code>                       | <code>java.lang.String</code>                                    | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.assumeRolePolicyArns">assumeRolePolicyArns</a></code>               | <code>java.util.List< java.lang.String ></code>                  | (Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.                                                                                                                      |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.assumeRoleTags">assumeRoleTags</a></code>                           | <code>java.util.Map< java.lang.String, java.lang.String ></code> | (Optional) Map of assume role session tags.                                                                                                                                                                                                                    |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.assumeRoleTransitiveTagKeys">assumeRoleTransitiveTagKeys</a></code> | <code>java.util.List< java.lang.String ></code>                  | (Optional) Set of assume role session tag keys to pass to any subsequent sessions.                                                                                                                                                                             |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.dynamodbEndpoint">dynamodbEndpoint</a></code>                       | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.dynamodbTable">dynamodbTable</a></code>                             | <code>java.lang.String</code>                                    | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.encrypt">encrypt</a></code>                                         | <code>java.lang.Boolean</code>                                   | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.endpoint">endpoint</a></code>                                       | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.externalId">externalId</a></code>                                   | <code>java.lang.String</code>                                    | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.forcePathStyle">forcePathStyle</a></code>                           | <code>java.lang.Boolean</code>                                   | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.iamEndpoint">iamEndpoint</a></code>                                 | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.kmsKeyId">kmsKeyId</a></code>                                       | <code>java.lang.String</code>                                    | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.maxRetries">maxRetries</a></code>                                   | <code>java.lang.Number</code>                                    | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.profile">profile</a></code>                                         | <code>java.lang.String</code>                                    | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.region">region</a></code>                                           | <code>java.lang.String</code>                                    | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.roleArn">roleArn</a></code>                                         | <code>java.lang.String</code>                                    | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.secretKey">secretKey</a></code>                                     | <code>java.lang.String</code>                                    | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.sessionName">sessionName</a></code>                                 | <code>java.lang.String</code>                                    | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.sharedCredentialsFile">sharedCredentialsFile</a></code>             | <code>java.lang.String</code>                                    | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.skipCredentialsValidation">skipCredentialsValidation</a></code>     | <code>java.lang.Boolean</code>                                   | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.skipMetadataApiCheck">skipMetadataApiCheck</a></code>               | <code>java.lang.Boolean</code>                                   | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.skipRegionValidation">skipRegionValidation</a></code>               | <code>java.lang.Boolean</code>                                   | (Optional) Skip validation of provided region name.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.sseCustomerKey">sseCustomerKey</a></code>                           | <code>java.lang.String</code>                                    | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.stsEndpoint">stsEndpoint</a></code>                                 | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.token">token</a></code>                                             | <code>java.lang.String</code>                                    | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.workspaceKeyPrefix">workspaceKeyPrefix</a></code>                   | <code>java.lang.String</code>                                    | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
 
 ---
 
@@ -10660,6 +10995,30 @@ or AWS shared configuration file (e.g. ~/.aws/config).
 - _Type:_ java.lang.String
 
 (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `assumeRolePolicyArns`<sup>Optional</sup> <a name="assumeRolePolicyArns" id="cdktf.S3Backend.Initializer.parameter.assumeRolePolicyArns"></a>
+
+- _Type:_ java.util.List< java.lang.String >
+
+(Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `assumeRoleTags`<sup>Optional</sup> <a name="assumeRoleTags" id="cdktf.S3Backend.Initializer.parameter.assumeRoleTags"></a>
+
+- _Type:_ java.util.Map< java.lang.String, java.lang.String >
+
+(Optional) Map of assume role session tags.
+
+---
+
+##### `assumeRoleTransitiveTagKeys`<sup>Optional</sup> <a name="assumeRoleTransitiveTagKeys" id="cdktf.S3Backend.Initializer.parameter.assumeRoleTransitiveTagKeys"></a>
+
+- _Type:_ java.util.List< java.lang.String >
+
+(Optional) Set of assume role session tag keys to pass to any subsequent sessions.
 
 ---
 
@@ -10822,6 +11181,14 @@ Defaults to ~/.aws/credentials.
 - _Type:_ java.lang.Boolean
 
 (Optional) Skip usage of EC2 Metadata API.
+
+---
+
+##### `skipRegionValidation`<sup>Optional</sup> <a name="skipRegionValidation" id="cdktf.S3Backend.Initializer.parameter.skipRegionValidation"></a>
+
+- _Type:_ java.lang.Boolean
+
+(Optional) Skip validation of provided region name.
 
 ---
 
@@ -11643,14 +12010,13 @@ Any object.
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                      | **Type**                                                        | **Description**                                                                                                    |
-| ----------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| <code><a href="#cdktf.TerraformAsset.property.node">node</a></code>           | <code>software.constructs.Node</code>                           | The tree node.                                                                                                     |
-| <code><a href="#cdktf.TerraformAsset.property.stack">stack</a></code>         | <code><a href="#cdktf.TerraformStack">TerraformStack</a></code> | The stack in which this resource is defined.                                                                       |
-| <code><a href="#cdktf.TerraformAsset.property.fileName">fileName</a></code>   | <code>java.lang.String</code>                                   | Name of the asset.                                                                                                 |
-| <code><a href="#cdktf.TerraformAsset.property.path">path</a></code>           | <code>java.lang.String</code>                                   | The path relative to the root of the terraform directory in posix format Use this property to reference the asset. |
-| <code><a href="#cdktf.TerraformAsset.property.assetHash">assetHash</a></code> | <code>java.lang.String</code>                                   | _No description._                                                                                                  |
-| <code><a href="#cdktf.TerraformAsset.property.type">type</a></code>           | <code><a href="#cdktf.AssetType">AssetType</a></code>           | _No description._                                                                                                  |
+| **Name**                                                                      | **Type**                                              | **Description**                                                                                                    |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| <code><a href="#cdktf.TerraformAsset.property.node">node</a></code>           | <code>software.constructs.Node</code>                 | The tree node.                                                                                                     |
+| <code><a href="#cdktf.TerraformAsset.property.fileName">fileName</a></code>   | <code>java.lang.String</code>                         | Name of the asset.                                                                                                 |
+| <code><a href="#cdktf.TerraformAsset.property.path">path</a></code>           | <code>java.lang.String</code>                         | The path relative to the root of the terraform directory in posix format Use this property to reference the asset. |
+| <code><a href="#cdktf.TerraformAsset.property.assetHash">assetHash</a></code> | <code>java.lang.String</code>                         | _No description._                                                                                                  |
+| <code><a href="#cdktf.TerraformAsset.property.type">type</a></code>           | <code><a href="#cdktf.AssetType">AssetType</a></code> | _No description._                                                                                                  |
 
 ---
 
@@ -11663,18 +12029,6 @@ public Node getNode();
 - _Type:_ software.constructs.Node
 
 The tree node.
-
----
-
-##### `stack`<sup>Required</sup> <a name="stack" id="cdktf.TerraformAsset.property.stack"></a>
-
-```java
-public TerraformStack getStack();
-```
-
-- _Type:_ <a href="#cdktf.TerraformStack">TerraformStack</a>
-
-The stack in which this resource is defined.
 
 ---
 
@@ -15184,6 +15538,7 @@ new TerraformStack(Construct scope, java.lang.String id);
 | <code><a href="#cdktf.TerraformStack.prepareStack">prepareStack</a></code>                                               | _No description._                                  |
 | <code><a href="#cdktf.TerraformStack.registerIncomingCrossStackReference">registerIncomingCrossStackReference</a></code> | _No description._                                  |
 | <code><a href="#cdktf.TerraformStack.registerOutgoingCrossStackReference">registerOutgoingCrossStackReference</a></code> | _No description._                                  |
+| <code><a href="#cdktf.TerraformStack.runAllValidations">runAllValidations</a></code>                                     | Run all validations on the stack.                  |
 | <code><a href="#cdktf.TerraformStack.toTerraform">toTerraform</a></code>                                                 | _No description._                                  |
 
 ---
@@ -15291,6 +15646,14 @@ public TerraformOutput registerOutgoingCrossStackReference(java.lang.String iden
 - _Type:_ java.lang.String
 
 ---
+
+##### `runAllValidations` <a name="runAllValidations" id="cdktf.TerraformStack.runAllValidations"></a>
+
+```java
+public void runAllValidations()
+```
+
+Run all validations on the stack.
 
 ##### `toTerraform` <a name="toTerraform" id="cdktf.TerraformStack.toTerraform"></a>
 
@@ -16254,6 +16617,90 @@ public java.lang.Boolean getUseMsi();
 (Optional) Should Managed Service Identity authentication be used?
 
 This can also be sourced from the ARM_USE_MSI environment variable.
+
+---
+
+### CloudBackendProps <a name="CloudBackendProps" id="cdktf.CloudBackendProps"></a>
+
+The Cloud Backend synthesizes a {@link https://www.terraform.io/cli/cloud/settings#the-cloud-block cloud block}. The cloud block is a nested block within the top-level terraform settings block. It specifies which Terraform Cloud workspaces to use for the current working directory. The cloud block only affects Terraform CLI's behavior. When Terraform Cloud uses a configuration that contains a cloud block - for example, when a workspace is configured to use a VCS provider directly - it ignores the block and behaves according to its own workspace settings.
+
+https://www.terraform.io/cli/cloud/settings#arguments
+
+#### Initializer <a name="Initializer" id="cdktf.CloudBackendProps.Initializer"></a>
+
+```java
+import com.hashicorp.cdktf.CloudBackendProps;
+
+CloudBackendProps.builder()
+    .organization(java.lang.String)
+    .workspaces(NamedCloudWorkspace)
+    .workspaces(TaggedCloudWorkspaces)
+//  .hostname(java.lang.String)
+//  .token(java.lang.String)
+    .build();
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name**                                                                               | **Type**                                                                                                                                      | **Description**                                                                                             |
+| -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.CloudBackendProps.property.organization">organization</a></code> | <code>java.lang.String</code>                                                                                                                 | The name of the organization containing the workspace(s) the current configuration should use.              |
+| <code><a href="#cdktf.CloudBackendProps.property.workspaces">workspaces</a></code>     | <code><a href="#cdktf.NamedCloudWorkspace">NamedCloudWorkspace</a> OR <a href="#cdktf.TaggedCloudWorkspaces">TaggedCloudWorkspaces</a></code> | A nested block that specifies which remote Terraform Cloud workspaces to use for the current configuration. |
+| <code><a href="#cdktf.CloudBackendProps.property.hostname">hostname</a></code>         | <code>java.lang.String</code>                                                                                                                 | The hostname of a Terraform Enterprise installation, if using Terraform Enterprise.                         |
+| <code><a href="#cdktf.CloudBackendProps.property.token">token</a></code>               | <code>java.lang.String</code>                                                                                                                 | The token used to authenticate with Terraform Cloud.                                                        |
+
+---
+
+##### `organization`<sup>Required</sup> <a name="organization" id="cdktf.CloudBackendProps.property.organization"></a>
+
+```java
+public java.lang.String getOrganization();
+```
+
+- _Type:_ java.lang.String
+
+The name of the organization containing the workspace(s) the current configuration should use.
+
+---
+
+##### `workspaces`<sup>Required</sup> <a name="workspaces" id="cdktf.CloudBackendProps.property.workspaces"></a>
+
+```java
+public java.lang.Object getWorkspaces();
+```
+
+- _Type:_ <a href="#cdktf.NamedCloudWorkspace">NamedCloudWorkspace</a> OR <a href="#cdktf.TaggedCloudWorkspaces">TaggedCloudWorkspaces</a>
+
+A nested block that specifies which remote Terraform Cloud workspaces to use for the current configuration.
+
+The workspaces block must contain exactly one of the following arguments, each denoting a strategy for how workspaces should be mapped:
+
+---
+
+##### `hostname`<sup>Optional</sup> <a name="hostname" id="cdktf.CloudBackendProps.property.hostname"></a>
+
+```java
+public java.lang.String getHostname();
+```
+
+- _Type:_ java.lang.String
+- _Default:_ app.terraform.io
+
+The hostname of a Terraform Enterprise installation, if using Terraform Enterprise.
+
+---
+
+##### `token`<sup>Optional</sup> <a name="token" id="cdktf.CloudBackendProps.property.token"></a>
+
+```java
+public java.lang.String getToken();
+```
+
+- _Type:_ java.lang.String
+
+The token used to authenticate with Terraform Cloud.
+
+We recommend omitting the token from the configuration, and instead using terraform login or manually configuring credentials in the CLI config file.
 
 ---
 
@@ -18656,6 +19103,9 @@ DataTerraformRemoteStateS3Config.builder()
 //  .accessKey(java.lang.String)
 //  .acl(java.lang.String)
 //  .assumeRolePolicy(java.lang.String)
+//  .assumeRolePolicyArns(java.util.List< java.lang.String >)
+//  .assumeRoleTags(java.util.Map< java.lang.String, java.lang.String >)
+//  .assumeRoleTransitiveTagKeys(java.util.List< java.lang.String >)
 //  .dynamodbEndpoint(java.lang.String)
 //  .dynamodbTable(java.lang.String)
 //  .encrypt(java.lang.Boolean)
@@ -18673,6 +19123,7 @@ DataTerraformRemoteStateS3Config.builder()
 //  .sharedCredentialsFile(java.lang.String)
 //  .skipCredentialsValidation(java.lang.Boolean)
 //  .skipMetadataApiCheck(java.lang.Boolean)
+//  .skipRegionValidation(java.lang.Boolean)
 //  .sseCustomerKey(java.lang.String)
 //  .stsEndpoint(java.lang.String)
 //  .token(java.lang.String)
@@ -18682,36 +19133,40 @@ DataTerraformRemoteStateS3Config.builder()
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                                                        | **Type**                                                         | **Description**                                                                                                                                                                                                                                                |
-| ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.defaults">defaults</a></code>                                   | <code>java.util.Map< java.lang.String, java.lang.Object ></code> | _No description._                                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.workspace">workspace</a></code>                                 | <code>java.lang.String</code>                                    | _No description._                                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.bucket">bucket</a></code>                                       | <code>java.lang.String</code>                                    | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.key">key</a></code>                                             | <code>java.lang.String</code>                                    | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.accessKey">accessKey</a></code>                                 | <code>java.lang.String</code>                                    | (Optional) AWS access key.                                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.acl">acl</a></code>                                             | <code>java.lang.String</code>                                    | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRolePolicy">assumeRolePolicy</a></code>                   | <code>java.lang.String</code>                                    | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.dynamodbEndpoint">dynamodbEndpoint</a></code>                   | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.dynamodbTable">dynamodbTable</a></code>                         | <code>java.lang.String</code>                                    | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.encrypt">encrypt</a></code>                                     | <code>java.lang.Boolean</code>                                   | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.endpoint">endpoint</a></code>                                   | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.externalId">externalId</a></code>                               | <code>java.lang.String</code>                                    | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.forcePathStyle">forcePathStyle</a></code>                       | <code>java.lang.Boolean</code>                                   | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.iamEndpoint">iamEndpoint</a></code>                             | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.kmsKeyId">kmsKeyId</a></code>                                   | <code>java.lang.String</code>                                    | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.maxRetries">maxRetries</a></code>                               | <code>java.lang.Number</code>                                    | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.profile">profile</a></code>                                     | <code>java.lang.String</code>                                    | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.region">region</a></code>                                       | <code>java.lang.String</code>                                    | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.roleArn">roleArn</a></code>                                     | <code>java.lang.String</code>                                    | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.secretKey">secretKey</a></code>                                 | <code>java.lang.String</code>                                    | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sessionName">sessionName</a></code>                             | <code>java.lang.String</code>                                    | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sharedCredentialsFile">sharedCredentialsFile</a></code>         | <code>java.lang.String</code>                                    | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipCredentialsValidation">skipCredentialsValidation</a></code> | <code>java.lang.Boolean</code>                                   | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipMetadataApiCheck">skipMetadataApiCheck</a></code>           | <code>java.lang.Boolean</code>                                   | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sseCustomerKey">sseCustomerKey</a></code>                       | <code>java.lang.String</code>                                    | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.stsEndpoint">stsEndpoint</a></code>                             | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.token">token</a></code>                                         | <code>java.lang.String</code>                                    | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.workspaceKeyPrefix">workspaceKeyPrefix</a></code>               | <code>java.lang.String</code>                                    | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
+| **Name**                                                                                                                            | **Type**                                                         | **Description**                                                                                                                                                                                                                                                |
+| ----------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.defaults">defaults</a></code>                                       | <code>java.util.Map< java.lang.String, java.lang.Object ></code> | _No description._                                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.workspace">workspace</a></code>                                     | <code>java.lang.String</code>                                    | _No description._                                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.bucket">bucket</a></code>                                           | <code>java.lang.String</code>                                    | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.key">key</a></code>                                                 | <code>java.lang.String</code>                                    | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.accessKey">accessKey</a></code>                                     | <code>java.lang.String</code>                                    | (Optional) AWS access key.                                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.acl">acl</a></code>                                                 | <code>java.lang.String</code>                                    | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRolePolicy">assumeRolePolicy</a></code>                       | <code>java.lang.String</code>                                    | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRolePolicyArns">assumeRolePolicyArns</a></code>               | <code>java.util.List< java.lang.String ></code>                  | (Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.                                                                                                                      |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRoleTags">assumeRoleTags</a></code>                           | <code>java.util.Map< java.lang.String, java.lang.String ></code> | (Optional) Map of assume role session tags.                                                                                                                                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRoleTransitiveTagKeys">assumeRoleTransitiveTagKeys</a></code> | <code>java.util.List< java.lang.String ></code>                  | (Optional) Set of assume role session tag keys to pass to any subsequent sessions.                                                                                                                                                                             |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.dynamodbEndpoint">dynamodbEndpoint</a></code>                       | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.dynamodbTable">dynamodbTable</a></code>                             | <code>java.lang.String</code>                                    | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.encrypt">encrypt</a></code>                                         | <code>java.lang.Boolean</code>                                   | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.endpoint">endpoint</a></code>                                       | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.externalId">externalId</a></code>                                   | <code>java.lang.String</code>                                    | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.forcePathStyle">forcePathStyle</a></code>                           | <code>java.lang.Boolean</code>                                   | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.iamEndpoint">iamEndpoint</a></code>                                 | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.kmsKeyId">kmsKeyId</a></code>                                       | <code>java.lang.String</code>                                    | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.maxRetries">maxRetries</a></code>                                   | <code>java.lang.Number</code>                                    | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.profile">profile</a></code>                                         | <code>java.lang.String</code>                                    | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.region">region</a></code>                                           | <code>java.lang.String</code>                                    | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.roleArn">roleArn</a></code>                                         | <code>java.lang.String</code>                                    | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.secretKey">secretKey</a></code>                                     | <code>java.lang.String</code>                                    | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sessionName">sessionName</a></code>                                 | <code>java.lang.String</code>                                    | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sharedCredentialsFile">sharedCredentialsFile</a></code>             | <code>java.lang.String</code>                                    | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipCredentialsValidation">skipCredentialsValidation</a></code>     | <code>java.lang.Boolean</code>                                   | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipMetadataApiCheck">skipMetadataApiCheck</a></code>               | <code>java.lang.Boolean</code>                                   | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipRegionValidation">skipRegionValidation</a></code>               | <code>java.lang.Boolean</code>                                   | (Optional) Skip validation of provided region name.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sseCustomerKey">sseCustomerKey</a></code>                           | <code>java.lang.String</code>                                    | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.stsEndpoint">stsEndpoint</a></code>                                 | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.token">token</a></code>                                             | <code>java.lang.String</code>                                    | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.workspaceKeyPrefix">workspaceKeyPrefix</a></code>                   | <code>java.lang.String</code>                                    | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
 
 ---
 
@@ -18800,6 +19255,42 @@ public java.lang.String getAssumeRolePolicy();
 - _Type:_ java.lang.String
 
 (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `assumeRolePolicyArns`<sup>Optional</sup> <a name="assumeRolePolicyArns" id="cdktf.DataTerraformRemoteStateS3Config.property.assumeRolePolicyArns"></a>
+
+```java
+public java.util.List< java.lang.String > getAssumeRolePolicyArns();
+```
+
+- _Type:_ java.util.List< java.lang.String >
+
+(Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `assumeRoleTags`<sup>Optional</sup> <a name="assumeRoleTags" id="cdktf.DataTerraformRemoteStateS3Config.property.assumeRoleTags"></a>
+
+```java
+public java.util.Map< java.lang.String, java.lang.String > getAssumeRoleTags();
+```
+
+- _Type:_ java.util.Map< java.lang.String, java.lang.String >
+
+(Optional) Map of assume role session tags.
+
+---
+
+##### `assumeRoleTransitiveTagKeys`<sup>Optional</sup> <a name="assumeRoleTransitiveTagKeys" id="cdktf.DataTerraformRemoteStateS3Config.property.assumeRoleTransitiveTagKeys"></a>
+
+```java
+public java.util.List< java.lang.String > getAssumeRoleTransitiveTagKeys();
+```
+
+- _Type:_ java.util.List< java.lang.String >
+
+(Optional) Set of assume role session tag keys to pass to any subsequent sessions.
 
 ---
 
@@ -19030,6 +19521,18 @@ public java.lang.Boolean getSkipMetadataApiCheck();
 - _Type:_ java.lang.Boolean
 
 (Optional) Skip usage of EC2 Metadata API.
+
+---
+
+##### `skipRegionValidation`<sup>Optional</sup> <a name="skipRegionValidation" id="cdktf.DataTerraformRemoteStateS3Config.property.skipRegionValidation"></a>
+
+```java
+public java.lang.Boolean getSkipRegionValidation();
+```
+
+- _Type:_ java.lang.Boolean
+
+(Optional) Skip validation of provided region name.
 
 ---
 
@@ -21198,6 +21701,9 @@ S3BackendProps.builder()
 //  .accessKey(java.lang.String)
 //  .acl(java.lang.String)
 //  .assumeRolePolicy(java.lang.String)
+//  .assumeRolePolicyArns(java.util.List< java.lang.String >)
+//  .assumeRoleTags(java.util.Map< java.lang.String, java.lang.String >)
+//  .assumeRoleTransitiveTagKeys(java.util.List< java.lang.String >)
 //  .dynamodbEndpoint(java.lang.String)
 //  .dynamodbTable(java.lang.String)
 //  .encrypt(java.lang.Boolean)
@@ -21215,6 +21721,7 @@ S3BackendProps.builder()
 //  .sharedCredentialsFile(java.lang.String)
 //  .skipCredentialsValidation(java.lang.Boolean)
 //  .skipMetadataApiCheck(java.lang.Boolean)
+//  .skipRegionValidation(java.lang.Boolean)
 //  .sseCustomerKey(java.lang.String)
 //  .stsEndpoint(java.lang.String)
 //  .token(java.lang.String)
@@ -21224,34 +21731,38 @@ S3BackendProps.builder()
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                                      | **Type**                       | **Description**                                                                                                                                                                                                                                                |
-| ------------------------------------------------------------------------------------------------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.S3BackendProps.property.bucket">bucket</a></code>                                       | <code>java.lang.String</code>  | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
-| <code><a href="#cdktf.S3BackendProps.property.key">key</a></code>                                             | <code>java.lang.String</code>  | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
-| <code><a href="#cdktf.S3BackendProps.property.accessKey">accessKey</a></code>                                 | <code>java.lang.String</code>  | (Optional) AWS access key.                                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.S3BackendProps.property.acl">acl</a></code>                                             | <code>java.lang.String</code>  | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.S3BackendProps.property.assumeRolePolicy">assumeRolePolicy</a></code>                   | <code>java.lang.String</code>  | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
-| <code><a href="#cdktf.S3BackendProps.property.dynamodbEndpoint">dynamodbEndpoint</a></code>                   | <code>java.lang.String</code>  | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
-| <code><a href="#cdktf.S3BackendProps.property.dynamodbTable">dynamodbTable</a></code>                         | <code>java.lang.String</code>  | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
-| <code><a href="#cdktf.S3BackendProps.property.encrypt">encrypt</a></code>                                     | <code>java.lang.Boolean</code> | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
-| <code><a href="#cdktf.S3BackendProps.property.endpoint">endpoint</a></code>                                   | <code>java.lang.String</code>  | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
-| <code><a href="#cdktf.S3BackendProps.property.externalId">externalId</a></code>                               | <code>java.lang.String</code>  | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
-| <code><a href="#cdktf.S3BackendProps.property.forcePathStyle">forcePathStyle</a></code>                       | <code>java.lang.Boolean</code> | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
-| <code><a href="#cdktf.S3BackendProps.property.iamEndpoint">iamEndpoint</a></code>                             | <code>java.lang.String</code>  | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
-| <code><a href="#cdktf.S3BackendProps.property.kmsKeyId">kmsKeyId</a></code>                                   | <code>java.lang.String</code>  | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
-| <code><a href="#cdktf.S3BackendProps.property.maxRetries">maxRetries</a></code>                               | <code>java.lang.Number</code>  | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
-| <code><a href="#cdktf.S3BackendProps.property.profile">profile</a></code>                                     | <code>java.lang.String</code>  | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
-| <code><a href="#cdktf.S3BackendProps.property.region">region</a></code>                                       | <code>java.lang.String</code>  | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
-| <code><a href="#cdktf.S3BackendProps.property.roleArn">roleArn</a></code>                                     | <code>java.lang.String</code>  | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
-| <code><a href="#cdktf.S3BackendProps.property.secretKey">secretKey</a></code>                                 | <code>java.lang.String</code>  | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.S3BackendProps.property.sessionName">sessionName</a></code>                             | <code>java.lang.String</code>  | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.S3BackendProps.property.sharedCredentialsFile">sharedCredentialsFile</a></code>         | <code>java.lang.String</code>  | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.S3BackendProps.property.skipCredentialsValidation">skipCredentialsValidation</a></code> | <code>java.lang.Boolean</code> | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
-| <code><a href="#cdktf.S3BackendProps.property.skipMetadataApiCheck">skipMetadataApiCheck</a></code>           | <code>java.lang.Boolean</code> | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.S3BackendProps.property.sseCustomerKey">sseCustomerKey</a></code>                       | <code>java.lang.String</code>  | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
-| <code><a href="#cdktf.S3BackendProps.property.stsEndpoint">stsEndpoint</a></code>                             | <code>java.lang.String</code>  | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
-| <code><a href="#cdktf.S3BackendProps.property.token">token</a></code>                                         | <code>java.lang.String</code>  | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.S3BackendProps.property.workspaceKeyPrefix">workspaceKeyPrefix</a></code>               | <code>java.lang.String</code>  | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
+| **Name**                                                                                                          | **Type**                                                         | **Description**                                                                                                                                                                                                                                                |
+| ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.S3BackendProps.property.bucket">bucket</a></code>                                           | <code>java.lang.String</code>                                    | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
+| <code><a href="#cdktf.S3BackendProps.property.key">key</a></code>                                                 | <code>java.lang.String</code>                                    | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
+| <code><a href="#cdktf.S3BackendProps.property.accessKey">accessKey</a></code>                                     | <code>java.lang.String</code>                                    | (Optional) AWS access key.                                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.S3BackendProps.property.acl">acl</a></code>                                                 | <code>java.lang.String</code>                                    | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.S3BackendProps.property.assumeRolePolicy">assumeRolePolicy</a></code>                       | <code>java.lang.String</code>                                    | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
+| <code><a href="#cdktf.S3BackendProps.property.assumeRolePolicyArns">assumeRolePolicyArns</a></code>               | <code>java.util.List< java.lang.String ></code>                  | (Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.                                                                                                                      |
+| <code><a href="#cdktf.S3BackendProps.property.assumeRoleTags">assumeRoleTags</a></code>                           | <code>java.util.Map< java.lang.String, java.lang.String ></code> | (Optional) Map of assume role session tags.                                                                                                                                                                                                                    |
+| <code><a href="#cdktf.S3BackendProps.property.assumeRoleTransitiveTagKeys">assumeRoleTransitiveTagKeys</a></code> | <code>java.util.List< java.lang.String ></code>                  | (Optional) Set of assume role session tag keys to pass to any subsequent sessions.                                                                                                                                                                             |
+| <code><a href="#cdktf.S3BackendProps.property.dynamodbEndpoint">dynamodbEndpoint</a></code>                       | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
+| <code><a href="#cdktf.S3BackendProps.property.dynamodbTable">dynamodbTable</a></code>                             | <code>java.lang.String</code>                                    | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
+| <code><a href="#cdktf.S3BackendProps.property.encrypt">encrypt</a></code>                                         | <code>java.lang.Boolean</code>                                   | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
+| <code><a href="#cdktf.S3BackendProps.property.endpoint">endpoint</a></code>                                       | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
+| <code><a href="#cdktf.S3BackendProps.property.externalId">externalId</a></code>                                   | <code>java.lang.String</code>                                    | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
+| <code><a href="#cdktf.S3BackendProps.property.forcePathStyle">forcePathStyle</a></code>                           | <code>java.lang.Boolean</code>                                   | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
+| <code><a href="#cdktf.S3BackendProps.property.iamEndpoint">iamEndpoint</a></code>                                 | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
+| <code><a href="#cdktf.S3BackendProps.property.kmsKeyId">kmsKeyId</a></code>                                       | <code>java.lang.String</code>                                    | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
+| <code><a href="#cdktf.S3BackendProps.property.maxRetries">maxRetries</a></code>                                   | <code>java.lang.Number</code>                                    | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
+| <code><a href="#cdktf.S3BackendProps.property.profile">profile</a></code>                                         | <code>java.lang.String</code>                                    | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
+| <code><a href="#cdktf.S3BackendProps.property.region">region</a></code>                                           | <code>java.lang.String</code>                                    | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
+| <code><a href="#cdktf.S3BackendProps.property.roleArn">roleArn</a></code>                                         | <code>java.lang.String</code>                                    | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
+| <code><a href="#cdktf.S3BackendProps.property.secretKey">secretKey</a></code>                                     | <code>java.lang.String</code>                                    | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.S3BackendProps.property.sessionName">sessionName</a></code>                                 | <code>java.lang.String</code>                                    | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.S3BackendProps.property.sharedCredentialsFile">sharedCredentialsFile</a></code>             | <code>java.lang.String</code>                                    | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.S3BackendProps.property.skipCredentialsValidation">skipCredentialsValidation</a></code>     | <code>java.lang.Boolean</code>                                   | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
+| <code><a href="#cdktf.S3BackendProps.property.skipMetadataApiCheck">skipMetadataApiCheck</a></code>               | <code>java.lang.Boolean</code>                                   | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.S3BackendProps.property.skipRegionValidation">skipRegionValidation</a></code>               | <code>java.lang.Boolean</code>                                   | (Optional) Skip validation of provided region name.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.S3BackendProps.property.sseCustomerKey">sseCustomerKey</a></code>                           | <code>java.lang.String</code>                                    | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
+| <code><a href="#cdktf.S3BackendProps.property.stsEndpoint">stsEndpoint</a></code>                                 | <code>java.lang.String</code>                                    | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
+| <code><a href="#cdktf.S3BackendProps.property.token">token</a></code>                                             | <code>java.lang.String</code>                                    | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.S3BackendProps.property.workspaceKeyPrefix">workspaceKeyPrefix</a></code>                   | <code>java.lang.String</code>                                    | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
 
 ---
 
@@ -21320,6 +21831,42 @@ public java.lang.String getAssumeRolePolicy();
 - _Type:_ java.lang.String
 
 (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `assumeRolePolicyArns`<sup>Optional</sup> <a name="assumeRolePolicyArns" id="cdktf.S3BackendProps.property.assumeRolePolicyArns"></a>
+
+```java
+public java.util.List< java.lang.String > getAssumeRolePolicyArns();
+```
+
+- _Type:_ java.util.List< java.lang.String >
+
+(Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `assumeRoleTags`<sup>Optional</sup> <a name="assumeRoleTags" id="cdktf.S3BackendProps.property.assumeRoleTags"></a>
+
+```java
+public java.util.Map< java.lang.String, java.lang.String > getAssumeRoleTags();
+```
+
+- _Type:_ java.util.Map< java.lang.String, java.lang.String >
+
+(Optional) Map of assume role session tags.
+
+---
+
+##### `assumeRoleTransitiveTagKeys`<sup>Optional</sup> <a name="assumeRoleTransitiveTagKeys" id="cdktf.S3BackendProps.property.assumeRoleTransitiveTagKeys"></a>
+
+```java
+public java.util.List< java.lang.String > getAssumeRoleTransitiveTagKeys();
+```
+
+- _Type:_ java.util.List< java.lang.String >
+
+(Optional) Set of assume role session tag keys to pass to any subsequent sessions.
 
 ---
 
@@ -21550,6 +22097,18 @@ public java.lang.Boolean getSkipMetadataApiCheck();
 - _Type:_ java.lang.Boolean
 
 (Optional) Skip usage of EC2 Metadata API.
+
+---
+
+##### `skipRegionValidation`<sup>Optional</sup> <a name="skipRegionValidation" id="cdktf.S3BackendProps.property.skipRegionValidation"></a>
+
+```java
+public java.lang.Boolean getSkipRegionValidation();
+```
+
+- _Type:_ java.lang.Boolean
+
+(Optional) Skip validation of provided region name.
 
 ---
 
@@ -24654,6 +25213,37 @@ public java.lang.String getFqn();
 - _Type:_ java.lang.String
 
 ---
+
+### CloudWorkspace <a name="CloudWorkspace" id="cdktf.CloudWorkspace"></a>
+
+A cloud workspace can either be a single named workspace, or a list of tagged workspaces.
+
+#### Initializers <a name="Initializers" id="cdktf.CloudWorkspace.Initializer"></a>
+
+```java
+import com.hashicorp.cdktf.CloudWorkspace;
+
+new CloudWorkspace();
+```
+
+| **Name** | **Type** | **Description** |
+| -------- | -------- | --------------- |
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name**                                                                 | **Description**   |
+| ------------------------------------------------------------------------ | ----------------- |
+| <code><a href="#cdktf.CloudWorkspace.toTerraform">toTerraform</a></code> | _No description._ |
+
+---
+
+##### `toTerraform` <a name="toTerraform" id="cdktf.CloudWorkspace.toTerraform"></a>
+
+```java
+public java.lang.Object toTerraform()
+```
 
 ### ComplexComputedList <a name="ComplexComputedList" id="cdktf.ComplexComputedList"></a>
 
@@ -28645,6 +29235,64 @@ Returns the value of the current item iterated over.
 
 ---
 
+### NamedCloudWorkspace <a name="NamedCloudWorkspace" id="cdktf.NamedCloudWorkspace"></a>
+
+The name of a single Terraform Cloud workspace.
+
+You will only be able to use the workspace specified in the configuration with this working directory, and cannot manage workspaces from the CLI (e.g. terraform workspace select or terraform workspace new).
+
+#### Initializers <a name="Initializers" id="cdktf.NamedCloudWorkspace.Initializer"></a>
+
+```java
+import com.hashicorp.cdktf.NamedCloudWorkspace;
+
+new NamedCloudWorkspace(java.lang.String name);
+```
+
+| **Name**                                                                              | **Type**                      | **Description**   |
+| ------------------------------------------------------------------------------------- | ----------------------------- | ----------------- |
+| <code><a href="#cdktf.NamedCloudWorkspace.Initializer.parameter.name">name</a></code> | <code>java.lang.String</code> | _No description._ |
+
+---
+
+##### `name`<sup>Required</sup> <a name="name" id="cdktf.NamedCloudWorkspace.Initializer.parameter.name"></a>
+
+- _Type:_ java.lang.String
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name**                                                                      | **Description**   |
+| ----------------------------------------------------------------------------- | ----------------- |
+| <code><a href="#cdktf.NamedCloudWorkspace.toTerraform">toTerraform</a></code> | _No description._ |
+
+---
+
+##### `toTerraform` <a name="toTerraform" id="cdktf.NamedCloudWorkspace.toTerraform"></a>
+
+```java
+public java.lang.Object toTerraform()
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name**                                                                 | **Type**                      | **Description**   |
+| ------------------------------------------------------------------------ | ----------------------------- | ----------------- |
+| <code><a href="#cdktf.NamedCloudWorkspace.property.name">name</a></code> | <code>java.lang.String</code> | _No description._ |
+
+---
+
+##### `name`<sup>Required</sup> <a name="name" id="cdktf.NamedCloudWorkspace.property.name"></a>
+
+```java
+public java.lang.String getName();
+```
+
+- _Type:_ java.lang.String
+
+---
+
 ### NamedRemoteWorkspace <a name="NamedRemoteWorkspace" id="cdktf.NamedRemoteWorkspace"></a>
 
 - _Implements:_ <a href="#cdktf.IRemoteWorkspace">IRemoteWorkspace</a>
@@ -29286,6 +29934,64 @@ public java.lang.String getFqn();
 
 ---
 
+### TaggedCloudWorkspaces <a name="TaggedCloudWorkspaces" id="cdktf.TaggedCloudWorkspaces"></a>
+
+A set of Terraform Cloud workspace tags.
+
+You will be able to use this working directory with any workspaces that have all of the specified tags, and can use the terraform workspace commands to switch between them or create new workspaces. New workspaces will automatically have the specified tags. This option conflicts with name.
+
+#### Initializers <a name="Initializers" id="cdktf.TaggedCloudWorkspaces.Initializer"></a>
+
+```java
+import com.hashicorp.cdktf.TaggedCloudWorkspaces;
+
+new TaggedCloudWorkspaces(java.util.List< java.lang.String > tags);
+```
+
+| **Name**                                                                                | **Type**                                        | **Description**   |
+| --------------------------------------------------------------------------------------- | ----------------------------------------------- | ----------------- |
+| <code><a href="#cdktf.TaggedCloudWorkspaces.Initializer.parameter.tags">tags</a></code> | <code>java.util.List< java.lang.String ></code> | _No description._ |
+
+---
+
+##### `tags`<sup>Required</sup> <a name="tags" id="cdktf.TaggedCloudWorkspaces.Initializer.parameter.tags"></a>
+
+- _Type:_ java.util.List< java.lang.String >
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name**                                                                        | **Description**   |
+| ------------------------------------------------------------------------------- | ----------------- |
+| <code><a href="#cdktf.TaggedCloudWorkspaces.toTerraform">toTerraform</a></code> | _No description._ |
+
+---
+
+##### `toTerraform` <a name="toTerraform" id="cdktf.TaggedCloudWorkspaces.toTerraform"></a>
+
+```java
+public java.lang.Object toTerraform()
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name**                                                                   | **Type**                                        | **Description**   |
+| -------------------------------------------------------------------------- | ----------------------------------------------- | ----------------- |
+| <code><a href="#cdktf.TaggedCloudWorkspaces.property.tags">tags</a></code> | <code>java.util.List< java.lang.String ></code> | _No description._ |
+
+---
+
+##### `tags`<sup>Required</sup> <a name="tags" id="cdktf.TaggedCloudWorkspaces.property.tags"></a>
+
+```java
+public java.util.List< java.lang.String > getTags();
+```
+
+- _Type:_ java.util.List< java.lang.String >
+
+---
+
 ### TerraformIterator <a name="TerraformIterator" id="cdktf.TerraformIterator"></a>
 
 - _Implements:_ <a href="#cdktf.ITerraformIterator">ITerraformIterator</a>
@@ -29751,7 +30457,7 @@ Testing.stubVersion(App app)
 ```java
 import com.hashicorp.cdktf.Testing;
 
-Testing.synth(TerraformStack stack)
+Testing.synth(TerraformStack stack),Testing.synth(TerraformStack stack, java.lang.Boolean runValidations)
 ```
 
 Returns the Terraform synthesized JSON.
@@ -29759,6 +30465,12 @@ Returns the Terraform synthesized JSON.
 ###### `stack`<sup>Required</sup> <a name="stack" id="cdktf.Testing.synth.parameter.stack"></a>
 
 - _Type:_ <a href="#cdktf.TerraformStack">TerraformStack</a>
+
+---
+
+###### `runValidations`<sup>Optional</sup> <a name="runValidations" id="cdktf.Testing.synth.parameter.runValidations"></a>
+
+- _Type:_ java.lang.Boolean
 
 ---
 
@@ -31294,7 +32006,7 @@ True when ${} should be ommitted (because already inside them), false otherwise.
 
 - _Extends:_ software.constructs.IConstruct
 
-- _Implemented By:_ <a href="#cdktf.Resource">Resource</a>, <a href="#cdktf.TerraformAsset">TerraformAsset</a>, <a href="#cdktf.IResource">IResource</a>
+- _Implemented By:_ <a href="#cdktf.Resource">Resource</a>, <a href="#cdktf.IResource">IResource</a>
 
 #### Properties <a name="Properties" id="Properties"></a>
 

--- a/website/docs/cdktf/api-reference/python.mdx
+++ b/website/docs/cdktf/api-reference/python.mdx
@@ -988,6 +988,302 @@ friendly_unique_id: str
 
 ---
 
+### CloudBackend <a name="CloudBackend" id="cdktf.CloudBackend"></a>
+
+The Cloud Backend synthesizes a {@link https://www.terraform.io/cli/cloud/settings#the-cloud-block cloud block}. The cloud block is a nested block within the top-level terraform settings block. It specifies which Terraform Cloud workspaces to use for the current working directory. The cloud block only affects Terraform CLI's behavior. When Terraform Cloud uses a configuration that contains a cloud block - for example, when a workspace is configured to use a VCS provider directly - it ignores the block and behaves according to its own workspace settings.
+
+#### Initializers <a name="Initializers" id="cdktf.CloudBackend.Initializer"></a>
+
+```python
+import cdktf
+
+cdktf.CloudBackend(
+  scope: Construct,
+  organization: str,
+  workspaces: typing.Union[NamedCloudWorkspace, TaggedCloudWorkspaces],
+  hostname: str = None,
+  token: str = None
+)
+```
+
+| **Name**                                                                                       | **Type**                                                                                                                                                  | **Description**                                                                                             |
+| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.CloudBackend.Initializer.parameter.scope">scope</a></code>               | <code>constructs.Construct</code>                                                                                                                         | _No description._                                                                                           |
+| <code><a href="#cdktf.CloudBackend.Initializer.parameter.organization">organization</a></code> | <code>str</code>                                                                                                                                          | The name of the organization containing the workspace(s) the current configuration should use.              |
+| <code><a href="#cdktf.CloudBackend.Initializer.parameter.workspaces">workspaces</a></code>     | <code>typing.Union[<a href="#cdktf.NamedCloudWorkspace">NamedCloudWorkspace</a>, <a href="#cdktf.TaggedCloudWorkspaces">TaggedCloudWorkspaces</a>]</code> | A nested block that specifies which remote Terraform Cloud workspaces to use for the current configuration. |
+| <code><a href="#cdktf.CloudBackend.Initializer.parameter.hostname">hostname</a></code>         | <code>str</code>                                                                                                                                          | The hostname of a Terraform Enterprise installation, if using Terraform Enterprise.                         |
+| <code><a href="#cdktf.CloudBackend.Initializer.parameter.token">token</a></code>               | <code>str</code>                                                                                                                                          | The token used to authenticate with Terraform Cloud.                                                        |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="cdktf.CloudBackend.Initializer.parameter.scope"></a>
+
+- _Type:_ constructs.Construct
+
+---
+
+##### `organization`<sup>Required</sup> <a name="organization" id="cdktf.CloudBackend.Initializer.parameter.organization"></a>
+
+- _Type:_ str
+
+The name of the organization containing the workspace(s) the current configuration should use.
+
+---
+
+##### `workspaces`<sup>Required</sup> <a name="workspaces" id="cdktf.CloudBackend.Initializer.parameter.workspaces"></a>
+
+- _Type:_ typing.Union[<a href="#cdktf.NamedCloudWorkspace">NamedCloudWorkspace</a>, <a href="#cdktf.TaggedCloudWorkspaces">TaggedCloudWorkspaces</a>]
+
+A nested block that specifies which remote Terraform Cloud workspaces to use for the current configuration.
+
+The workspaces block must contain exactly one of the following arguments, each denoting a strategy for how workspaces should be mapped:
+
+---
+
+##### `hostname`<sup>Optional</sup> <a name="hostname" id="cdktf.CloudBackend.Initializer.parameter.hostname"></a>
+
+- _Type:_ str
+- _Default:_ app.terraform.io
+
+The hostname of a Terraform Enterprise installation, if using Terraform Enterprise.
+
+---
+
+##### `token`<sup>Optional</sup> <a name="token" id="cdktf.CloudBackend.Initializer.parameter.token"></a>
+
+- _Type:_ str
+
+The token used to authenticate with Terraform Cloud.
+
+We recommend omitting the token from the configuration, and instead using terraform login or manually configuring credentials in the CLI config file.
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name**                                                                                             | **Description**                                                                   |
+| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.CloudBackend.toString">to_string</a></code>                                    | Returns a string representation of this construct.                                |
+| <code><a href="#cdktf.CloudBackend.addOverride">add_override</a></code>                              | _No description._                                                                 |
+| <code><a href="#cdktf.CloudBackend.overrideLogicalId">override_logical_id</a></code>                 | Overrides the auto-generated logical ID with a specific ID.                       |
+| <code><a href="#cdktf.CloudBackend.resetOverrideLogicalId">reset_override_logical_id</a></code>      | Resets a previously passed logical Id to use the auto-generated logical id again. |
+| <code><a href="#cdktf.CloudBackend.toMetadata">to_metadata</a></code>                                | _No description._                                                                 |
+| <code><a href="#cdktf.CloudBackend.toTerraform">to_terraform</a></code>                              | Adds this resource to the terraform JSON output.                                  |
+| <code><a href="#cdktf.CloudBackend.getRemoteStateDataSource">get_remote_state_data_source</a></code> | Creates a TerraformRemoteState resource that accesses this backend.               |
+
+---
+
+##### `to_string` <a name="to_string" id="cdktf.CloudBackend.toString"></a>
+
+```python
+def to_string() - > str
+```
+
+Returns a string representation of this construct.
+
+##### `add_override` <a name="add_override" id="cdktf.CloudBackend.addOverride"></a>
+
+```python
+def add_override(
+  path: str,
+  value: typing.Any
+) - > None
+```
+
+###### `path`<sup>Required</sup> <a name="path" id="cdktf.CloudBackend.addOverride.parameter.path"></a>
+
+- _Type:_ str
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="cdktf.CloudBackend.addOverride.parameter.value"></a>
+
+- _Type:_ typing.Any
+
+---
+
+##### `override_logical_id` <a name="override_logical_id" id="cdktf.CloudBackend.overrideLogicalId"></a>
+
+```python
+def override_logical_id(
+  new_logical_id: str
+) - > None
+```
+
+Overrides the auto-generated logical ID with a specific ID.
+
+###### `new_logical_id`<sup>Required</sup> <a name="new_logical_id" id="cdktf.CloudBackend.overrideLogicalId.parameter.newLogicalId"></a>
+
+- _Type:_ str
+
+The new logical ID to use for this stack element.
+
+---
+
+##### `reset_override_logical_id` <a name="reset_override_logical_id" id="cdktf.CloudBackend.resetOverrideLogicalId"></a>
+
+```python
+def reset_override_logical_id() - > None
+```
+
+Resets a previously passed logical Id to use the auto-generated logical id again.
+
+##### `to_metadata` <a name="to_metadata" id="cdktf.CloudBackend.toMetadata"></a>
+
+```python
+def to_metadata() - > typing.Any
+```
+
+##### `to_terraform` <a name="to_terraform" id="cdktf.CloudBackend.toTerraform"></a>
+
+```python
+def to_terraform() - > typing.Any
+```
+
+Adds this resource to the terraform JSON output.
+
+##### `get_remote_state_data_source` <a name="get_remote_state_data_source" id="cdktf.CloudBackend.getRemoteStateDataSource"></a>
+
+```python
+def get_remote_state_data_source(
+  scope: Construct,
+  name: str,
+  _fromstack: str
+) - > TerraformRemoteState
+```
+
+Creates a TerraformRemoteState resource that accesses this backend.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="cdktf.CloudBackend.getRemoteStateDataSource.parameter.scope"></a>
+
+- _Type:_ constructs.Construct
+
+---
+
+###### `name`<sup>Required</sup> <a name="name" id="cdktf.CloudBackend.getRemoteStateDataSource.parameter.name"></a>
+
+- _Type:_ str
+
+---
+
+###### `_fromstack`<sup>Required</sup> <a name="_fromstack" id="cdktf.CloudBackend.getRemoteStateDataSource.parameter._fromStack"></a>
+
+- _Type:_ str
+
+---
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name**                                                                | **Description**               |
+| ----------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.CloudBackend.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#cdktf.CloudBackend.isBackend">is_backend</a></code>     | _No description._             |
+
+---
+
+##### `is_construct` <a name="is_construct" id="cdktf.CloudBackend.isConstruct"></a>
+
+```python
+import cdktf
+
+cdktf.CloudBackend.is_construct(
+  x: typing.Any
+)
+```
+
+Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.CloudBackend.isConstruct.parameter.x"></a>
+
+- _Type:_ typing.Any
+
+Any object.
+
+---
+
+##### `is_backend` <a name="is_backend" id="cdktf.CloudBackend.isBackend"></a>
+
+```python
+import cdktf
+
+cdktf.CloudBackend.is_backend(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.CloudBackend.isBackend.parameter.x"></a>
+
+- _Type:_ typing.Any
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name**                                                                                    | **Type**                                                        | **Description**   |
+| ------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ----------------- |
+| <code><a href="#cdktf.CloudBackend.property.node">node</a></code>                           | <code>constructs.Node</code>                                    | The tree node.    |
+| <code><a href="#cdktf.CloudBackend.property.cdktfStack">cdktf_stack</a></code>              | <code><a href="#cdktf.TerraformStack">TerraformStack</a></code> | _No description._ |
+| <code><a href="#cdktf.CloudBackend.property.fqn">fqn</a></code>                             | <code>str</code>                                                | _No description._ |
+| <code><a href="#cdktf.CloudBackend.property.friendlyUniqueId">friendly_unique_id</a></code> | <code>str</code>                                                | _No description._ |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="cdktf.CloudBackend.property.node"></a>
+
+```python
+node: Node
+```
+
+- _Type:_ constructs.Node
+
+The tree node.
+
+---
+
+##### `cdktf_stack`<sup>Required</sup> <a name="cdktf_stack" id="cdktf.CloudBackend.property.cdktfStack"></a>
+
+```python
+cdktf_stack: TerraformStack
+```
+
+- _Type:_ <a href="#cdktf.TerraformStack">TerraformStack</a>
+
+---
+
+##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.CloudBackend.property.fqn"></a>
+
+```python
+fqn: str
+```
+
+- _Type:_ str
+
+---
+
+##### `friendly_unique_id`<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.CloudBackend.property.friendlyUniqueId"></a>
+
+```python
+friendly_unique_id: str
+```
+
+- _Type:_ str
+
+---
+
 ### ConsulBackend <a name="ConsulBackend" id="cdktf.ConsulBackend"></a>
 
 #### Initializers <a name="Initializers" id="cdktf.ConsulBackend.Initializer"></a>
@@ -6899,6 +7195,9 @@ cdktf.DataTerraformRemoteStateS3(
   access_key: str = None,
   acl: str = None,
   assume_role_policy: str = None,
+  assume_role_policy_arns: typing.List[str] = None,
+  assume_role_tags: typing.Mapping[str] = None,
+  assume_role_transitive_tag_keys: typing.List[str] = None,
   dynamodb_endpoint: str = None,
   dynamodb_table: str = None,
   encrypt: bool = None,
@@ -6916,6 +7215,7 @@ cdktf.DataTerraformRemoteStateS3(
   shared_credentials_file: str = None,
   skip_credentials_validation: bool = None,
   skip_metadata_api_check: bool = None,
+  skip_region_validation: bool = None,
   sse_customer_key: str = None,
   sts_endpoint: str = None,
   token: str = None,
@@ -6923,38 +7223,42 @@ cdktf.DataTerraformRemoteStateS3(
 )
 ```
 
-| **Name**                                                                                                                                 | **Type**                                | **Description**                                                                                                                                                                                                                                                |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.scope">scope</a></code>                                           | <code>constructs.Construct</code>       | _No description._                                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.id">id</a></code>                                                 | <code>str</code>                        | _No description._                                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.defaults">defaults</a></code>                                     | <code>typing.Mapping[typing.Any]</code> | _No description._                                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.workspace">workspace</a></code>                                   | <code>str</code>                        | _No description._                                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.bucket">bucket</a></code>                                         | <code>str</code>                        | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.key">key</a></code>                                               | <code>str</code>                        | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.accessKey">access_key</a></code>                                  | <code>str</code>                        | (Optional) AWS access key.                                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.acl">acl</a></code>                                               | <code>str</code>                        | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.assumeRolePolicy">assume_role_policy</a></code>                   | <code>str</code>                        | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.dynamodbEndpoint">dynamodb_endpoint</a></code>                    | <code>str</code>                        | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.dynamodbTable">dynamodb_table</a></code>                          | <code>str</code>                        | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.encrypt">encrypt</a></code>                                       | <code>bool</code>                       | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.endpoint">endpoint</a></code>                                     | <code>str</code>                        | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.externalId">external_id</a></code>                                | <code>str</code>                        | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.forcePathStyle">force_path_style</a></code>                       | <code>bool</code>                       | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.iamEndpoint">iam_endpoint</a></code>                              | <code>str</code>                        | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.kmsKeyId">kms_key_id</a></code>                                   | <code>str</code>                        | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.maxRetries">max_retries</a></code>                                | <code>typing.Union[int, float]</code>   | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.profile">profile</a></code>                                       | <code>str</code>                        | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.region">region</a></code>                                         | <code>str</code>                        | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.roleArn">role_arn</a></code>                                      | <code>str</code>                        | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.secretKey">secret_key</a></code>                                  | <code>str</code>                        | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.sessionName">session_name</a></code>                              | <code>str</code>                        | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.sharedCredentialsFile">shared_credentials_file</a></code>         | <code>str</code>                        | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.skipCredentialsValidation">skip_credentials_validation</a></code> | <code>bool</code>                       | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.skipMetadataApiCheck">skip_metadata_api_check</a></code>          | <code>bool</code>                       | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.sseCustomerKey">sse_customer_key</a></code>                       | <code>str</code>                        | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.stsEndpoint">sts_endpoint</a></code>                              | <code>str</code>                        | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.token">token</a></code>                                           | <code>str</code>                        | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.workspaceKeyPrefix">workspace_key_prefix</a></code>               | <code>str</code>                        | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
+| **Name**                                                                                                                                       | **Type**                                | **Description**                                                                                                                                                                                                                                                |
+| ---------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.scope">scope</a></code>                                                 | <code>constructs.Construct</code>       | _No description._                                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.id">id</a></code>                                                       | <code>str</code>                        | _No description._                                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.defaults">defaults</a></code>                                           | <code>typing.Mapping[typing.Any]</code> | _No description._                                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.workspace">workspace</a></code>                                         | <code>str</code>                        | _No description._                                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.bucket">bucket</a></code>                                               | <code>str</code>                        | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.key">key</a></code>                                                     | <code>str</code>                        | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.accessKey">access_key</a></code>                                        | <code>str</code>                        | (Optional) AWS access key.                                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.acl">acl</a></code>                                                     | <code>str</code>                        | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.assumeRolePolicy">assume_role_policy</a></code>                         | <code>str</code>                        | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.assumeRolePolicyArns">assume_role_policy_arns</a></code>                | <code>typing.List[str]</code>           | (Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.                                                                                                                      |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.assumeRoleTags">assume_role_tags</a></code>                             | <code>typing.Mapping[str]</code>        | (Optional) Map of assume role session tags.                                                                                                                                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.assumeRoleTransitiveTagKeys">assume_role_transitive_tag_keys</a></code> | <code>typing.List[str]</code>           | (Optional) Set of assume role session tag keys to pass to any subsequent sessions.                                                                                                                                                                             |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.dynamodbEndpoint">dynamodb_endpoint</a></code>                          | <code>str</code>                        | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.dynamodbTable">dynamodb_table</a></code>                                | <code>str</code>                        | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.encrypt">encrypt</a></code>                                             | <code>bool</code>                       | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.endpoint">endpoint</a></code>                                           | <code>str</code>                        | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.externalId">external_id</a></code>                                      | <code>str</code>                        | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.forcePathStyle">force_path_style</a></code>                             | <code>bool</code>                       | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.iamEndpoint">iam_endpoint</a></code>                                    | <code>str</code>                        | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.kmsKeyId">kms_key_id</a></code>                                         | <code>str</code>                        | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.maxRetries">max_retries</a></code>                                      | <code>typing.Union[int, float]</code>   | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.profile">profile</a></code>                                             | <code>str</code>                        | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.region">region</a></code>                                               | <code>str</code>                        | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.roleArn">role_arn</a></code>                                            | <code>str</code>                        | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.secretKey">secret_key</a></code>                                        | <code>str</code>                        | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.sessionName">session_name</a></code>                                    | <code>str</code>                        | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.sharedCredentialsFile">shared_credentials_file</a></code>               | <code>str</code>                        | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.skipCredentialsValidation">skip_credentials_validation</a></code>       | <code>bool</code>                       | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.skipMetadataApiCheck">skip_metadata_api_check</a></code>                | <code>bool</code>                       | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.skipRegionValidation">skip_region_validation</a></code>                 | <code>bool</code>                       | (Optional) Skip validation of provided region name.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.sseCustomerKey">sse_customer_key</a></code>                             | <code>str</code>                        | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.stsEndpoint">sts_endpoint</a></code>                                    | <code>str</code>                        | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.token">token</a></code>                                                 | <code>str</code>                        | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.Initializer.parameter.workspaceKeyPrefix">workspace_key_prefix</a></code>                     | <code>str</code>                        | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
 
 ---
 
@@ -7027,6 +7331,30 @@ or AWS shared configuration file (e.g. ~/.aws/config).
 - _Type:_ str
 
 (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `assume_role_policy_arns`<sup>Optional</sup> <a name="assume_role_policy_arns" id="cdktf.DataTerraformRemoteStateS3.Initializer.parameter.assumeRolePolicyArns"></a>
+
+- _Type:_ typing.List[str]
+
+(Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `assume_role_tags`<sup>Optional</sup> <a name="assume_role_tags" id="cdktf.DataTerraformRemoteStateS3.Initializer.parameter.assumeRoleTags"></a>
+
+- _Type:_ typing.Mapping[str]
+
+(Optional) Map of assume role session tags.
+
+---
+
+##### `assume_role_transitive_tag_keys`<sup>Optional</sup> <a name="assume_role_transitive_tag_keys" id="cdktf.DataTerraformRemoteStateS3.Initializer.parameter.assumeRoleTransitiveTagKeys"></a>
+
+- _Type:_ typing.List[str]
+
+(Optional) Set of assume role session tag keys to pass to any subsequent sessions.
 
 ---
 
@@ -7189,6 +7517,14 @@ Defaults to ~/.aws/credentials.
 - _Type:_ bool
 
 (Optional) Skip usage of EC2 Metadata API.
+
+---
+
+##### `skip_region_validation`<sup>Optional</sup> <a name="skip_region_validation" id="cdktf.DataTerraformRemoteStateS3.Initializer.parameter.skipRegionValidation"></a>
+
+- _Type:_ bool
+
+(Optional) Skip validation of provided region name.
 
 ---
 
@@ -10939,7 +11275,7 @@ cdktf.Resource(
 
 ---
 
-##### `to_string` <a name="to_string" id="cdktf.Resource.toString"></a>
+##### ~~`to_string`~~ <a name="to_string" id="cdktf.Resource.toString"></a>
 
 ```python
 def to_string() - > str
@@ -10955,7 +11291,7 @@ Returns a string representation of this construct.
 
 ---
 
-##### `is_construct` <a name="is_construct" id="cdktf.Resource.isConstruct"></a>
+##### ~~`is_construct`~~ <a name="is_construct" id="cdktf.Resource.isConstruct"></a>
 
 ```python
 import cdktf
@@ -10998,7 +11334,9 @@ Any object.
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.Resource.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.Resource.property.node"></a>
+
+- _Deprecated:_ - Please use Construct from the constructs package instead.
 
 ```python
 node: Node
@@ -11010,7 +11348,9 @@ The tree node.
 
 ---
 
-##### `stack`<sup>Required</sup> <a name="stack" id="cdktf.Resource.property.stack"></a>
+##### ~~`stack`~~<sup>Required</sup> <a name="stack" id="cdktf.Resource.property.stack"></a>
+
+- _Deprecated:_ - Please use Construct from the constructs package instead.
 
 ```python
 stack: TerraformStack
@@ -11036,6 +11376,9 @@ cdktf.S3Backend(
   access_key: str = None,
   acl: str = None,
   assume_role_policy: str = None,
+  assume_role_policy_arns: typing.List[str] = None,
+  assume_role_tags: typing.Mapping[str] = None,
+  assume_role_transitive_tag_keys: typing.List[str] = None,
   dynamodb_endpoint: str = None,
   dynamodb_table: str = None,
   encrypt: bool = None,
@@ -11053,6 +11396,7 @@ cdktf.S3Backend(
   shared_credentials_file: str = None,
   skip_credentials_validation: bool = None,
   skip_metadata_api_check: bool = None,
+  skip_region_validation: bool = None,
   sse_customer_key: str = None,
   sts_endpoint: str = None,
   token: str = None,
@@ -11060,35 +11404,39 @@ cdktf.S3Backend(
 )
 ```
 
-| **Name**                                                                                                                | **Type**                              | **Description**                                                                                                                                                                                                                                                |
-| ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.scope">scope</a></code>                                           | <code>constructs.Construct</code>     | _No description._                                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.bucket">bucket</a></code>                                         | <code>str</code>                      | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.key">key</a></code>                                               | <code>str</code>                      | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.accessKey">access_key</a></code>                                  | <code>str</code>                      | (Optional) AWS access key.                                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.acl">acl</a></code>                                               | <code>str</code>                      | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.assumeRolePolicy">assume_role_policy</a></code>                   | <code>str</code>                      | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.dynamodbEndpoint">dynamodb_endpoint</a></code>                    | <code>str</code>                      | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.dynamodbTable">dynamodb_table</a></code>                          | <code>str</code>                      | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.encrypt">encrypt</a></code>                                       | <code>bool</code>                     | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.endpoint">endpoint</a></code>                                     | <code>str</code>                      | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.externalId">external_id</a></code>                                | <code>str</code>                      | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.forcePathStyle">force_path_style</a></code>                       | <code>bool</code>                     | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.iamEndpoint">iam_endpoint</a></code>                              | <code>str</code>                      | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.kmsKeyId">kms_key_id</a></code>                                   | <code>str</code>                      | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.maxRetries">max_retries</a></code>                                | <code>typing.Union[int, float]</code> | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.profile">profile</a></code>                                       | <code>str</code>                      | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.region">region</a></code>                                         | <code>str</code>                      | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.roleArn">role_arn</a></code>                                      | <code>str</code>                      | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.secretKey">secret_key</a></code>                                  | <code>str</code>                      | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.sessionName">session_name</a></code>                              | <code>str</code>                      | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.sharedCredentialsFile">shared_credentials_file</a></code>         | <code>str</code>                      | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.skipCredentialsValidation">skip_credentials_validation</a></code> | <code>bool</code>                     | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.skipMetadataApiCheck">skip_metadata_api_check</a></code>          | <code>bool</code>                     | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.sseCustomerKey">sse_customer_key</a></code>                       | <code>str</code>                      | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.stsEndpoint">sts_endpoint</a></code>                              | <code>str</code>                      | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.token">token</a></code>                                           | <code>str</code>                      | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.S3Backend.Initializer.parameter.workspaceKeyPrefix">workspace_key_prefix</a></code>               | <code>str</code>                      | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
+| **Name**                                                                                                                      | **Type**                              | **Description**                                                                                                                                                                                                                                                |
+| ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.scope">scope</a></code>                                                 | <code>constructs.Construct</code>     | _No description._                                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.bucket">bucket</a></code>                                               | <code>str</code>                      | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.key">key</a></code>                                                     | <code>str</code>                      | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.accessKey">access_key</a></code>                                        | <code>str</code>                      | (Optional) AWS access key.                                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.acl">acl</a></code>                                                     | <code>str</code>                      | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.assumeRolePolicy">assume_role_policy</a></code>                         | <code>str</code>                      | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.assumeRolePolicyArns">assume_role_policy_arns</a></code>                | <code>typing.List[str]</code>         | (Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.                                                                                                                      |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.assumeRoleTags">assume_role_tags</a></code>                             | <code>typing.Mapping[str]</code>      | (Optional) Map of assume role session tags.                                                                                                                                                                                                                    |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.assumeRoleTransitiveTagKeys">assume_role_transitive_tag_keys</a></code> | <code>typing.List[str]</code>         | (Optional) Set of assume role session tag keys to pass to any subsequent sessions.                                                                                                                                                                             |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.dynamodbEndpoint">dynamodb_endpoint</a></code>                          | <code>str</code>                      | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.dynamodbTable">dynamodb_table</a></code>                                | <code>str</code>                      | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.encrypt">encrypt</a></code>                                             | <code>bool</code>                     | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.endpoint">endpoint</a></code>                                           | <code>str</code>                      | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.externalId">external_id</a></code>                                      | <code>str</code>                      | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.forcePathStyle">force_path_style</a></code>                             | <code>bool</code>                     | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.iamEndpoint">iam_endpoint</a></code>                                    | <code>str</code>                      | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.kmsKeyId">kms_key_id</a></code>                                         | <code>str</code>                      | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.maxRetries">max_retries</a></code>                                      | <code>typing.Union[int, float]</code> | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.profile">profile</a></code>                                             | <code>str</code>                      | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.region">region</a></code>                                               | <code>str</code>                      | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.roleArn">role_arn</a></code>                                            | <code>str</code>                      | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.secretKey">secret_key</a></code>                                        | <code>str</code>                      | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.sessionName">session_name</a></code>                                    | <code>str</code>                      | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.sharedCredentialsFile">shared_credentials_file</a></code>               | <code>str</code>                      | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.skipCredentialsValidation">skip_credentials_validation</a></code>       | <code>bool</code>                     | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.skipMetadataApiCheck">skip_metadata_api_check</a></code>                | <code>bool</code>                     | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.skipRegionValidation">skip_region_validation</a></code>                 | <code>bool</code>                     | (Optional) Skip validation of provided region name.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.sseCustomerKey">sse_customer_key</a></code>                             | <code>str</code>                      | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.stsEndpoint">sts_endpoint</a></code>                                    | <code>str</code>                      | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.token">token</a></code>                                                 | <code>str</code>                      | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.S3Backend.Initializer.parameter.workspaceKeyPrefix">workspace_key_prefix</a></code>                     | <code>str</code>                      | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
 
 ---
 
@@ -11143,6 +11491,30 @@ or AWS shared configuration file (e.g. ~/.aws/config).
 - _Type:_ str
 
 (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `assume_role_policy_arns`<sup>Optional</sup> <a name="assume_role_policy_arns" id="cdktf.S3Backend.Initializer.parameter.assumeRolePolicyArns"></a>
+
+- _Type:_ typing.List[str]
+
+(Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `assume_role_tags`<sup>Optional</sup> <a name="assume_role_tags" id="cdktf.S3Backend.Initializer.parameter.assumeRoleTags"></a>
+
+- _Type:_ typing.Mapping[str]
+
+(Optional) Map of assume role session tags.
+
+---
+
+##### `assume_role_transitive_tag_keys`<sup>Optional</sup> <a name="assume_role_transitive_tag_keys" id="cdktf.S3Backend.Initializer.parameter.assumeRoleTransitiveTagKeys"></a>
+
+- _Type:_ typing.List[str]
+
+(Optional) Set of assume role session tag keys to pass to any subsequent sessions.
 
 ---
 
@@ -11305,6 +11677,14 @@ Defaults to ~/.aws/credentials.
 - _Type:_ bool
 
 (Optional) Skip usage of EC2 Metadata API.
+
+---
+
+##### `skip_region_validation`<sup>Optional</sup> <a name="skip_region_validation" id="cdktf.S3Backend.Initializer.parameter.skipRegionValidation"></a>
+
+- _Type:_ bool
+
+(Optional) Skip validation of provided region name.
 
 ---
 
@@ -12157,14 +12537,13 @@ Any object.
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                       | **Type**                                                        | **Description**                                                                                                    |
-| ------------------------------------------------------------------------------ | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| <code><a href="#cdktf.TerraformAsset.property.node">node</a></code>            | <code>constructs.Node</code>                                    | The tree node.                                                                                                     |
-| <code><a href="#cdktf.TerraformAsset.property.stack">stack</a></code>          | <code><a href="#cdktf.TerraformStack">TerraformStack</a></code> | The stack in which this resource is defined.                                                                       |
-| <code><a href="#cdktf.TerraformAsset.property.fileName">file_name</a></code>   | <code>str</code>                                                | Name of the asset.                                                                                                 |
-| <code><a href="#cdktf.TerraformAsset.property.path">path</a></code>            | <code>str</code>                                                | The path relative to the root of the terraform directory in posix format Use this property to reference the asset. |
-| <code><a href="#cdktf.TerraformAsset.property.assetHash">asset_hash</a></code> | <code>str</code>                                                | _No description._                                                                                                  |
-| <code><a href="#cdktf.TerraformAsset.property.type">type</a></code>            | <code><a href="#cdktf.AssetType">AssetType</a></code>           | _No description._                                                                                                  |
+| **Name**                                                                       | **Type**                                              | **Description**                                                                                                    |
+| ------------------------------------------------------------------------------ | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| <code><a href="#cdktf.TerraformAsset.property.node">node</a></code>            | <code>constructs.Node</code>                          | The tree node.                                                                                                     |
+| <code><a href="#cdktf.TerraformAsset.property.fileName">file_name</a></code>   | <code>str</code>                                      | Name of the asset.                                                                                                 |
+| <code><a href="#cdktf.TerraformAsset.property.path">path</a></code>            | <code>str</code>                                      | The path relative to the root of the terraform directory in posix format Use this property to reference the asset. |
+| <code><a href="#cdktf.TerraformAsset.property.assetHash">asset_hash</a></code> | <code>str</code>                                      | _No description._                                                                                                  |
+| <code><a href="#cdktf.TerraformAsset.property.type">type</a></code>            | <code><a href="#cdktf.AssetType">AssetType</a></code> | _No description._                                                                                                  |
 
 ---
 
@@ -12177,18 +12556,6 @@ node: Node
 - _Type:_ constructs.Node
 
 The tree node.
-
----
-
-##### `stack`<sup>Required</sup> <a name="stack" id="cdktf.TerraformAsset.property.stack"></a>
-
-```python
-stack: TerraformStack
-```
-
-- _Type:_ <a href="#cdktf.TerraformStack">TerraformStack</a>
-
-The stack in which this resource is defined.
 
 ---
 
@@ -15871,6 +16238,7 @@ cdktf.TerraformStack(
 | <code><a href="#cdktf.TerraformStack.prepareStack">prepare_stack</a></code>                                                  | _No description._                                  |
 | <code><a href="#cdktf.TerraformStack.registerIncomingCrossStackReference">register_incoming_cross_stack_reference</a></code> | _No description._                                  |
 | <code><a href="#cdktf.TerraformStack.registerOutgoingCrossStackReference">register_outgoing_cross_stack_reference</a></code> | _No description._                                  |
+| <code><a href="#cdktf.TerraformStack.runAllValidations">run_all_validations</a></code>                                       | Run all validations on the stack.                  |
 | <code><a href="#cdktf.TerraformStack.toTerraform">to_terraform</a></code>                                                    | _No description._                                  |
 
 ---
@@ -15991,6 +16359,14 @@ def register_outgoing_cross_stack_reference(
 - _Type:_ str
 
 ---
+
+##### `run_all_validations` <a name="run_all_validations" id="cdktf.TerraformStack.runAllValidations"></a>
+
+```python
+def run_all_validations() - > None
+```
+
+Run all validations on the stack.
 
 ##### `to_terraform` <a name="to_terraform" id="cdktf.TerraformStack.toTerraform"></a>
 
@@ -16978,6 +17354,89 @@ use_msi: bool
 (Optional) Should Managed Service Identity authentication be used?
 
 This can also be sourced from the ARM_USE_MSI environment variable.
+
+---
+
+### CloudBackendProps <a name="CloudBackendProps" id="cdktf.CloudBackendProps"></a>
+
+The Cloud Backend synthesizes a {@link https://www.terraform.io/cli/cloud/settings#the-cloud-block cloud block}. The cloud block is a nested block within the top-level terraform settings block. It specifies which Terraform Cloud workspaces to use for the current working directory. The cloud block only affects Terraform CLI's behavior. When Terraform Cloud uses a configuration that contains a cloud block - for example, when a workspace is configured to use a VCS provider directly - it ignores the block and behaves according to its own workspace settings.
+
+https://www.terraform.io/cli/cloud/settings#arguments
+
+#### Initializer <a name="Initializer" id="cdktf.CloudBackendProps.Initializer"></a>
+
+```python
+import cdktf
+
+cdktf.CloudBackendProps(
+  organization: str,
+  workspaces: typing.Union[NamedCloudWorkspace, TaggedCloudWorkspaces],
+  hostname: str = None,
+  token: str = None
+)
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name**                                                                               | **Type**                                                                                                                                                  | **Description**                                                                                             |
+| -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.CloudBackendProps.property.organization">organization</a></code> | <code>str</code>                                                                                                                                          | The name of the organization containing the workspace(s) the current configuration should use.              |
+| <code><a href="#cdktf.CloudBackendProps.property.workspaces">workspaces</a></code>     | <code>typing.Union[<a href="#cdktf.NamedCloudWorkspace">NamedCloudWorkspace</a>, <a href="#cdktf.TaggedCloudWorkspaces">TaggedCloudWorkspaces</a>]</code> | A nested block that specifies which remote Terraform Cloud workspaces to use for the current configuration. |
+| <code><a href="#cdktf.CloudBackendProps.property.hostname">hostname</a></code>         | <code>str</code>                                                                                                                                          | The hostname of a Terraform Enterprise installation, if using Terraform Enterprise.                         |
+| <code><a href="#cdktf.CloudBackendProps.property.token">token</a></code>               | <code>str</code>                                                                                                                                          | The token used to authenticate with Terraform Cloud.                                                        |
+
+---
+
+##### `organization`<sup>Required</sup> <a name="organization" id="cdktf.CloudBackendProps.property.organization"></a>
+
+```python
+organization: str
+```
+
+- _Type:_ str
+
+The name of the organization containing the workspace(s) the current configuration should use.
+
+---
+
+##### `workspaces`<sup>Required</sup> <a name="workspaces" id="cdktf.CloudBackendProps.property.workspaces"></a>
+
+```python
+workspaces: typing.Union[NamedCloudWorkspace, TaggedCloudWorkspaces]
+```
+
+- _Type:_ typing.Union[<a href="#cdktf.NamedCloudWorkspace">NamedCloudWorkspace</a>, <a href="#cdktf.TaggedCloudWorkspaces">TaggedCloudWorkspaces</a>]
+
+A nested block that specifies which remote Terraform Cloud workspaces to use for the current configuration.
+
+The workspaces block must contain exactly one of the following arguments, each denoting a strategy for how workspaces should be mapped:
+
+---
+
+##### `hostname`<sup>Optional</sup> <a name="hostname" id="cdktf.CloudBackendProps.property.hostname"></a>
+
+```python
+hostname: str
+```
+
+- _Type:_ str
+- _Default:_ app.terraform.io
+
+The hostname of a Terraform Enterprise installation, if using Terraform Enterprise.
+
+---
+
+##### `token`<sup>Optional</sup> <a name="token" id="cdktf.CloudBackendProps.property.token"></a>
+
+```python
+token: str
+```
+
+- _Type:_ str
+
+The token used to authenticate with Terraform Cloud.
+
+We recommend omitting the token from the configuration, and instead using terraform login or manually configuring credentials in the CLI config file.
 
 ---
 
@@ -19380,6 +19839,9 @@ cdktf.DataTerraformRemoteStateS3Config(
   access_key: str = None,
   acl: str = None,
   assume_role_policy: str = None,
+  assume_role_policy_arns: typing.List[str] = None,
+  assume_role_tags: typing.Mapping[str] = None,
+  assume_role_transitive_tag_keys: typing.List[str] = None,
   dynamodb_endpoint: str = None,
   dynamodb_table: str = None,
   encrypt: bool = None,
@@ -19397,6 +19859,7 @@ cdktf.DataTerraformRemoteStateS3Config(
   shared_credentials_file: str = None,
   skip_credentials_validation: bool = None,
   skip_metadata_api_check: bool = None,
+  skip_region_validation: bool = None,
   sse_customer_key: str = None,
   sts_endpoint: str = None,
   token: str = None,
@@ -19406,36 +19869,40 @@ cdktf.DataTerraformRemoteStateS3Config(
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                                                          | **Type**                                | **Description**                                                                                                                                                                                                                                                |
-| --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.defaults">defaults</a></code>                                     | <code>typing.Mapping[typing.Any]</code> | _No description._                                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.workspace">workspace</a></code>                                   | <code>str</code>                        | _No description._                                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.bucket">bucket</a></code>                                         | <code>str</code>                        | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.key">key</a></code>                                               | <code>str</code>                        | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.accessKey">access_key</a></code>                                  | <code>str</code>                        | (Optional) AWS access key.                                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.acl">acl</a></code>                                               | <code>str</code>                        | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRolePolicy">assume_role_policy</a></code>                   | <code>str</code>                        | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.dynamodbEndpoint">dynamodb_endpoint</a></code>                    | <code>str</code>                        | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.dynamodbTable">dynamodb_table</a></code>                          | <code>str</code>                        | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.encrypt">encrypt</a></code>                                       | <code>bool</code>                       | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.endpoint">endpoint</a></code>                                     | <code>str</code>                        | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.externalId">external_id</a></code>                                | <code>str</code>                        | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.forcePathStyle">force_path_style</a></code>                       | <code>bool</code>                       | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.iamEndpoint">iam_endpoint</a></code>                              | <code>str</code>                        | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.kmsKeyId">kms_key_id</a></code>                                   | <code>str</code>                        | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.maxRetries">max_retries</a></code>                                | <code>typing.Union[int, float]</code>   | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.profile">profile</a></code>                                       | <code>str</code>                        | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.region">region</a></code>                                         | <code>str</code>                        | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.roleArn">role_arn</a></code>                                      | <code>str</code>                        | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.secretKey">secret_key</a></code>                                  | <code>str</code>                        | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sessionName">session_name</a></code>                              | <code>str</code>                        | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sharedCredentialsFile">shared_credentials_file</a></code>         | <code>str</code>                        | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipCredentialsValidation">skip_credentials_validation</a></code> | <code>bool</code>                       | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipMetadataApiCheck">skip_metadata_api_check</a></code>          | <code>bool</code>                       | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sseCustomerKey">sse_customer_key</a></code>                       | <code>str</code>                        | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.stsEndpoint">sts_endpoint</a></code>                              | <code>str</code>                        | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.token">token</a></code>                                           | <code>str</code>                        | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.workspaceKeyPrefix">workspace_key_prefix</a></code>               | <code>str</code>                        | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
+| **Name**                                                                                                                                | **Type**                                | **Description**                                                                                                                                                                                                                                                |
+| --------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.defaults">defaults</a></code>                                           | <code>typing.Mapping[typing.Any]</code> | _No description._                                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.workspace">workspace</a></code>                                         | <code>str</code>                        | _No description._                                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.bucket">bucket</a></code>                                               | <code>str</code>                        | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.key">key</a></code>                                                     | <code>str</code>                        | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.accessKey">access_key</a></code>                                        | <code>str</code>                        | (Optional) AWS access key.                                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.acl">acl</a></code>                                                     | <code>str</code>                        | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRolePolicy">assume_role_policy</a></code>                         | <code>str</code>                        | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRolePolicyArns">assume_role_policy_arns</a></code>                | <code>typing.List[str]</code>           | (Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.                                                                                                                      |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRoleTags">assume_role_tags</a></code>                             | <code>typing.Mapping[str]</code>        | (Optional) Map of assume role session tags.                                                                                                                                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRoleTransitiveTagKeys">assume_role_transitive_tag_keys</a></code> | <code>typing.List[str]</code>           | (Optional) Set of assume role session tag keys to pass to any subsequent sessions.                                                                                                                                                                             |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.dynamodbEndpoint">dynamodb_endpoint</a></code>                          | <code>str</code>                        | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.dynamodbTable">dynamodb_table</a></code>                                | <code>str</code>                        | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.encrypt">encrypt</a></code>                                             | <code>bool</code>                       | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.endpoint">endpoint</a></code>                                           | <code>str</code>                        | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.externalId">external_id</a></code>                                      | <code>str</code>                        | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.forcePathStyle">force_path_style</a></code>                             | <code>bool</code>                       | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.iamEndpoint">iam_endpoint</a></code>                                    | <code>str</code>                        | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.kmsKeyId">kms_key_id</a></code>                                         | <code>str</code>                        | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.maxRetries">max_retries</a></code>                                      | <code>typing.Union[int, float]</code>   | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.profile">profile</a></code>                                             | <code>str</code>                        | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.region">region</a></code>                                               | <code>str</code>                        | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.roleArn">role_arn</a></code>                                            | <code>str</code>                        | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.secretKey">secret_key</a></code>                                        | <code>str</code>                        | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sessionName">session_name</a></code>                                    | <code>str</code>                        | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sharedCredentialsFile">shared_credentials_file</a></code>               | <code>str</code>                        | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipCredentialsValidation">skip_credentials_validation</a></code>       | <code>bool</code>                       | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipMetadataApiCheck">skip_metadata_api_check</a></code>                | <code>bool</code>                       | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipRegionValidation">skip_region_validation</a></code>                 | <code>bool</code>                       | (Optional) Skip validation of provided region name.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sseCustomerKey">sse_customer_key</a></code>                             | <code>str</code>                        | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.stsEndpoint">sts_endpoint</a></code>                                    | <code>str</code>                        | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.token">token</a></code>                                                 | <code>str</code>                        | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.workspaceKeyPrefix">workspace_key_prefix</a></code>                     | <code>str</code>                        | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
 
 ---
 
@@ -19524,6 +19991,42 @@ assume_role_policy: str
 - _Type:_ str
 
 (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `assume_role_policy_arns`<sup>Optional</sup> <a name="assume_role_policy_arns" id="cdktf.DataTerraformRemoteStateS3Config.property.assumeRolePolicyArns"></a>
+
+```python
+assume_role_policy_arns: typing.List[str]
+```
+
+- _Type:_ typing.List[str]
+
+(Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `assume_role_tags`<sup>Optional</sup> <a name="assume_role_tags" id="cdktf.DataTerraformRemoteStateS3Config.property.assumeRoleTags"></a>
+
+```python
+assume_role_tags: typing.Mapping[str]
+```
+
+- _Type:_ typing.Mapping[str]
+
+(Optional) Map of assume role session tags.
+
+---
+
+##### `assume_role_transitive_tag_keys`<sup>Optional</sup> <a name="assume_role_transitive_tag_keys" id="cdktf.DataTerraformRemoteStateS3Config.property.assumeRoleTransitiveTagKeys"></a>
+
+```python
+assume_role_transitive_tag_keys: typing.List[str]
+```
+
+- _Type:_ typing.List[str]
+
+(Optional) Set of assume role session tag keys to pass to any subsequent sessions.
 
 ---
 
@@ -19754,6 +20257,18 @@ skip_metadata_api_check: bool
 - _Type:_ bool
 
 (Optional) Skip usage of EC2 Metadata API.
+
+---
+
+##### `skip_region_validation`<sup>Optional</sup> <a name="skip_region_validation" id="cdktf.DataTerraformRemoteStateS3Config.property.skipRegionValidation"></a>
+
+```python
+skip_region_validation: bool
+```
+
+- _Type:_ bool
+
+(Optional) Skip validation of provided region name.
 
 ---
 
@@ -21920,6 +22435,9 @@ cdktf.S3BackendProps(
   access_key: str = None,
   acl: str = None,
   assume_role_policy: str = None,
+  assume_role_policy_arns: typing.List[str] = None,
+  assume_role_tags: typing.Mapping[str] = None,
+  assume_role_transitive_tag_keys: typing.List[str] = None,
   dynamodb_endpoint: str = None,
   dynamodb_table: str = None,
   encrypt: bool = None,
@@ -21937,6 +22455,7 @@ cdktf.S3BackendProps(
   shared_credentials_file: str = None,
   skip_credentials_validation: bool = None,
   skip_metadata_api_check: bool = None,
+  skip_region_validation: bool = None,
   sse_customer_key: str = None,
   sts_endpoint: str = None,
   token: str = None,
@@ -21946,34 +22465,38 @@ cdktf.S3BackendProps(
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                                        | **Type**                              | **Description**                                                                                                                                                                                                                                                |
-| --------------------------------------------------------------------------------------------------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.S3BackendProps.property.bucket">bucket</a></code>                                         | <code>str</code>                      | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
-| <code><a href="#cdktf.S3BackendProps.property.key">key</a></code>                                               | <code>str</code>                      | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
-| <code><a href="#cdktf.S3BackendProps.property.accessKey">access_key</a></code>                                  | <code>str</code>                      | (Optional) AWS access key.                                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.S3BackendProps.property.acl">acl</a></code>                                               | <code>str</code>                      | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.S3BackendProps.property.assumeRolePolicy">assume_role_policy</a></code>                   | <code>str</code>                      | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
-| <code><a href="#cdktf.S3BackendProps.property.dynamodbEndpoint">dynamodb_endpoint</a></code>                    | <code>str</code>                      | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
-| <code><a href="#cdktf.S3BackendProps.property.dynamodbTable">dynamodb_table</a></code>                          | <code>str</code>                      | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
-| <code><a href="#cdktf.S3BackendProps.property.encrypt">encrypt</a></code>                                       | <code>bool</code>                     | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
-| <code><a href="#cdktf.S3BackendProps.property.endpoint">endpoint</a></code>                                     | <code>str</code>                      | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
-| <code><a href="#cdktf.S3BackendProps.property.externalId">external_id</a></code>                                | <code>str</code>                      | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
-| <code><a href="#cdktf.S3BackendProps.property.forcePathStyle">force_path_style</a></code>                       | <code>bool</code>                     | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
-| <code><a href="#cdktf.S3BackendProps.property.iamEndpoint">iam_endpoint</a></code>                              | <code>str</code>                      | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
-| <code><a href="#cdktf.S3BackendProps.property.kmsKeyId">kms_key_id</a></code>                                   | <code>str</code>                      | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
-| <code><a href="#cdktf.S3BackendProps.property.maxRetries">max_retries</a></code>                                | <code>typing.Union[int, float]</code> | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
-| <code><a href="#cdktf.S3BackendProps.property.profile">profile</a></code>                                       | <code>str</code>                      | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
-| <code><a href="#cdktf.S3BackendProps.property.region">region</a></code>                                         | <code>str</code>                      | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
-| <code><a href="#cdktf.S3BackendProps.property.roleArn">role_arn</a></code>                                      | <code>str</code>                      | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
-| <code><a href="#cdktf.S3BackendProps.property.secretKey">secret_key</a></code>                                  | <code>str</code>                      | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.S3BackendProps.property.sessionName">session_name</a></code>                              | <code>str</code>                      | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.S3BackendProps.property.sharedCredentialsFile">shared_credentials_file</a></code>         | <code>str</code>                      | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.S3BackendProps.property.skipCredentialsValidation">skip_credentials_validation</a></code> | <code>bool</code>                     | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
-| <code><a href="#cdktf.S3BackendProps.property.skipMetadataApiCheck">skip_metadata_api_check</a></code>          | <code>bool</code>                     | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.S3BackendProps.property.sseCustomerKey">sse_customer_key</a></code>                       | <code>str</code>                      | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
-| <code><a href="#cdktf.S3BackendProps.property.stsEndpoint">sts_endpoint</a></code>                              | <code>str</code>                      | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
-| <code><a href="#cdktf.S3BackendProps.property.token">token</a></code>                                           | <code>str</code>                      | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.S3BackendProps.property.workspaceKeyPrefix">workspace_key_prefix</a></code>               | <code>str</code>                      | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
+| **Name**                                                                                                              | **Type**                              | **Description**                                                                                                                                                                                                                                                |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.S3BackendProps.property.bucket">bucket</a></code>                                               | <code>str</code>                      | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
+| <code><a href="#cdktf.S3BackendProps.property.key">key</a></code>                                                     | <code>str</code>                      | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
+| <code><a href="#cdktf.S3BackendProps.property.accessKey">access_key</a></code>                                        | <code>str</code>                      | (Optional) AWS access key.                                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.S3BackendProps.property.acl">acl</a></code>                                                     | <code>str</code>                      | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.S3BackendProps.property.assumeRolePolicy">assume_role_policy</a></code>                         | <code>str</code>                      | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
+| <code><a href="#cdktf.S3BackendProps.property.assumeRolePolicyArns">assume_role_policy_arns</a></code>                | <code>typing.List[str]</code>         | (Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.                                                                                                                      |
+| <code><a href="#cdktf.S3BackendProps.property.assumeRoleTags">assume_role_tags</a></code>                             | <code>typing.Mapping[str]</code>      | (Optional) Map of assume role session tags.                                                                                                                                                                                                                    |
+| <code><a href="#cdktf.S3BackendProps.property.assumeRoleTransitiveTagKeys">assume_role_transitive_tag_keys</a></code> | <code>typing.List[str]</code>         | (Optional) Set of assume role session tag keys to pass to any subsequent sessions.                                                                                                                                                                             |
+| <code><a href="#cdktf.S3BackendProps.property.dynamodbEndpoint">dynamodb_endpoint</a></code>                          | <code>str</code>                      | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
+| <code><a href="#cdktf.S3BackendProps.property.dynamodbTable">dynamodb_table</a></code>                                | <code>str</code>                      | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
+| <code><a href="#cdktf.S3BackendProps.property.encrypt">encrypt</a></code>                                             | <code>bool</code>                     | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
+| <code><a href="#cdktf.S3BackendProps.property.endpoint">endpoint</a></code>                                           | <code>str</code>                      | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
+| <code><a href="#cdktf.S3BackendProps.property.externalId">external_id</a></code>                                      | <code>str</code>                      | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
+| <code><a href="#cdktf.S3BackendProps.property.forcePathStyle">force_path_style</a></code>                             | <code>bool</code>                     | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
+| <code><a href="#cdktf.S3BackendProps.property.iamEndpoint">iam_endpoint</a></code>                                    | <code>str</code>                      | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
+| <code><a href="#cdktf.S3BackendProps.property.kmsKeyId">kms_key_id</a></code>                                         | <code>str</code>                      | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
+| <code><a href="#cdktf.S3BackendProps.property.maxRetries">max_retries</a></code>                                      | <code>typing.Union[int, float]</code> | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
+| <code><a href="#cdktf.S3BackendProps.property.profile">profile</a></code>                                             | <code>str</code>                      | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
+| <code><a href="#cdktf.S3BackendProps.property.region">region</a></code>                                               | <code>str</code>                      | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
+| <code><a href="#cdktf.S3BackendProps.property.roleArn">role_arn</a></code>                                            | <code>str</code>                      | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
+| <code><a href="#cdktf.S3BackendProps.property.secretKey">secret_key</a></code>                                        | <code>str</code>                      | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.S3BackendProps.property.sessionName">session_name</a></code>                                    | <code>str</code>                      | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.S3BackendProps.property.sharedCredentialsFile">shared_credentials_file</a></code>               | <code>str</code>                      | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.S3BackendProps.property.skipCredentialsValidation">skip_credentials_validation</a></code>       | <code>bool</code>                     | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
+| <code><a href="#cdktf.S3BackendProps.property.skipMetadataApiCheck">skip_metadata_api_check</a></code>                | <code>bool</code>                     | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.S3BackendProps.property.skipRegionValidation">skip_region_validation</a></code>                 | <code>bool</code>                     | (Optional) Skip validation of provided region name.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.S3BackendProps.property.sseCustomerKey">sse_customer_key</a></code>                             | <code>str</code>                      | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
+| <code><a href="#cdktf.S3BackendProps.property.stsEndpoint">sts_endpoint</a></code>                                    | <code>str</code>                      | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
+| <code><a href="#cdktf.S3BackendProps.property.token">token</a></code>                                                 | <code>str</code>                      | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.S3BackendProps.property.workspaceKeyPrefix">workspace_key_prefix</a></code>                     | <code>str</code>                      | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
 
 ---
 
@@ -22042,6 +22565,42 @@ assume_role_policy: str
 - _Type:_ str
 
 (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `assume_role_policy_arns`<sup>Optional</sup> <a name="assume_role_policy_arns" id="cdktf.S3BackendProps.property.assumeRolePolicyArns"></a>
+
+```python
+assume_role_policy_arns: typing.List[str]
+```
+
+- _Type:_ typing.List[str]
+
+(Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `assume_role_tags`<sup>Optional</sup> <a name="assume_role_tags" id="cdktf.S3BackendProps.property.assumeRoleTags"></a>
+
+```python
+assume_role_tags: typing.Mapping[str]
+```
+
+- _Type:_ typing.Mapping[str]
+
+(Optional) Map of assume role session tags.
+
+---
+
+##### `assume_role_transitive_tag_keys`<sup>Optional</sup> <a name="assume_role_transitive_tag_keys" id="cdktf.S3BackendProps.property.assumeRoleTransitiveTagKeys"></a>
+
+```python
+assume_role_transitive_tag_keys: typing.List[str]
+```
+
+- _Type:_ typing.List[str]
+
+(Optional) Set of assume role session tag keys to pass to any subsequent sessions.
 
 ---
 
@@ -22272,6 +22831,18 @@ skip_metadata_api_check: bool
 - _Type:_ bool
 
 (Optional) Skip usage of EC2 Metadata API.
+
+---
+
+##### `skip_region_validation`<sup>Optional</sup> <a name="skip_region_validation" id="cdktf.S3BackendProps.property.skipRegionValidation"></a>
+
+```python
+skip_region_validation: bool
+```
+
+- _Type:_ bool
+
+(Optional) Skip validation of provided region name.
 
 ---
 
@@ -25415,6 +25986,37 @@ fqn: str
 - _Type:_ str
 
 ---
+
+### CloudWorkspace <a name="CloudWorkspace" id="cdktf.CloudWorkspace"></a>
+
+A cloud workspace can either be a single named workspace, or a list of tagged workspaces.
+
+#### Initializers <a name="Initializers" id="cdktf.CloudWorkspace.Initializer"></a>
+
+```python
+import cdktf
+
+cdktf.CloudWorkspace()
+```
+
+| **Name** | **Type** | **Description** |
+| -------- | -------- | --------------- |
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name**                                                                  | **Description**   |
+| ------------------------------------------------------------------------- | ----------------- |
+| <code><a href="#cdktf.CloudWorkspace.toTerraform">to_terraform</a></code> | _No description._ |
+
+---
+
+##### `to_terraform` <a name="to_terraform" id="cdktf.CloudWorkspace.toTerraform"></a>
+
+```python
+def to_terraform() - > typing.Any
+```
 
 ### ComplexComputedList <a name="ComplexComputedList" id="cdktf.ComplexComputedList"></a>
 
@@ -29856,6 +30458,66 @@ Returns the value of the current item iterated over.
 
 ---
 
+### NamedCloudWorkspace <a name="NamedCloudWorkspace" id="cdktf.NamedCloudWorkspace"></a>
+
+The name of a single Terraform Cloud workspace.
+
+You will only be able to use the workspace specified in the configuration with this working directory, and cannot manage workspaces from the CLI (e.g. terraform workspace select or terraform workspace new).
+
+#### Initializers <a name="Initializers" id="cdktf.NamedCloudWorkspace.Initializer"></a>
+
+```python
+import cdktf
+
+cdktf.NamedCloudWorkspace(
+  name: str
+)
+```
+
+| **Name**                                                                              | **Type**         | **Description**   |
+| ------------------------------------------------------------------------------------- | ---------------- | ----------------- |
+| <code><a href="#cdktf.NamedCloudWorkspace.Initializer.parameter.name">name</a></code> | <code>str</code> | _No description._ |
+
+---
+
+##### `name`<sup>Required</sup> <a name="name" id="cdktf.NamedCloudWorkspace.Initializer.parameter.name"></a>
+
+- _Type:_ str
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name**                                                                       | **Description**   |
+| ------------------------------------------------------------------------------ | ----------------- |
+| <code><a href="#cdktf.NamedCloudWorkspace.toTerraform">to_terraform</a></code> | _No description._ |
+
+---
+
+##### `to_terraform` <a name="to_terraform" id="cdktf.NamedCloudWorkspace.toTerraform"></a>
+
+```python
+def to_terraform() - > typing.Any
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name**                                                                 | **Type**         | **Description**   |
+| ------------------------------------------------------------------------ | ---------------- | ----------------- |
+| <code><a href="#cdktf.NamedCloudWorkspace.property.name">name</a></code> | <code>str</code> | _No description._ |
+
+---
+
+##### `name`<sup>Required</sup> <a name="name" id="cdktf.NamedCloudWorkspace.property.name"></a>
+
+```python
+name: str
+```
+
+- _Type:_ str
+
+---
+
 ### NamedRemoteWorkspace <a name="NamedRemoteWorkspace" id="cdktf.NamedRemoteWorkspace"></a>
 
 - _Implements:_ <a href="#cdktf.IRemoteWorkspace">IRemoteWorkspace</a>
@@ -30538,6 +31200,66 @@ fqn: str
 
 ---
 
+### TaggedCloudWorkspaces <a name="TaggedCloudWorkspaces" id="cdktf.TaggedCloudWorkspaces"></a>
+
+A set of Terraform Cloud workspace tags.
+
+You will be able to use this working directory with any workspaces that have all of the specified tags, and can use the terraform workspace commands to switch between them or create new workspaces. New workspaces will automatically have the specified tags. This option conflicts with name.
+
+#### Initializers <a name="Initializers" id="cdktf.TaggedCloudWorkspaces.Initializer"></a>
+
+```python
+import cdktf
+
+cdktf.TaggedCloudWorkspaces(
+  tags: typing.List[str]
+)
+```
+
+| **Name**                                                                                | **Type**                      | **Description**   |
+| --------------------------------------------------------------------------------------- | ----------------------------- | ----------------- |
+| <code><a href="#cdktf.TaggedCloudWorkspaces.Initializer.parameter.tags">tags</a></code> | <code>typing.List[str]</code> | _No description._ |
+
+---
+
+##### `tags`<sup>Required</sup> <a name="tags" id="cdktf.TaggedCloudWorkspaces.Initializer.parameter.tags"></a>
+
+- _Type:_ typing.List[str]
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name**                                                                         | **Description**   |
+| -------------------------------------------------------------------------------- | ----------------- |
+| <code><a href="#cdktf.TaggedCloudWorkspaces.toTerraform">to_terraform</a></code> | _No description._ |
+
+---
+
+##### `to_terraform` <a name="to_terraform" id="cdktf.TaggedCloudWorkspaces.toTerraform"></a>
+
+```python
+def to_terraform() - > typing.Any
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name**                                                                   | **Type**                      | **Description**   |
+| -------------------------------------------------------------------------- | ----------------------------- | ----------------- |
+| <code><a href="#cdktf.TaggedCloudWorkspaces.property.tags">tags</a></code> | <code>typing.List[str]</code> | _No description._ |
+
+---
+
+##### `tags`<sup>Required</sup> <a name="tags" id="cdktf.TaggedCloudWorkspaces.property.tags"></a>
+
+```python
+tags: typing.List[str]
+```
+
+- _Type:_ typing.List[str]
+
+---
+
 ### TerraformIterator <a name="TerraformIterator" id="cdktf.TerraformIterator"></a>
 
 - _Implements:_ <a href="#cdktf.ITerraformIterator">ITerraformIterator</a>
@@ -31078,7 +31800,8 @@ cdktf.Testing.stub_version(
 import cdktf
 
 cdktf.Testing.synth(
-  stack: TerraformStack
+  stack: TerraformStack,
+  run_validations: bool = None
 )
 ```
 
@@ -31087,6 +31810,12 @@ Returns the Terraform synthesized JSON.
 ###### `stack`<sup>Required</sup> <a name="stack" id="cdktf.Testing.synth.parameter.stack"></a>
 
 - _Type:_ <a href="#cdktf.TerraformStack">TerraformStack</a>
+
+---
+
+###### `run_validations`<sup>Optional</sup> <a name="run_validations" id="cdktf.Testing.synth.parameter.runValidations"></a>
+
+- _Type:_ bool
 
 ---
 
@@ -32771,7 +33500,7 @@ True when ${} should be ommitted (because already inside them), false otherwise.
 
 - _Extends:_ constructs.IConstruct
 
-- _Implemented By:_ <a href="#cdktf.Resource">Resource</a>, <a href="#cdktf.TerraformAsset">TerraformAsset</a>, <a href="#cdktf.IResource">IResource</a>
+- _Implemented By:_ <a href="#cdktf.Resource">Resource</a>, <a href="#cdktf.IResource">IResource</a>
 
 #### Properties <a name="Properties" id="Properties"></a>
 

--- a/website/docs/cdktf/api-reference/typescript.mdx
+++ b/website/docs/cdktf/api-reference/typescript.mdx
@@ -712,6 +712,249 @@ public readonly friendlyUniqueId: string;
 
 ---
 
+### CloudBackend <a name="CloudBackend" id="cdktf.CloudBackend"></a>
+
+The Cloud Backend synthesizes a {@link https://www.terraform.io/cli/cloud/settings#the-cloud-block cloud block}. The cloud block is a nested block within the top-level terraform settings block. It specifies which Terraform Cloud workspaces to use for the current working directory. The cloud block only affects Terraform CLI's behavior. When Terraform Cloud uses a configuration that contains a cloud block - for example, when a workspace is configured to use a VCS provider directly - it ignores the block and behaves according to its own workspace settings.
+
+#### Initializers <a name="Initializers" id="cdktf.CloudBackend.Initializer"></a>
+
+```typescript
+import { CloudBackend } from 'cdktf'
+
+new CloudBackend(scope: Construct, props: CloudBackendProps)
+```
+
+| **Name**                                                                         | **Type**                                                              | **Description**   |
+| -------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ----------------- |
+| <code><a href="#cdktf.CloudBackend.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code>                                     | _No description._ |
+| <code><a href="#cdktf.CloudBackend.Initializer.parameter.props">props</a></code> | <code><a href="#cdktf.CloudBackendProps">CloudBackendProps</a></code> | _No description._ |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="cdktf.CloudBackend.Initializer.parameter.scope"></a>
+
+- _Type:_ constructs.Construct
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="cdktf.CloudBackend.Initializer.parameter.props"></a>
+
+- _Type:_ <a href="#cdktf.CloudBackendProps">CloudBackendProps</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name**                                                                                         | **Description**                                                                   |
+| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.CloudBackend.toString">toString</a></code>                                 | Returns a string representation of this construct.                                |
+| <code><a href="#cdktf.CloudBackend.addOverride">addOverride</a></code>                           | _No description._                                                                 |
+| <code><a href="#cdktf.CloudBackend.overrideLogicalId">overrideLogicalId</a></code>               | Overrides the auto-generated logical ID with a specific ID.                       |
+| <code><a href="#cdktf.CloudBackend.resetOverrideLogicalId">resetOverrideLogicalId</a></code>     | Resets a previously passed logical Id to use the auto-generated logical id again. |
+| <code><a href="#cdktf.CloudBackend.toMetadata">toMetadata</a></code>                             | _No description._                                                                 |
+| <code><a href="#cdktf.CloudBackend.toTerraform">toTerraform</a></code>                           | Adds this resource to the terraform JSON output.                                  |
+| <code><a href="#cdktf.CloudBackend.getRemoteStateDataSource">getRemoteStateDataSource</a></code> | Creates a TerraformRemoteState resource that accesses this backend.               |
+
+---
+
+##### `toString` <a name="toString" id="cdktf.CloudBackend.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+##### `addOverride` <a name="addOverride" id="cdktf.CloudBackend.addOverride"></a>
+
+```typescript
+public addOverride(path: string, value: any): void
+```
+
+###### `path`<sup>Required</sup> <a name="path" id="cdktf.CloudBackend.addOverride.parameter.path"></a>
+
+- _Type:_ string
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="cdktf.CloudBackend.addOverride.parameter.value"></a>
+
+- _Type:_ any
+
+---
+
+##### `overrideLogicalId` <a name="overrideLogicalId" id="cdktf.CloudBackend.overrideLogicalId"></a>
+
+```typescript
+public overrideLogicalId(newLogicalId: string): void
+```
+
+Overrides the auto-generated logical ID with a specific ID.
+
+###### `newLogicalId`<sup>Required</sup> <a name="newLogicalId" id="cdktf.CloudBackend.overrideLogicalId.parameter.newLogicalId"></a>
+
+- _Type:_ string
+
+The new logical ID to use for this stack element.
+
+---
+
+##### `resetOverrideLogicalId` <a name="resetOverrideLogicalId" id="cdktf.CloudBackend.resetOverrideLogicalId"></a>
+
+```typescript
+public resetOverrideLogicalId(): void
+```
+
+Resets a previously passed logical Id to use the auto-generated logical id again.
+
+##### `toMetadata` <a name="toMetadata" id="cdktf.CloudBackend.toMetadata"></a>
+
+```typescript
+public toMetadata(): any
+```
+
+##### `toTerraform` <a name="toTerraform" id="cdktf.CloudBackend.toTerraform"></a>
+
+```typescript
+public toTerraform(): any
+```
+
+Adds this resource to the terraform JSON output.
+
+##### `getRemoteStateDataSource` <a name="getRemoteStateDataSource" id="cdktf.CloudBackend.getRemoteStateDataSource"></a>
+
+```typescript
+public getRemoteStateDataSource(scope: Construct, name: string, _fromStack: string): TerraformRemoteState
+```
+
+Creates a TerraformRemoteState resource that accesses this backend.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="cdktf.CloudBackend.getRemoteStateDataSource.parameter.scope"></a>
+
+- _Type:_ constructs.Construct
+
+---
+
+###### `name`<sup>Required</sup> <a name="name" id="cdktf.CloudBackend.getRemoteStateDataSource.parameter.name"></a>
+
+- _Type:_ string
+
+---
+
+###### `_fromStack`<sup>Required</sup> <a name="_fromStack" id="cdktf.CloudBackend.getRemoteStateDataSource.parameter._fromStack"></a>
+
+- _Type:_ string
+
+---
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name**                                                               | **Description**               |
+| ---------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.CloudBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#cdktf.CloudBackend.isBackend">isBackend</a></code>     | _No description._             |
+
+---
+
+##### `isConstruct` <a name="isConstruct" id="cdktf.CloudBackend.isConstruct"></a>
+
+```typescript
+import { CloudBackend } from 'cdktf'
+
+CloudBackend.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.CloudBackend.isConstruct.parameter.x"></a>
+
+- _Type:_ any
+
+Any object.
+
+---
+
+##### `isBackend` <a name="isBackend" id="cdktf.CloudBackend.isBackend"></a>
+
+```typescript
+import { CloudBackend } from 'cdktf'
+
+CloudBackend.isBackend(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.CloudBackend.isBackend.parameter.x"></a>
+
+- _Type:_ any
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name**                                                                                  | **Type**                                                        | **Description**   |
+| ----------------------------------------------------------------------------------------- | --------------------------------------------------------------- | ----------------- |
+| <code><a href="#cdktf.CloudBackend.property.node">node</a></code>                         | <code>constructs.Node</code>                                    | The tree node.    |
+| <code><a href="#cdktf.CloudBackend.property.cdktfStack">cdktfStack</a></code>             | <code><a href="#cdktf.TerraformStack">TerraformStack</a></code> | _No description._ |
+| <code><a href="#cdktf.CloudBackend.property.fqn">fqn</a></code>                           | <code>string</code>                                             | _No description._ |
+| <code><a href="#cdktf.CloudBackend.property.friendlyUniqueId">friendlyUniqueId</a></code> | <code>string</code>                                             | _No description._ |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="cdktf.CloudBackend.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- _Type:_ constructs.Node
+
+The tree node.
+
+---
+
+##### `cdktfStack`<sup>Required</sup> <a name="cdktfStack" id="cdktf.CloudBackend.property.cdktfStack"></a>
+
+```typescript
+public readonly cdktfStack: TerraformStack;
+```
+
+- _Type:_ <a href="#cdktf.TerraformStack">TerraformStack</a>
+
+---
+
+##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.CloudBackend.property.fqn"></a>
+
+```typescript
+public readonly fqn: string;
+```
+
+- _Type:_ string
+
+---
+
+##### `friendlyUniqueId`<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.CloudBackend.property.friendlyUniqueId"></a>
+
+```typescript
+public readonly friendlyUniqueId: string;
+```
+
+- _Type:_ string
+
+---
+
 ### ConsulBackend <a name="ConsulBackend" id="cdktf.ConsulBackend"></a>
 
 #### Initializers <a name="Initializers" id="cdktf.ConsulBackend.Initializer"></a>
@@ -7739,7 +7982,7 @@ new Resource(scope: Construct, id: string)
 
 ---
 
-##### `toString` <a name="toString" id="cdktf.Resource.toString"></a>
+##### ~~`toString`~~ <a name="toString" id="cdktf.Resource.toString"></a>
 
 ```typescript
 public toString(): string
@@ -7755,7 +7998,7 @@ Returns a string representation of this construct.
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdktf.Resource.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdktf.Resource.isConstruct"></a>
 
 ```typescript
 import { Resource } from 'cdktf'
@@ -7796,7 +8039,9 @@ Any object.
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.Resource.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.Resource.property.node"></a>
+
+- _Deprecated:_ - Please use Construct from the constructs package instead.
 
 ```typescript
 public readonly node: Node;
@@ -7808,7 +8053,9 @@ The tree node.
 
 ---
 
-##### `stack`<sup>Required</sup> <a name="stack" id="cdktf.Resource.property.stack"></a>
+##### ~~`stack`~~<sup>Required</sup> <a name="stack" id="cdktf.Resource.property.stack"></a>
+
+- _Deprecated:_ - Please use Construct from the constructs package instead.
 
 ```typescript
 public readonly stack: TerraformStack;
@@ -8396,14 +8643,13 @@ Any object.
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                      | **Type**                                                        | **Description**                                                                                                    |
-| ----------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| <code><a href="#cdktf.TerraformAsset.property.node">node</a></code>           | <code>constructs.Node</code>                                    | The tree node.                                                                                                     |
-| <code><a href="#cdktf.TerraformAsset.property.stack">stack</a></code>         | <code><a href="#cdktf.TerraformStack">TerraformStack</a></code> | The stack in which this resource is defined.                                                                       |
-| <code><a href="#cdktf.TerraformAsset.property.fileName">fileName</a></code>   | <code>string</code>                                             | Name of the asset.                                                                                                 |
-| <code><a href="#cdktf.TerraformAsset.property.path">path</a></code>           | <code>string</code>                                             | The path relative to the root of the terraform directory in posix format Use this property to reference the asset. |
-| <code><a href="#cdktf.TerraformAsset.property.assetHash">assetHash</a></code> | <code>string</code>                                             | _No description._                                                                                                  |
-| <code><a href="#cdktf.TerraformAsset.property.type">type</a></code>           | <code><a href="#cdktf.AssetType">AssetType</a></code>           | _No description._                                                                                                  |
+| **Name**                                                                      | **Type**                                              | **Description**                                                                                                    |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| <code><a href="#cdktf.TerraformAsset.property.node">node</a></code>           | <code>constructs.Node</code>                          | The tree node.                                                                                                     |
+| <code><a href="#cdktf.TerraformAsset.property.fileName">fileName</a></code>   | <code>string</code>                                   | Name of the asset.                                                                                                 |
+| <code><a href="#cdktf.TerraformAsset.property.path">path</a></code>           | <code>string</code>                                   | The path relative to the root of the terraform directory in posix format Use this property to reference the asset. |
+| <code><a href="#cdktf.TerraformAsset.property.assetHash">assetHash</a></code> | <code>string</code>                                   | _No description._                                                                                                  |
+| <code><a href="#cdktf.TerraformAsset.property.type">type</a></code>           | <code><a href="#cdktf.AssetType">AssetType</a></code> | _No description._                                                                                                  |
 
 ---
 
@@ -8416,18 +8662,6 @@ public readonly node: Node;
 - _Type:_ constructs.Node
 
 The tree node.
-
----
-
-##### `stack`<sup>Required</sup> <a name="stack" id="cdktf.TerraformAsset.property.stack"></a>
-
-```typescript
-public readonly stack: TerraformStack;
-```
-
-- _Type:_ <a href="#cdktf.TerraformStack">TerraformStack</a>
-
-The stack in which this resource is defined.
 
 ---
 
@@ -11640,6 +11874,7 @@ new TerraformStack(scope: Construct, id: string)
 | <code><a href="#cdktf.TerraformStack.prepareStack">prepareStack</a></code>                                               | _No description._                                  |
 | <code><a href="#cdktf.TerraformStack.registerIncomingCrossStackReference">registerIncomingCrossStackReference</a></code> | _No description._                                  |
 | <code><a href="#cdktf.TerraformStack.registerOutgoingCrossStackReference">registerOutgoingCrossStackReference</a></code> | _No description._                                  |
+| <code><a href="#cdktf.TerraformStack.runAllValidations">runAllValidations</a></code>                                     | Run all validations on the stack.                  |
 | <code><a href="#cdktf.TerraformStack.toTerraform">toTerraform</a></code>                                                 | _No description._                                  |
 
 ---
@@ -11747,6 +11982,14 @@ public registerOutgoingCrossStackReference(identifier: string): TerraformOutput
 - _Type:_ string
 
 ---
+
+##### `runAllValidations` <a name="runAllValidations" id="cdktf.TerraformStack.runAllValidations"></a>
+
+```typescript
+public runAllValidations(): void
+```
+
+Run all validations on the stack.
 
 ##### `toTerraform` <a name="toTerraform" id="cdktf.TerraformStack.toTerraform"></a>
 
@@ -12616,6 +12859,84 @@ public readonly useMsi: boolean;
 (Optional) Should Managed Service Identity authentication be used?
 
 This can also be sourced from the ARM_USE_MSI environment variable.
+
+---
+
+### CloudBackendProps <a name="CloudBackendProps" id="cdktf.CloudBackendProps"></a>
+
+The Cloud Backend synthesizes a {@link https://www.terraform.io/cli/cloud/settings#the-cloud-block cloud block}. The cloud block is a nested block within the top-level terraform settings block. It specifies which Terraform Cloud workspaces to use for the current working directory. The cloud block only affects Terraform CLI's behavior. When Terraform Cloud uses a configuration that contains a cloud block - for example, when a workspace is configured to use a VCS provider directly - it ignores the block and behaves according to its own workspace settings.
+
+https://www.terraform.io/cli/cloud/settings#arguments
+
+#### Initializer <a name="Initializer" id="cdktf.CloudBackendProps.Initializer"></a>
+
+```typescript
+import { CloudBackendProps } from 'cdktf'
+
+const cloudBackendProps: CloudBackendProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name**                                                                               | **Type**                                                                                                                                      | **Description**                                                                                             |
+| -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.CloudBackendProps.property.organization">organization</a></code> | <code>string</code>                                                                                                                           | The name of the organization containing the workspace(s) the current configuration should use.              |
+| <code><a href="#cdktf.CloudBackendProps.property.workspaces">workspaces</a></code>     | <code><a href="#cdktf.NamedCloudWorkspace">NamedCloudWorkspace</a> \| <a href="#cdktf.TaggedCloudWorkspaces">TaggedCloudWorkspaces</a></code> | A nested block that specifies which remote Terraform Cloud workspaces to use for the current configuration. |
+| <code><a href="#cdktf.CloudBackendProps.property.hostname">hostname</a></code>         | <code>string</code>                                                                                                                           | The hostname of a Terraform Enterprise installation, if using Terraform Enterprise.                         |
+| <code><a href="#cdktf.CloudBackendProps.property.token">token</a></code>               | <code>string</code>                                                                                                                           | The token used to authenticate with Terraform Cloud.                                                        |
+
+---
+
+##### `organization`<sup>Required</sup> <a name="organization" id="cdktf.CloudBackendProps.property.organization"></a>
+
+```typescript
+public readonly organization: string;
+```
+
+- _Type:_ string
+
+The name of the organization containing the workspace(s) the current configuration should use.
+
+---
+
+##### `workspaces`<sup>Required</sup> <a name="workspaces" id="cdktf.CloudBackendProps.property.workspaces"></a>
+
+```typescript
+public readonly workspaces: NamedCloudWorkspace | TaggedCloudWorkspaces;
+```
+
+- _Type:_ <a href="#cdktf.NamedCloudWorkspace">NamedCloudWorkspace</a> | <a href="#cdktf.TaggedCloudWorkspaces">TaggedCloudWorkspaces</a>
+
+A nested block that specifies which remote Terraform Cloud workspaces to use for the current configuration.
+
+The workspaces block must contain exactly one of the following arguments, each denoting a strategy for how workspaces should be mapped:
+
+---
+
+##### `hostname`<sup>Optional</sup> <a name="hostname" id="cdktf.CloudBackendProps.property.hostname"></a>
+
+```typescript
+public readonly hostname: string;
+```
+
+- _Type:_ string
+- _Default:_ app.terraform.io
+
+The hostname of a Terraform Enterprise installation, if using Terraform Enterprise.
+
+---
+
+##### `token`<sup>Optional</sup> <a name="token" id="cdktf.CloudBackendProps.property.token"></a>
+
+```typescript
+public readonly token: string;
+```
+
+- _Type:_ string
+
+The token used to authenticate with Terraform Cloud.
+
+We recommend omitting the token from the configuration, and instead using terraform login or manually configuring credentials in the CLI config file.
 
 ---
 
@@ -14850,36 +15171,40 @@ const dataTerraformRemoteStateS3Config: DataTerraformRemoteStateS3Config = { ...
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                                                        | **Type**                            | **Description**                                                                                                                                                                                                                                                |
-| ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.defaults">defaults</a></code>                                   | <code>{[ key: string ]: any}</code> | _No description._                                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.workspace">workspace</a></code>                                 | <code>string</code>                 | _No description._                                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.bucket">bucket</a></code>                                       | <code>string</code>                 | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.key">key</a></code>                                             | <code>string</code>                 | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.accessKey">accessKey</a></code>                                 | <code>string</code>                 | (Optional) AWS access key.                                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.acl">acl</a></code>                                             | <code>string</code>                 | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRolePolicy">assumeRolePolicy</a></code>                   | <code>string</code>                 | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.dynamodbEndpoint">dynamodbEndpoint</a></code>                   | <code>string</code>                 | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.dynamodbTable">dynamodbTable</a></code>                         | <code>string</code>                 | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.encrypt">encrypt</a></code>                                     | <code>boolean</code>                | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.endpoint">endpoint</a></code>                                   | <code>string</code>                 | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.externalId">externalId</a></code>                               | <code>string</code>                 | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.forcePathStyle">forcePathStyle</a></code>                       | <code>boolean</code>                | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.iamEndpoint">iamEndpoint</a></code>                             | <code>string</code>                 | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.kmsKeyId">kmsKeyId</a></code>                                   | <code>string</code>                 | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.maxRetries">maxRetries</a></code>                               | <code>number</code>                 | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.profile">profile</a></code>                                     | <code>string</code>                 | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.region">region</a></code>                                       | <code>string</code>                 | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.roleArn">roleArn</a></code>                                     | <code>string</code>                 | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.secretKey">secretKey</a></code>                                 | <code>string</code>                 | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sessionName">sessionName</a></code>                             | <code>string</code>                 | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sharedCredentialsFile">sharedCredentialsFile</a></code>         | <code>string</code>                 | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipCredentialsValidation">skipCredentialsValidation</a></code> | <code>boolean</code>                | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipMetadataApiCheck">skipMetadataApiCheck</a></code>           | <code>boolean</code>                | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sseCustomerKey">sseCustomerKey</a></code>                       | <code>string</code>                 | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.stsEndpoint">stsEndpoint</a></code>                             | <code>string</code>                 | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.token">token</a></code>                                         | <code>string</code>                 | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.workspaceKeyPrefix">workspaceKeyPrefix</a></code>               | <code>string</code>                 | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
+| **Name**                                                                                                                            | **Type**                               | **Description**                                                                                                                                                                                                                                                |
+| ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.defaults">defaults</a></code>                                       | <code>{[ key: string ]: any}</code>    | _No description._                                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.workspace">workspace</a></code>                                     | <code>string</code>                    | _No description._                                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.bucket">bucket</a></code>                                           | <code>string</code>                    | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.key">key</a></code>                                                 | <code>string</code>                    | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.accessKey">accessKey</a></code>                                     | <code>string</code>                    | (Optional) AWS access key.                                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.acl">acl</a></code>                                                 | <code>string</code>                    | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRolePolicy">assumeRolePolicy</a></code>                       | <code>string</code>                    | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRolePolicyArns">assumeRolePolicyArns</a></code>               | <code>string[]</code>                  | (Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.                                                                                                                      |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRoleTags">assumeRoleTags</a></code>                           | <code>{[ key: string ]: string}</code> | (Optional) Map of assume role session tags.                                                                                                                                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.assumeRoleTransitiveTagKeys">assumeRoleTransitiveTagKeys</a></code> | <code>string[]</code>                  | (Optional) Set of assume role session tag keys to pass to any subsequent sessions.                                                                                                                                                                             |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.dynamodbEndpoint">dynamodbEndpoint</a></code>                       | <code>string</code>                    | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.dynamodbTable">dynamodbTable</a></code>                             | <code>string</code>                    | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.encrypt">encrypt</a></code>                                         | <code>boolean</code>                   | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.endpoint">endpoint</a></code>                                       | <code>string</code>                    | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.externalId">externalId</a></code>                                   | <code>string</code>                    | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.forcePathStyle">forcePathStyle</a></code>                           | <code>boolean</code>                   | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.iamEndpoint">iamEndpoint</a></code>                                 | <code>string</code>                    | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.kmsKeyId">kmsKeyId</a></code>                                       | <code>string</code>                    | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.maxRetries">maxRetries</a></code>                                   | <code>number</code>                    | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.profile">profile</a></code>                                         | <code>string</code>                    | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.region">region</a></code>                                           | <code>string</code>                    | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.roleArn">roleArn</a></code>                                         | <code>string</code>                    | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.secretKey">secretKey</a></code>                                     | <code>string</code>                    | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sessionName">sessionName</a></code>                                 | <code>string</code>                    | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sharedCredentialsFile">sharedCredentialsFile</a></code>             | <code>string</code>                    | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipCredentialsValidation">skipCredentialsValidation</a></code>     | <code>boolean</code>                   | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipMetadataApiCheck">skipMetadataApiCheck</a></code>               | <code>boolean</code>                   | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.skipRegionValidation">skipRegionValidation</a></code>               | <code>boolean</code>                   | (Optional) Skip validation of provided region name.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.sseCustomerKey">sseCustomerKey</a></code>                           | <code>string</code>                    | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.stsEndpoint">stsEndpoint</a></code>                                 | <code>string</code>                    | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.token">token</a></code>                                             | <code>string</code>                    | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3Config.property.workspaceKeyPrefix">workspaceKeyPrefix</a></code>                   | <code>string</code>                    | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
 
 ---
 
@@ -14968,6 +15293,42 @@ public readonly assumeRolePolicy: string;
 - _Type:_ string
 
 (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `assumeRolePolicyArns`<sup>Optional</sup> <a name="assumeRolePolicyArns" id="cdktf.DataTerraformRemoteStateS3Config.property.assumeRolePolicyArns"></a>
+
+```typescript
+public readonly assumeRolePolicyArns: string[];
+```
+
+- _Type:_ string[]
+
+(Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `assumeRoleTags`<sup>Optional</sup> <a name="assumeRoleTags" id="cdktf.DataTerraformRemoteStateS3Config.property.assumeRoleTags"></a>
+
+```typescript
+public readonly assumeRoleTags: {[ key: string ]: string};
+```
+
+- _Type:_ {[ key: string ]: string}
+
+(Optional) Map of assume role session tags.
+
+---
+
+##### `assumeRoleTransitiveTagKeys`<sup>Optional</sup> <a name="assumeRoleTransitiveTagKeys" id="cdktf.DataTerraformRemoteStateS3Config.property.assumeRoleTransitiveTagKeys"></a>
+
+```typescript
+public readonly assumeRoleTransitiveTagKeys: string[];
+```
+
+- _Type:_ string[]
+
+(Optional) Set of assume role session tag keys to pass to any subsequent sessions.
 
 ---
 
@@ -15198,6 +15559,18 @@ public readonly skipMetadataApiCheck: boolean;
 - _Type:_ boolean
 
 (Optional) Skip usage of EC2 Metadata API.
+
+---
+
+##### `skipRegionValidation`<sup>Optional</sup> <a name="skipRegionValidation" id="cdktf.DataTerraformRemoteStateS3Config.property.skipRegionValidation"></a>
+
+```typescript
+public readonly skipRegionValidation: boolean;
+```
+
+- _Type:_ boolean
+
+(Optional) Skip validation of provided region name.
 
 ---
 
@@ -17222,34 +17595,38 @@ const s3BackendProps: S3BackendProps = { ... }
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                                      | **Type**             | **Description**                                                                                                                                                                                                                                                |
-| ------------------------------------------------------------------------------------------------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.S3BackendProps.property.bucket">bucket</a></code>                                       | <code>string</code>  | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
-| <code><a href="#cdktf.S3BackendProps.property.key">key</a></code>                                             | <code>string</code>  | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
-| <code><a href="#cdktf.S3BackendProps.property.accessKey">accessKey</a></code>                                 | <code>string</code>  | (Optional) AWS access key.                                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.S3BackendProps.property.acl">acl</a></code>                                             | <code>string</code>  | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.S3BackendProps.property.assumeRolePolicy">assumeRolePolicy</a></code>                   | <code>string</code>  | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
-| <code><a href="#cdktf.S3BackendProps.property.dynamodbEndpoint">dynamodbEndpoint</a></code>                   | <code>string</code>  | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
-| <code><a href="#cdktf.S3BackendProps.property.dynamodbTable">dynamodbTable</a></code>                         | <code>string</code>  | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
-| <code><a href="#cdktf.S3BackendProps.property.encrypt">encrypt</a></code>                                     | <code>boolean</code> | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
-| <code><a href="#cdktf.S3BackendProps.property.endpoint">endpoint</a></code>                                   | <code>string</code>  | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
-| <code><a href="#cdktf.S3BackendProps.property.externalId">externalId</a></code>                               | <code>string</code>  | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
-| <code><a href="#cdktf.S3BackendProps.property.forcePathStyle">forcePathStyle</a></code>                       | <code>boolean</code> | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
-| <code><a href="#cdktf.S3BackendProps.property.iamEndpoint">iamEndpoint</a></code>                             | <code>string</code>  | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
-| <code><a href="#cdktf.S3BackendProps.property.kmsKeyId">kmsKeyId</a></code>                                   | <code>string</code>  | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
-| <code><a href="#cdktf.S3BackendProps.property.maxRetries">maxRetries</a></code>                               | <code>number</code>  | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
-| <code><a href="#cdktf.S3BackendProps.property.profile">profile</a></code>                                     | <code>string</code>  | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
-| <code><a href="#cdktf.S3BackendProps.property.region">region</a></code>                                       | <code>string</code>  | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
-| <code><a href="#cdktf.S3BackendProps.property.roleArn">roleArn</a></code>                                     | <code>string</code>  | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
-| <code><a href="#cdktf.S3BackendProps.property.secretKey">secretKey</a></code>                                 | <code>string</code>  | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
-| <code><a href="#cdktf.S3BackendProps.property.sessionName">sessionName</a></code>                             | <code>string</code>  | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
-| <code><a href="#cdktf.S3BackendProps.property.sharedCredentialsFile">sharedCredentialsFile</a></code>         | <code>string</code>  | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.S3BackendProps.property.skipCredentialsValidation">skipCredentialsValidation</a></code> | <code>boolean</code> | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
-| <code><a href="#cdktf.S3BackendProps.property.skipMetadataApiCheck">skipMetadataApiCheck</a></code>           | <code>boolean</code> | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
-| <code><a href="#cdktf.S3BackendProps.property.sseCustomerKey">sseCustomerKey</a></code>                       | <code>string</code>  | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
-| <code><a href="#cdktf.S3BackendProps.property.stsEndpoint">stsEndpoint</a></code>                             | <code>string</code>  | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
-| <code><a href="#cdktf.S3BackendProps.property.token">token</a></code>                                         | <code>string</code>  | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
-| <code><a href="#cdktf.S3BackendProps.property.workspaceKeyPrefix">workspaceKeyPrefix</a></code>               | <code>string</code>  | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
+| **Name**                                                                                                          | **Type**                               | **Description**                                                                                                                                                                                                                                                |
+| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.S3BackendProps.property.bucket">bucket</a></code>                                           | <code>string</code>                    | Name of the S3 Bucket.                                                                                                                                                                                                                                         |
+| <code><a href="#cdktf.S3BackendProps.property.key">key</a></code>                                                 | <code>string</code>                    | Path to the state file inside the S3 Bucket.                                                                                                                                                                                                                   |
+| <code><a href="#cdktf.S3BackendProps.property.accessKey">accessKey</a></code>                                     | <code>string</code>                    | (Optional) AWS access key.                                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.S3BackendProps.property.acl">acl</a></code>                                                 | <code>string</code>                    | (Optional) Canned ACL to be applied to the state file.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.S3BackendProps.property.assumeRolePolicy">assumeRolePolicy</a></code>                       | <code>string</code>                    | (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.                                                                                                                                                          |
+| <code><a href="#cdktf.S3BackendProps.property.assumeRolePolicyArns">assumeRolePolicyArns</a></code>               | <code>string[]</code>                  | (Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.                                                                                                                      |
+| <code><a href="#cdktf.S3BackendProps.property.assumeRoleTags">assumeRoleTags</a></code>                           | <code>{[ key: string ]: string}</code> | (Optional) Map of assume role session tags.                                                                                                                                                                                                                    |
+| <code><a href="#cdktf.S3BackendProps.property.assumeRoleTransitiveTagKeys">assumeRoleTransitiveTagKeys</a></code> | <code>string[]</code>                  | (Optional) Set of assume role session tag keys to pass to any subsequent sessions.                                                                                                                                                                             |
+| <code><a href="#cdktf.S3BackendProps.property.dynamodbEndpoint">dynamodbEndpoint</a></code>                       | <code>string</code>                    | (Optional) Custom endpoint for the AWS DynamoDB API.                                                                                                                                                                                                           |
+| <code><a href="#cdktf.S3BackendProps.property.dynamodbTable">dynamodbTable</a></code>                             | <code>string</code>                    | (Optional) Name of DynamoDB Table to use for state locking and consistency.                                                                                                                                                                                    |
+| <code><a href="#cdktf.S3BackendProps.property.encrypt">encrypt</a></code>                                         | <code>boolean</code>                   | (Optional) Enable server side encryption of the state file.                                                                                                                                                                                                    |
+| <code><a href="#cdktf.S3BackendProps.property.endpoint">endpoint</a></code>                                       | <code>string</code>                    | (Optional) Custom endpoint for the AWS S3 API.                                                                                                                                                                                                                 |
+| <code><a href="#cdktf.S3BackendProps.property.externalId">externalId</a></code>                                   | <code>string</code>                    | (Optional) External identifier to use when assuming the role.                                                                                                                                                                                                  |
+| <code><a href="#cdktf.S3BackendProps.property.forcePathStyle">forcePathStyle</a></code>                           | <code>boolean</code>                   | (Optional) Enable path-style S3 URLs (https://< HOST >/< BUCKET > instead of https://< BUCKET >.< HOST >).                                                                                                                                                     |
+| <code><a href="#cdktf.S3BackendProps.property.iamEndpoint">iamEndpoint</a></code>                                 | <code>string</code>                    | (Optional) Custom endpoint for the AWS Identity and Access Management (IAM) API.                                                                                                                                                                               |
+| <code><a href="#cdktf.S3BackendProps.property.kmsKeyId">kmsKeyId</a></code>                                       | <code>string</code>                    | (Optional) Amazon Resource Name (ARN) of a Key Management Service (KMS) Key to use for encrypting the state.                                                                                                                                                   |
+| <code><a href="#cdktf.S3BackendProps.property.maxRetries">maxRetries</a></code>                                   | <code>number</code>                    | (Optional) The maximum number of times an AWS API request is retried on retryable failure.                                                                                                                                                                     |
+| <code><a href="#cdktf.S3BackendProps.property.profile">profile</a></code>                                         | <code>string</code>                    | (Optional) Name of AWS profile in AWS shared credentials file (e.g. ~/.aws/credentials) or AWS shared configuration file (e.g. ~/.aws/config) to use for credentials and/or configuration. This can also be sourced from the AWS_PROFILE environment variable. |
+| <code><a href="#cdktf.S3BackendProps.property.region">region</a></code>                                           | <code>string</code>                    | AWS Region of the S3 Bucket and DynamoDB Table (if used).                                                                                                                                                                                                      |
+| <code><a href="#cdktf.S3BackendProps.property.roleArn">roleArn</a></code>                                         | <code>string</code>                    | (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.                                                                                                                                                                                               |
+| <code><a href="#cdktf.S3BackendProps.property.secretKey">secretKey</a></code>                                     | <code>string</code>                    | (Optional) AWS secret access key.                                                                                                                                                                                                                              |
+| <code><a href="#cdktf.S3BackendProps.property.sessionName">sessionName</a></code>                                 | <code>string</code>                    | (Optional) Session name to use when assuming the role.                                                                                                                                                                                                         |
+| <code><a href="#cdktf.S3BackendProps.property.sharedCredentialsFile">sharedCredentialsFile</a></code>             | <code>string</code>                    | (Optional) Path to the AWS shared credentials file.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.S3BackendProps.property.skipCredentialsValidation">skipCredentialsValidation</a></code>     | <code>boolean</code>                   | (Optional) Skip credentials validation via the STS API.                                                                                                                                                                                                        |
+| <code><a href="#cdktf.S3BackendProps.property.skipMetadataApiCheck">skipMetadataApiCheck</a></code>               | <code>boolean</code>                   | (Optional) Skip usage of EC2 Metadata API.                                                                                                                                                                                                                     |
+| <code><a href="#cdktf.S3BackendProps.property.skipRegionValidation">skipRegionValidation</a></code>               | <code>boolean</code>                   | (Optional) Skip validation of provided region name.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.S3BackendProps.property.sseCustomerKey">sseCustomerKey</a></code>                           | <code>string</code>                    | (Optional) The key to use for encrypting state with Server-Side Encryption with Customer-Provided Keys (SSE-C).                                                                                                                                                |
+| <code><a href="#cdktf.S3BackendProps.property.stsEndpoint">stsEndpoint</a></code>                                 | <code>string</code>                    | (Optional) Custom endpoint for the AWS Security Token Service (STS) API.                                                                                                                                                                                       |
+| <code><a href="#cdktf.S3BackendProps.property.token">token</a></code>                                             | <code>string</code>                    | (Optional) Multi-Factor Authentication (MFA) token.                                                                                                                                                                                                            |
+| <code><a href="#cdktf.S3BackendProps.property.workspaceKeyPrefix">workspaceKeyPrefix</a></code>                   | <code>string</code>                    | (Optional) Prefix applied to the state path inside the bucket.                                                                                                                                                                                                 |
 
 ---
 
@@ -17318,6 +17695,42 @@ public readonly assumeRolePolicy: string;
 - _Type:_ string
 
 (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `assumeRolePolicyArns`<sup>Optional</sup> <a name="assumeRolePolicyArns" id="cdktf.S3BackendProps.property.assumeRolePolicyArns"></a>
+
+```typescript
+public readonly assumeRolePolicyArns: string[];
+```
+
+- _Type:_ string[]
+
+(Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+
+---
+
+##### `assumeRoleTags`<sup>Optional</sup> <a name="assumeRoleTags" id="cdktf.S3BackendProps.property.assumeRoleTags"></a>
+
+```typescript
+public readonly assumeRoleTags: {[ key: string ]: string};
+```
+
+- _Type:_ {[ key: string ]: string}
+
+(Optional) Map of assume role session tags.
+
+---
+
+##### `assumeRoleTransitiveTagKeys`<sup>Optional</sup> <a name="assumeRoleTransitiveTagKeys" id="cdktf.S3BackendProps.property.assumeRoleTransitiveTagKeys"></a>
+
+```typescript
+public readonly assumeRoleTransitiveTagKeys: string[];
+```
+
+- _Type:_ string[]
+
+(Optional) Set of assume role session tag keys to pass to any subsequent sessions.
 
 ---
 
@@ -17548,6 +17961,18 @@ public readonly skipMetadataApiCheck: boolean;
 - _Type:_ boolean
 
 (Optional) Skip usage of EC2 Metadata API.
+
+---
+
+##### `skipRegionValidation`<sup>Optional</sup> <a name="skipRegionValidation" id="cdktf.S3BackendProps.property.skipRegionValidation"></a>
+
+```typescript
+public readonly skipRegionValidation: boolean;
+```
+
+- _Type:_ boolean
+
+(Optional) Skip validation of provided region name.
 
 ---
 
@@ -20475,6 +20900,37 @@ public readonly fqn: string;
 - _Type:_ string
 
 ---
+
+### CloudWorkspace <a name="CloudWorkspace" id="cdktf.CloudWorkspace"></a>
+
+A cloud workspace can either be a single named workspace, or a list of tagged workspaces.
+
+#### Initializers <a name="Initializers" id="cdktf.CloudWorkspace.Initializer"></a>
+
+```typescript
+import { CloudWorkspace } from "cdktf";
+
+new CloudWorkspace();
+```
+
+| **Name** | **Type** | **Description** |
+| -------- | -------- | --------------- |
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name**                                                                 | **Description**   |
+| ------------------------------------------------------------------------ | ----------------- |
+| <code><a href="#cdktf.CloudWorkspace.toTerraform">toTerraform</a></code> | _No description._ |
+
+---
+
+##### `toTerraform` <a name="toTerraform" id="cdktf.CloudWorkspace.toTerraform"></a>
+
+```typescript
+public toTerraform(): any
+```
 
 ### ComplexComputedList <a name="ComplexComputedList" id="cdktf.ComplexComputedList"></a>
 
@@ -24466,6 +24922,64 @@ Returns the value of the current item iterated over.
 
 ---
 
+### NamedCloudWorkspace <a name="NamedCloudWorkspace" id="cdktf.NamedCloudWorkspace"></a>
+
+The name of a single Terraform Cloud workspace.
+
+You will only be able to use the workspace specified in the configuration with this working directory, and cannot manage workspaces from the CLI (e.g. terraform workspace select or terraform workspace new).
+
+#### Initializers <a name="Initializers" id="cdktf.NamedCloudWorkspace.Initializer"></a>
+
+```typescript
+import { NamedCloudWorkspace } from 'cdktf'
+
+new NamedCloudWorkspace(name: string)
+```
+
+| **Name**                                                                              | **Type**            | **Description**   |
+| ------------------------------------------------------------------------------------- | ------------------- | ----------------- |
+| <code><a href="#cdktf.NamedCloudWorkspace.Initializer.parameter.name">name</a></code> | <code>string</code> | _No description._ |
+
+---
+
+##### `name`<sup>Required</sup> <a name="name" id="cdktf.NamedCloudWorkspace.Initializer.parameter.name"></a>
+
+- _Type:_ string
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name**                                                                      | **Description**   |
+| ----------------------------------------------------------------------------- | ----------------- |
+| <code><a href="#cdktf.NamedCloudWorkspace.toTerraform">toTerraform</a></code> | _No description._ |
+
+---
+
+##### `toTerraform` <a name="toTerraform" id="cdktf.NamedCloudWorkspace.toTerraform"></a>
+
+```typescript
+public toTerraform(): any
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name**                                                                 | **Type**            | **Description**   |
+| ------------------------------------------------------------------------ | ------------------- | ----------------- |
+| <code><a href="#cdktf.NamedCloudWorkspace.property.name">name</a></code> | <code>string</code> | _No description._ |
+
+---
+
+##### `name`<sup>Required</sup> <a name="name" id="cdktf.NamedCloudWorkspace.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- _Type:_ string
+
+---
+
 ### NamedRemoteWorkspace <a name="NamedRemoteWorkspace" id="cdktf.NamedRemoteWorkspace"></a>
 
 - _Implements:_ <a href="#cdktf.IRemoteWorkspace">IRemoteWorkspace</a>
@@ -25107,6 +25621,64 @@ public readonly fqn: string;
 
 ---
 
+### TaggedCloudWorkspaces <a name="TaggedCloudWorkspaces" id="cdktf.TaggedCloudWorkspaces"></a>
+
+A set of Terraform Cloud workspace tags.
+
+You will be able to use this working directory with any workspaces that have all of the specified tags, and can use the terraform workspace commands to switch between them or create new workspaces. New workspaces will automatically have the specified tags. This option conflicts with name.
+
+#### Initializers <a name="Initializers" id="cdktf.TaggedCloudWorkspaces.Initializer"></a>
+
+```typescript
+import { TaggedCloudWorkspaces } from 'cdktf'
+
+new TaggedCloudWorkspaces(tags: string[])
+```
+
+| **Name**                                                                                | **Type**              | **Description**   |
+| --------------------------------------------------------------------------------------- | --------------------- | ----------------- |
+| <code><a href="#cdktf.TaggedCloudWorkspaces.Initializer.parameter.tags">tags</a></code> | <code>string[]</code> | _No description._ |
+
+---
+
+##### `tags`<sup>Required</sup> <a name="tags" id="cdktf.TaggedCloudWorkspaces.Initializer.parameter.tags"></a>
+
+- _Type:_ string[]
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name**                                                                        | **Description**   |
+| ------------------------------------------------------------------------------- | ----------------- |
+| <code><a href="#cdktf.TaggedCloudWorkspaces.toTerraform">toTerraform</a></code> | _No description._ |
+
+---
+
+##### `toTerraform` <a name="toTerraform" id="cdktf.TaggedCloudWorkspaces.toTerraform"></a>
+
+```typescript
+public toTerraform(): any
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name**                                                                   | **Type**              | **Description**   |
+| -------------------------------------------------------------------------- | --------------------- | ----------------- |
+| <code><a href="#cdktf.TaggedCloudWorkspaces.property.tags">tags</a></code> | <code>string[]</code> | _No description._ |
+
+---
+
+##### `tags`<sup>Required</sup> <a name="tags" id="cdktf.TaggedCloudWorkspaces.property.tags"></a>
+
+```typescript
+public readonly tags: string[];
+```
+
+- _Type:_ string[]
+
+---
+
 ### TerraformIterator <a name="TerraformIterator" id="cdktf.TerraformIterator"></a>
 
 - _Implements:_ <a href="#cdktf.ITerraformIterator">ITerraformIterator</a>
@@ -25572,7 +26144,7 @@ Testing.stubVersion(app: App)
 ```typescript
 import { Testing } from 'cdktf'
 
-Testing.synth(stack: TerraformStack)
+Testing.synth(stack: TerraformStack, runValidations?: boolean)
 ```
 
 Returns the Terraform synthesized JSON.
@@ -25580,6 +26152,12 @@ Returns the Terraform synthesized JSON.
 ###### `stack`<sup>Required</sup> <a name="stack" id="cdktf.Testing.synth.parameter.stack"></a>
 
 - _Type:_ <a href="#cdktf.TerraformStack">TerraformStack</a>
+
+---
+
+###### `runValidations`<sup>Optional</sup> <a name="runValidations" id="cdktf.Testing.synth.parameter.runValidations"></a>
+
+- _Type:_ boolean
 
 ---
 
@@ -27115,7 +27693,7 @@ True when ${} should be ommitted (because already inside them), false otherwise.
 
 - _Extends:_ constructs.IConstruct
 
-- _Implemented By:_ <a href="#cdktf.Resource">Resource</a>, <a href="#cdktf.TerraformAsset">TerraformAsset</a>, <a href="#cdktf.IResource">IResource</a>
+- _Implemented By:_ <a href="#cdktf.Resource">Resource</a>, <a href="#cdktf.IResource">IResource</a>
 
 #### Properties <a name="Properties" id="Properties"></a>
 


### PR DESCRIPTION
## 0.12.2

**Breaking Changes**

A very minor change in the interface names for provisioners occured [to support them in JSII languages](https://github.com/hashicorp/terraform-cdk/pull/2042), renaming the following interfaces:

- `ISSHProvisionerConnection` to `SSHProvisionerConnection`
- `IWinrmProvisionerConnection` to `WinrmProvisionerConnection`
- `IFileProvisioner` to `FileProvisioner`
- `ILocalExecProvisioner` to `LocalExecProvisioner`
- `IRemoteExecProvisioner` to `RemoteExecProvisioner`

Another very minor change is that we now use the `CloudBackend` by default when running cdktf init. This requires Terraform >=1.1, therefore an error is thrown on `cdktf init` if you want to use Terraform Cloud and are on an older version. Already existing projects are not affected and you can use `cdktf init --local` and configure the `RemoteBackend` if you need to use an older version.

### feat

- feat(cli): throw an error if a user tries to create a new project with TFC on an old TF version [\#2062](https://github.com/hashicorp/terraform-cdk/pull/2062)
- feat: install time tool in Docker container to be able to use it for memory consumption tracking in tests [\#2059](https://github.com/hashicorp/terraform-cdk/pull/2059)
- feat: add Go port of TypeScript Google CloudRun example [\#2035](https://github.com/hashicorp/terraform-cdk/pull/2035)
- feat(lib): add support for cloud backend [\#1924](https://github.com/hashicorp/terraform-cdk/pull/1924)

### fix

- fix(provider-generator): use terraform get instead of init to download modules [\#2057](https://github.com/hashicorp/terraform-cdk/pull/2057)
- fix(lib): Add missing config options for S3Backend: skipRegionValidation, assumeRolePolicyArns, assumeRoleTags, and assumeRoleTransitiveTagKeys [\#2050](https://github.com/hashicorp/terraform-cdk/pull/2050)
- fix: support provisioners in JSII languages [\#2042](https://github.com/hashicorp/terraform-cdk/pull/2042)
- fix(hcl2json): add fs-extra to dependencies [\#2040](https://github.com/hashicorp/terraform-cdk/pull/2040)
- fix(lib): Improve error message when provider constructs are missing [\#2039](https://github.com/hashicorp/terraform-cdk/pull/2039)
- fix(cli): Make provider add command case insensitive for provider names [\#2038](https://github.com/hashicorp/terraform-cdk/pull/2038)
- fix(cli): run a speculative plan on diff [\#2033](https://github.com/hashicorp/terraform-cdk/pull/2033)

### chore

- chore(cli): remove red and magenta from colors for stack names [\#2064](https://github.com/hashicorp/terraform-cdk/pull/2064)
- chore: add link to hybrid module talk [\#2054](https://github.com/hashicorp/terraform-cdk/pull/2054)
- chore: make Terraform 1.2.8 available in Docker image [\#2051](https://github.com/hashicorp/terraform-cdk/pull/2051)
- chore: document updating the API documentation [\#2046](https://github.com/hashicorp/terraform-cdk/pull/2046)
- chore(docs): Remove positional language + fix style nits [\#2045](https://github.com/hashicorp/terraform-cdk/pull/2045)
- chore(lib): deprecate Resource in favor of Construct [\#2044](https://github.com/hashicorp/terraform-cdk/pull/2044)
- chore: update links in our youtube playlist examples [\#2043](https://github.com/hashicorp/terraform-cdk/pull/2043)
- chore: npm-check-updates && yarn upgrade [\#2025](https://github.com/hashicorp/terraform-cdk/pull/2025)
- chore: translate parts of the documentation [\#2011](https://github.com/hashicorp/terraform-cdk/pull/2011)

### refactor

- refactor: port example script to JS [\#2047](https://github.com/hashicorp/terraform-cdk/pull/2047)
