### PR TITLE
fix(cli): Use 'id' as argument name for all templates

### DIFF
--- a/packages/cdktf-cli/templates/python-pip/main.py
+++ b/packages/cdktf-cli/templates/python-pip/main.py
@@ -4,8 +4,8 @@ from cdktf import App, TerraformStack
 
 
 class MyStack(TerraformStack):
-    def __init__(self, scope: Construct, ns: str):
-        super().__init__(scope, ns)
+    def __init__(self, scope: Construct, id: str):
+        super().__init__(scope, id)
 
         # define resources here
 

--- a/packages/cdktf-cli/templates/python/main.py
+++ b/packages/cdktf-cli/templates/python/main.py
@@ -4,8 +4,8 @@ from cdktf import App, TerraformStack
 
 
 class MyStack(TerraformStack):
-    def __init__(self, scope: Construct, ns: str):
-        super().__init__(scope, ns)
+    def __init__(self, scope: Construct, id: str):
+        super().__init__(scope, id)
 
         # define resources here
 

--- a/packages/cdktf-cli/templates/typescript/main.ts
+++ b/packages/cdktf-cli/templates/typescript/main.ts
@@ -1,9 +1,11 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
 import { Construct } from "constructs";
 import { App, TerraformStack } from "cdktf";
 
 class MyStack extends TerraformStack {
-  constructor(scope: Construct, name: string) {
-    super(scope, name);
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
 
     // define resources here
   }

--- a/test/typescript/init-from-tf/__snapshots__/test.ts.snap
+++ b/test/typescript/init-from-tf/__snapshots__/test.ts.snap
@@ -4,12 +4,14 @@ exports[`full integration test main.ts is valid 1`] = `
 "import * as cdktf from \\"cdktf\\";
 import * as Test from \\"./.gen/modules/modules/test\\";
 
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
 import { Construct } from \\"constructs\\";
 import { App, TerraformStack } from \\"cdktf\\";
 
 class MyStack extends TerraformStack {
-  constructor(scope: Construct, name: string) {
-    super(scope, name);
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
 
     const test = new Test.Test(this, \\"test\\", {});
     new cdktf.TerraformOutput(this, \\"module_value\\", {


### PR DESCRIPTION
previously `name` and `ns` were used a swell.

Using `id` as that is the name of that attribute in the parent Construct class as well and that is also used in templates of the AWS CDK.