### PR TITLE
chore(lib)!: Replace all instanceof checks with Symbols and add lint rule against accidentally adding new ones

### DIFF
--- a/packages/cdktf/lib/app.ts
+++ b/packages/cdktf/lib/app.ts
@@ -123,9 +123,7 @@ export class App extends Construct {
 
     const stacks = this.node
       .findAll()
-      .filter<TerraformStack>(
-        (c): c is TerraformStack => c instanceof TerraformStack
-      );
+      .filter<TerraformStack>(TerraformStack.isStack);
 
     stacks.forEach((stack) => stack.prepareStack());
     stacks.forEach((stack) => stack.synthesizer.synthesize(session));

--- a/packages/cdktf/lib/terraform-data-source.ts
+++ b/packages/cdktf/lib/terraform-data-source.ts
@@ -17,6 +17,8 @@ import { IInterpolatingParent } from "./terraform-addressable";
 import { ITerraformIterator } from "./terraform-iterator";
 import assert = require("assert");
 
+const TERRAFORM_DATA_SOURCE_SYMBOL = Symbol.for("cdktf/TerraformDataSource");
+
 // eslint-disable-next-line jsdoc/require-jsdoc
 export class TerraformDataSource
   extends TerraformElement
@@ -35,6 +37,7 @@ export class TerraformDataSource
 
   constructor(scope: Construct, id: string, config: TerraformResourceConfig) {
     super(scope, id, `data.${config.terraformResourceType}`);
+    Object.defineProperty(this, TERRAFORM_DATA_SOURCE_SYMBOL, { value: true });
 
     this.terraformResourceType = config.terraformResourceType;
     this.terraformGeneratorMetadata = config.terraformGeneratorMetadata;
@@ -47,6 +50,12 @@ export class TerraformDataSource
     this.provider = config.provider;
     this.lifecycle = config.lifecycle;
     this.forEach = config.forEach;
+  }
+
+  public static isTerraformDataSource(x: any): x is TerraformDataSource {
+    return (
+      x !== null && typeof x === "object" && TERRAFORM_DATA_SOURCE_SYMBOL in x
+    );
   }
 
   public getStringAttribute(terraformAttribute: string) {

--- a/packages/cdktf/lib/terraform-element.ts
+++ b/packages/cdktf/lib/terraform-element.ts
@@ -6,6 +6,8 @@ import { Token } from ".";
 import { TerraformStack } from "./terraform-stack";
 import { ref } from "./tfExpression";
 
+const TERRAFORM_ELEMENT_SYMBOL = Symbol.for("cdktf/TerraformElement");
+
 export interface TerraformElementMetadata {
   readonly path: string;
   readonly uniqueId: string;
@@ -32,6 +34,7 @@ export class TerraformElement extends Construct {
 
   constructor(scope: Construct, id: string, elementType?: string) {
     super(scope, id);
+    Object.defineProperty(this, TERRAFORM_ELEMENT_SYMBOL, { value: true });
     this._elementType = elementType;
 
     if (Token.isUnresolved(id)) {
@@ -42,6 +45,10 @@ export class TerraformElement extends Construct {
 
     this.node.addMetadata("stacktrace", "trace");
     this.cdktfStack = TerraformStack.of(this);
+  }
+
+  public static isTerraformElement(x: any): x is TerraformElement {
+    return x !== null && typeof x === "object" && TERRAFORM_ELEMENT_SYMBOL in x;
   }
 
   public toTerraform(): any {

--- a/packages/cdktf/lib/terraform-element.ts
+++ b/packages/cdktf/lib/terraform-element.ts
@@ -16,7 +16,6 @@ export interface TerraformElementMetadata {
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 export class TerraformElement extends Construct {
-  public readonly cdktfStack: TerraformStack;
   protected readonly rawOverrides: any = {};
 
   /**
@@ -44,7 +43,10 @@ export class TerraformElement extends Construct {
     }
 
     this.node.addMetadata("stacktrace", "trace");
-    this.cdktfStack = TerraformStack.of(this);
+  }
+
+  public get cdktfStack(): TerraformStack {
+    return TerraformStack.of(this);
   }
 
   public static isTerraformElement(x: any): x is TerraformElement {

--- a/packages/cdktf/lib/terraform-module.ts
+++ b/packages/cdktf/lib/terraform-module.ts
@@ -101,7 +101,7 @@ export abstract class TerraformModule
         source: this.source,
         version: this.version,
         providers: this._providers?.reduce((a, p) => {
-          if (p instanceof TerraformProvider) {
+          if (TerraformProvider.isTerraformProvider(p)) {
             return { ...a, [p.terraformResourceType]: p.fqn };
           } else {
             return {
@@ -140,7 +140,7 @@ export abstract class TerraformModule
 
   private validateIfProvidersHaveUniqueKeys(): void {
     const moduleAliases = this._providers?.map((p) => {
-      if (p instanceof TerraformProvider) {
+      if (TerraformProvider.isTerraformProvider(p)) {
         return p.terraformResourceType;
       } else {
         return `${p.provider.terraformResourceType}.${p.moduleAlias}`;

--- a/packages/cdktf/lib/terraform-provider.ts
+++ b/packages/cdktf/lib/terraform-provider.ts
@@ -6,6 +6,8 @@ import { TerraformElement } from "./terraform-element";
 import { TerraformProviderGeneratorMetadata } from "./terraform-resource";
 import { keysToSnakeCase, deepMerge, processDynamicAttributes } from "./util";
 
+const TERRAFORM_PROVIDER_SYMBOL = Symbol.for("cdktf/TerraformProvider");
+
 export interface TerraformProviderConfig {
   readonly terraformResourceType: string;
   readonly terraformGeneratorMetadata?: TerraformProviderGeneratorMetadata;
@@ -20,10 +22,17 @@ export abstract class TerraformProvider extends TerraformElement {
 
   constructor(scope: Construct, id: string, config: TerraformProviderConfig) {
     super(scope, id);
+    Object.defineProperty(this, TERRAFORM_PROVIDER_SYMBOL, { value: true });
 
     this.terraformResourceType = config.terraformResourceType;
     this.terraformGeneratorMetadata = config.terraformGeneratorMetadata;
     this.terraformProviderSource = config.terraformProviderSource;
+  }
+
+  public static isTerraformProvider(x: any): x is TerraformProvider {
+    return (
+      x !== null && typeof x === "object" && TERRAFORM_PROVIDER_SYMBOL in x
+    );
   }
 
   public get alias(): string | undefined {

--- a/packages/cdktf/lib/terraform-resource.ts
+++ b/packages/cdktf/lib/terraform-resource.ts
@@ -21,6 +21,8 @@ import {
   RemoteExecProvisioner,
 } from "./terraform-provisioner";
 
+const TERRAFORM_RESOURCE_SYMBOL = Symbol.for("cdktf/TerraformResource");
+
 export interface ITerraformResource {
   readonly terraformResourceType: string;
   readonly fqn: string;
@@ -86,6 +88,7 @@ export class TerraformResource
 
   constructor(scope: Construct, id: string, config: TerraformResourceConfig) {
     super(scope, id, config.terraformResourceType);
+    Object.defineProperty(this, TERRAFORM_RESOURCE_SYMBOL, { value: true });
 
     this.terraformResourceType = config.terraformResourceType;
     this.terraformGeneratorMetadata = config.terraformGeneratorMetadata;
@@ -100,6 +103,12 @@ export class TerraformResource
     this.forEach = config.forEach;
     this.provisioners = config.provisioners;
     this.connection = config.connection;
+  }
+
+  public static isTerraformResource(x: any): x is TerraformResource {
+    return (
+      x !== null && typeof x === "object" && TERRAFORM_RESOURCE_SYMBOL in x
+    );
   }
 
   public getStringAttribute(terraformAttribute: string) {

--- a/packages/cdktf/lib/terraform-stack.ts
+++ b/packages/cdktf/lib/terraform-stack.ts
@@ -117,16 +117,14 @@ export class TerraformStack extends Construct {
     }
   }
 
-  private findAll<T>({
-    byPredicate,
-  }: {
-    byPredicate: (node: unknown) => boolean;
-  }): T[] {
+  private findAll<T extends IConstruct>(
+    predicate: (node: unknown) => node is T
+  ): T[] {
     const items: T[] = [];
 
     const visit = async (node: IConstruct) => {
-      if (byPredicate(node)) {
-        items.push(node as unknown as T);
+      if (predicate(node)) {
+        items.push(node);
       }
 
       for (const child of node.node.children) {
@@ -211,16 +209,11 @@ export class TerraformStack extends Construct {
   }
 
   public allProviders(): TerraformProvider[] {
-    return this.findAll({
-      byPredicate: (item: unknown) =>
-        TerraformProvider.isTerraformProvider(item),
-    });
+    return this.findAll(TerraformProvider.isTerraformProvider);
   }
 
   public ensureBackendExists(): TerraformBackend {
-    const backends = this.findAll<TerraformBackend>({
-      byPredicate: (item: unknown) => TerraformBackend.isBackend(item),
-    });
+    const backends = this.findAll(TerraformBackend.isBackend);
     return backends[0] || new LocalBackend(this, {});
   }
 

--- a/packages/cdktf/lib/testing/index.ts
+++ b/packages/cdktf/lib/testing/index.ts
@@ -162,10 +162,9 @@ export class Testing {
         const symbol = isLast ? "└" : "├";
         prefix = `${spaces}${symbol}── `;
       }
-      const name =
-        construct instanceof App
-          ? "App"
-          : `${construct.node.id} (${construct.constructor.name})`;
+      const name = App.isApp(construct)
+        ? "App"
+        : `${construct.node.id} (${construct.constructor.name})`;
       return `${prefix}${name}\n${construct.node.children
         .map((child, idx, arr) => {
           const isLast = idx === arr.length - 1;

--- a/packages/cdktf/lib/tokens/private/resolve.ts
+++ b/packages/cdktf/lib/tokens/private/resolve.ts
@@ -184,6 +184,7 @@ export function resolve(obj: any, options: IResolveOptions): any {
   // primitives - as-is
   //
 
+  // eslint-disable-next-line no-instanceof/no-instanceof
   if (typeof obj !== "object" || obj instanceof Date) {
     return obj;
   }

--- a/packages/cdktf/lib/validations/validate-provider-presence.ts
+++ b/packages/cdktf/lib/validations/validate-provider-presence.ts
@@ -29,15 +29,15 @@ export class ValidateProviderPresence implements IValidation {
    */
   public check(node: IConstruct) {
     if (
-      node instanceof TerraformResource ||
-      node instanceof TerraformDataSource
+      TerraformResource.isTerraformResource(node) ||
+      TerraformDataSource.isTerraformDataSource(node)
     ) {
       if (node.terraformGeneratorMetadata) {
         this.providerNames.add(node.terraformGeneratorMetadata.providerName);
       }
     }
 
-    if (node instanceof TerraformProvider) {
+    if (TerraformProvider.isTerraformProvider(node)) {
       this.foundProviders.push(node);
     }
 

--- a/packages/cdktf/package.json
+++ b/packages/cdktf/package.json
@@ -59,7 +59,8 @@
     "parser": "@typescript-eslint/parser",
     "plugins": [
       "@typescript-eslint",
-      "jsdoc"
+      "jsdoc",
+      "no-instanceof"
     ],
     "extends": [
       "eslint:recommended",
@@ -73,7 +74,15 @@
       "@typescript-eslint/no-empty-interface": 0,
       "@typescript-eslint/explicit-module-boundary-types": 0,
       "no-sequences": "error",
-      "jsdoc/require-jsdoc": ["error", { "contexts": ["ClassDeclaration"] }]
+      "jsdoc/require-jsdoc": [
+        "error",
+        {
+          "contexts": [
+            "ClassDeclaration"
+          ]
+        }
+      ],
+      "no-instanceof/no-instanceof": "error"
     },
     "ignorePatterns": [
       "node_modules",
@@ -94,6 +103,7 @@
     "constructs": "^10.0.25",
     "eslint": "^7.32.0",
     "eslint-plugin-jsdoc": "^39.3.6",
+    "eslint-plugin-no-instanceof": "1.0.1",
     "jest": "^26.6.3",
     "jsii": "^1.68.0",
     "jsii-docgen": "^7.0.95",

--- a/test/typescript/feature-flags/__snapshots__/test.ts.snap
+++ b/test/typescript/feature-flags/__snapshots__/test.ts.snap
@@ -45,7 +45,7 @@ exports[`full integration test with allowSepCharsInLogicalIds feature 1`] = `
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"null\\",
-        \\"version\\": \\"3.1.1\\"
+        \\"version\\": \\"3.2.0\\"
       }
     }
   }
@@ -97,7 +97,7 @@ exports[`full integration test with excludeStackIdFromLogicalIds feature 1`] = `
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"null\\",
-        \\"version\\": \\"3.1.1\\"
+        \\"version\\": \\"3.2.0\\"
       }
     }
   }
@@ -149,7 +149,7 @@ exports[`full integration test without features 1`] = `
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"null\\",
-        \\"version\\": \\"3.1.1\\"
+        \\"version\\": \\"3.2.0\\"
       }
     }
   }

--- a/website/docs/cdktf/api-reference/csharp.mdx
+++ b/website/docs/cdktf/api-reference/csharp.mdx
@@ -365,10 +365,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                     | **Description**               |
-| ---------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.ArtifactoryBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.ArtifactoryBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                                   | **Description**               |
+| ------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.ArtifactoryBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.ArtifactoryBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.ArtifactoryBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -401,6 +402,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.ArtifactoryBackend.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+ArtifactoryBackend.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.ArtifactoryBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -606,10 +621,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                 | **Description**               |
-| ------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.AzurermBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.AzurermBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                               | **Description**               |
+| -------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.AzurermBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.AzurermBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.AzurermBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -642,6 +658,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.AzurermBackend.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+AzurermBackend.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.AzurermBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -849,10 +879,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                               | **Description**               |
-| ---------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.CloudBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.CloudBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                             | **Description**               |
+| ------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.CloudBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.CloudBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.CloudBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -885,6 +916,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.CloudBackend.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+CloudBackend.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.CloudBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -1090,10 +1135,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                | **Description**               |
-| ----------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.ConsulBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.ConsulBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                              | **Description**               |
+| ------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.ConsulBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.ConsulBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.ConsulBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -1126,6 +1172,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.ConsulBackend.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+ConsulBackend.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.ConsulBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -1331,10 +1391,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                             | **Description**               |
-| -------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.CosBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.CosBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                           | **Description**               |
+| ---------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.CosBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.CosBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.CosBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -1367,6 +1428,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.CosBackend.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+CosBackend.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.CosBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -1617,9 +1692,10 @@ private string GetString(string Output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                           | **Description**               |
-| ---------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteState.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                         | **Description**               |
+| ------------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteState.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteState.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -1652,6 +1728,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteState.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+DataTerraformRemoteState.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.DataTerraformRemoteState.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -1906,9 +1996,10 @@ private string GetString(string Output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                      | **Description**               |
-| --------------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateArtifactory.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                                    | **Description**               |
+| ----------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateArtifactory.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -1941,6 +2032,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+DataTerraformRemoteStateArtifactory.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -2195,9 +2300,10 @@ private string GetString(string Output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                  | **Description**               |
-| ----------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                                | **Description**               |
+| ------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -2230,6 +2336,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateAzurerm.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+DataTerraformRemoteStateAzurerm.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.DataTerraformRemoteStateAzurerm.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -2484,9 +2604,10 @@ private string GetString(string Output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                 | **Description**               |
-| ---------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateConsul.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                               | **Description**               |
+| ------------------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateConsul.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateConsul.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -2519,6 +2640,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateConsul.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+DataTerraformRemoteStateConsul.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.DataTerraformRemoteStateConsul.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -2773,9 +2908,10 @@ private string GetString(string Output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                              | **Description**               |
-| ------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateCos.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                            | **Description**               |
+| --------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateCos.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateCos.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -2808,6 +2944,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateCos.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+DataTerraformRemoteStateCos.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.DataTerraformRemoteStateCos.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -3062,9 +3212,10 @@ private string GetString(string Output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                               | **Description**               |
-| -------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateEtcd.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                             | **Description**               |
+| ---------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateEtcd.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateEtcd.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -3097,6 +3248,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateEtcd.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+DataTerraformRemoteStateEtcd.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.DataTerraformRemoteStateEtcd.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -3351,9 +3516,10 @@ private string GetString(string Output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                 | **Description**               |
-| ---------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateEtcdV3.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                               | **Description**               |
+| ------------------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateEtcdV3.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -3386,6 +3552,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+DataTerraformRemoteStateEtcdV3.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -3640,9 +3820,10 @@ private string GetString(string Output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                              | **Description**               |
-| ------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateGcs.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                            | **Description**               |
+| --------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateGcs.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateGcs.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -3675,6 +3856,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateGcs.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+DataTerraformRemoteStateGcs.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.DataTerraformRemoteStateGcs.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -3929,9 +4124,10 @@ private string GetString(string Output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                               | **Description**               |
-| -------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateHttp.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                             | **Description**               |
+| ---------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateHttp.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateHttp.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -3964,6 +4160,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateHttp.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+DataTerraformRemoteStateHttp.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.DataTerraformRemoteStateHttp.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -4218,9 +4428,10 @@ private string GetString(string Output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                | **Description**               |
-| --------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateLocal.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                              | **Description**               |
+| ----------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateLocal.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateLocal.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -4253,6 +4464,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateLocal.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+DataTerraformRemoteStateLocal.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.DataTerraformRemoteStateLocal.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -4507,9 +4732,10 @@ private string GetString(string Output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                | **Description**               |
-| --------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateManta.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                              | **Description**               |
+| ----------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateManta.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateManta.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -4542,6 +4768,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateManta.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+DataTerraformRemoteStateManta.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.DataTerraformRemoteStateManta.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -4796,9 +5036,10 @@ private string GetString(string Output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                              | **Description**               |
-| ------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateOss.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                            | **Description**               |
+| --------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateOss.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateOss.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -4831,6 +5072,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateOss.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+DataTerraformRemoteStateOss.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.DataTerraformRemoteStateOss.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -5085,9 +5340,10 @@ private string GetString(string Output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                             | **Description**               |
-| ------------------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStatePg.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                           | **Description**               |
+| -------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStatePg.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStatePg.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -5120,6 +5376,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStatePg.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+DataTerraformRemoteStatePg.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.DataTerraformRemoteStatePg.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -5374,9 +5644,10 @@ private string GetString(string Output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                             | **Description**               |
-| ------------------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                           | **Description**               |
+| -------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -5409,6 +5680,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateS3.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+DataTerraformRemoteStateS3.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.DataTerraformRemoteStateS3.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -5663,9 +5948,10 @@ private string GetString(string Output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                | **Description**               |
-| --------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateSwift.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                              | **Description**               |
+| ----------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateSwift.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateSwift.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -5698,6 +5984,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateSwift.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+DataTerraformRemoteStateSwift.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.DataTerraformRemoteStateSwift.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -5907,10 +6207,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                              | **Description**               |
-| --------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.EtcdBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.EtcdBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                            | **Description**               |
+| ----------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.EtcdBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.EtcdBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.EtcdBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -5943,6 +6244,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.EtcdBackend.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+EtcdBackend.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.EtcdBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -6148,10 +6463,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                | **Description**               |
-| ----------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.EtcdV3Backend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.EtcdV3Backend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                              | **Description**               |
+| ------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.EtcdV3Backend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.EtcdV3Backend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.EtcdV3Backend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -6184,6 +6500,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.EtcdV3Backend.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+EtcdV3Backend.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.EtcdV3Backend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -6389,10 +6719,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                             | **Description**               |
-| -------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.GcsBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.GcsBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                           | **Description**               |
+| ---------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.GcsBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.GcsBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.GcsBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -6425,6 +6756,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.GcsBackend.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+GcsBackend.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.GcsBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -6630,10 +6975,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                              | **Description**               |
-| --------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.HttpBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.HttpBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                            | **Description**               |
+| ----------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.HttpBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.HttpBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.HttpBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -6666,6 +7012,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.HttpBackend.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+HttpBackend.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.HttpBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -6871,10 +7231,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                               | **Description**               |
-| ---------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.LocalBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.LocalBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                             | **Description**               |
+| ------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.LocalBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.LocalBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.LocalBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -6907,6 +7268,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.LocalBackend.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+LocalBackend.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.LocalBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -7112,10 +7487,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                               | **Description**               |
-| ---------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.MantaBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.MantaBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                             | **Description**               |
+| ------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.MantaBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.MantaBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.MantaBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -7148,6 +7524,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.MantaBackend.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+MantaBackend.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.MantaBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -7353,10 +7743,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                             | **Description**               |
-| -------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.OssBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.OssBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                           | **Description**               |
+| ---------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.OssBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.OssBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.OssBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -7389,6 +7780,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.OssBackend.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+OssBackend.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.OssBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -7594,10 +7999,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                            | **Description**               |
-| ------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.PgBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.PgBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                          | **Description**               |
+| --------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.PgBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.PgBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.PgBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -7630,6 +8036,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.PgBackend.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+PgBackend.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.PgBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -7835,10 +8255,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                | **Description**               |
-| ----------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.RemoteBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.RemoteBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                              | **Description**               |
+| ------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.RemoteBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.RemoteBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.RemoteBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -7871,6 +8292,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.RemoteBackend.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+RemoteBackend.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.RemoteBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -8202,10 +8637,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                            | **Description**               |
-| ------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.S3Backend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.S3Backend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                          | **Description**               |
+| --------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.S3Backend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.S3Backend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.S3Backend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -8238,6 +8674,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.S3Backend.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+S3Backend.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.S3Backend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -8443,10 +8893,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                               | **Description**               |
-| ---------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.SwiftBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.SwiftBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                             | **Description**               |
+| ------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.SwiftBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.SwiftBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.SwiftBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -8479,6 +8930,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.SwiftBackend.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+SwiftBackend.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.SwiftBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -8851,10 +9316,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                   | **Description**               |
-| -------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.TerraformBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                                 | **Description**               |
+| ---------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.TerraformBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -8887,6 +9353,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.TerraformBackend.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+TerraformBackend.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.TerraformBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -9204,9 +9684,11 @@ private IResolvable InterpolationForAttribute(string TerraformAttribute)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                      | **Description**               |
-| ----------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformDataSource.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                          | **Description**               |
+| ------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformDataSource.isConstruct">IsConstruct</a></code>                     | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformDataSource.isTerraformElement">IsTerraformElement</a></code>       | _No description._             |
+| <code><a href="#cdktf.TerraformDataSource.isTerraformDataSource">IsTerraformDataSource</a></code> | _No description._             |
 
 ---
 
@@ -9239,6 +9721,34 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.TerraformDataSource.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+TerraformDataSource.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.TerraformDataSource.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
+
+---
+
+##### `IsTerraformDataSource` <a name="IsTerraformDataSource" id="cdktf.TerraformDataSource.isTerraformDataSource"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+TerraformDataSource.IsTerraformDataSource(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.TerraformDataSource.isTerraformDataSource.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -9496,9 +10006,10 @@ private object ToTerraform()
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                   | **Description**               |
-| -------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformElement.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                 | **Description**               |
+| ---------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformElement.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformElement.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -9531,6 +10042,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.TerraformElement.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+TerraformElement.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.TerraformElement.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -9810,9 +10335,10 @@ private void Set(string Variable, object Value)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                     | **Description**               |
-| ---------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformHclModule.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                   | **Description**               |
+| ------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.TerraformHclModule.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformHclModule.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -9845,6 +10371,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.TerraformHclModule.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+TerraformHclModule.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.TerraformHclModule.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -10093,9 +10633,10 @@ private object ToTerraform()
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                 | **Description**               |
-| ------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.TerraformLocal.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                               | **Description**               |
+| -------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformLocal.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformLocal.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -10128,6 +10669,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.TerraformLocal.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+TerraformLocal.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.TerraformLocal.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -10393,9 +10948,10 @@ private IResolvable InterpolationForOutput(string ModuleOutput)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                  | **Description**               |
-| ------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformModule.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                | **Description**               |
+| --------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformModule.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformModule.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -10428,6 +10984,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.TerraformModule.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+TerraformModule.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.TerraformModule.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -10663,10 +11233,11 @@ private object ToTerraform()
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                              | **Description**               |
-| ------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformOutput.isConstruct">IsConstruct</a></code>             | Checks if `x` is a construct. |
-| <code><a href="#cdktf.TerraformOutput.isTerrafromOutput">IsTerrafromOutput</a></code> | _No description._             |
+| **Name**                                                                                | **Description**               |
+| --------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformOutput.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformOutput.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.TerraformOutput.isTerrafromOutput">IsTerrafromOutput</a></code>   | _No description._             |
 
 ---
 
@@ -10699,6 +11270,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.TerraformOutput.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+TerraformOutput.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.TerraformOutput.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -10939,9 +11524,11 @@ Adds this resource to the terraform JSON output.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                    | **Description**               |
-| --------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformProvider.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                    | **Description**               |
+| ------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformProvider.isConstruct">IsConstruct</a></code>                 | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformProvider.isTerraformElement">IsTerraformElement</a></code>   | _No description._             |
+| <code><a href="#cdktf.TerraformProvider.isTerraformProvider">IsTerraformProvider</a></code> | _No description._             |
 
 ---
 
@@ -10974,6 +11561,34 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.TerraformProvider.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+TerraformProvider.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.TerraformProvider.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
+
+---
+
+##### `IsTerraformProvider` <a name="IsTerraformProvider" id="cdktf.TerraformProvider.isTerraformProvider"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+TerraformProvider.IsTerraformProvider(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.TerraformProvider.isTerraformProvider.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -11274,9 +11889,10 @@ private string GetString(string Output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                       | **Description**               |
-| ------------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.TerraformRemoteState.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                     | **Description**               |
+| -------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformRemoteState.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformRemoteState.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -11309,6 +11925,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.TerraformRemoteState.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+TerraformRemoteState.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.TerraformRemoteState.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -11630,9 +12260,11 @@ private IResolvable InterpolationForAttribute(string TerraformAttribute)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                    | **Description**               |
-| --------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformResource.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                    | **Description**               |
+| ------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformResource.isConstruct">IsConstruct</a></code>                 | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformResource.isTerraformElement">IsTerraformElement</a></code>   | _No description._             |
+| <code><a href="#cdktf.TerraformResource.isTerraformResource">IsTerraformResource</a></code> | _No description._             |
 
 ---
 
@@ -11665,6 +12297,34 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.TerraformResource.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+TerraformResource.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.TerraformResource.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
+
+---
+
+##### `IsTerraformResource` <a name="IsTerraformResource" id="cdktf.TerraformResource.isTerraformResource"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+TerraformResource.IsTerraformResource(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.TerraformResource.isTerraformResource.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 
@@ -12244,9 +12904,10 @@ private System.Collections.Generic.IDictionary< string, object > SynthesizeAttri
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                    | **Description**               |
-| --------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformVariable.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                  | **Description**               |
+| ----------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformVariable.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformVariable.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -12279,6 +12940,20 @@ this type-testing method instead.
 - _Type:_ object
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.TerraformVariable.isTerraformElement"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+TerraformVariable.IsTerraformElement(object X);
+```
+
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.TerraformVariable.isTerraformElement.parameter.x"></a>
+
+- _Type:_ object
 
 ---
 

--- a/website/docs/cdktf/api-reference/go.mdx
+++ b/website/docs/cdktf/api-reference/go.mdx
@@ -365,10 +365,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                     | **Description**               |
-| ---------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.ArtifactoryBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.ArtifactoryBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                                   | **Description**               |
+| ------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.ArtifactoryBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.ArtifactoryBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.ArtifactoryBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -401,6 +402,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.ArtifactoryBackend.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.ArtifactoryBackend_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.ArtifactoryBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -606,10 +621,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                 | **Description**               |
-| ------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.AzurermBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.AzurermBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                               | **Description**               |
+| -------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.AzurermBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.AzurermBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.AzurermBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -642,6 +658,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.AzurermBackend.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.AzurermBackend_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.AzurermBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -849,10 +879,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                               | **Description**               |
-| ---------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.CloudBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.CloudBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                             | **Description**               |
+| ------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.CloudBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.CloudBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.CloudBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -885,6 +916,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.CloudBackend.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.CloudBackend_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.CloudBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -1090,10 +1135,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                | **Description**               |
-| ----------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.ConsulBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.ConsulBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                              | **Description**               |
+| ------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.ConsulBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.ConsulBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.ConsulBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -1126,6 +1172,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.ConsulBackend.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.ConsulBackend_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.ConsulBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -1331,10 +1391,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                             | **Description**               |
-| -------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.CosBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.CosBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                           | **Description**               |
+| ---------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.CosBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.CosBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.CosBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -1367,6 +1428,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.CosBackend.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.CosBackend_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.CosBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -1617,9 +1692,10 @@ func GetString(output *string) *string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                           | **Description**               |
-| ---------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteState.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                         | **Description**               |
+| ------------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteState.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteState.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -1652,6 +1728,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteState.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.DataTerraformRemoteState_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteState.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -1906,9 +1996,10 @@ func GetString(output *string) *string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                      | **Description**               |
-| --------------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateArtifactory.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                                    | **Description**               |
+| ----------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateArtifactory.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -1941,6 +2032,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.DataTerraformRemoteStateArtifactory_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -2195,9 +2300,10 @@ func GetString(output *string) *string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                  | **Description**               |
-| ----------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                                | **Description**               |
+| ------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -2230,6 +2336,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateAzurerm.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.DataTerraformRemoteStateAzurerm_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateAzurerm.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -2484,9 +2604,10 @@ func GetString(output *string) *string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                 | **Description**               |
-| ---------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateConsul.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                               | **Description**               |
+| ------------------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateConsul.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateConsul.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -2519,6 +2640,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateConsul.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.DataTerraformRemoteStateConsul_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateConsul.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -2773,9 +2908,10 @@ func GetString(output *string) *string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                              | **Description**               |
-| ------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateCos.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                            | **Description**               |
+| --------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateCos.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateCos.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -2808,6 +2944,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateCos.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.DataTerraformRemoteStateCos_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateCos.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -3062,9 +3212,10 @@ func GetString(output *string) *string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                               | **Description**               |
-| -------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateEtcd.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                             | **Description**               |
+| ---------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateEtcd.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateEtcd.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -3097,6 +3248,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateEtcd.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.DataTerraformRemoteStateEtcd_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateEtcd.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -3351,9 +3516,10 @@ func GetString(output *string) *string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                 | **Description**               |
-| ---------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateEtcdV3.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                               | **Description**               |
+| ------------------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateEtcdV3.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -3386,6 +3552,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.DataTerraformRemoteStateEtcdV3_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -3640,9 +3820,10 @@ func GetString(output *string) *string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                              | **Description**               |
-| ------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateGcs.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                            | **Description**               |
+| --------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateGcs.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateGcs.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -3675,6 +3856,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateGcs.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.DataTerraformRemoteStateGcs_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateGcs.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -3929,9 +4124,10 @@ func GetString(output *string) *string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                               | **Description**               |
-| -------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateHttp.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                             | **Description**               |
+| ---------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateHttp.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateHttp.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -3964,6 +4160,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateHttp.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.DataTerraformRemoteStateHttp_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateHttp.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -4218,9 +4428,10 @@ func GetString(output *string) *string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                | **Description**               |
-| --------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateLocal.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                              | **Description**               |
+| ----------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateLocal.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateLocal.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -4253,6 +4464,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateLocal.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.DataTerraformRemoteStateLocal_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateLocal.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -4507,9 +4732,10 @@ func GetString(output *string) *string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                | **Description**               |
-| --------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateManta.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                              | **Description**               |
+| ----------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateManta.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateManta.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -4542,6 +4768,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateManta.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.DataTerraformRemoteStateManta_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateManta.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -4796,9 +5036,10 @@ func GetString(output *string) *string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                              | **Description**               |
-| ------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateOss.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                            | **Description**               |
+| --------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateOss.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateOss.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -4831,6 +5072,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateOss.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.DataTerraformRemoteStateOss_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateOss.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -5085,9 +5340,10 @@ func GetString(output *string) *string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                             | **Description**               |
-| ------------------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStatePg.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                           | **Description**               |
+| -------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStatePg.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStatePg.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -5120,6 +5376,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStatePg.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.DataTerraformRemoteStatePg_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStatePg.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -5374,9 +5644,10 @@ func GetString(output *string) *string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                             | **Description**               |
-| ------------------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                           | **Description**               |
+| -------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -5409,6 +5680,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateS3.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.DataTerraformRemoteStateS3_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateS3.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -5663,9 +5948,10 @@ func GetString(output *string) *string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                | **Description**               |
-| --------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateSwift.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                              | **Description**               |
+| ----------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateSwift.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateSwift.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -5698,6 +5984,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateSwift.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.DataTerraformRemoteStateSwift_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateSwift.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -5907,10 +6207,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                              | **Description**               |
-| --------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.EtcdBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.EtcdBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                            | **Description**               |
+| ----------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.EtcdBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.EtcdBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.EtcdBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -5943,6 +6244,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.EtcdBackend.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.EtcdBackend_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.EtcdBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -6148,10 +6463,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                | **Description**               |
-| ----------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.EtcdV3Backend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.EtcdV3Backend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                              | **Description**               |
+| ------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.EtcdV3Backend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.EtcdV3Backend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.EtcdV3Backend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -6184,6 +6500,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.EtcdV3Backend.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.EtcdV3Backend_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.EtcdV3Backend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -6389,10 +6719,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                             | **Description**               |
-| -------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.GcsBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.GcsBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                           | **Description**               |
+| ---------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.GcsBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.GcsBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.GcsBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -6425,6 +6756,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.GcsBackend.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.GcsBackend_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.GcsBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -6630,10 +6975,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                              | **Description**               |
-| --------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.HttpBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.HttpBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                            | **Description**               |
+| ----------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.HttpBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.HttpBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.HttpBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -6666,6 +7012,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.HttpBackend.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.HttpBackend_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.HttpBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -6871,10 +7231,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                               | **Description**               |
-| ---------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.LocalBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.LocalBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                             | **Description**               |
+| ------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.LocalBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.LocalBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.LocalBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -6907,6 +7268,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.LocalBackend.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.LocalBackend_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.LocalBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -7112,10 +7487,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                               | **Description**               |
-| ---------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.MantaBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.MantaBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                             | **Description**               |
+| ------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.MantaBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.MantaBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.MantaBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -7148,6 +7524,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.MantaBackend.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.MantaBackend_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.MantaBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -7353,10 +7743,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                             | **Description**               |
-| -------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.OssBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.OssBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                           | **Description**               |
+| ---------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.OssBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.OssBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.OssBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -7389,6 +7780,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.OssBackend.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.OssBackend_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.OssBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -7594,10 +7999,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                            | **Description**               |
-| ------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.PgBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.PgBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                          | **Description**               |
+| --------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.PgBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.PgBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.PgBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -7630,6 +8036,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.PgBackend.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.PgBackend_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.PgBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -7835,10 +8255,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                | **Description**               |
-| ----------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.RemoteBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.RemoteBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                              | **Description**               |
+| ------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.RemoteBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.RemoteBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.RemoteBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -7871,6 +8292,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.RemoteBackend.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.RemoteBackend_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.RemoteBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -8202,10 +8637,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                            | **Description**               |
-| ------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.S3Backend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.S3Backend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                          | **Description**               |
+| --------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.S3Backend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.S3Backend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.S3Backend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -8238,6 +8674,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.S3Backend.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.S3Backend_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.S3Backend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -8443,10 +8893,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                               | **Description**               |
-| ---------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.SwiftBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.SwiftBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                             | **Description**               |
+| ------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.SwiftBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.SwiftBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.SwiftBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -8479,6 +8930,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.SwiftBackend.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.SwiftBackend_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.SwiftBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -8851,10 +9316,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                   | **Description**               |
-| -------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformBackend.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.TerraformBackend.isBackend">IsBackend</a></code>     | _No description._             |
+| **Name**                                                                                 | **Description**               |
+| ---------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformBackend.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformBackend.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.TerraformBackend.isBackend">IsBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -8887,6 +9353,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.TerraformBackend.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.TerraformBackend_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -9204,9 +9684,11 @@ func InterpolationForAttribute(terraformAttribute *string) IResolvable
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                      | **Description**               |
-| ----------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformDataSource.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                          | **Description**               |
+| ------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformDataSource.isConstruct">IsConstruct</a></code>                     | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformDataSource.isTerraformElement">IsTerraformElement</a></code>       | _No description._             |
+| <code><a href="#cdktf.TerraformDataSource.isTerraformDataSource">IsTerraformDataSource</a></code> | _No description._             |
 
 ---
 
@@ -9239,6 +9721,34 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.TerraformDataSource.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.TerraformDataSource_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformDataSource.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
+
+---
+
+##### `IsTerraformDataSource` <a name="IsTerraformDataSource" id="cdktf.TerraformDataSource.isTerraformDataSource"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.TerraformDataSource_IsTerraformDataSource(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformDataSource.isTerraformDataSource.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -9496,9 +10006,10 @@ func ToTerraform() interface{}
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                   | **Description**               |
-| -------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformElement.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                 | **Description**               |
+| ---------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformElement.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformElement.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -9531,6 +10042,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.TerraformElement.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.TerraformElement_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformElement.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -9810,9 +10335,10 @@ func Set(variable *string, value interface{})
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                     | **Description**               |
-| ---------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformHclModule.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                   | **Description**               |
+| ------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.TerraformHclModule.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformHclModule.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -9845,6 +10371,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.TerraformHclModule.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.TerraformHclModule_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformHclModule.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -10093,9 +10633,10 @@ func ToTerraform() interface{}
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                 | **Description**               |
-| ------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.TerraformLocal.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                               | **Description**               |
+| -------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformLocal.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformLocal.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -10128,6 +10669,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.TerraformLocal.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.TerraformLocal_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformLocal.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -10393,9 +10948,10 @@ func InterpolationForOutput(moduleOutput *string) IResolvable
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                  | **Description**               |
-| ------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformModule.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                | **Description**               |
+| --------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformModule.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformModule.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -10428,6 +10984,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.TerraformModule.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.TerraformModule_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformModule.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -10663,10 +11233,11 @@ func ToTerraform() interface{}
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                              | **Description**               |
-| ------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformOutput.isConstruct">IsConstruct</a></code>             | Checks if `x` is a construct. |
-| <code><a href="#cdktf.TerraformOutput.isTerrafromOutput">IsTerrafromOutput</a></code> | _No description._             |
+| **Name**                                                                                | **Description**               |
+| --------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformOutput.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformOutput.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.TerraformOutput.isTerrafromOutput">IsTerrafromOutput</a></code>   | _No description._             |
 
 ---
 
@@ -10699,6 +11270,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.TerraformOutput.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.TerraformOutput_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformOutput.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -10939,9 +11524,11 @@ Adds this resource to the terraform JSON output.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                    | **Description**               |
-| --------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformProvider.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                    | **Description**               |
+| ------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformProvider.isConstruct">IsConstruct</a></code>                 | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformProvider.isTerraformElement">IsTerraformElement</a></code>   | _No description._             |
+| <code><a href="#cdktf.TerraformProvider.isTerraformProvider">IsTerraformProvider</a></code> | _No description._             |
 
 ---
 
@@ -10974,6 +11561,34 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.TerraformProvider.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.TerraformProvider_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformProvider.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
+
+---
+
+##### `IsTerraformProvider` <a name="IsTerraformProvider" id="cdktf.TerraformProvider.isTerraformProvider"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.TerraformProvider_IsTerraformProvider(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformProvider.isTerraformProvider.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -11274,9 +11889,10 @@ func GetString(output *string) *string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                       | **Description**               |
-| ------------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.TerraformRemoteState.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                     | **Description**               |
+| -------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformRemoteState.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformRemoteState.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -11309,6 +11925,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.TerraformRemoteState.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.TerraformRemoteState_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformRemoteState.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -11630,9 +12260,11 @@ func InterpolationForAttribute(terraformAttribute *string) IResolvable
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                    | **Description**               |
-| --------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformResource.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                    | **Description**               |
+| ------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformResource.isConstruct">IsConstruct</a></code>                 | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformResource.isTerraformElement">IsTerraformElement</a></code>   | _No description._             |
+| <code><a href="#cdktf.TerraformResource.isTerraformResource">IsTerraformResource</a></code> | _No description._             |
 
 ---
 
@@ -11665,6 +12297,34 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.TerraformResource.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.TerraformResource_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformResource.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
+
+---
+
+##### `IsTerraformResource` <a name="IsTerraformResource" id="cdktf.TerraformResource.isTerraformResource"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.TerraformResource_IsTerraformResource(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformResource.isTerraformResource.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 
@@ -12244,9 +12904,10 @@ func SynthesizeAttributes() *map[string]interface{}
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                    | **Description**               |
-| --------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformVariable.isConstruct">IsConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                  | **Description**               |
+| ----------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformVariable.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformVariable.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -12279,6 +12940,20 @@ this type-testing method instead.
 - _Type:_ interface{}
 
 Any object.
+
+---
+
+##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.TerraformVariable.isTerraformElement"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.TerraformVariable_IsTerraformElement(x interface{}) *bool
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformVariable.isTerraformElement.parameter.x"></a>
+
+- _Type:_ interface{}
 
 ---
 

--- a/website/docs/cdktf/api-reference/java.mdx
+++ b/website/docs/cdktf/api-reference/java.mdx
@@ -448,10 +448,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                     | **Description**               |
-| ---------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.ArtifactoryBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.ArtifactoryBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                                   | **Description**               |
+| ------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.ArtifactoryBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.ArtifactoryBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.ArtifactoryBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -484,6 +485,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.ArtifactoryBackend.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.ArtifactoryBackend;
+
+ArtifactoryBackend.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.ArtifactoryBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -957,10 +972,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                 | **Description**               |
-| ------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.AzurermBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.AzurermBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                               | **Description**               |
+| -------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.AzurermBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.AzurermBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.AzurermBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -993,6 +1009,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.AzurermBackend.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.AzurermBackend;
+
+AzurermBackend.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.AzurermBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -1240,10 +1270,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                               | **Description**               |
-| ---------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.CloudBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.CloudBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                             | **Description**               |
+| ------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.CloudBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.CloudBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.CloudBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -1276,6 +1307,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.CloudBackend.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.CloudBackend;
+
+CloudBackend.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.CloudBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -1596,10 +1641,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                | **Description**               |
-| ----------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.ConsulBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.ConsulBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                              | **Description**               |
+| ------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.ConsulBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.ConsulBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.ConsulBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -1632,6 +1678,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.ConsulBackend.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.ConsulBackend;
+
+ConsulBackend.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.ConsulBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -1927,10 +1987,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                             | **Description**               |
-| -------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.CosBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.CosBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                           | **Description**               |
+| ---------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.CosBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.CosBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.CosBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -1963,6 +2024,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.CosBackend.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.CosBackend;
+
+CosBackend.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.CosBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -2255,9 +2330,10 @@ public java.lang.String getString(java.lang.String output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                           | **Description**               |
-| ---------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteState.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                         | **Description**               |
+| ------------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteState.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteState.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -2290,6 +2366,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteState.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.DataTerraformRemoteState;
+
+DataTerraformRemoteState.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteState.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -2606,9 +2696,10 @@ public java.lang.String getString(java.lang.String output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                      | **Description**               |
-| --------------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateArtifactory.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                                    | **Description**               |
+| ----------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateArtifactory.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -2641,6 +2732,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.DataTerraformRemoteStateArtifactory;
+
+DataTerraformRemoteStateArtifactory.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -3179,9 +3284,10 @@ public java.lang.String getString(java.lang.String output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                  | **Description**               |
-| ----------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                                | **Description**               |
+| ------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -3214,6 +3320,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateAzurerm.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.DataTerraformRemoteStateAzurerm;
+
+DataTerraformRemoteStateAzurerm.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateAzurerm.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -3599,9 +3719,10 @@ public java.lang.String getString(java.lang.String output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                 | **Description**               |
-| ---------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateConsul.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                               | **Description**               |
+| ------------------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateConsul.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateConsul.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -3634,6 +3755,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateConsul.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.DataTerraformRemoteStateConsul;
+
+DataTerraformRemoteStateConsul.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateConsul.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -3994,9 +4129,10 @@ public java.lang.String getString(java.lang.String output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                              | **Description**               |
-| ------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateCos.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                            | **Description**               |
+| --------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateCos.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateCos.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -4029,6 +4165,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateCos.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.DataTerraformRemoteStateCos;
+
+DataTerraformRemoteStateCos.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateCos.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -4333,9 +4483,10 @@ public java.lang.String getString(java.lang.String output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                               | **Description**               |
-| -------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateEtcd.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                             | **Description**               |
+| ---------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateEtcd.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateEtcd.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -4368,6 +4519,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateEtcd.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.DataTerraformRemoteStateEtcd;
+
+DataTerraformRemoteStateEtcd.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateEtcd.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -4716,9 +4881,10 @@ public java.lang.String getString(java.lang.String output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                 | **Description**               |
-| ---------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateEtcdV3.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                               | **Description**               |
+| ------------------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateEtcdV3.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -4751,6 +4917,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.DataTerraformRemoteStateEtcdV3;
+
+DataTerraformRemoteStateEtcdV3.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -5099,9 +5279,10 @@ public java.lang.String getString(java.lang.String output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                              | **Description**               |
-| ------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateGcs.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                            | **Description**               |
+| --------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateGcs.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateGcs.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -5134,6 +5315,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateGcs.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.DataTerraformRemoteStateGcs;
+
+DataTerraformRemoteStateGcs.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateGcs.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -5536,9 +5731,10 @@ public java.lang.String getString(java.lang.String output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                               | **Description**               |
-| -------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateHttp.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                             | **Description**               |
+| ---------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateHttp.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateHttp.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -5571,6 +5767,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateHttp.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.DataTerraformRemoteStateHttp;
+
+DataTerraformRemoteStateHttp.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateHttp.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -5856,9 +6066,10 @@ public java.lang.String getString(java.lang.String output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                | **Description**               |
-| --------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateLocal.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                              | **Description**               |
+| ----------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateLocal.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateLocal.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -5891,6 +6102,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateLocal.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.DataTerraformRemoteStateLocal;
+
+DataTerraformRemoteStateLocal.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateLocal.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -6219,9 +6444,10 @@ public java.lang.String getString(java.lang.String output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                | **Description**               |
-| --------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateManta.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                              | **Description**               |
+| ----------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateManta.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateManta.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -6254,6 +6480,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateManta.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.DataTerraformRemoteStateManta;
+
+DataTerraformRemoteStateManta.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateManta.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -6646,9 +6886,10 @@ public java.lang.String getString(java.lang.String output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                              | **Description**               |
-| ------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateOss.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                            | **Description**               |
+| --------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateOss.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateOss.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -6681,6 +6922,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateOss.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.DataTerraformRemoteStateOss;
+
+DataTerraformRemoteStateOss.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateOss.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -6969,9 +7224,10 @@ public java.lang.String getString(java.lang.String output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                             | **Description**               |
-| ------------------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStatePg.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                           | **Description**               |
+| -------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStatePg.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStatePg.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -7004,6 +7260,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStatePg.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.DataTerraformRemoteStatePg;
+
+DataTerraformRemoteStatePg.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStatePg.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -7613,9 +7883,10 @@ public java.lang.String getString(java.lang.String output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                             | **Description**               |
-| ------------------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                           | **Description**               |
+| -------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -7648,6 +7919,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateS3.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.DataTerraformRemoteStateS3;
+
+DataTerraformRemoteStateS3.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateS3.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -8128,9 +8413,10 @@ public java.lang.String getString(java.lang.String output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                | **Description**               |
-| --------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateSwift.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                              | **Description**               |
+| ----------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateSwift.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateSwift.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -8163,6 +8449,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateSwift.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.DataTerraformRemoteStateSwift;
+
+DataTerraformRemoteStateSwift.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateSwift.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -8406,10 +8706,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                              | **Description**               |
-| --------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.EtcdBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.EtcdBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                            | **Description**               |
+| ----------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.EtcdBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.EtcdBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.EtcdBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -8442,6 +8743,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.EtcdBackend.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.EtcdBackend;
+
+EtcdBackend.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.EtcdBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -8725,10 +9040,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                | **Description**               |
-| ----------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.EtcdV3Backend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.EtcdV3Backend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                              | **Description**               |
+| ------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.EtcdV3Backend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.EtcdV3Backend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.EtcdV3Backend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -8761,6 +9077,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.EtcdV3Backend.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.EtcdV3Backend;
+
+EtcdV3Backend.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.EtcdV3Backend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -9044,10 +9374,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                             | **Description**               |
-| -------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.GcsBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.GcsBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                           | **Description**               |
+| ---------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.GcsBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.GcsBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.GcsBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -9080,6 +9411,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.GcsBackend.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.GcsBackend;
+
+GcsBackend.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.GcsBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -9417,10 +9762,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                              | **Description**               |
-| --------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.HttpBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.HttpBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                            | **Description**               |
+| ----------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.HttpBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.HttpBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.HttpBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -9453,6 +9799,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.HttpBackend.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.HttpBackend;
+
+HttpBackend.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.HttpBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -9673,10 +10033,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                               | **Description**               |
-| ---------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.LocalBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.LocalBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                             | **Description**               |
+| ------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.LocalBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.LocalBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.LocalBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -9709,6 +10070,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.LocalBackend.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.LocalBackend;
+
+LocalBackend.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.LocalBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -9972,10 +10347,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                               | **Description**               |
-| ---------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.MantaBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.MantaBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                             | **Description**               |
+| ------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.MantaBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.MantaBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.MantaBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -10008,6 +10384,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.MantaBackend.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.MantaBackend;
+
+MantaBackend.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.MantaBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -10335,10 +10725,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                             | **Description**               |
-| -------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.OssBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.OssBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                           | **Description**               |
+| ---------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.OssBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.OssBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.OssBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -10371,6 +10762,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.OssBackend.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.OssBackend;
+
+OssBackend.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.OssBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -10594,10 +10999,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                            | **Description**               |
-| ------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.PgBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.PgBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                          | **Description**               |
+| --------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.PgBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.PgBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.PgBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -10630,6 +11036,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.PgBackend.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.PgBackend;
+
+PgBackend.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.PgBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -10861,10 +11281,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                | **Description**               |
-| ----------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.RemoteBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.RemoteBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                              | **Description**               |
+| ------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.RemoteBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.RemoteBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.RemoteBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -10897,6 +11318,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.RemoteBackend.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.RemoteBackend;
+
+RemoteBackend.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.RemoteBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -11567,10 +12002,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                            | **Description**               |
-| ------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.S3Backend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.S3Backend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                          | **Description**               |
+| --------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.S3Backend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.S3Backend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.S3Backend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -11603,6 +12039,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.S3Backend.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.S3Backend;
+
+S3Backend.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.S3Backend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -12018,10 +12468,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                               | **Description**               |
-| ---------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.SwiftBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.SwiftBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                             | **Description**               |
+| ------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.SwiftBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.SwiftBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.SwiftBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -12054,6 +12505,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.SwiftBackend.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.SwiftBackend;
+
+SwiftBackend.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.SwiftBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -12444,10 +12909,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                   | **Description**               |
-| -------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.TerraformBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                                 | **Description**               |
+| ---------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.TerraformBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -12480,6 +12946,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.TerraformBackend.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.TerraformBackend;
+
+TerraformBackend.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -12866,9 +13346,11 @@ public IResolvable interpolationForAttribute(java.lang.String terraformAttribute
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                      | **Description**               |
-| ----------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformDataSource.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                          | **Description**               |
+| ------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformDataSource.isConstruct">isConstruct</a></code>                     | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformDataSource.isTerraformElement">isTerraformElement</a></code>       | _No description._             |
+| <code><a href="#cdktf.TerraformDataSource.isTerraformDataSource">isTerraformDataSource</a></code> | _No description._             |
 
 ---
 
@@ -12901,6 +13383,34 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.TerraformDataSource.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.TerraformDataSource;
+
+TerraformDataSource.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformDataSource.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
+
+---
+
+##### `isTerraformDataSource` <a name="isTerraformDataSource" id="cdktf.TerraformDataSource.isTerraformDataSource"></a>
+
+```java
+import com.hashicorp.cdktf.TerraformDataSource;
+
+TerraformDataSource.isTerraformDataSource(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformDataSource.isTerraformDataSource.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -13158,9 +13668,10 @@ public java.lang.Object toTerraform()
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                   | **Description**               |
-| -------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformElement.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                 | **Description**               |
+| ---------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformElement.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformElement.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -13193,6 +13704,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.TerraformElement.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.TerraformElement;
+
+TerraformElement.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformElement.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -13523,9 +14048,10 @@ public void set(java.lang.String variable, java.lang.Object value)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                     | **Description**               |
-| ---------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformHclModule.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                   | **Description**               |
+| ------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.TerraformHclModule.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformHclModule.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -13558,6 +14084,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.TerraformHclModule.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.TerraformHclModule;
+
+TerraformHclModule.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformHclModule.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -13806,9 +14346,10 @@ public java.lang.Object toTerraform()
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                 | **Description**               |
-| ------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.TerraformLocal.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                               | **Description**               |
+| -------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformLocal.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformLocal.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -13841,6 +14382,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.TerraformLocal.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.TerraformLocal;
+
+TerraformLocal.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformLocal.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -14149,9 +14704,10 @@ public IResolvable interpolationForOutput(java.lang.String moduleOutput)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                  | **Description**               |
-| ------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformModule.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                | **Description**               |
+| --------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformModule.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformModule.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -14184,6 +14740,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.TerraformModule.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.TerraformModule;
+
+TerraformModule.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformModule.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -14456,10 +15026,11 @@ public java.lang.Object toTerraform()
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                              | **Description**               |
-| ------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformOutput.isConstruct">isConstruct</a></code>             | Checks if `x` is a construct. |
-| <code><a href="#cdktf.TerraformOutput.isTerrafromOutput">isTerrafromOutput</a></code> | _No description._             |
+| **Name**                                                                                | **Description**               |
+| --------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformOutput.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformOutput.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.TerraformOutput.isTerrafromOutput">isTerrafromOutput</a></code>   | _No description._             |
 
 ---
 
@@ -14492,6 +15063,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.TerraformOutput.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.TerraformOutput;
+
+TerraformOutput.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformOutput.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -14750,9 +15335,11 @@ Adds this resource to the terraform JSON output.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                    | **Description**               |
-| --------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformProvider.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                    | **Description**               |
+| ------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformProvider.isConstruct">isConstruct</a></code>                 | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformProvider.isTerraformElement">isTerraformElement</a></code>   | _No description._             |
+| <code><a href="#cdktf.TerraformProvider.isTerraformProvider">isTerraformProvider</a></code> | _No description._             |
 
 ---
 
@@ -14785,6 +15372,34 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.TerraformProvider.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.TerraformProvider;
+
+TerraformProvider.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformProvider.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
+
+---
+
+##### `isTerraformProvider` <a name="isTerraformProvider" id="cdktf.TerraformProvider.isTerraformProvider"></a>
+
+```java
+import com.hashicorp.cdktf.TerraformProvider;
+
+TerraformProvider.isTerraformProvider(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformProvider.isTerraformProvider.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -15095,9 +15710,10 @@ public java.lang.String getString(java.lang.String output)
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                       | **Description**               |
-| ------------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.TerraformRemoteState.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                     | **Description**               |
+| -------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformRemoteState.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformRemoteState.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -15130,6 +15746,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.TerraformRemoteState.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.TerraformRemoteState;
+
+TerraformRemoteState.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformRemoteState.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -15520,9 +16150,11 @@ public IResolvable interpolationForAttribute(java.lang.String terraformAttribute
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                    | **Description**               |
-| --------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformResource.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                    | **Description**               |
+| ------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformResource.isConstruct">isConstruct</a></code>                 | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformResource.isTerraformElement">isTerraformElement</a></code>   | _No description._             |
+| <code><a href="#cdktf.TerraformResource.isTerraformResource">isTerraformResource</a></code> | _No description._             |
 
 ---
 
@@ -15555,6 +16187,34 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.TerraformResource.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.TerraformResource;
+
+TerraformResource.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformResource.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
+
+---
+
+##### `isTerraformResource` <a name="isTerraformResource" id="cdktf.TerraformResource.isTerraformResource"></a>
+
+```java
+import com.hashicorp.cdktf.TerraformResource;
+
+TerraformResource.isTerraformResource(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformResource.isTerraformResource.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 
@@ -16202,9 +16862,10 @@ public java.util.Map< java.lang.String, java.lang.Object > synthesizeAttributes(
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                    | **Description**               |
-| --------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformVariable.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                  | **Description**               |
+| ----------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformVariable.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformVariable.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -16237,6 +16898,20 @@ this type-testing method instead.
 - _Type:_ java.lang.Object
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.TerraformVariable.isTerraformElement"></a>
+
+```java
+import com.hashicorp.cdktf.TerraformVariable;
+
+TerraformVariable.isTerraformElement(java.lang.Object x)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformVariable.isTerraformElement.parameter.x"></a>
+
+- _Type:_ java.lang.Object
 
 ---
 

--- a/website/docs/cdktf/api-reference/python.mdx
+++ b/website/docs/cdktf/api-reference/python.mdx
@@ -468,10 +468,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                      | **Description**               |
-| ----------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.ArtifactoryBackend.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.ArtifactoryBackend.isBackend">is_backend</a></code>     | _No description._             |
+| **Name**                                                                                     | **Description**               |
+| -------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.ArtifactoryBackend.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.ArtifactoryBackend.isTerraformElement">is_terraform_element</a></code> | _No description._             |
+| <code><a href="#cdktf.ArtifactoryBackend.isBackend">is_backend</a></code>                    | _No description._             |
 
 ---
 
@@ -506,6 +507,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.ArtifactoryBackend.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.ArtifactoryBackend.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.ArtifactoryBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -991,10 +1008,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                  | **Description**               |
-| ------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.AzurermBackend.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.AzurermBackend.isBackend">is_backend</a></code>     | _No description._             |
+| **Name**                                                                                 | **Description**               |
+| ---------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.AzurermBackend.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.AzurermBackend.isTerraformElement">is_terraform_element</a></code> | _No description._             |
+| <code><a href="#cdktf.AzurermBackend.isBackend">is_backend</a></code>                    | _No description._             |
 
 ---
 
@@ -1029,6 +1047,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.AzurermBackend.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.AzurermBackend.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.AzurermBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -1287,10 +1321,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                | **Description**               |
-| ----------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.CloudBackend.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.CloudBackend.isBackend">is_backend</a></code>     | _No description._             |
+| **Name**                                                                               | **Description**               |
+| -------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.CloudBackend.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.CloudBackend.isTerraformElement">is_terraform_element</a></code> | _No description._             |
+| <code><a href="#cdktf.CloudBackend.isBackend">is_backend</a></code>                    | _No description._             |
 
 ---
 
@@ -1325,6 +1360,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.CloudBackend.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.CloudBackend.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.CloudBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -1657,10 +1708,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                 | **Description**               |
-| ------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.ConsulBackend.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.ConsulBackend.isBackend">is_backend</a></code>     | _No description._             |
+| **Name**                                                                                | **Description**               |
+| --------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.ConsulBackend.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.ConsulBackend.isTerraformElement">is_terraform_element</a></code> | _No description._             |
+| <code><a href="#cdktf.ConsulBackend.isBackend">is_backend</a></code>                    | _No description._             |
 
 ---
 
@@ -1695,6 +1747,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.ConsulBackend.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.ConsulBackend.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.ConsulBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -2002,10 +2070,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                              | **Description**               |
-| --------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.CosBackend.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.CosBackend.isBackend">is_backend</a></code>     | _No description._             |
+| **Name**                                                                             | **Description**               |
+| ------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.CosBackend.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.CosBackend.isTerraformElement">is_terraform_element</a></code> | _No description._             |
+| <code><a href="#cdktf.CosBackend.isBackend">is_backend</a></code>                    | _No description._             |
 
 ---
 
@@ -2040,6 +2109,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.CosBackend.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.CosBackend.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.CosBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -2351,9 +2436,10 @@ def get_string(
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                            | **Description**               |
-| ----------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteState.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                           | **Description**               |
+| -------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteState.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteState.isTerraformElement">is_terraform_element</a></code> | _No description._             |
 
 ---
 
@@ -2388,6 +2474,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.DataTerraformRemoteState.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.DataTerraformRemoteState.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteState.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -2721,9 +2823,10 @@ def get_string(
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                       | **Description**               |
-| ---------------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateArtifactory.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                                      | **Description**               |
+| ------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateArtifactory.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement">is_terraform_element</a></code> | _No description._             |
 
 ---
 
@@ -2758,6 +2861,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.DataTerraformRemoteStateArtifactory.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -3313,9 +3432,10 @@ def get_string(
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                   | **Description**               |
-| ------------------------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                                  | **Description**               |
+| --------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.isTerraformElement">is_terraform_element</a></code> | _No description._             |
 
 ---
 
@@ -3350,6 +3470,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStateAzurerm.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.DataTerraformRemoteStateAzurerm.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateAzurerm.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -3752,9 +3888,10 @@ def get_string(
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                  | **Description**               |
-| ----------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateConsul.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                                 | **Description**               |
+| -------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateConsul.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateConsul.isTerraformElement">is_terraform_element</a></code> | _No description._             |
 
 ---
 
@@ -3789,6 +3926,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStateConsul.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.DataTerraformRemoteStateConsul.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateConsul.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -4166,9 +4319,10 @@ def get_string(
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                               | **Description**               |
-| -------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateCos.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                              | **Description**               |
+| ----------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateCos.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateCos.isTerraformElement">is_terraform_element</a></code> | _No description._             |
 
 ---
 
@@ -4203,6 +4357,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStateCos.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.DataTerraformRemoteStateCos.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateCos.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -4524,9 +4694,10 @@ def get_string(
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                | **Description**               |
-| --------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateEtcd.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                               | **Description**               |
+| ------------------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateEtcd.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateEtcd.isTerraformElement">is_terraform_element</a></code> | _No description._             |
 
 ---
 
@@ -4561,6 +4732,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStateEtcd.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.DataTerraformRemoteStateEtcd.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateEtcd.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -4926,9 +5113,10 @@ def get_string(
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                  | **Description**               |
-| ----------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateEtcdV3.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                                 | **Description**               |
+| -------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateEtcdV3.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement">is_terraform_element</a></code> | _No description._             |
 
 ---
 
@@ -4963,6 +5151,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.DataTerraformRemoteStateEtcdV3.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -5328,9 +5532,10 @@ def get_string(
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                               | **Description**               |
-| -------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateGcs.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                              | **Description**               |
+| ----------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateGcs.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateGcs.isTerraformElement">is_terraform_element</a></code> | _No description._             |
 
 ---
 
@@ -5365,6 +5570,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStateGcs.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.DataTerraformRemoteStateGcs.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateGcs.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -5784,9 +6005,10 @@ def get_string(
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                | **Description**               |
-| --------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateHttp.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                               | **Description**               |
+| ------------------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateHttp.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateHttp.isTerraformElement">is_terraform_element</a></code> | _No description._             |
 
 ---
 
@@ -5821,6 +6043,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStateHttp.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.DataTerraformRemoteStateHttp.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateHttp.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -6123,9 +6361,10 @@ def get_string(
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                 | **Description**               |
-| ---------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateLocal.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                                | **Description**               |
+| ------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateLocal.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateLocal.isTerraformElement">is_terraform_element</a></code> | _No description._             |
 
 ---
 
@@ -6160,6 +6399,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStateLocal.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.DataTerraformRemoteStateLocal.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateLocal.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -6505,9 +6760,10 @@ def get_string(
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                 | **Description**               |
-| ---------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateManta.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                                | **Description**               |
+| ------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateManta.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateManta.isTerraformElement">is_terraform_element</a></code> | _No description._             |
 
 ---
 
@@ -6542,6 +6798,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStateManta.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.DataTerraformRemoteStateManta.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateManta.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -6951,9 +7223,10 @@ def get_string(
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                               | **Description**               |
-| -------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateOss.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                              | **Description**               |
+| ----------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateOss.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateOss.isTerraformElement">is_terraform_element</a></code> | _No description._             |
 
 ---
 
@@ -6988,6 +7261,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStateOss.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.DataTerraformRemoteStateOss.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateOss.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -7293,9 +7582,10 @@ def get_string(
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                              | **Description**               |
-| ------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStatePg.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                             | **Description**               |
+| ---------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStatePg.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStatePg.isTerraformElement">is_terraform_element</a></code> | _No description._             |
 
 ---
 
@@ -7330,6 +7620,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStatePg.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.DataTerraformRemoteStatePg.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStatePg.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -7956,9 +8262,10 @@ def get_string(
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                              | **Description**               |
-| ------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                             | **Description**               |
+| ---------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.isTerraformElement">is_terraform_element</a></code> | _No description._             |
 
 ---
 
@@ -7993,6 +8300,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStateS3.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.DataTerraformRemoteStateS3.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateS3.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -8490,9 +8813,10 @@ def get_string(
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                 | **Description**               |
-| ---------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateSwift.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                                | **Description**               |
+| ------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateSwift.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateSwift.isTerraformElement">is_terraform_element</a></code> | _No description._             |
 
 ---
 
@@ -8527,6 +8851,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStateSwift.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.DataTerraformRemoteStateSwift.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateSwift.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -8780,10 +9120,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                               | **Description**               |
-| ---------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.EtcdBackend.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.EtcdBackend.isBackend">is_backend</a></code>     | _No description._             |
+| **Name**                                                                              | **Description**               |
+| ------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.EtcdBackend.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.EtcdBackend.isTerraformElement">is_terraform_element</a></code> | _No description._             |
+| <code><a href="#cdktf.EtcdBackend.isBackend">is_backend</a></code>                    | _No description._             |
 
 ---
 
@@ -8818,6 +9159,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.EtcdBackend.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.EtcdBackend.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.EtcdBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -9113,10 +9470,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                 | **Description**               |
-| ------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.EtcdV3Backend.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.EtcdV3Backend.isBackend">is_backend</a></code>     | _No description._             |
+| **Name**                                                                                | **Description**               |
+| --------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.EtcdV3Backend.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.EtcdV3Backend.isTerraformElement">is_terraform_element</a></code> | _No description._             |
+| <code><a href="#cdktf.EtcdV3Backend.isBackend">is_backend</a></code>                    | _No description._             |
 
 ---
 
@@ -9151,6 +9509,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.EtcdV3Backend.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.EtcdV3Backend.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.EtcdV3Backend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -9446,10 +9820,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                              | **Description**               |
-| --------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.GcsBackend.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.GcsBackend.isBackend">is_backend</a></code>     | _No description._             |
+| **Name**                                                                             | **Description**               |
+| ------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.GcsBackend.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.GcsBackend.isTerraformElement">is_terraform_element</a></code> | _No description._             |
+| <code><a href="#cdktf.GcsBackend.isBackend">is_backend</a></code>                    | _No description._             |
 
 ---
 
@@ -9484,6 +9859,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.GcsBackend.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.GcsBackend.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.GcsBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -9833,10 +10224,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                               | **Description**               |
-| ---------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.HttpBackend.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.HttpBackend.isBackend">is_backend</a></code>     | _No description._             |
+| **Name**                                                                              | **Description**               |
+| ------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.HttpBackend.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.HttpBackend.isTerraformElement">is_terraform_element</a></code> | _No description._             |
+| <code><a href="#cdktf.HttpBackend.isBackend">is_backend</a></code>                    | _No description._             |
 
 ---
 
@@ -9871,6 +10263,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.HttpBackend.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.HttpBackend.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.HttpBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -10103,10 +10511,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                | **Description**               |
-| ----------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.LocalBackend.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.LocalBackend.isBackend">is_backend</a></code>     | _No description._             |
+| **Name**                                                                               | **Description**               |
+| -------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.LocalBackend.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.LocalBackend.isTerraformElement">is_terraform_element</a></code> | _No description._             |
+| <code><a href="#cdktf.LocalBackend.isBackend">is_backend</a></code>                    | _No description._             |
 
 ---
 
@@ -10141,6 +10550,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.LocalBackend.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.LocalBackend.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.LocalBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -10416,10 +10841,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                | **Description**               |
-| ----------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.MantaBackend.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.MantaBackend.isBackend">is_backend</a></code>     | _No description._             |
+| **Name**                                                                               | **Description**               |
+| -------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.MantaBackend.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.MantaBackend.isTerraformElement">is_terraform_element</a></code> | _No description._             |
+| <code><a href="#cdktf.MantaBackend.isBackend">is_backend</a></code>                    | _No description._             |
 
 ---
 
@@ -10454,6 +10880,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.MantaBackend.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.MantaBackend.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.MantaBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -10793,10 +11235,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                              | **Description**               |
-| --------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.OssBackend.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.OssBackend.isBackend">is_backend</a></code>     | _No description._             |
+| **Name**                                                                             | **Description**               |
+| ------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.OssBackend.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.OssBackend.isTerraformElement">is_terraform_element</a></code> | _No description._             |
+| <code><a href="#cdktf.OssBackend.isBackend">is_backend</a></code>                    | _No description._             |
 
 ---
 
@@ -10831,6 +11274,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.OssBackend.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.OssBackend.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.OssBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -11066,10 +11525,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                             | **Description**               |
-| -------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.PgBackend.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.PgBackend.isBackend">is_backend</a></code>     | _No description._             |
+| **Name**                                                                            | **Description**               |
+| ----------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.PgBackend.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.PgBackend.isTerraformElement">is_terraform_element</a></code> | _No description._             |
+| <code><a href="#cdktf.PgBackend.isBackend">is_backend</a></code>                    | _No description._             |
 
 ---
 
@@ -11104,6 +11564,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.PgBackend.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.PgBackend.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.PgBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -11347,10 +11823,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                 | **Description**               |
-| ------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.RemoteBackend.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.RemoteBackend.isBackend">is_backend</a></code>     | _No description._             |
+| **Name**                                                                                | **Description**               |
+| --------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.RemoteBackend.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.RemoteBackend.isTerraformElement">is_terraform_element</a></code> | _No description._             |
+| <code><a href="#cdktf.RemoteBackend.isBackend">is_backend</a></code>                    | _No description._             |
 
 ---
 
@@ -11385,6 +11862,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.RemoteBackend.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.RemoteBackend.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.RemoteBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -12072,10 +12565,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                             | **Description**               |
-| -------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.S3Backend.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.S3Backend.isBackend">is_backend</a></code>     | _No description._             |
+| **Name**                                                                            | **Description**               |
+| ----------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.S3Backend.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.S3Backend.isTerraformElement">is_terraform_element</a></code> | _No description._             |
+| <code><a href="#cdktf.S3Backend.isBackend">is_backend</a></code>                    | _No description._             |
 
 ---
 
@@ -12110,6 +12604,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.S3Backend.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.S3Backend.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.S3Backend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -12537,10 +13047,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                | **Description**               |
-| ----------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.SwiftBackend.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.SwiftBackend.isBackend">is_backend</a></code>     | _No description._             |
+| **Name**                                                                               | **Description**               |
+| -------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.SwiftBackend.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.SwiftBackend.isTerraformElement">is_terraform_element</a></code> | _No description._             |
+| <code><a href="#cdktf.SwiftBackend.isBackend">is_backend</a></code>                    | _No description._             |
 
 ---
 
@@ -12575,6 +13086,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.SwiftBackend.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.SwiftBackend.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.SwiftBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -12984,10 +13511,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                    | **Description**               |
-| --------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformBackend.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.TerraformBackend.isBackend">is_backend</a></code>     | _No description._             |
+| **Name**                                                                                   | **Description**               |
+| ------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.TerraformBackend.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformBackend.isTerraformElement">is_terraform_element</a></code> | _No description._             |
+| <code><a href="#cdktf.TerraformBackend.isBackend">is_backend</a></code>                    | _No description._             |
 
 ---
 
@@ -13022,6 +13550,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.TerraformBackend.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.TerraformBackend.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -13434,9 +13978,11 @@ def interpolation_for_attribute(
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                       | **Description**               |
-| ------------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.TerraformDataSource.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                             | **Description**               |
+| ---------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformDataSource.isConstruct">is_construct</a></code>                       | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformDataSource.isTerraformElement">is_terraform_element</a></code>        | _No description._             |
+| <code><a href="#cdktf.TerraformDataSource.isTerraformDataSource">is_terraform_data_source</a></code> | _No description._             |
 
 ---
 
@@ -13471,6 +14017,38 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.TerraformDataSource.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.TerraformDataSource.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformDataSource.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
+
+---
+
+##### `is_terraform_data_source` <a name="is_terraform_data_source" id="cdktf.TerraformDataSource.isTerraformDataSource"></a>
+
+```python
+import cdktf
+
+cdktf.TerraformDataSource.is_terraform_data_source(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformDataSource.isTerraformDataSource.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -13737,9 +14315,10 @@ def to_terraform() - > typing.Any
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                    | **Description**               |
-| --------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformElement.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                   | **Description**               |
+| ------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.TerraformElement.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformElement.isTerraformElement">is_terraform_element</a></code> | _No description._             |
 
 ---
 
@@ -13774,6 +14353,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.TerraformElement.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.TerraformElement.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformElement.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -14127,9 +14722,10 @@ def set(
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                      | **Description**               |
-| ----------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformHclModule.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                     | **Description**               |
+| -------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformHclModule.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformHclModule.isTerraformElement">is_terraform_element</a></code> | _No description._             |
 
 ---
 
@@ -14164,6 +14760,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.TerraformHclModule.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.TerraformHclModule.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformHclModule.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -14421,9 +15033,10 @@ def to_terraform() - > typing.Any
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                  | **Description**               |
-| ------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformLocal.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                 | **Description**               |
+| ---------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformLocal.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformLocal.isTerraformElement">is_terraform_element</a></code> | _No description._             |
 
 ---
 
@@ -14458,6 +15071,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.TerraformLocal.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.TerraformLocal.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformLocal.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -14778,9 +15407,10 @@ def interpolation_for_output(
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                   | **Description**               |
-| -------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformModule.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                  | **Description**               |
+| ----------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformModule.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformModule.isTerraformElement">is_terraform_element</a></code> | _No description._             |
 
 ---
 
@@ -14815,6 +15445,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.TerraformModule.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.TerraformModule.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformModule.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -15094,10 +15740,11 @@ def to_terraform() - > typing.Any
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                | **Description**               |
-| --------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformOutput.isConstruct">is_construct</a></code>              | Checks if `x` is a construct. |
-| <code><a href="#cdktf.TerraformOutput.isTerrafromOutput">is_terrafrom_output</a></code> | _No description._             |
+| **Name**                                                                                  | **Description**               |
+| ----------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformOutput.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformOutput.isTerraformElement">is_terraform_element</a></code> | _No description._             |
+| <code><a href="#cdktf.TerraformOutput.isTerrafromOutput">is_terrafrom_output</a></code>   | _No description._             |
 
 ---
 
@@ -15132,6 +15779,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.TerraformOutput.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.TerraformOutput.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformOutput.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -15399,9 +16062,11 @@ Adds this resource to the terraform JSON output.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                     | **Description**               |
-| ---------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformProvider.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                      | **Description**               |
+| --------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformProvider.isConstruct">is_construct</a></code>                  | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformProvider.isTerraformElement">is_terraform_element</a></code>   | _No description._             |
+| <code><a href="#cdktf.TerraformProvider.isTerraformProvider">is_terraform_provider</a></code> | _No description._             |
 
 ---
 
@@ -15436,6 +16101,38 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.TerraformProvider.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.TerraformProvider.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformProvider.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
+
+---
+
+##### `is_terraform_provider` <a name="is_terraform_provider" id="cdktf.TerraformProvider.isTerraformProvider"></a>
+
+```python
+import cdktf
+
+cdktf.TerraformProvider.is_terraform_provider(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformProvider.isTerraformProvider.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -15764,9 +16461,10 @@ def get_string(
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                        | **Description**               |
-| ------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformRemoteState.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                       | **Description**               |
+| ---------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformRemoteState.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformRemoteState.isTerraformElement">is_terraform_element</a></code> | _No description._             |
 
 ---
 
@@ -15801,6 +16499,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.TerraformRemoteState.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.TerraformRemoteState.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformRemoteState.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -16215,9 +16929,11 @@ def interpolation_for_attribute(
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                     | **Description**               |
-| ---------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformResource.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                      | **Description**               |
+| --------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformResource.isConstruct">is_construct</a></code>                  | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformResource.isTerraformElement">is_terraform_element</a></code>   | _No description._             |
+| <code><a href="#cdktf.TerraformResource.isTerraformResource">is_terraform_resource</a></code> | _No description._             |
 
 ---
 
@@ -16252,6 +16968,38 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.TerraformResource.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.TerraformResource.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformResource.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
+
+---
+
+##### `is_terraform_resource` <a name="is_terraform_resource" id="cdktf.TerraformResource.isTerraformResource"></a>
+
+```python
+import cdktf
+
+cdktf.TerraformResource.is_terraform_resource(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformResource.isTerraformResource.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 
@@ -16937,9 +17685,10 @@ def synthesize_attributes() - > typing.Mapping[typing.Any]
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                     | **Description**               |
-| ---------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformVariable.isConstruct">is_construct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                    | **Description**               |
+| ------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformVariable.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformVariable.isTerraformElement">is_terraform_element</a></code> | _No description._             |
 
 ---
 
@@ -16974,6 +17723,22 @@ this type-testing method instead.
 - _Type:_ typing.Any
 
 Any object.
+
+---
+
+##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.TerraformVariable.isTerraformElement"></a>
+
+```python
+import cdktf
+
+cdktf.TerraformVariable.is_terraform_element(
+  x: typing.Any
+)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformVariable.isTerraformElement.parameter.x"></a>
+
+- _Type:_ typing.Any
 
 ---
 

--- a/website/docs/cdktf/api-reference/typescript.mdx
+++ b/website/docs/cdktf/api-reference/typescript.mdx
@@ -365,10 +365,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                     | **Description**               |
-| ---------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.ArtifactoryBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.ArtifactoryBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                                   | **Description**               |
+| ------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.ArtifactoryBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.ArtifactoryBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.ArtifactoryBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -401,6 +402,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.ArtifactoryBackend.isTerraformElement"></a>
+
+```typescript
+import { ArtifactoryBackend } from 'cdktf'
+
+ArtifactoryBackend.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.ArtifactoryBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -606,10 +621,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                 | **Description**               |
-| ------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.AzurermBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.AzurermBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                               | **Description**               |
+| -------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.AzurermBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.AzurermBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.AzurermBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -642,6 +658,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.AzurermBackend.isTerraformElement"></a>
+
+```typescript
+import { AzurermBackend } from 'cdktf'
+
+AzurermBackend.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.AzurermBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -849,10 +879,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                               | **Description**               |
-| ---------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.CloudBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.CloudBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                             | **Description**               |
+| ------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.CloudBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.CloudBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.CloudBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -885,6 +916,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.CloudBackend.isTerraformElement"></a>
+
+```typescript
+import { CloudBackend } from 'cdktf'
+
+CloudBackend.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.CloudBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -1090,10 +1135,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                | **Description**               |
-| ----------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.ConsulBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.ConsulBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                              | **Description**               |
+| ------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.ConsulBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.ConsulBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.ConsulBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -1126,6 +1172,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.ConsulBackend.isTerraformElement"></a>
+
+```typescript
+import { ConsulBackend } from 'cdktf'
+
+ConsulBackend.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.ConsulBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -1331,10 +1391,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                             | **Description**               |
-| -------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.CosBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.CosBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                           | **Description**               |
+| ---------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.CosBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.CosBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.CosBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -1367,6 +1428,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.CosBackend.isTerraformElement"></a>
+
+```typescript
+import { CosBackend } from 'cdktf'
+
+CosBackend.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.CosBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -1617,9 +1692,10 @@ public getString(output: string): string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                           | **Description**               |
-| ---------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteState.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                         | **Description**               |
+| ------------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteState.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteState.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -1652,6 +1728,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteState.isTerraformElement"></a>
+
+```typescript
+import { DataTerraformRemoteState } from 'cdktf'
+
+DataTerraformRemoteState.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteState.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -1906,9 +1996,10 @@ public getString(output: string): string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                      | **Description**               |
-| --------------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateArtifactory.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                                    | **Description**               |
+| ----------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateArtifactory.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -1941,6 +2032,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement"></a>
+
+```typescript
+import { DataTerraformRemoteStateArtifactory } from 'cdktf'
+
+DataTerraformRemoteStateArtifactory.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -2195,9 +2300,10 @@ public getString(output: string): string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                  | **Description**               |
-| ----------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                                | **Description**               |
+| ------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -2230,6 +2336,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateAzurerm.isTerraformElement"></a>
+
+```typescript
+import { DataTerraformRemoteStateAzurerm } from 'cdktf'
+
+DataTerraformRemoteStateAzurerm.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateAzurerm.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -2484,9 +2604,10 @@ public getString(output: string): string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                 | **Description**               |
-| ---------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateConsul.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                               | **Description**               |
+| ------------------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateConsul.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateConsul.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -2519,6 +2640,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateConsul.isTerraformElement"></a>
+
+```typescript
+import { DataTerraformRemoteStateConsul } from 'cdktf'
+
+DataTerraformRemoteStateConsul.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateConsul.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -2773,9 +2908,10 @@ public getString(output: string): string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                              | **Description**               |
-| ------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateCos.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                            | **Description**               |
+| --------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateCos.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateCos.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -2808,6 +2944,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateCos.isTerraformElement"></a>
+
+```typescript
+import { DataTerraformRemoteStateCos } from 'cdktf'
+
+DataTerraformRemoteStateCos.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateCos.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -3062,9 +3212,10 @@ public getString(output: string): string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                               | **Description**               |
-| -------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateEtcd.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                             | **Description**               |
+| ---------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateEtcd.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateEtcd.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -3097,6 +3248,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateEtcd.isTerraformElement"></a>
+
+```typescript
+import { DataTerraformRemoteStateEtcd } from 'cdktf'
+
+DataTerraformRemoteStateEtcd.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateEtcd.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -3351,9 +3516,10 @@ public getString(output: string): string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                 | **Description**               |
-| ---------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateEtcdV3.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                               | **Description**               |
+| ------------------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateEtcdV3.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -3386,6 +3552,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement"></a>
+
+```typescript
+import { DataTerraformRemoteStateEtcdV3 } from 'cdktf'
+
+DataTerraformRemoteStateEtcdV3.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -3640,9 +3820,10 @@ public getString(output: string): string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                              | **Description**               |
-| ------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateGcs.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                            | **Description**               |
+| --------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateGcs.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateGcs.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -3675,6 +3856,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateGcs.isTerraformElement"></a>
+
+```typescript
+import { DataTerraformRemoteStateGcs } from 'cdktf'
+
+DataTerraformRemoteStateGcs.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateGcs.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -3929,9 +4124,10 @@ public getString(output: string): string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                               | **Description**               |
-| -------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateHttp.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                             | **Description**               |
+| ---------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateHttp.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateHttp.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -3964,6 +4160,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateHttp.isTerraformElement"></a>
+
+```typescript
+import { DataTerraformRemoteStateHttp } from 'cdktf'
+
+DataTerraformRemoteStateHttp.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateHttp.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -4218,9 +4428,10 @@ public getString(output: string): string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                | **Description**               |
-| --------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateLocal.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                              | **Description**               |
+| ----------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateLocal.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateLocal.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -4253,6 +4464,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateLocal.isTerraformElement"></a>
+
+```typescript
+import { DataTerraformRemoteStateLocal } from 'cdktf'
+
+DataTerraformRemoteStateLocal.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateLocal.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -4507,9 +4732,10 @@ public getString(output: string): string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                | **Description**               |
-| --------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateManta.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                              | **Description**               |
+| ----------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateManta.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateManta.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -4542,6 +4768,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateManta.isTerraformElement"></a>
+
+```typescript
+import { DataTerraformRemoteStateManta } from 'cdktf'
+
+DataTerraformRemoteStateManta.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateManta.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -4796,9 +5036,10 @@ public getString(output: string): string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                              | **Description**               |
-| ------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateOss.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                            | **Description**               |
+| --------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateOss.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateOss.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -4831,6 +5072,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateOss.isTerraformElement"></a>
+
+```typescript
+import { DataTerraformRemoteStateOss } from 'cdktf'
+
+DataTerraformRemoteStateOss.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateOss.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -5085,9 +5340,10 @@ public getString(output: string): string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                             | **Description**               |
-| ------------------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStatePg.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                           | **Description**               |
+| -------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStatePg.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStatePg.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -5120,6 +5376,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStatePg.isTerraformElement"></a>
+
+```typescript
+import { DataTerraformRemoteStatePg } from 'cdktf'
+
+DataTerraformRemoteStatePg.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStatePg.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -5374,9 +5644,10 @@ public getString(output: string): string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                             | **Description**               |
-| ------------------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateS3.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                           | **Description**               |
+| -------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateS3.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -5409,6 +5680,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateS3.isTerraformElement"></a>
+
+```typescript
+import { DataTerraformRemoteStateS3 } from 'cdktf'
+
+DataTerraformRemoteStateS3.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateS3.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -5663,9 +5948,10 @@ public getString(output: string): string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                                | **Description**               |
-| --------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateSwift.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                              | **Description**               |
+| ----------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateSwift.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.DataTerraformRemoteStateSwift.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -5698,6 +5984,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateSwift.isTerraformElement"></a>
+
+```typescript
+import { DataTerraformRemoteStateSwift } from 'cdktf'
+
+DataTerraformRemoteStateSwift.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.DataTerraformRemoteStateSwift.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -5907,10 +6207,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                              | **Description**               |
-| --------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.EtcdBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.EtcdBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                            | **Description**               |
+| ----------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.EtcdBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.EtcdBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.EtcdBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -5943,6 +6244,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.EtcdBackend.isTerraformElement"></a>
+
+```typescript
+import { EtcdBackend } from 'cdktf'
+
+EtcdBackend.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.EtcdBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -6148,10 +6463,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                | **Description**               |
-| ----------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.EtcdV3Backend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.EtcdV3Backend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                              | **Description**               |
+| ------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.EtcdV3Backend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.EtcdV3Backend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.EtcdV3Backend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -6184,6 +6500,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.EtcdV3Backend.isTerraformElement"></a>
+
+```typescript
+import { EtcdV3Backend } from 'cdktf'
+
+EtcdV3Backend.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.EtcdV3Backend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -6389,10 +6719,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                             | **Description**               |
-| -------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.GcsBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.GcsBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                           | **Description**               |
+| ---------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.GcsBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.GcsBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.GcsBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -6425,6 +6756,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.GcsBackend.isTerraformElement"></a>
+
+```typescript
+import { GcsBackend } from 'cdktf'
+
+GcsBackend.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.GcsBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -6630,10 +6975,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                              | **Description**               |
-| --------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.HttpBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.HttpBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                            | **Description**               |
+| ----------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.HttpBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.HttpBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.HttpBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -6666,6 +7012,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.HttpBackend.isTerraformElement"></a>
+
+```typescript
+import { HttpBackend } from 'cdktf'
+
+HttpBackend.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.HttpBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -6871,10 +7231,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                               | **Description**               |
-| ---------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.LocalBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.LocalBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                             | **Description**               |
+| ------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.LocalBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.LocalBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.LocalBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -6907,6 +7268,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.LocalBackend.isTerraformElement"></a>
+
+```typescript
+import { LocalBackend } from 'cdktf'
+
+LocalBackend.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.LocalBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -7112,10 +7487,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                               | **Description**               |
-| ---------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.MantaBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.MantaBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                             | **Description**               |
+| ------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.MantaBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.MantaBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.MantaBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -7148,6 +7524,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.MantaBackend.isTerraformElement"></a>
+
+```typescript
+import { MantaBackend } from 'cdktf'
+
+MantaBackend.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.MantaBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -7353,10 +7743,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                             | **Description**               |
-| -------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.OssBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.OssBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                           | **Description**               |
+| ---------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.OssBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.OssBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.OssBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -7389,6 +7780,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.OssBackend.isTerraformElement"></a>
+
+```typescript
+import { OssBackend } from 'cdktf'
+
+OssBackend.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.OssBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -7594,10 +7999,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                            | **Description**               |
-| ------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.PgBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.PgBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                          | **Description**               |
+| --------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.PgBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.PgBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.PgBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -7630,6 +8036,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.PgBackend.isTerraformElement"></a>
+
+```typescript
+import { PgBackend } from 'cdktf'
+
+PgBackend.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.PgBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -7835,10 +8255,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                | **Description**               |
-| ----------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.RemoteBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.RemoteBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                              | **Description**               |
+| ------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.RemoteBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.RemoteBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.RemoteBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -7871,6 +8292,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.RemoteBackend.isTerraformElement"></a>
+
+```typescript
+import { RemoteBackend } from 'cdktf'
+
+RemoteBackend.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.RemoteBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -8202,10 +8637,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                            | **Description**               |
-| ------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.S3Backend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.S3Backend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                          | **Description**               |
+| --------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.S3Backend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.S3Backend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.S3Backend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -8238,6 +8674,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.S3Backend.isTerraformElement"></a>
+
+```typescript
+import { S3Backend } from 'cdktf'
+
+S3Backend.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.S3Backend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -8443,10 +8893,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                               | **Description**               |
-| ---------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.SwiftBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.SwiftBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                             | **Description**               |
+| ------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.SwiftBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.SwiftBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.SwiftBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -8479,6 +8930,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.SwiftBackend.isTerraformElement"></a>
+
+```typescript
+import { SwiftBackend } from 'cdktf'
+
+SwiftBackend.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.SwiftBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -8851,10 +9316,11 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                   | **Description**               |
-| -------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformBackend.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdktf.TerraformBackend.isBackend">isBackend</a></code>     | _No description._             |
+| **Name**                                                                                 | **Description**               |
+| ---------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformBackend.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformBackend.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.TerraformBackend.isBackend">isBackend</a></code>                   | _No description._             |
 
 ---
 
@@ -8887,6 +9353,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.TerraformBackend.isTerraformElement"></a>
+
+```typescript
+import { TerraformBackend } from 'cdktf'
+
+TerraformBackend.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformBackend.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -9204,9 +9684,11 @@ public interpolationForAttribute(terraformAttribute: string): IResolvable
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                      | **Description**               |
-| ----------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformDataSource.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                          | **Description**               |
+| ------------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformDataSource.isConstruct">isConstruct</a></code>                     | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformDataSource.isTerraformElement">isTerraformElement</a></code>       | _No description._             |
+| <code><a href="#cdktf.TerraformDataSource.isTerraformDataSource">isTerraformDataSource</a></code> | _No description._             |
 
 ---
 
@@ -9239,6 +9721,34 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.TerraformDataSource.isTerraformElement"></a>
+
+```typescript
+import { TerraformDataSource } from 'cdktf'
+
+TerraformDataSource.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformDataSource.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
+
+---
+
+##### `isTerraformDataSource` <a name="isTerraformDataSource" id="cdktf.TerraformDataSource.isTerraformDataSource"></a>
+
+```typescript
+import { TerraformDataSource } from 'cdktf'
+
+TerraformDataSource.isTerraformDataSource(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformDataSource.isTerraformDataSource.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -9496,9 +10006,10 @@ public toTerraform(): any
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                   | **Description**               |
-| -------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformElement.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                 | **Description**               |
+| ---------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformElement.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformElement.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -9531,6 +10042,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.TerraformElement.isTerraformElement"></a>
+
+```typescript
+import { TerraformElement } from 'cdktf'
+
+TerraformElement.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformElement.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -9810,9 +10335,10 @@ public set(variable: string, value: any): void
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                     | **Description**               |
-| ---------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformHclModule.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                   | **Description**               |
+| ------------------------------------------------------------------------------------------ | ----------------------------- |
+| <code><a href="#cdktf.TerraformHclModule.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformHclModule.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -9845,6 +10371,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.TerraformHclModule.isTerraformElement"></a>
+
+```typescript
+import { TerraformHclModule } from 'cdktf'
+
+TerraformHclModule.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformHclModule.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -10093,9 +10633,10 @@ public toTerraform(): any
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                 | **Description**               |
-| ------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.TerraformLocal.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                               | **Description**               |
+| -------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformLocal.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformLocal.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -10128,6 +10669,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.TerraformLocal.isTerraformElement"></a>
+
+```typescript
+import { TerraformLocal } from 'cdktf'
+
+TerraformLocal.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformLocal.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -10393,9 +10948,10 @@ public interpolationForOutput(moduleOutput: string): IResolvable
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                  | **Description**               |
-| ------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformModule.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                | **Description**               |
+| --------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformModule.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformModule.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -10428,6 +10984,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.TerraformModule.isTerraformElement"></a>
+
+```typescript
+import { TerraformModule } from 'cdktf'
+
+TerraformModule.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformModule.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -10663,10 +11233,11 @@ public toTerraform(): any
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                              | **Description**               |
-| ------------------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformOutput.isConstruct">isConstruct</a></code>             | Checks if `x` is a construct. |
-| <code><a href="#cdktf.TerraformOutput.isTerrafromOutput">isTerrafromOutput</a></code> | _No description._             |
+| **Name**                                                                                | **Description**               |
+| --------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformOutput.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformOutput.isTerraformElement">isTerraformElement</a></code> | _No description._             |
+| <code><a href="#cdktf.TerraformOutput.isTerrafromOutput">isTerrafromOutput</a></code>   | _No description._             |
 
 ---
 
@@ -10699,6 +11270,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.TerraformOutput.isTerraformElement"></a>
+
+```typescript
+import { TerraformOutput } from 'cdktf'
+
+TerraformOutput.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformOutput.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -10939,9 +11524,11 @@ Adds this resource to the terraform JSON output.
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                    | **Description**               |
-| --------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformProvider.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                    | **Description**               |
+| ------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformProvider.isConstruct">isConstruct</a></code>                 | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformProvider.isTerraformElement">isTerraformElement</a></code>   | _No description._             |
+| <code><a href="#cdktf.TerraformProvider.isTerraformProvider">isTerraformProvider</a></code> | _No description._             |
 
 ---
 
@@ -10974,6 +11561,34 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.TerraformProvider.isTerraformElement"></a>
+
+```typescript
+import { TerraformProvider } from 'cdktf'
+
+TerraformProvider.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformProvider.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
+
+---
+
+##### `isTerraformProvider` <a name="isTerraformProvider" id="cdktf.TerraformProvider.isTerraformProvider"></a>
+
+```typescript
+import { TerraformProvider } from 'cdktf'
+
+TerraformProvider.isTerraformProvider(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformProvider.isTerraformProvider.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -11274,9 +11889,10 @@ public getString(output: string): string
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                       | **Description**               |
-| ------------------------------------------------------------------------------ | ----------------------------- |
-| <code><a href="#cdktf.TerraformRemoteState.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                     | **Description**               |
+| -------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformRemoteState.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformRemoteState.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -11309,6 +11925,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.TerraformRemoteState.isTerraformElement"></a>
+
+```typescript
+import { TerraformRemoteState } from 'cdktf'
+
+TerraformRemoteState.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformRemoteState.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -11630,9 +12260,11 @@ public interpolationForAttribute(terraformAttribute: string): IResolvable
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                    | **Description**               |
-| --------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformResource.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                    | **Description**               |
+| ------------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformResource.isConstruct">isConstruct</a></code>                 | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformResource.isTerraformElement">isTerraformElement</a></code>   | _No description._             |
+| <code><a href="#cdktf.TerraformResource.isTerraformResource">isTerraformResource</a></code> | _No description._             |
 
 ---
 
@@ -11665,6 +12297,34 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.TerraformResource.isTerraformElement"></a>
+
+```typescript
+import { TerraformResource } from 'cdktf'
+
+TerraformResource.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformResource.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
+
+---
+
+##### `isTerraformResource` <a name="isTerraformResource" id="cdktf.TerraformResource.isTerraformResource"></a>
+
+```typescript
+import { TerraformResource } from 'cdktf'
+
+TerraformResource.isTerraformResource(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformResource.isTerraformResource.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 
@@ -12244,9 +12904,10 @@ public synthesizeAttributes(): {[ key: string ]: any}
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
-| **Name**                                                                    | **Description**               |
-| --------------------------------------------------------------------------- | ----------------------------- |
-| <code><a href="#cdktf.TerraformVariable.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| **Name**                                                                                  | **Description**               |
+| ----------------------------------------------------------------------------------------- | ----------------------------- |
+| <code><a href="#cdktf.TerraformVariable.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
+| <code><a href="#cdktf.TerraformVariable.isTerraformElement">isTerraformElement</a></code> | _No description._             |
 
 ---
 
@@ -12279,6 +12940,20 @@ this type-testing method instead.
 - _Type:_ any
 
 Any object.
+
+---
+
+##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.TerraformVariable.isTerraformElement"></a>
+
+```typescript
+import { TerraformVariable } from 'cdktf'
+
+TerraformVariable.isTerraformElement(x: any)
+```
+
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformVariable.isTerraformElement.parameter.x"></a>
+
+- _Type:_ any
 
 ---
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4358,6 +4358,11 @@ eslint-plugin-monorepo@^0.3.2:
     parse-package-name "^0.1.0"
     path-is-inside "^1.0.2"
 
+eslint-plugin-no-instanceof@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-instanceof/-/eslint-plugin-no-instanceof-1.0.1.tgz#5d9fc86d160df6991b654b294a62390207f1bb97"
+  integrity sha512-zlqQ7EsfzbRO68uI+p8FIE7zYB4njs+nNbkNjSb5QmLi2et67zQLqSeaao5U9SpnlZTTJC87nS2oyHo2ACtajw==
+
 eslint-plugin-react-hooks@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"


### PR DESCRIPTION
**BREAKING CHANGE** - as we learned the hard way in 0.12.2 this is a breaking change, as JSII bindings for Python are affected by changes to methods of parent classes and this could be the case for static methods as well. This is not a breaking change for users but it is internally as such that pre-built provider bindings need to be generated against this version to work.

Related to #1132