### PR TITLE
feat(cli): Add support for terraform's parallelism flag 

### DIFF
--- a/packages/cdktf-cli/bin/cmds/deploy.ts
+++ b/packages/cdktf-cli/bin/cmds/deploy.ts
@@ -56,6 +56,8 @@ class Command extends BaseCommand {
         default: false,
       })
       .option("parallelism", {
+        // Note: This parallelism doesn't affect the underlying Terraform traversal parallelism
+        // That is done by `terraform-parallelism`
         type: "number",
         required: false,
         desc: "Number of concurrent CDKTF stacks to run. Defaults to infinity, denoted by -1",
@@ -70,7 +72,8 @@ class Command extends BaseCommand {
       .option("terraform-parallelism", {
         type: "number",
         required: false,
-        desc: "Customize number of parallel graph traversals by Terraform. By default, the parallelism flag is not forwarded to Terraform.",
+        desc: "Customize number of parallel graph traversals by Terraform. By default, the parallelism flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend",
+        // Setting value to negative will prevent it from being forwarded to terraform as an argument
         default: -1,
       })
       .showHelpOnFail(true);

--- a/packages/cdktf-cli/bin/cmds/deploy.ts
+++ b/packages/cdktf-cli/bin/cmds/deploy.ts
@@ -72,7 +72,7 @@ class Command extends BaseCommand {
       .option("terraform-parallelism", {
         type: "number",
         required: false,
-        desc: "Customize number of parallel graph traversals by Terraform. By default, the parallelism flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend",
+        desc: "Forwards value as the `-parallelism` flag to Terraform. By default, the this flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend",
         // Setting value to negative will prevent it from being forwarded to terraform as an argument
         default: -1,
       })

--- a/packages/cdktf-cli/bin/cmds/deploy.ts
+++ b/packages/cdktf-cli/bin/cmds/deploy.ts
@@ -67,6 +67,12 @@ class Command extends BaseCommand {
         boolean: true,
         desc: 'Select the "refresh only" planning mode, which checks whether remote objects still match the outcome of the most recent Terraform apply but does not propose any actions to undo any changes made outside of Terraform.',
       })
+      .option("terraform-parallelism", {
+        type: "number",
+        required: false,
+        desc: "Customize number of parallel graph traversals by Terraform. By default, the parallelism flag is not forwarded to Terraform.",
+        default: -1,
+      })
       .showHelpOnFail(true);
 
   public async handleCommand(argv: any) {

--- a/packages/cdktf-cli/bin/cmds/destroy.ts
+++ b/packages/cdktf-cli/bin/cmds/destroy.ts
@@ -51,7 +51,7 @@ class Command extends BaseCommand {
       .option("terraform-parallelism", {
         type: "number",
         required: false,
-        desc: "Customize number of parallel graph traversals by Terraform. By default, the parallelism flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend",
+        desc: "Forwards value as the `-parallelism` flag to Terraform. By default, the this flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend",
         // Setting value to negative will prevent it from being forwarded to terraform as an argument
         default: -1,
       })

--- a/packages/cdktf-cli/bin/cmds/destroy.ts
+++ b/packages/cdktf-cli/bin/cmds/destroy.ts
@@ -48,6 +48,12 @@ class Command extends BaseCommand {
         desc: "Number of concurrent CDKTF stacks to run. Defaults to infinity, denoted by -1",
         default: -1,
       })
+      .option("terraform-parallelism", {
+        type: "number",
+        required: false,
+        desc: "Customize number of parallel graph traversals by Terraform. By default, the parallelism flag is not forwarded to Terraform.",
+        default: -1,
+      })
       .showHelpOnFail(true);
 
   public async handleCommand(argv: any) {

--- a/packages/cdktf-cli/bin/cmds/destroy.ts
+++ b/packages/cdktf-cli/bin/cmds/destroy.ts
@@ -51,7 +51,8 @@ class Command extends BaseCommand {
       .option("terraform-parallelism", {
         type: "number",
         required: false,
-        desc: "Customize number of parallel graph traversals by Terraform. By default, the parallelism flag is not forwarded to Terraform.",
+        desc: "Customize number of parallel graph traversals by Terraform. By default, the parallelism flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend",
+        // Setting value to negative will prevent it from being forwarded to terraform as an argument
         default: -1,
       })
       .showHelpOnFail(true);

--- a/packages/cdktf-cli/bin/cmds/diff.ts
+++ b/packages/cdktf-cli/bin/cmds/diff.ts
@@ -38,6 +38,13 @@ class Command extends BaseCommand {
         boolean: true,
         desc: 'Select the "refresh only" planning mode, which checks whether remote objects still match the outcome of the most recent Terraform apply but does not propose any actions to undo any changes made outside of Terraform.',
       })
+      .option("terraform-parallelism", {
+        type: "number",
+        required: false,
+        desc: "Customize number of parallel graph traversals by Terraform. By default, the parallelism flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend",
+        // Setting value to negative will prevent it from being forwarded to terraform as an argument
+        default: -1,
+      })
       .showHelpOnFail(true);
 
   public async handleCommand(argv: any) {

--- a/packages/cdktf-cli/bin/cmds/diff.ts
+++ b/packages/cdktf-cli/bin/cmds/diff.ts
@@ -41,7 +41,7 @@ class Command extends BaseCommand {
       .option("terraform-parallelism", {
         type: "number",
         required: false,
-        desc: "Customize number of parallel graph traversals by Terraform. By default, the parallelism flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend",
+        desc: "Forwards value as the `-parallelism` flag to Terraform. By default, the this flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend",
         // Setting value to negative will prevent it from being forwarded to terraform as an argument
         default: -1,
       })

--- a/packages/cdktf-cli/bin/cmds/handlers.ts
+++ b/packages/cdktf-cli/bin/cmds/handlers.ts
@@ -157,6 +157,7 @@ export async function destroy(argv: any) {
   const ignoreMissingStackDependencies =
     argv.ignoreMissingStackDependencies || false;
   const parallelism = argv.parallelism;
+  const terraformParallelism = argv.terraformParallelism;
 
   await renderInk(
     React.createElement(Destroy, {
@@ -166,6 +167,7 @@ export async function destroy(argv: any) {
       autoApprove,
       ignoreMissingStackDependencies,
       parallelism,
+      terraformParallelism,
     })
   );
 }
@@ -179,6 +181,7 @@ export async function diff(argv: any) {
   const outDir = argv.output;
   const stack = argv.stack;
   const refreshOnly = argv.refreshOnly;
+  const terraformParallelism = argv.terraformParallelism;
 
   await renderInk(
     React.createElement(Diff, {
@@ -186,6 +189,7 @@ export async function diff(argv: any) {
       refreshOnly,
       targetStack: stack,
       synthCommand: command,
+      terraformParallelism,
     })
   );
 }

--- a/packages/cdktf-cli/bin/cmds/handlers.ts
+++ b/packages/cdktf-cli/bin/cmds/handlers.ts
@@ -115,6 +115,9 @@ export async function deploy(argv: any) {
   const includeSensitiveOutputs = argv.outputsFileIncludeSensitiveOutputs;
   const refreshOnly = argv.refreshOnly;
   const terraformParallelism = argv.terraformParallelism;
+  const ignoreMissingStackDependencies =
+    argv.ignoreMissingStackDependencies || false;
+  const parallelism = argv.parallelism;
 
   let outputsPath: string | undefined = undefined;
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -134,9 +137,8 @@ export async function deploy(argv: any) {
       autoApprove,
       onOutputsRetrieved,
       outputsPath,
-      ignoreMissingStackDependencies:
-        argv.ignoreMissingStackDependencies || false,
-      parallelism: argv.parallelism,
+      ignoreMissingStackDependencies,
+      parallelism,
       refreshOnly,
       terraformParallelism,
     })
@@ -152,6 +154,9 @@ export async function destroy(argv: any) {
   const outDir = argv.output;
   const autoApprove = argv.autoApprove;
   const stacks = argv.stacks;
+  const ignoreMissingStackDependencies =
+    argv.ignoreMissingStackDependencies || false;
+  const parallelism = argv.parallelism;
 
   await renderInk(
     React.createElement(Destroy, {
@@ -159,9 +164,8 @@ export async function destroy(argv: any) {
       targetStacks: stacks,
       synthCommand: command,
       autoApprove,
-      ignoreMissingStackDependencies:
-        argv.ignoreMissingStackDependencies || false,
-      parallelism: argv.parallelism,
+      ignoreMissingStackDependencies,
+      parallelism,
     })
   );
 }

--- a/packages/cdktf-cli/bin/cmds/handlers.ts
+++ b/packages/cdktf-cli/bin/cmds/handlers.ts
@@ -333,6 +333,8 @@ export async function watch(argv: any) {
   const outDir = argv.output;
   const autoApprove = argv.autoApprove;
   const stacks = argv.stacks;
+  const terraformParallelism = argv.terraformParallelism;
+  const parallelism = argv.parallelism;
 
   if (!autoApprove) {
     console.error(
@@ -347,6 +349,8 @@ export async function watch(argv: any) {
       targetStacks: stacks,
       synthCommand: command,
       autoApprove,
+      terraformParallelism,
+      parallelism,
     })
   );
 }

--- a/packages/cdktf-cli/bin/cmds/handlers.ts
+++ b/packages/cdktf-cli/bin/cmds/handlers.ts
@@ -114,6 +114,7 @@ export async function deploy(argv: any) {
   const stacks = argv.stacks;
   const includeSensitiveOutputs = argv.outputsFileIncludeSensitiveOutputs;
   const refreshOnly = argv.refreshOnly;
+  const terraformParallelism = argv.terraformParallelism;
 
   let outputsPath: string | undefined = undefined;
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -137,6 +138,7 @@ export async function deploy(argv: any) {
         argv.ignoreMissingStackDependencies || false,
       parallelism: argv.parallelism,
       refreshOnly,
+      terraformParallelism,
     })
   );
 }

--- a/packages/cdktf-cli/bin/cmds/ui/deploy.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/deploy.tsx
@@ -56,6 +56,7 @@ interface DeployConfig {
   ignoreMissingStackDependencies?: boolean;
   parallelism?: number;
   refreshOnly?: boolean;
+  terraformParallelism?: number;
 }
 
 export const Deploy = ({
@@ -68,6 +69,7 @@ export const Deploy = ({
   ignoreMissingStackDependencies,
   parallelism,
   refreshOnly,
+  terraformParallelism,
 }: DeployConfig): React.ReactElement => {
   const [outputs, setOutputs] = useState<NestedTerraformOutputs>();
   const { status, logEntries } = useCdktfProject(
@@ -79,6 +81,7 @@ export const Deploy = ({
         ignoreMissingStackDependencies,
         parallelism,
         refreshOnly,
+        terraformParallelism,
       });
 
       if (onOutputsRetrieved) {

--- a/packages/cdktf-cli/bin/cmds/ui/destroy.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/destroy.tsx
@@ -15,6 +15,7 @@ interface DestroyConfig {
   autoApprove: boolean;
   ignoreMissingStackDependencies?: boolean;
   parallelism?: number;
+  terraformParallelism?: number;
 }
 
 export const Destroy = ({
@@ -24,6 +25,7 @@ export const Destroy = ({
   autoApprove,
   ignoreMissingStackDependencies,
   parallelism,
+  terraformParallelism,
 }: DestroyConfig): React.ReactElement => {
   const { status, logEntries } = useCdktfProject(
     { outDir, synthCommand },
@@ -33,6 +35,7 @@ export const Destroy = ({
         autoApprove,
         ignoreMissingStackDependencies,
         parallelism,
+        terraformParallelism,
       })
   );
 

--- a/packages/cdktf-cli/bin/cmds/ui/diff.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/diff.tsx
@@ -8,6 +8,7 @@ interface DiffConfig {
   targetStack?: string;
   synthCommand: string;
   refreshOnly?: boolean;
+  terraformParallelism?: number;
 }
 
 export const Diff = ({
@@ -15,10 +16,16 @@ export const Diff = ({
   targetStack,
   synthCommand,
   refreshOnly,
+  terraformParallelism,
 }: DiffConfig): React.ReactElement => {
   const { status, logEntries } = useCdktfProject(
     { outDir, synthCommand },
-    (project) => project.diff({ stackName: targetStack, refreshOnly })
+    (project) =>
+      project.diff({
+        stackName: targetStack,
+        refreshOnly,
+        terraformParallelism,
+      })
   );
 
   return (

--- a/packages/cdktf-cli/bin/cmds/ui/watch.tsx
+++ b/packages/cdktf-cli/bin/cmds/ui/watch.tsx
@@ -10,6 +10,7 @@ interface WatchConfig {
   parallelism?: number;
   synthCommand: string;
   autoApprove: boolean;
+  terraformParallelism?: number;
 }
 
 export const Watch = ({
@@ -18,6 +19,7 @@ export const Watch = ({
   synthCommand,
   autoApprove,
   parallelism,
+  terraformParallelism,
 }: WatchConfig): React.ReactElement => {
   const [logEntryId, setLogEntryId] = useState<number>(0);
   const [logEntries, setLogEntries] = useState<LogEntry[]>([]);
@@ -57,6 +59,7 @@ export const Watch = ({
         autoApprove,
         stackNames: targetStacks,
         parallelism,
+        terraformParallelism,
       },
       ac.signal,
       (state) => {

--- a/packages/cdktf-cli/bin/cmds/watch.ts
+++ b/packages/cdktf-cli/bin/cmds/watch.ts
@@ -43,6 +43,13 @@ class Command extends BaseCommand {
         desc: "Number of concurrent CDKTF stacks to run. Defaults to infinity, denoted by -1",
         default: -1,
       })
+      .option("terraform-parallelism", {
+        type: "number",
+        required: false,
+        desc: "Customize number of parallel graph traversals by Terraform. By default, the parallelism flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend",
+        // Setting value to negative will prevent it from being forwarded to terraform as an argument
+        default: -1,
+      })
       .showHelpOnFail(true);
 
   public async handleCommand(argv: any) {

--- a/packages/cdktf-cli/bin/cmds/watch.ts
+++ b/packages/cdktf-cli/bin/cmds/watch.ts
@@ -46,7 +46,7 @@ class Command extends BaseCommand {
       .option("terraform-parallelism", {
         type: "number",
         required: false,
-        desc: "Customize number of parallel graph traversals by Terraform. By default, the parallelism flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend",
+        desc: "Forwards value as the `-parallelism` flag to Terraform. By default, the this flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend",
         // Setting value to negative will prevent it from being forwarded to terraform as an argument
         default: -1,
       })

--- a/packages/cdktf-cli/lib/cdktf-project.ts
+++ b/packages/cdktf-cli/lib/cdktf-project.ts
@@ -285,6 +285,7 @@ export type AutoApproveOptions = {
 
 export type DiffOptions = SingleStackOptions & {
   refreshOnly?: boolean;
+  terraformParallelism?: number;
 };
 
 export type MutationOptions = MultipleStackOptions &
@@ -513,7 +514,7 @@ export class CdktfProject {
     const stack = this.getStackExecutor(
       getSingleStack(stacks, opts?.stackName, "diff")
     );
-    await stack.diff({ refreshOnly: opts?.refreshOnly });
+    await stack.diff(opts?.refreshOnly, opts?.terraformParallelism);
     if (!stack.currentPlan)
       throw Errors.External(
         `Stack failed to plan: ${stack.stack.name}. Please check the logs for more information.`

--- a/packages/cdktf-cli/lib/cdktf-stack.ts
+++ b/packages/cdktf-cli/lib/cdktf-stack.ts
@@ -269,12 +269,16 @@ export class CdktfStack {
     });
   }
 
-  public async deploy(refreshOnly?: boolean) {
+  public async deploy(refreshOnly?: boolean, terraformParallelism?: number) {
     await this.run(async () => {
       this.updateState({ type: "planning", stackName: this.stack.name });
       const terraform = await this.initalizeTerraform({ isSpeculative: false });
 
-      const plan = await terraform.plan(false, refreshOnly);
+      const plan = await terraform.plan(
+        false,
+        refreshOnly,
+        terraformParallelism
+      );
       this.updateState({ type: "planned", stackName: this.stack.name, plan });
 
       const approved = this.options.autoApprove
@@ -288,7 +292,11 @@ export class CdktfStack {
 
       this.updateState({ type: "deploying", stackName: this.stack.name });
       if (plan.needsApply) {
-        await terraform.deploy(plan.planFile, refreshOnly);
+        await terraform.deploy(
+          plan.planFile,
+          refreshOnly,
+          terraformParallelism
+        );
       }
 
       const outputs = await terraform.output();
@@ -306,7 +314,7 @@ export class CdktfStack {
     });
   }
 
-  public async destroy() {
+  public async destroy(terraformParallelism = -1) {
     await this.run(async () => {
       this.updateState({ type: "planning", stackName: this.stack.name });
       const terraform = await this.initalizeTerraform({ isSpeculative: false });
@@ -323,7 +331,7 @@ export class CdktfStack {
       }
 
       this.updateState({ type: "destroying", stackName: this.stack.name });
-      await terraform.destroy();
+      await terraform.destroy(terraformParallelism);
 
       this.updateState({
         type: "destroyed",

--- a/packages/cdktf-cli/lib/cdktf-stack.ts
+++ b/packages/cdktf-cli/lib/cdktf-stack.ts
@@ -258,12 +258,16 @@ export class CdktfStack {
     this.currentWorkPromise = undefined;
   }
 
-  public async diff({ refreshOnly }: { refreshOnly?: boolean }) {
+  public async diff(refreshOnly?: boolean, terraformParallelism?: number) {
     await this.run(async () => {
       this.updateState({ type: "planning", stackName: this.stack.name });
       const terraform = await this.initalizeTerraform({ isSpeculative: true });
 
-      const plan = await terraform.plan(false, refreshOnly);
+      const plan = await terraform.plan(
+        false,
+        refreshOnly,
+        terraformParallelism
+      );
       this.currentPlan = plan;
       this.updateState({ type: "planned", stackName: this.stack.name, plan });
     });
@@ -314,7 +318,7 @@ export class CdktfStack {
     });
   }
 
-  public async destroy(terraformParallelism = -1) {
+  public async destroy(terraformParallelism?: number) {
     await this.run(async () => {
       this.updateState({ type: "planning", stackName: this.stack.name });
       const terraform = await this.initalizeTerraform({ isSpeculative: false });

--- a/packages/cdktf-cli/lib/models/terraform-cli.ts
+++ b/packages/cdktf-cli/lib/models/terraform-cli.ts
@@ -59,7 +59,8 @@ export class TerraformCli implements Terraform {
 
   public async plan(
     destroy = false,
-    refreshOnly = false
+    refreshOnly = false,
+    parallelism = -1
   ): Promise<TerraformPlan> {
     const planFile = "plan";
     const options = ["plan", "-input=false", "-out", planFile];
@@ -68,6 +69,9 @@ export class TerraformCli implements Terraform {
     }
     if (refreshOnly) {
       options.push("-refresh-only");
+    }
+    if (parallelism !== -1) {
+      options.push(`-parallelism=${parallelism}`);
     }
     await this.setUserAgent();
     await exec(
@@ -96,6 +100,7 @@ export class TerraformCli implements Terraform {
   public async deploy(
     planFile: string,
     refreshOnly = false,
+    parallelism = -1,
     extraOptions: string[] = []
   ): Promise<void> {
     await this.setUserAgent();
@@ -107,10 +112,11 @@ export class TerraformCli implements Terraform {
         "-input=false",
 
         ...extraOptions,
+        ...(refreshOnly ? ["-refresh-only"] : []),
+        ...(parallelism > -1 ? [`-parallelism=${parallelism}`] : []),
         // only appends planFile if not empty
         // this allows deploying without a plan (as used in watch)
         ...(planFile ? [planFile] : []),
-        ...(refreshOnly ? ["-refresh-only"] : []),
       ],
       { cwd: this.workdir, env: process.env, signal: this.abortSignal },
       this.onStdout("deploy"),
@@ -118,11 +124,16 @@ export class TerraformCli implements Terraform {
     );
   }
 
-  public async destroy(): Promise<void> {
+  public async destroy(parallelism = -1): Promise<void> {
     await this.setUserAgent();
+    const options = ["destroy", "-auto-approve", "-input=false"];
+    if (parallelism > -1) {
+      options.push(`-parallelism=${parallelism}`);
+    }
+
     await exec(
       terraformBinaryName,
-      ["destroy", "-auto-approve", "-input=false"],
+      options,
       { cwd: this.workdir, env: process.env, signal: this.abortSignal },
       this.onStdout("destroy"),
       this.onStderr("destroy")

--- a/packages/cdktf-cli/lib/models/terraform-cli.ts
+++ b/packages/cdktf-cli/lib/models/terraform-cli.ts
@@ -70,7 +70,7 @@ export class TerraformCli implements Terraform {
     if (refreshOnly) {
       options.push("-refresh-only");
     }
-    if (parallelism !== -1) {
+    if (parallelism > -1) {
       options.push(`-parallelism=${parallelism}`);
     }
     await this.setUserAgent();

--- a/packages/cdktf-cli/lib/models/terraform-cloud.ts
+++ b/packages/cdktf-cli/lib/models/terraform-cloud.ts
@@ -458,7 +458,7 @@ export class TerraformCloud implements Terraform {
         this.organizationName,
         this.workspaceName
       );
-    } catch (e: any) {
+    } catch (e) {
       if (e.response?.status === 404) {
         // return a more descriptive error message as http response is not descriptive enough
         // will not be touched by BeautifyErrors decorator

--- a/packages/cdktf-cli/lib/models/terraform-cloud.ts
+++ b/packages/cdktf-cli/lib/models/terraform-cloud.ts
@@ -234,6 +234,7 @@ export class TerraformCloud implements Terraform {
   public async plan(
     destroy = false,
     refreshOnly = false,
+    // Parallelism is ignored as custom parallelism is not supported by TFC yet
     _parallelism = -1
   ): Promise<TerraformPlan> {
     if (!this.configurationVersionId)
@@ -353,6 +354,7 @@ export class TerraformCloud implements Terraform {
   public async deploy(
     _planFile: string,
     _refreshOnly?: boolean,
+    // Parallelism is ignored as custom parallelism is not supported by TFC yet
     _parallelism?: number
   ): Promise<void> {
     const sendLog = this.createTerraformLogHandler("deploy");
@@ -456,7 +458,7 @@ export class TerraformCloud implements Terraform {
         this.organizationName,
         this.workspaceName
       );
-    } catch (e) {
+    } catch (e: any) {
       if (e.response?.status === 404) {
         // return a more descriptive error message as http response is not descriptive enough
         // will not be touched by BeautifyErrors decorator

--- a/packages/cdktf-cli/lib/models/terraform-cloud.ts
+++ b/packages/cdktf-cli/lib/models/terraform-cloud.ts
@@ -233,7 +233,8 @@ export class TerraformCloud implements Terraform {
   @BeautifyErrors("Plan")
   public async plan(
     destroy = false,
-    refreshOnly = false
+    refreshOnly = false,
+    _parallelism = -1
   ): Promise<TerraformPlan> {
     if (!this.configurationVersionId)
       throw new Error("Please create a ConfigurationVersion before planning");
@@ -351,7 +352,8 @@ export class TerraformCloud implements Terraform {
   @BeautifyErrors("Deploy")
   public async deploy(
     _planFile: string,
-    _refreshOnly?: boolean
+    _refreshOnly?: boolean,
+    _parallelism?: number
   ): Promise<void> {
     const sendLog = this.createTerraformLogHandler("deploy");
     if (!this.run)

--- a/packages/cdktf-cli/lib/models/terraform.ts
+++ b/packages/cdktf-cli/lib/models/terraform.ts
@@ -115,9 +115,17 @@ export abstract class AbstractTerraformPlan implements TerraformPlan {
 
 export interface Terraform {
   init: () => Promise<void>;
-  plan: (destroy: boolean, refreshOnly?: boolean) => Promise<TerraformPlan>;
-  deploy(planFile: string, refreshOnly?: boolean): Promise<void>;
-  destroy(): Promise<void>;
+  plan: (
+    destroy: boolean,
+    refreshOnly?: boolean,
+    parallelism?: number
+  ) => Promise<TerraformPlan>;
+  deploy(
+    planFile: string,
+    refreshOnly?: boolean,
+    parallelism?: number
+  ): Promise<void>;
+  destroy(parallelism?: number): Promise<void>;
   output(): Promise<{ [key: string]: TerraformOutput }>;
   abort: () => Promise<void>;
 }

--- a/packages/cdktf-cli/lib/watch.ts
+++ b/packages/cdktf-cli/lib/watch.ts
@@ -4,7 +4,7 @@ import path from "path";
 import {
   CdktfProject,
   CdktfProjectOptions,
-  ExecutionOptions,
+  MutationOptions,
 } from "./cdktf-project";
 import { Errors } from "./errors";
 import * as fs from "fs";
@@ -93,7 +93,7 @@ export type State =
 
 export async function watch(
   projectOptions: CdktfProjectOptions,
-  executionOptions: ExecutionOptions,
+  mutationOptions: MutationOptions,
   abortSignal: AbortSignal,
   onStateChange: (newState: State) => void
 ) {
@@ -122,7 +122,7 @@ export async function watch(
     });
     const abort = () => project.hardAbort();
     abortSignal.addEventListener("abort", abort);
-    await project.deploy(executionOptions);
+    await project.deploy(mutationOptions);
     abortSignal.removeEventListener("abort", abort);
     logger.debug("cdktf deploy finished");
 

--- a/packages/cdktf-cli/test/lib/cdktf-project.test.ts
+++ b/packages/cdktf-cli/test/lib/cdktf-project.test.ts
@@ -6,12 +6,23 @@ import * as os from "os";
 import { CdktfProject, get, init, Language } from "../../lib/index";
 import { SynthesizedStack } from "../../lib/synth-stack";
 import { getMultipleStacks } from "../../lib/cdktf-project";
+import { exec } from "cdktf-cli/lib/util";
 
 function eventNames(events: any[]) {
   return events
     .map((event) => event.type)
     .filter((name) => !name.includes("update"));
 }
+
+jest.mock("cdktf-cli/lib/util", () => {
+  const originalModule = jest.requireActual("cdktf-cli/lib/util");
+
+  return {
+    __esmodule: true,
+    ...originalModule,
+    exec: jest.fn().mockImplementation(originalModule.exec),
+  };
+});
 
 function installFixturesInWorkingDirectory(
   {
@@ -86,6 +97,14 @@ describe("CdktfProject", () => {
         outDir,
       };
     };
+  });
+
+  beforeEach(() => {
+    (exec as jest.Mock).mockClear();
+  });
+
+  afterAll(() => {
+    jest.resetModules();
   });
 
   it("should be able to create a CdktfProject", () => {
@@ -211,6 +230,60 @@ describe("CdktfProject", () => {
       ]);
       return expect(eventTypes.includes("waiting for approval")).toBeFalsy();
     });
+
+    it("runs without terraform parallelism", async () => {
+      const events: any[] = [];
+      const cdktfProject = new CdktfProject({
+        synthCommand: "npx ts-node ./main.ts",
+        ...inNewWorkingDirectory(),
+        onUpdate: (event) => {
+          events.push(event);
+          if (event.type === "waiting for approval") {
+            event.approve();
+          }
+        },
+      });
+
+      await cdktfProject.deploy({
+        stackNames: ["first"],
+        autoApprove: true,
+        parallelism: 1,
+        terraformParallelism: 1,
+      });
+
+      const execCalls = (exec as jest.Mock).mock.calls;
+      const planCall = execCalls.find((call) => call[1][0] === "plan");
+      const applyCall = execCalls.find((call) => call[1][0] === "apply");
+      expect(planCall[1]).toContain("-parallelism=1");
+      expect(applyCall[1]).toContain("-parallelism=1");
+    });
+
+    it("ignores the terraform parallelism flag if negative", async () => {
+      const events: any[] = [];
+      const cdktfProject = new CdktfProject({
+        synthCommand: "npx ts-node ./main.ts",
+        ...inNewWorkingDirectory(),
+        onUpdate: (event) => {
+          events.push(event);
+          if (event.type === "waiting for approval") {
+            event.approve();
+          }
+        },
+      });
+
+      await cdktfProject.deploy({
+        stackNames: ["first"],
+        autoApprove: true,
+        parallelism: 1,
+        terraformParallelism: -1,
+      });
+
+      const execCalls = (exec as jest.Mock).mock.calls;
+      const planCall = execCalls.find((call) => call[1][0] === "plan");
+      const applyCall = execCalls.find((call) => call[1][0] === "apply");
+      expect(planCall[1]).not.toContain("-parallelism=-1");
+      expect(applyCall[1]).not.toContain("-parallelism=1");
+    });
   });
 
   describe("destroy", () => {
@@ -267,6 +340,50 @@ describe("CdktfProject", () => {
         "destroyed",
       ]);
       return expect(eventTypes.includes("waiting for approval")).toBeFalsy();
+    });
+
+    it("passes the terraform parallelism flag to terraform", async () => {
+      const events: any[] = [];
+      const cdktfProject = new CdktfProject({
+        synthCommand: "npx ts-node ./main.ts",
+        ...inNewWorkingDirectory(),
+        onUpdate: (event) => {
+          events.push(event);
+        },
+      });
+
+      await cdktfProject.destroy({
+        stackNames: ["second"],
+        autoApprove: true,
+        parallelism: 1,
+        terraformParallelism: 1,
+      });
+
+      const execCalls = (exec as jest.Mock).mock.calls;
+      const destroyCall = execCalls.find((call) => call[1][0] === "destroy");
+      expect(destroyCall[1]).toContain("-parallelism=1");
+    });
+
+    it("doesn't pass the terraform parallelism flag if negative", async () => {
+      const events: any[] = [];
+      const cdktfProject = new CdktfProject({
+        synthCommand: "npx ts-node ./main.ts",
+        ...inNewWorkingDirectory(),
+        onUpdate: (event) => {
+          events.push(event);
+        },
+      });
+
+      await cdktfProject.destroy({
+        stackNames: ["second"],
+        autoApprove: true,
+        parallelism: 1,
+        terraformParallelism: -1,
+      });
+
+      const execCalls = (exec as jest.Mock).mock.calls;
+      const destroyCall = execCalls.find((call) => call[1][0] === "destroy");
+      expect(destroyCall[1]).not.toContain("-parallelism=-1");
     });
   });
 

--- a/packages/cdktf-cli/test/lib/terraform-parallelism.test.ts
+++ b/packages/cdktf-cli/test/lib/terraform-parallelism.test.ts
@@ -1,0 +1,256 @@
+import path from "path";
+import * as fs from "fs-extra";
+import os from "os";
+import { CdktfProject, init, Language, get } from "../../lib/index";
+import { exec } from "cdktf-cli/lib/util";
+
+jest.mock("cdktf-cli/lib/util", () => {
+  const originalModule = jest.requireActual("cdktf-cli/lib/util");
+
+  return {
+    __esmodule: true,
+    ...originalModule,
+    // exec: jest.fn().mockImplementation(originalModule.exec),
+    exec: jest.fn().mockImplementation(async (_binary, args) => {
+      // Fake "show" to ensure we perform apply
+      if (args[0] !== "show") {
+        return Promise.resolve(JSON.stringify({}));
+      }
+      return Promise.resolve(
+        JSON.stringify({
+          resource_changes: [
+            {
+              address: "null_resource.first_test_83862C81",
+              mode: "managed",
+              type: "null_resource",
+              name: "first_test_83862C81",
+              provider_name: "registry.terraform.io/hashicorp/null",
+              change: {
+                actions: ["create"],
+                before: null,
+                after: { triggers: null },
+                after_unknown: { id: true },
+                before_sensitive: false,
+                after_sensitive: {},
+              },
+            },
+          ],
+        })
+      );
+    }),
+  };
+});
+let inNewWorkingDirectory: () => {
+  workingDirectory: string;
+  outDir: string;
+};
+
+jest.setTimeout(30000);
+describe("terraform parallelism", () => {
+  beforeAll(async () => {
+    const workingDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "cdktf."));
+    await init({
+      destination: workingDirectory,
+      templatePath: path.join(__dirname, "../../templates/typescript"),
+      projectId: "test",
+      projectInfo: {
+        Description: "cdktf-api-test",
+        Name: "cdktf-api-test",
+      },
+      sendCrashReports: false,
+      dist: path.join(__dirname, "../../../../dist"),
+    });
+
+    fs.copyFileSync(
+      path.resolve(__dirname, "fixtures/default/main.ts.fixture"),
+      path.resolve(workingDirectory, "main.ts")
+    );
+    fs.copyFileSync(
+      path.resolve(__dirname, "fixtures/default/cdktf.json"),
+      path.resolve(workingDirectory, "cdktf.json")
+    );
+
+    await get({
+      constraints: [
+        {
+          name: "null",
+          version: "3.1.0",
+          source: "null",
+          fqn: "hashicorp/null",
+        },
+      ],
+      constructsOptions: {
+        codeMakerOutput: path.resolve(workingDirectory, ".gen"),
+        targetLanguage: Language.TYPESCRIPT,
+      },
+    });
+
+    inNewWorkingDirectory = function inNewWorkingDirectory() {
+      const wd = fs.mkdtempSync(path.join(os.tmpdir(), "cdktf."));
+      const outDir = path.resolve(wd, "out");
+
+      fs.copySync(workingDirectory, wd);
+
+      return {
+        workingDirectory: wd,
+        outDir,
+      };
+    };
+  });
+  beforeEach(() => {
+    (exec as jest.Mock).mockClear();
+  });
+  afterAll(() => {
+    jest.resetModules();
+  });
+
+  describe("terraform parallelism flag in deploy", () => {
+    it("passes the terraform parallelism flag to terraform", async () => {
+      const events: any[] = [];
+      const cdktfProject = new CdktfProject({
+        synthCommand: "npx ts-node main.ts",
+        ...inNewWorkingDirectory(),
+        onUpdate: (event) => {
+          events.push(event);
+          if (event.type === "waiting for approval") {
+            event.approve();
+          }
+        },
+      });
+
+      await cdktfProject.deploy({
+        stackNames: ["first"],
+        autoApprove: true,
+        parallelism: 1,
+        terraformParallelism: 1,
+      });
+
+      const execCalls = (exec as jest.Mock).mock.calls;
+      const planCall = execCalls.find((call) => call[1][0] === "plan");
+      const applyCall = execCalls.find((call) => call[1][0] === "apply");
+      expect(planCall[1]).toContain("-parallelism=1");
+      expect(applyCall[1]).toContain("-parallelism=1");
+    });
+
+    it("ignores the terraform parallelism flag if negative", async () => {
+      const events: any[] = [];
+      const cdktfProject = new CdktfProject({
+        synthCommand: "npx ts-node ./main.ts",
+        ...inNewWorkingDirectory(),
+        onUpdate: (event) => {
+          events.push(event);
+          if (event.type === "waiting for approval") {
+            event.approve();
+          }
+        },
+      });
+
+      await cdktfProject.deploy({
+        stackNames: ["first"],
+        autoApprove: true,
+        parallelism: 1,
+        terraformParallelism: -1,
+      });
+
+      const execCalls = (exec as jest.Mock).mock.calls;
+      const planCall = execCalls.find((call) => call[1][0] === "plan");
+      const applyCall = execCalls.find((call) => call[1][0] === "apply");
+      expect(planCall[1]).not.toContain("-parallelism=-1");
+      expect(applyCall[1]).not.toContain("-parallelism=1");
+    });
+  });
+
+  describe("terraform parallelism flag in destroy", () => {
+    it("passes the terraform parallelism flag to terraform", async () => {
+      const events: any[] = [];
+      const cdktfProject = new CdktfProject({
+        synthCommand: "npx ts-node ./main.ts",
+        ...inNewWorkingDirectory(),
+        onUpdate: (event) => {
+          events.push(event);
+        },
+      });
+
+      await cdktfProject.destroy({
+        stackNames: ["second"],
+        autoApprove: true,
+        parallelism: 1,
+        terraformParallelism: 1,
+      });
+
+      const execCalls = (exec as jest.Mock).mock.calls;
+      const destroyCall = execCalls.find((call) => call[1][0] === "destroy");
+      expect(destroyCall[1]).toContain("-parallelism=1");
+    });
+
+    it("doesn't pass the terraform parallelism flag if negative", async () => {
+      const events: any[] = [];
+      const cdktfProject = new CdktfProject({
+        synthCommand: "npx ts-node ./main.ts",
+        ...inNewWorkingDirectory(),
+        onUpdate: (event) => {
+          events.push(event);
+        },
+      });
+
+      await cdktfProject.destroy({
+        stackNames: ["second"],
+        autoApprove: true,
+        parallelism: 1,
+        terraformParallelism: -1,
+      });
+
+      const execCalls = (exec as jest.Mock).mock.calls;
+      const destroyCall = execCalls.find((call) => call[1][0] === "destroy");
+      expect(destroyCall[1]).not.toContain("-parallelism=-1");
+    });
+  });
+
+  describe("terraform parallelism flag in diff", () => {
+    it("passes the terraform parallelism flag to terraform", async () => {
+      const events: any[] = [];
+      const cdktfProject = new CdktfProject({
+        synthCommand: "npx ts-node main.ts",
+        ...inNewWorkingDirectory(),
+        onUpdate: (event) => {
+          events.push(event);
+          if (event.type === "waiting for approval") {
+            event.approve();
+          }
+        },
+      });
+
+      await cdktfProject.diff({
+        stackName: "first",
+        terraformParallelism: 1,
+      });
+
+      const execCalls = (exec as jest.Mock).mock.calls;
+      const planCall = execCalls.find((call) => call[1][0] === "plan");
+      expect(planCall[1]).toContain("-parallelism=1");
+    });
+
+    it("ignores the terraform parallelism flag if negative", async () => {
+      const events: any[] = [];
+      const cdktfProject = new CdktfProject({
+        synthCommand: "npx ts-node ./main.ts",
+        ...inNewWorkingDirectory(),
+        onUpdate: (event) => {
+          events.push(event);
+          if (event.type === "waiting for approval") {
+            event.approve();
+          }
+        },
+      });
+
+      await cdktfProject.diff({
+        stackName: "first",
+        terraformParallelism: -1,
+      });
+
+      const execCalls = (exec as jest.Mock).mock.calls;
+      const planCall = execCalls.find((call) => call[1][0] === "plan");
+      expect(planCall[1]).not.toContain("-parallelism=-1");
+    });
+  });
+});

--- a/website/docs/cdktf/cli-reference/commands.mdx
+++ b/website/docs/cdktf/cli-reference/commands.mdx
@@ -135,22 +135,22 @@ cdktf deploy [stacks...]
 Deploy the given stacks
 
 Positionals:
-  stacks  Deploy stacks matching the given ids. Required when more than one stack is present in the app                                                                                                                                                                       [array] [default: []]
+  stacks  Deploy stacks matching the given ids. Required when more than one stack is present in the app  [array] [default: []]
 
 Options:
-      --version                                 Show version number                                                                                                                                                                                                                       [boolean]
-      --disable-plugin-cache-env                Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env CDKTF_DISABLE_PLUGIN_CACHE_ENV.                                                      [boolean] [default: false]
-      --log-level                               Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL                                                                                                                                                      [string]
-  -a, --app                                     Command to use in order to execute cdktf app                                                                                                                                                                                             [required]
-  -o, --output                                  Output directory for the synthesized Terraform config                                                                                                                                                             [required] [default: "cdktf.out"]
-      --auto-approve                            Auto approve                                                                                                                                                                                                             [boolean] [default: false]
-      --outputs-file                             Path to file where stack outputs will be written as JSON                                                                                                                                                                                   [string]
-      --outputs-file-include-sensitive-outputs   Whether to include sensitive outputs in the output file                                                                                                                                                                  [boolean] [default: false]
-      --ignore-missing-stack-dependencies       Don't check if all stacks specified in the command have their dependencies included as well                                                                                                                              [boolean] [default: false]
-      --parallelism                             Number of concurrent CDKTF stacks to run. Defaults to infinity, denoted by -1                                                                                                                                                [number] [default: -1]
+      --version                                 Show version number  [boolean]
+      --disable-plugin-cache-env                Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env CDKTF_DISABLE_PLUGIN_CACHE_ENV.  [boolean] [default: false]
+      --log-level                               Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL  [string]
+  -a, --app                                     Command to use in order to execute cdktf app  [required]
+  -o, --output                                  Output directory for the synthesized Terraform config  [required] [default: "cdktf.out"]
+      --auto-approve                            Auto approve  [boolean] [default: false]
+      --outputs-file                            Path to file where stack outputs will be written as JSON  [string]
+      --outputs-file-include-sensitive-outputs  Whether to include sensitive outputs in the output file  [boolean] [default: false]
+      --ignore-missing-stack-dependencies       Don't check if all stacks specified in the command have their dependencies included as well  [boolean] [default: false]
+      --parallelism                             Number of concurrent CDKTF stacks to run. Defaults to infinity, denoted by -1  [number] [default: -1]
       --refresh-only                            Select the "refresh only" planning mode, which checks whether remote objects still match the outcome of the most recent Terraform apply but does not propose any actions to undo any changes made outside of Terraform.  [boolean] [default: false]
-      --terraform-parallelism                   Customize number of parallel graph traversals by Terraform. By default, the parallelism flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend                                       [number] [default: -1]
-  -h, --help                                    Show help                                                                                                                                                                                                                                 [boolean]
+      --terraform-parallelism                   Forwards value as the `-parallelism` flag to Terraform. By default, the this flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend  [number] [default: -1]
+  -h, --help                                    Show help  [boolean]
 ```
 
 ~> **Note:** The `parallelism` flag has a different behavior than the [terraform parallelism flag](https://www.terraform.io/cli/commands/apply#parallelism-n). To set the custom terraform parallelism flag, please use the `--terraform-parallelism` flag instead.
@@ -207,19 +207,19 @@ cdktf destroy [stacks..]
 Destroy the given stacks
 
 Positionals:
-  stacks  Destroy stacks matching the given ids. Required when more than one stack is present in the app                                                                                                                             [array] [default: []]
+  stacks  Destroy stacks matching the given ids. Required when more than one stack is present in the app  [array] [default: []]
 
 Options:
-      --version                            Show version number                                                                                                                                                                                   [boolean]
-      --disable-plugin-cache-env           Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env CDKTF_DISABLE_PLUGIN_CACHE_ENV.                  [boolean] [default: false]
-      --log-level                          Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL                                                                                                                  [string]
-  -a, --app                                Command to use in order to execute cdktf app                                                                                                                                                         [required]
-  -o, --output                             Output directory for the synthesized Terraform config                                                                                                                         [required] [default: "cdktf.out"]
-      --auto-approve                       Auto approve                                                                                                                                                                         [boolean] [default: false]
-      --ignore-missing-stack-dependencies  Don't check if all stacks specified in the command have their dependencies included as well                                                                                          [boolean] [default: false]
-      --parallelism                        Number of concurrent CDKTF stacks to run. Defaults to infinity, denoted by -1                                                                                                            [number] [default: -1]
-      --terraform-parallelism              Customize number of parallel graph traversals by Terraform. By default, the parallelism flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend   [number] [default: -1]
-  -h, --help                               Show help                                                                                                                                                                                             [boolean]
+      --version                            Show version number  [boolean]
+      --disable-plugin-cache-env           Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env CDKTF_DISABLE_PLUGIN_CACHE_ENV.  [boolean] [default: false]
+      --log-level                          Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL  [string]
+  -a, --app                                Command to use in order to execute cdktf app  [required]
+  -o, --output                             Output directory for the synthesized Terraform config  [required] [default: "cdktf.out"]
+      --auto-approve                       Auto approve  [boolean] [default: false]
+      --ignore-missing-stack-dependencies  Don't check if all stacks specified in the command have their dependencies included as well  [boolean] [default: false]
+      --parallelism                        Number of concurrent CDKTF stacks to run. Defaults to infinity, denoted by -1  [number] [default: -1]
+      --terraform-parallelism              Forwards value as the `-parallelism` flag to Terraform. By default, the this flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend  [number] [default: -1]
+  -h, --help                               Show help  [boolean]
 ```
 
 ~> **Note:** The `parallelism` flag has a different behavior than the [terraform parallelism flag](https://www.terraform.io/cli/commands/apply#parallelism-n). To set the custom terraform parallelism flag, please use the `--terraform-parallelism` flag instead.
@@ -274,18 +274,17 @@ cdktf diff [stack]
 Perform a diff (terraform plan) for the given stack
 
 Positionals:
-  stack  Diff stack which matches the given id only. Required when more than one stack is present in the app                                                                                                                                                [string]
+  stack  Diff stack which matches the given id only. Required when more than one stack is present in the app  [string]
 
 Options:
-      --version                   Show version number                                                                                                                                                                                                      [boolean]
-      --disable-plugin-cache-env  Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env CDKTF_DISABLE_PLUGIN_CACHE_ENV.                                     [boolean] [default: false]
-      --log-level                 Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL                                                                                                                                     [string]
-  -a, --app                       Command to use in order to execute cdktf app                                                                                                                                                                            [required]
-  -o, --output                    Output directory for the synthesized Terraform config                                                                                                                                            [required] [default: "cdktf.out"]
-      --refresh-only              Select the "refresh only" planning mode, which checks whether remote objects still match the outcome of the most recent Terraform apply but does not propose any actions to undo any changes made outside of Terraform.
-                                                                                                                                                                                                                                          [boolean] [default: false]
-      --terraform-parallelism     Customize number of parallel graph traversals by Terraform. By default, the parallelism flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend                      [number] [default: -1]
-  -h, --help                      Show help                                                                                                                                                                                                                [boolean]
+      --version                   Show version number  [boolean]
+      --disable-plugin-cache-env  Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env CDKTF_DISABLE_PLUGIN_CACHE_ENV.  [boolean] [default: false]
+      --log-level                 Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL  [string]
+  -a, --app                       Command to use in order to execute cdktf app  [required]
+  -o, --output                    Output directory for the synthesized Terraform config  [required] [default: "cdktf.out"]
+      --refresh-only              Select the "refresh only" planning mode, which checks whether remote objects still match the outcome of the most recent Terraform apply but does not propose any actions to undo any changes made outside of Terraform.  [boolean] [default: false]
+      --terraform-parallelism     Forwards value as the `-parallelism` flag to Terraform. By default, the this flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend  [number] [default: -1]
+  -h, --help                      Show help  [boolean]
 ```
 
 ~> **Note:** The `parallelism` flag has a different behavior than the [terraform parallelism flag](https://www.terraform.io/cli/commands/plan#parallelism-n). To set the custom terraform parallelism flag, please use the `--terraform-parallelism` flag instead.
@@ -503,18 +502,18 @@ cdktf watch [stacks..]
 [experimental] Watch for file changes and automatically trigger a deploy
 
 Positionals:
-  stacks  Deploy stacks matching the given ids. Required when more than one stack is present in the app                                                                                                                                        [array] [default: []]
+  stacks  Deploy stacks matching the given ids. Required when more than one stack is present in the app  [array] [default: []]
 
 Options:
-      --version                   Show version number                                                                                                                                                                                                      [boolean]
-      --disable-plugin-cache-env  Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env CDKTF_DISABLE_PLUGIN_CACHE_ENV.                                     [boolean] [default: false]
-      --log-level                 Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL                                                                                                                                     [string]
-  -a, --app                       Command to use in order to execute cdktf app                                                                                                                                                                            [required]
-  -o, --output                    Output directory for the synthesized Terraform config                                                                                                                                            [required] [default: "cdktf.out"]
-      --auto-approve              Auto approve                                                                                                                                                                                            [boolean] [default: false]
-      --parallelism               Number of concurrent CDKTF stacks to run. Defaults to infinity, denoted by -1                                                                                                                               [number] [default: -1]
-      --terraform-parallelism     Customize number of parallel graph traversals by Terraform. By default, the parallelism flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend                      [number] [default: -1]
-  -h, --help                      Show help                                                                                                                                                                                                                [boolean]
+      --version                   Show version number  [boolean]
+      --disable-plugin-cache-env  Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env CDKTF_DISABLE_PLUGIN_CACHE_ENV.  [boolean] [default: false]
+      --log-level                 Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL  [string]
+  -a, --app                       Command to use in order to execute cdktf app  [required]
+  -o, --output                    Output directory for the synthesized Terraform config  [required] [default: "cdktf.out"]
+      --auto-approve              Auto approve  [boolean] [default: false]
+      --parallelism               Number of concurrent CDKTF stacks to run. Defaults to infinity, denoted by -1  [number] [default: -1]
+      --terraform-parallelism     Forwards value as the `-parallelism` flag to Terraform. By default, the this flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend  [number] [default: -1]
+  -h, --help                      Show help  [boolean]
 ```
 
 ~> **Note:** The `parallelism` flag has a different behavior than the [terraform parallelism flag](https://www.terraform.io/cli/commands/apply#parallelism-n). To set the custom terraform parallelism flag, please use the `--terraform-parallelism` flag instead.

--- a/website/docs/cdktf/cli-reference/commands.mdx
+++ b/website/docs/cdktf/cli-reference/commands.mdx
@@ -130,27 +130,30 @@ $ cdktf deploy --help
 **Help Output**
 
 ```
-cdktf deploy [OPTIONS] <stacks..>
+cdktf deploy [stacks...]
 
 Deploy the given stacks
 
 Positionals:
-  stacks  Deploy stacks matching the given ids. Required when more than one stack is present in the app                                                                          [array] [required] [default: []]
+  stacks  Deploy stacks matching the given ids. Required when more than one stack is present in the app                                                                                                                                                                       [array] [default: []]
 
 Options:
-      --version                                 Show version number                                                                                                                                     [boolean]
-      --disable-plugin-cache-env                Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env
-                                                CDKTF_DISABLE_PLUGIN_CACHE_ENV.                                                                                                        [boolean] [default: false]
-      --log-level                               Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL                                                                    [string]
-  -a, --app                                     Command to use in order to execute cdktf app                                                                          [required] [default: "npx ts-node main.ts"]
-  -o, --output                                  Output directory for the synthesized Terraform config                                                                           [required] [default: "cdktf.out"]
-      --auto-approve                            Auto approve                                                                                                                           [boolean] [default: false]
-      --outputs-file                            Path to file where stack outputs will be written as JSON                                                                                                 [string]
-      --outputs-file-include-sensitive-outputs  Whether to include sensitive outputs in the output file                                                                                [boolean] [default: false]
-      --ignore-missing-stack-dependencies       Don't check if all stacks specified in the command have their dependencies included as well                                            [boolean] [default: false]
-      --parallelism                             Number of concurrent CDKTF stacks to run. Defaults to infinity, denoted by -1                                                              [number] [default: -1]
-  -h, --help                                    Show help                                                                                                                                               [boolean]
+      --version                                 Show version number                                                                                                                                                                                                                       [boolean]
+      --disable-plugin-cache-env                Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env CDKTF_DISABLE_PLUGIN_CACHE_ENV.                                                      [boolean] [default: false]
+      --log-level                               Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL                                                                                                                                                      [string]
+  -a, --app                                     Command to use in order to execute cdktf app                                                                                                                                                                                             [required]
+  -o, --output                                  Output directory for the synthesized Terraform config                                                                                                                                                             [required] [default: "cdktf.out"]
+      --auto-approve                            Auto approve                                                                                                                                                                                                             [boolean] [default: false]
+      --outputs-file                             Path to file where stack outputs will be written as JSON                                                                                                                                                                                   [string]
+      --outputs-file-include-sensitive-outputs   Whether to include sensitive outputs in the output file                                                                                                                                                                  [boolean] [default: false]
+      --ignore-missing-stack-dependencies       Don't check if all stacks specified in the command have their dependencies included as well                                                                                                                              [boolean] [default: false]
+      --parallelism                             Number of concurrent CDKTF stacks to run. Defaults to infinity, denoted by -1                                                                                                                                                [number] [default: -1]
+      --refresh-only                            Select the "refresh only" planning mode, which checks whether remote objects still match the outcome of the most recent Terraform apply but does not propose any actions to undo any changes made outside of Terraform.  [boolean] [default: false]
+      --terraform-parallelism                   Customize number of parallel graph traversals by Terraform. By default, the parallelism flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend                                       [number] [default: -1]
+  -h, --help                                    Show help                                                                                                                                                                                                                                 [boolean]
 ```
+
+~> **Note:** The `parallelism` flag has a different behavior than the [terraform parallelism flag](https://www.terraform.io/cli/commands/apply#parallelism-n). To set the custom terraform parallelism flag, please use the `--terraform-parallelism` flag instead.
 
 **Examples**
 
@@ -199,25 +202,27 @@ $ cdktf destroy --help
 Help output:
 
 ```
-cdktf destroy [OPTIONS] <stacks..>
+cdktf destroy [stacks..]
 
 Destroy the given stacks
 
 Positionals:
-  stacks  Destroy stacks matching the given ids. Required when more than one stack is present in the app                                                                         [array] [required] [default: []]
+  stacks  Destroy stacks matching the given ids. Required when more than one stack is present in the app                                                                                                                             [array] [default: []]
 
 Options:
-      --version                            Show version number                                                                                                                                          [boolean]
-      --disable-plugin-cache-env           Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env CDKTF_DISABLE_PLUGIN_CACHE_ENV.
-                                                                                                                                                                                       [boolean] [default: false]
-      --log-level                          Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL                                                                         [string]
-  -a, --app                                Command to use in order to execute cdktf app                                                                               [required] [default: "npx ts-node main.ts"]
-  -o, --output                             Output directory for the synthesized Terraform config                                                                                [required] [default: "cdktf.out"]
-      --auto-approve                       Auto approve                                                                                                                                [boolean] [default: false]
-      --ignore-missing-stack-dependencies  Don't check if all stacks specified in the command have their dependencies included as well                                                 [boolean] [default: false]
-      --parallelism                        Number of concurrent CDKTF stacks to run. Defaults to infinity, denoted by -1                                                                   [number] [default: -1]
-  -h, --help                               Show help                                                                                                                                                    [boolean]
+      --version                            Show version number                                                                                                                                                                                   [boolean]
+      --disable-plugin-cache-env           Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env CDKTF_DISABLE_PLUGIN_CACHE_ENV.                  [boolean] [default: false]
+      --log-level                          Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL                                                                                                                  [string]
+  -a, --app                                Command to use in order to execute cdktf app                                                                                                                                                         [required]
+  -o, --output                             Output directory for the synthesized Terraform config                                                                                                                         [required] [default: "cdktf.out"]
+      --auto-approve                       Auto approve                                                                                                                                                                         [boolean] [default: false]
+      --ignore-missing-stack-dependencies  Don't check if all stacks specified in the command have their dependencies included as well                                                                                          [boolean] [default: false]
+      --parallelism                        Number of concurrent CDKTF stacks to run. Defaults to infinity, denoted by -1                                                                                                            [number] [default: -1]
+      --terraform-parallelism              Customize number of parallel graph traversals by Terraform. By default, the parallelism flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend   [number] [default: -1]
+  -h, --help                               Show help                                                                                                                                                                                             [boolean]
 ```
+
+~> **Note:** The `parallelism` flag has a different behavior than the [terraform parallelism flag](https://www.terraform.io/cli/commands/apply#parallelism-n). To set the custom terraform parallelism flag, please use the `--terraform-parallelism` flag instead.
 
 **Examples**
 
@@ -264,17 +269,26 @@ $ cdktf diff --help
 Help output:
 
 ```
-cdktf diff [OPTIONS]
+cdktf diff [stack]
 
 Perform a diff (terraform plan) for the given stack
 
+Positionals:
+  stack  Diff stack which matches the given id only. Required when more than one stack is present in the app                                                                                                                                                [string]
+
 Options:
-  --version          Show version number                                                                                                                                           [boolean]
-  --log-level        Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL                                                                          [string]
-  --app, -a          Command to use in order to execute cdktf app                                                                                                                 [required]
-  --output, -o       Output directory                                                                                                                      [required] [default: "cdktf.out"]
-  -h, --help         Show help                                                                                                                                                     [boolean]
+      --version                   Show version number                                                                                                                                                                                                      [boolean]
+      --disable-plugin-cache-env  Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env CDKTF_DISABLE_PLUGIN_CACHE_ENV.                                     [boolean] [default: false]
+      --log-level                 Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL                                                                                                                                     [string]
+  -a, --app                       Command to use in order to execute cdktf app                                                                                                                                                                            [required]
+  -o, --output                    Output directory for the synthesized Terraform config                                                                                                                                            [required] [default: "cdktf.out"]
+      --refresh-only              Select the "refresh only" planning mode, which checks whether remote objects still match the outcome of the most recent Terraform apply but does not propose any actions to undo any changes made outside of Terraform.
+                                                                                                                                                                                                                                          [boolean] [default: false]
+      --terraform-parallelism     Customize number of parallel graph traversals by Terraform. By default, the parallelism flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend                      [number] [default: -1]
+  -h, --help                      Show help                                                                                                                                                                                                                [boolean]
 ```
+
+~> **Note:** The `parallelism` flag has a different behavior than the [terraform parallelism flag](https://www.terraform.io/cli/commands/plan#parallelism-n). To set the custom terraform parallelism flag, please use the `--terraform-parallelism` flag instead.
 
 Examples:
 
@@ -484,24 +498,26 @@ $ cdktf watch --help
 **Help Output**
 
 ```
-cdktf watch  [OPTIONS] <stacks..>
+cdktf watch [stacks..]
 
 [experimental] Watch for file changes and automatically trigger a deploy
 
 Positionals:
-  stacks  Deploy stacks matching the given ids. Required when more than one stack is present in the app                                                                                       [array] [required] [default: []]
+  stacks  Deploy stacks matching the given ids. Required when more than one stack is present in the app                                                                                                                                        [array] [default: []]
 
 Options:
-      --version                   Show version number                                                                                                                                                                [boolean]
-      --disable-plugin-cache-env  Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env CDKTF_DISABLE_PLUGIN_CACHE_ENV.
-                                                                                                                                                                                                    [boolean] [default: false]
-      --log-level                 Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL                                                                                               [string]
-  -a, --app                       Command to use in order to execute cdktf app                                                                                                     [required] [default: "npx ts-node main.ts"]
-  -o, --output                    Output directory for the synthesized Terraform config                                                                                                      [required] [default: "cdktf.out"]
-      --auto-approve              Auto approve                                                                                                                                                      [boolean] [default: false]
-      --parallelism               Number of concurrent CDKTF stacks to run. Defaults to infinity, denoted by -1                                                                                         [number] [default: -1]
-  -h, --help                      Show help                                                                                                                                                                          [boolean]
+      --version                   Show version number                                                                                                                                                                                                      [boolean]
+      --disable-plugin-cache-env  Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env CDKTF_DISABLE_PLUGIN_CACHE_ENV.                                     [boolean] [default: false]
+      --log-level                 Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL                                                                                                                                     [string]
+  -a, --app                       Command to use in order to execute cdktf app                                                                                                                                                                            [required]
+  -o, --output                    Output directory for the synthesized Terraform config                                                                                                                                            [required] [default: "cdktf.out"]
+      --auto-approve              Auto approve                                                                                                                                                                                            [boolean] [default: false]
+      --parallelism               Number of concurrent CDKTF stacks to run. Defaults to infinity, denoted by -1                                                                                                                               [number] [default: -1]
+      --terraform-parallelism     Customize number of parallel graph traversals by Terraform. By default, the parallelism flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend                      [number] [default: -1]
+  -h, --help                      Show help                                                                                                                                                                                                                [boolean]
 ```
+
+~> **Note:** The `parallelism` flag has a different behavior than the [terraform parallelism flag](https://www.terraform.io/cli/commands/apply#parallelism-n). To set the custom terraform parallelism flag, please use the `--terraform-parallelism` flag instead.
 
 **Examples**
 


### PR DESCRIPTION
Fixes #1715 

This PR adds the `-terraform-parallelism` flag to the CLI. This flag is only available for `deploy` and `destroy`. One note here is that due the nature of `deploy`, the parallelism flag will be used for both `plan` and `apply` within the Terraform CLI during the `deploy` operation.

One thing to note: The `parallelism` flag is not supported by Terraform Cloud, so setting that for remote backends will be ignored.

Also, now now have two `parallelism` flags. One is `--parallelism` and the other is `--terraform-parallelism`. The former only affects how `cdktf` processes multiple stacks, while the latter is passed on to the Terraform CLI and changes how many concurrent operations Terraform starts as it walks the graph.
