### PR TITLE
chore(cli): Don't trim output for unstructured logs

### DIFF
--- a/packages/cdktf-cli/lib/server/terraform-logs.ts
+++ b/packages/cdktf-cli/lib/server/terraform-logs.ts
@@ -1,16 +1,12 @@
 function extractJsonLogLineIfPresent(logLine: string): string {
   try {
     const extractedMessage = JSON.parse(logLine)["@message"];
-    return extractedMessage ? extractedMessage : logLine;
+    return extractedMessage ? extractedMessage.trim() : logLine;
   } catch (e) {
     return logLine;
   }
 }
 
 export function extractJsonLogIfPresent(logLines: string): string {
-  return logLines
-    .split("\n")
-    .map(extractJsonLogLineIfPresent)
-    .map((line) => line.trim())
-    .join("\n");
+  return logLines.split("\n").map(extractJsonLogLineIfPresent).join("\n");
 }

--- a/packages/cdktf-cli/test/lib/terraform-logs.test.ts
+++ b/packages/cdktf-cli/test/lib/terraform-logs.test.ts
@@ -33,16 +33,16 @@ describe("extractJsonLogIfPresent", () => {
           {"@level":"info","@message":"null_resource.sleep-79_null-resource_7E1E3312 (sleep-79/null-resource): Plan to create","@module":"terraform.ui","@timestamp":"2022-03-24T14:31:25.720738Z","change":{"resource":{"addr":"null_resource.sleep-79_null-resource_7E1E3312","module":"","resource":"null_resource.sleep-79_null-resource_7E1E3312","implied_provider":"null","resource_type":"null_resource","resource_name":"sleep-79_null-resource_7E1E3312","resource_key":null},"action":"create"},"type":"planned_change"}`
       )
     ).toMatchInlineSnapshot(`
-        "Terraform v1.1.7
-        on linux_amd64
-        Initializing plugins and modules...
-        Terraform 1.1.7
-        null_resource.sleep-78_null-resource_BC9416E8 (sleep-78/null-resource): Plan to create
-        null_resource.sleep-72_null-resource_6139DD69 (sleep-72/null-resource): Plan to create
-        null_resource.sleep-71_null-resource_28FC0011 (sleep-71/null-resource): Plan to create
-        null_resource.sleep-73_null-resource_48B30717 (sleep-73/null-resource): Plan to create
-        null_resource.sleep-79_null-resource_7E1E3312 (sleep-79/null-resource): Plan to create"
-      `);
+      "Terraform v1.1.7
+                on linux_amd64
+                Initializing plugins and modules...
+      Terraform 1.1.7
+      null_resource.sleep-78_null-resource_BC9416E8 (sleep-78/null-resource): Plan to create
+      null_resource.sleep-72_null-resource_6139DD69 (sleep-72/null-resource): Plan to create
+      null_resource.sleep-71_null-resource_28FC0011 (sleep-71/null-resource): Plan to create
+      null_resource.sleep-73_null-resource_48B30717 (sleep-73/null-resource): Plan to create
+      null_resource.sleep-79_null-resource_7E1E3312 (sleep-79/null-resource): Plan to create"
+    `);
   });
 
   it("removes any whitespace before json messages", () => {

--- a/packages/cdktf-cli/test/lib/terraform-logs.test.ts
+++ b/packages/cdktf-cli/test/lib/terraform-logs.test.ts
@@ -44,4 +44,28 @@ describe("extractJsonLogIfPresent", () => {
         null_resource.sleep-79_null-resource_7E1E3312 (sleep-79/null-resource): Plan to create"
       `);
   });
+
+  it("removes any whitespace before json messages", () => {
+    expect(
+      extractJsonLogIfPresent(
+        `{"@level":"info","@message":" Terraform 1.1.7","@module":"terraform.ui","@timestamp":"2022-03-24T14:17:24.197605Z","terraform":"1.1.7","type":"version","ui":"1.0"}`
+      )
+    ).toMatchInlineSnapshot(`"Terraform 1.1.7"`);
+  });
+
+  it("does not remove whitespace before non-json messages", () => {
+    expect(
+      extractJsonLogIfPresent(
+        [
+          "Terraform v1.1.7",
+          "\ton linux_amd64",
+          "\tInitializing plugins and modules...",
+        ].join("\n")
+      )
+    ).toMatchInlineSnapshot(`
+      "Terraform v1.1.7
+      	on linux_amd64
+      	Initializing plugins and modules..."
+    `);
+  });
 });


### PR DESCRIPTION
Previously, the output of Terraform was flattened, removing indentation of non-json output.

Before: 
<img width="681" alt="image" src="https://user-images.githubusercontent.com/573531/188873842-869896d4-acbf-46c4-b4db-ef19dbb76004.png">

with:
<img width="636" alt="image" src="https://user-images.githubusercontent.com/573531/188874130-1dc61924-d042-422d-8f61-716ecfdff03d.png">

## Questions / Thoughts:
- I was not able to try out a proper structured output run, as speculative runs on TF Cloud also are non-json. Maybe I can get some help with testing?