### PR TITLE
fix(cli): Update require package in template

### DIFF
--- a/packages/cdktf-cli/templates/python-pip/.hooks.sscaff.js
+++ b/packages/cdktf-cli/templates/python-pip/.hooks.sscaff.js
@@ -29,8 +29,8 @@ exports.post = options => {
     throw new Error(`missing context "pypi_cdktf"`);
   }
 
-  writeFileSync('requirements.txt', pypi_cdktf, 'utf-8');
-  writeFileSync('requirements.txt', 'pytest', 'utf-8');
+  writeFileSync('requirements.txt', pypi_cdktf + '\r\npytest\r\n', 'utf-8');
+  
   let installArgs = '';
   if (!process.env.VIRTUAL_ENV) {
     installArgs += '--user'


### PR DESCRIPTION
Hello,
When we generate `python-pip` project via template, requirements.txt only includes `pytest` though it also needs `cdktf` package. Looks like this is being overwritten.

Please take a look for this change 🙏 
