### PR TITLE
fix(lib): Add missing config options for AzurermBackend

### DIFF
--- a/packages/cdktf/lib/backends/azurerm-backend.ts
+++ b/packages/cdktf/lib/backends/azurerm-backend.ts
@@ -83,6 +83,12 @@ export interface AzurermBackendProps {
    */
   readonly endpoint?: string;
   /**
+   * (Optional) Should the Blob used to store the Terraform Statefile be
+   * snapshotted before use? Defaults to false. This value can also be sourced
+   * from the ARM_SNAPSHOT environment variable.
+   */
+  readonly snapshot?: boolean;
+  /**
    * (Optional) The Subscription ID in which the Storage Account exists.
    * This can also be sourced from the ARM_SUBSCRIPTION_ID environment variable.
    */
@@ -127,6 +133,59 @@ export interface AzurermBackendProps {
    * This can also be sourced from the ARM_CLIENT_SECRET environment variable.
    */
   readonly clientSecret?: string;
+  /**
+   * (Optional) The password associated with the Client Certificate specified
+   * in client_certificate_path. This can also be sourced from the
+   * ARM_CLIENT_CERTIFICATE_PASSWORD environment variable.
+   */
+  readonly clientCertificatePassword?: string;
+  /**
+   * (Optional) The path to the PFX file used as the Client Certificate when
+   * authenticating as a Service Principal. This can also be sourced from the
+   * ARM_CLIENT_CERTIFICATE_PATH environment variable.
+   */
+  readonly clientCertificatePath?: string;
+  /**
+   * (Optional) Should MSAL be used for authentication instead of ADAL, and
+   * should Microsoft Graph be used instead of Azure Active Directory Graph?
+   * Defaults to true.
+   *
+   * Note: In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph)
+   * rather than ADAL (and Azure Active Directory Graph) for authentication by
+   * default - you can disable this by setting use_microsoft_graph to false.
+   * This setting will be removed in Terraform 1.3, due to Microsoft's
+   * deprecation of ADAL.
+   */
+  readonly useMicrosoftGraph?: boolean;
+  /**
+   * (Optional) The URL for the OIDC provider from which to request an ID token.
+   * This can also be sourced from the ARM_OIDC_REQUEST_URL or
+   * ACTIONS_ID_TOKEN_REQUEST_URL environment variables.
+   */
+  readonly oidcRequestUrl?: string;
+  /**
+   * (Optional) The bearer token for the request to the OIDC provider. This can
+   * also be sourced from the ARM_OIDC_REQUEST_TOKEN or
+   * ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variables.
+   */
+  readonly oidcRequestToken?: string;
+  /**
+   * (Optional) Should OIDC authentication be used? This can also be sourced
+   * from the ARM_USE_OIDC environment variable.
+   *
+   * Note: When using OIDC for authentication, use_microsoft_graph
+   * must be set to true (which is the default).
+   */
+  readonly useOidc?: boolean;
+  /**
+   * (Optional) Should AzureAD Authentication be used to access the Blob Storage
+   * Account. This can also be sourced from the ARM_USE_AZUREAD environment
+   * variable.
+   *
+   * Note: When using AzureAD for Authentication to Storage you also need to
+   * ensure the Storage Blob Data Owner role is assigned.
+   */
+  readonly useAzureadAuth?: boolean;
 }
 
 export interface DataTerraformRemoteStateAzurermConfig

--- a/website/docs/cdktf/api-reference/csharp.mdx
+++ b/website/docs/cdktf/api-reference/csharp.mdx
@@ -12665,37 +12665,53 @@ new AzurermBackendProps {
     string Key,
     string StorageAccountName,
     string AccessKey = null,
+    string ClientCertificatePassword = null,
+    string ClientCertificatePath = null,
     string ClientId = null,
     string ClientSecret = null,
     string Endpoint = null,
     string Environment = null,
     string MsiEndpoint = null,
+    string OidcRequestToken = null,
+    string OidcRequestUrl = null,
     string ResourceGroupName = null,
     string SasToken = null,
+    bool Snapshot = null,
     string SubscriptionId = null,
     string TenantId = null,
-    bool UseMsi = null
+    bool UseAzureadAuth = null,
+    bool UseMicrosoftGraph = null,
+    bool UseMsi = null,
+    bool UseOidc = null
 };
 ```
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                             | **Type**            | **Description**                                                                                                                 |
-| ---------------------------------------------------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.AzurermBackendProps.property.containerName">ContainerName</a></code>           | <code>string</code> | (Required) The Name of the Storage Container within the Storage Account.                                                        |
-| <code><a href="#cdktf.AzurermBackendProps.property.key">Key</a></code>                               | <code>string</code> | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                     |
-| <code><a href="#cdktf.AzurermBackendProps.property.storageAccountName">StorageAccountName</a></code> | <code>string</code> | (Required) The Name of the Storage Account.                                                                                     |
-| <code><a href="#cdktf.AzurermBackendProps.property.accessKey">AccessKey</a></code>                   | <code>string</code> | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                 |
-| <code><a href="#cdktf.AzurermBackendProps.property.clientId">ClientId</a></code>                     | <code>string</code> | (Optional) The Client ID of the Service Principal.                                                                              |
-| <code><a href="#cdktf.AzurermBackendProps.property.clientSecret">ClientSecret</a></code>             | <code>string</code> | (Optional) The Client Secret of the Service Principal.                                                                          |
-| <code><a href="#cdktf.AzurermBackendProps.property.endpoint">Endpoint</a></code>                     | <code>string</code> | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable. |
-| <code><a href="#cdktf.AzurermBackendProps.property.environment">Environment</a></code>               | <code>string</code> | (Optional) The Azure Environment which should be used.                                                                          |
-| <code><a href="#cdktf.AzurermBackendProps.property.msiEndpoint">MsiEndpoint</a></code>               | <code>string</code> | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.           |
-| <code><a href="#cdktf.AzurermBackendProps.property.resourceGroupName">ResourceGroupName</a></code>   | <code>string</code> | (Required) The Name of the Resource Group in which the Storage Account exists.                                                  |
-| <code><a href="#cdktf.AzurermBackendProps.property.sasToken">SasToken</a></code>                     | <code>string</code> | (Optional) The SAS Token used to access the Blob Storage Account.                                                               |
-| <code><a href="#cdktf.AzurermBackendProps.property.subscriptionId">SubscriptionId</a></code>         | <code>string</code> | (Optional) The Subscription ID in which the Storage Account exists.                                                             |
-| <code><a href="#cdktf.AzurermBackendProps.property.tenantId">TenantId</a></code>                     | <code>string</code> | (Optional) The Tenant ID in which the Subscription exists.                                                                      |
-| <code><a href="#cdktf.AzurermBackendProps.property.useMsi">UseMsi</a></code>                         | <code>bool</code>   | (Optional) Should Managed Service Identity authentication be used?                                                              |
+| **Name**                                                                                                           | **Type**            | **Description**                                                                                                                                |
+| ------------------------------------------------------------------------------------------------------------------ | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.AzurermBackendProps.property.containerName">ContainerName</a></code>                         | <code>string</code> | (Required) The Name of the Storage Container within the Storage Account.                                                                       |
+| <code><a href="#cdktf.AzurermBackendProps.property.key">Key</a></code>                                             | <code>string</code> | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                                    |
+| <code><a href="#cdktf.AzurermBackendProps.property.storageAccountName">StorageAccountName</a></code>               | <code>string</code> | (Required) The Name of the Storage Account.                                                                                                    |
+| <code><a href="#cdktf.AzurermBackendProps.property.accessKey">AccessKey</a></code>                                 | <code>string</code> | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                                |
+| <code><a href="#cdktf.AzurermBackendProps.property.clientCertificatePassword">ClientCertificatePassword</a></code> | <code>string</code> | (Optional) The password associated with the Client Certificate specified in client_certificate_path.                                           |
+| <code><a href="#cdktf.AzurermBackendProps.property.clientCertificatePath">ClientCertificatePath</a></code>         | <code>string</code> | (Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.                                 |
+| <code><a href="#cdktf.AzurermBackendProps.property.clientId">ClientId</a></code>                                   | <code>string</code> | (Optional) The Client ID of the Service Principal.                                                                                             |
+| <code><a href="#cdktf.AzurermBackendProps.property.clientSecret">ClientSecret</a></code>                           | <code>string</code> | (Optional) The Client Secret of the Service Principal.                                                                                         |
+| <code><a href="#cdktf.AzurermBackendProps.property.endpoint">Endpoint</a></code>                                   | <code>string</code> | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable.                |
+| <code><a href="#cdktf.AzurermBackendProps.property.environment">Environment</a></code>                             | <code>string</code> | (Optional) The Azure Environment which should be used.                                                                                         |
+| <code><a href="#cdktf.AzurermBackendProps.property.msiEndpoint">MsiEndpoint</a></code>                             | <code>string</code> | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.                          |
+| <code><a href="#cdktf.AzurermBackendProps.property.oidcRequestToken">OidcRequestToken</a></code>                   | <code>string</code> | (Optional) The bearer token for the request to the OIDC provider.                                                                              |
+| <code><a href="#cdktf.AzurermBackendProps.property.oidcRequestUrl">OidcRequestUrl</a></code>                       | <code>string</code> | (Optional) The URL for the OIDC provider from which to request an ID token.                                                                    |
+| <code><a href="#cdktf.AzurermBackendProps.property.resourceGroupName">ResourceGroupName</a></code>                 | <code>string</code> | (Required) The Name of the Resource Group in which the Storage Account exists.                                                                 |
+| <code><a href="#cdktf.AzurermBackendProps.property.sasToken">SasToken</a></code>                                   | <code>string</code> | (Optional) The SAS Token used to access the Blob Storage Account.                                                                              |
+| <code><a href="#cdktf.AzurermBackendProps.property.snapshot">Snapshot</a></code>                                   | <code>bool</code>   | (Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?                                                    |
+| <code><a href="#cdktf.AzurermBackendProps.property.subscriptionId">SubscriptionId</a></code>                       | <code>string</code> | (Optional) The Subscription ID in which the Storage Account exists.                                                                            |
+| <code><a href="#cdktf.AzurermBackendProps.property.tenantId">TenantId</a></code>                                   | <code>string</code> | (Optional) The Tenant ID in which the Subscription exists.                                                                                     |
+| <code><a href="#cdktf.AzurermBackendProps.property.useAzureadAuth">UseAzureadAuth</a></code>                       | <code>bool</code>   | (Optional) Should AzureAD Authentication be used to access the Blob Storage Account.                                                           |
+| <code><a href="#cdktf.AzurermBackendProps.property.useMicrosoftGraph">UseMicrosoftGraph</a></code>                 | <code>bool</code>   | (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? |
+| <code><a href="#cdktf.AzurermBackendProps.property.useMsi">UseMsi</a></code>                                       | <code>bool</code>   | (Optional) Should Managed Service Identity authentication be used?                                                                             |
+| <code><a href="#cdktf.AzurermBackendProps.property.useOidc">UseOidc</a></code>                                     | <code>bool</code>   | (Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.                            |
 
 ---
 
@@ -12746,6 +12762,36 @@ public string AccessKey { get; set; }
 access_key - (Optional) The Access Key used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_ACCESS_KEY environment variable.
+
+---
+
+##### `ClientCertificatePassword`<sup>Optional</sup> <a name="ClientCertificatePassword" id="cdktf.AzurermBackendProps.property.clientCertificatePassword"></a>
+
+```csharp
+public string ClientCertificatePassword { get; set; }
+```
+
+- _Type:_ string
+
+(Optional) The password associated with the Client Certificate specified in client_certificate_path.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PASSWORD environment variable.
+
+---
+
+##### `ClientCertificatePath`<sup>Optional</sup> <a name="ClientCertificatePath" id="cdktf.AzurermBackendProps.property.clientCertificatePath"></a>
+
+```csharp
+public string ClientCertificatePath { get; set; }
+```
+
+- _Type:_ string
+
+(Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PATH environment variable.
 
 ---
 
@@ -12820,6 +12866,37 @@ This can also be sourced from the ARM_MSI_ENDPOINT environment variable.
 
 ---
 
+##### `OidcRequestToken`<sup>Optional</sup> <a name="OidcRequestToken" id="cdktf.AzurermBackendProps.property.oidcRequestToken"></a>
+
+```csharp
+public string OidcRequestToken { get; set; }
+```
+
+- _Type:_ string
+
+(Optional) The bearer token for the request to the OIDC provider.
+
+This can
+also be sourced from the ARM_OIDC_REQUEST_TOKEN or
+ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variables.
+
+---
+
+##### `OidcRequestUrl`<sup>Optional</sup> <a name="OidcRequestUrl" id="cdktf.AzurermBackendProps.property.oidcRequestUrl"></a>
+
+```csharp
+public string OidcRequestUrl { get; set; }
+```
+
+- _Type:_ string
+
+(Optional) The URL for the OIDC provider from which to request an ID token.
+
+This can also be sourced from the ARM_OIDC_REQUEST_URL or
+ACTIONS_ID_TOKEN_REQUEST_URL environment variables.
+
+---
+
 ##### `ResourceGroupName`<sup>Optional</sup> <a name="ResourceGroupName" id="cdktf.AzurermBackendProps.property.resourceGroupName"></a>
 
 ```csharp
@@ -12843,6 +12920,21 @@ public string SasToken { get; set; }
 (Optional) The SAS Token used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_SAS_TOKEN environment variable.
+
+---
+
+##### `Snapshot`<sup>Optional</sup> <a name="Snapshot" id="cdktf.AzurermBackendProps.property.snapshot"></a>
+
+```csharp
+public bool Snapshot { get; set; }
+```
+
+- _Type:_ bool
+
+(Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?
+
+Defaults to false. This value can also be sourced
+from the ARM_SNAPSHOT environment variable.
 
 ---
 
@@ -12874,6 +12966,44 @@ This can also be sourced from the ARM_TENANT_ID environment variable.
 
 ---
 
+##### `UseAzureadAuth`<sup>Optional</sup> <a name="UseAzureadAuth" id="cdktf.AzurermBackendProps.property.useAzureadAuth"></a>
+
+```csharp
+public bool UseAzureadAuth { get; set; }
+```
+
+- _Type:_ bool
+
+(Optional) Should AzureAD Authentication be used to access the Blob Storage Account.
+
+This can also be sourced from the ARM_USE_AZUREAD environment
+variable.
+
+Note: When using AzureAD for Authentication to Storage you also need to
+ensure the Storage Blob Data Owner role is assigned.
+
+---
+
+##### `UseMicrosoftGraph`<sup>Optional</sup> <a name="UseMicrosoftGraph" id="cdktf.AzurermBackendProps.property.useMicrosoftGraph"></a>
+
+```csharp
+public bool UseMicrosoftGraph { get; set; }
+```
+
+- _Type:_ bool
+
+(Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph?
+
+Defaults to true.
+
+Note: In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph)
+rather than ADAL (and Azure Active Directory Graph) for authentication by
+default - you can disable this by setting use_microsoft_graph to false.
+This setting will be removed in Terraform 1.3, due to Microsoft's
+deprecation of ADAL.
+
+---
+
 ##### `UseMsi`<sup>Optional</sup> <a name="UseMsi" id="cdktf.AzurermBackendProps.property.useMsi"></a>
 
 ```csharp
@@ -12885,6 +13015,21 @@ public bool UseMsi { get; set; }
 (Optional) Should Managed Service Identity authentication be used?
 
 This can also be sourced from the ARM_USE_MSI environment variable.
+
+---
+
+##### `UseOidc`<sup>Optional</sup> <a name="UseOidc" id="cdktf.AzurermBackendProps.property.useOidc"></a>
+
+```csharp
+public bool UseOidc { get; set; }
+```
+
+- _Type:_ bool
+
+(Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.
+
+Note: When using OIDC for authentication, use_microsoft_graph
+must be set to true (which is the default).
 
 ---
 
@@ -13442,39 +13587,55 @@ new DataTerraformRemoteStateAzurermConfig {
     string Key,
     string StorageAccountName,
     string AccessKey = null,
+    string ClientCertificatePassword = null,
+    string ClientCertificatePath = null,
     string ClientId = null,
     string ClientSecret = null,
     string Endpoint = null,
     string Environment = null,
     string MsiEndpoint = null,
+    string OidcRequestToken = null,
+    string OidcRequestUrl = null,
     string ResourceGroupName = null,
     string SasToken = null,
+    bool Snapshot = null,
     string SubscriptionId = null,
     string TenantId = null,
-    bool UseMsi = null
+    bool UseAzureadAuth = null,
+    bool UseMicrosoftGraph = null,
+    bool UseMsi = null,
+    bool UseOidc = null
 };
 ```
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                                               | **Type**                                                              | **Description**                                                                                                                 |
-| ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.defaults">Defaults</a></code>                     | <code>System.Collections.Generic.IDictionary< string, object ></code> | _No description._                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.workspace">Workspace</a></code>                   | <code>string</code>                                                   | _No description._                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.containerName">ContainerName</a></code>           | <code>string</code>                                                   | (Required) The Name of the Storage Container within the Storage Account.                                                        |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.key">Key</a></code>                               | <code>string</code>                                                   | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.storageAccountName">StorageAccountName</a></code> | <code>string</code>                                                   | (Required) The Name of the Storage Account.                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.accessKey">AccessKey</a></code>                   | <code>string</code>                                                   | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                 |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientId">ClientId</a></code>                     | <code>string</code>                                                   | (Optional) The Client ID of the Service Principal.                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientSecret">ClientSecret</a></code>             | <code>string</code>                                                   | (Optional) The Client Secret of the Service Principal.                                                                          |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.endpoint">Endpoint</a></code>                     | <code>string</code>                                                   | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable. |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.environment">Environment</a></code>               | <code>string</code>                                                   | (Optional) The Azure Environment which should be used.                                                                          |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.msiEndpoint">MsiEndpoint</a></code>               | <code>string</code>                                                   | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.           |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.resourceGroupName">ResourceGroupName</a></code>   | <code>string</code>                                                   | (Required) The Name of the Resource Group in which the Storage Account exists.                                                  |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.sasToken">SasToken</a></code>                     | <code>string</code>                                                   | (Optional) The SAS Token used to access the Blob Storage Account.                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.subscriptionId">SubscriptionId</a></code>         | <code>string</code>                                                   | (Optional) The Subscription ID in which the Storage Account exists.                                                             |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.tenantId">TenantId</a></code>                     | <code>string</code>                                                   | (Optional) The Tenant ID in which the Subscription exists.                                                                      |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useMsi">UseMsi</a></code>                         | <code>bool</code>                                                     | (Optional) Should Managed Service Identity authentication be used?                                                              |
+| **Name**                                                                                                                             | **Type**                                                              | **Description**                                                                                                                                |
+| ------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.defaults">Defaults</a></code>                                   | <code>System.Collections.Generic.IDictionary< string, object ></code> | _No description._                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.workspace">Workspace</a></code>                                 | <code>string</code>                                                   | _No description._                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.containerName">ContainerName</a></code>                         | <code>string</code>                                                   | (Required) The Name of the Storage Container within the Storage Account.                                                                       |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.key">Key</a></code>                                             | <code>string</code>                                                   | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.storageAccountName">StorageAccountName</a></code>               | <code>string</code>                                                   | (Required) The Name of the Storage Account.                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.accessKey">AccessKey</a></code>                                 | <code>string</code>                                                   | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                                |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientCertificatePassword">ClientCertificatePassword</a></code> | <code>string</code>                                                   | (Optional) The password associated with the Client Certificate specified in client_certificate_path.                                           |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientCertificatePath">ClientCertificatePath</a></code>         | <code>string</code>                                                   | (Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.                                 |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientId">ClientId</a></code>                                   | <code>string</code>                                                   | (Optional) The Client ID of the Service Principal.                                                                                             |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientSecret">ClientSecret</a></code>                           | <code>string</code>                                                   | (Optional) The Client Secret of the Service Principal.                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.endpoint">Endpoint</a></code>                                   | <code>string</code>                                                   | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable.                |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.environment">Environment</a></code>                             | <code>string</code>                                                   | (Optional) The Azure Environment which should be used.                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.msiEndpoint">MsiEndpoint</a></code>                             | <code>string</code>                                                   | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.                          |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.oidcRequestToken">OidcRequestToken</a></code>                   | <code>string</code>                                                   | (Optional) The bearer token for the request to the OIDC provider.                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.oidcRequestUrl">OidcRequestUrl</a></code>                       | <code>string</code>                                                   | (Optional) The URL for the OIDC provider from which to request an ID token.                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.resourceGroupName">ResourceGroupName</a></code>                 | <code>string</code>                                                   | (Required) The Name of the Resource Group in which the Storage Account exists.                                                                 |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.sasToken">SasToken</a></code>                                   | <code>string</code>                                                   | (Optional) The SAS Token used to access the Blob Storage Account.                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.snapshot">Snapshot</a></code>                                   | <code>bool</code>                                                     | (Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.subscriptionId">SubscriptionId</a></code>                       | <code>string</code>                                                   | (Optional) The Subscription ID in which the Storage Account exists.                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.tenantId">TenantId</a></code>                                   | <code>string</code>                                                   | (Optional) The Tenant ID in which the Subscription exists.                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useAzureadAuth">UseAzureadAuth</a></code>                       | <code>bool</code>                                                     | (Optional) Should AzureAD Authentication be used to access the Blob Storage Account.                                                           |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useMicrosoftGraph">UseMicrosoftGraph</a></code>                 | <code>bool</code>                                                     | (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useMsi">UseMsi</a></code>                                       | <code>bool</code>                                                     | (Optional) Should Managed Service Identity authentication be used?                                                                             |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useOidc">UseOidc</a></code>                                     | <code>bool</code>                                                     | (Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.                            |
 
 ---
 
@@ -13545,6 +13706,36 @@ public string AccessKey { get; set; }
 access_key - (Optional) The Access Key used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_ACCESS_KEY environment variable.
+
+---
+
+##### `ClientCertificatePassword`<sup>Optional</sup> <a name="ClientCertificatePassword" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.clientCertificatePassword"></a>
+
+```csharp
+public string ClientCertificatePassword { get; set; }
+```
+
+- _Type:_ string
+
+(Optional) The password associated with the Client Certificate specified in client_certificate_path.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PASSWORD environment variable.
+
+---
+
+##### `ClientCertificatePath`<sup>Optional</sup> <a name="ClientCertificatePath" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.clientCertificatePath"></a>
+
+```csharp
+public string ClientCertificatePath { get; set; }
+```
+
+- _Type:_ string
+
+(Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PATH environment variable.
 
 ---
 
@@ -13619,6 +13810,37 @@ This can also be sourced from the ARM_MSI_ENDPOINT environment variable.
 
 ---
 
+##### `OidcRequestToken`<sup>Optional</sup> <a name="OidcRequestToken" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.oidcRequestToken"></a>
+
+```csharp
+public string OidcRequestToken { get; set; }
+```
+
+- _Type:_ string
+
+(Optional) The bearer token for the request to the OIDC provider.
+
+This can
+also be sourced from the ARM_OIDC_REQUEST_TOKEN or
+ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variables.
+
+---
+
+##### `OidcRequestUrl`<sup>Optional</sup> <a name="OidcRequestUrl" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.oidcRequestUrl"></a>
+
+```csharp
+public string OidcRequestUrl { get; set; }
+```
+
+- _Type:_ string
+
+(Optional) The URL for the OIDC provider from which to request an ID token.
+
+This can also be sourced from the ARM_OIDC_REQUEST_URL or
+ACTIONS_ID_TOKEN_REQUEST_URL environment variables.
+
+---
+
 ##### `ResourceGroupName`<sup>Optional</sup> <a name="ResourceGroupName" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.resourceGroupName"></a>
 
 ```csharp
@@ -13642,6 +13864,21 @@ public string SasToken { get; set; }
 (Optional) The SAS Token used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_SAS_TOKEN environment variable.
+
+---
+
+##### `Snapshot`<sup>Optional</sup> <a name="Snapshot" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.snapshot"></a>
+
+```csharp
+public bool Snapshot { get; set; }
+```
+
+- _Type:_ bool
+
+(Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?
+
+Defaults to false. This value can also be sourced
+from the ARM_SNAPSHOT environment variable.
 
 ---
 
@@ -13673,6 +13910,44 @@ This can also be sourced from the ARM_TENANT_ID environment variable.
 
 ---
 
+##### `UseAzureadAuth`<sup>Optional</sup> <a name="UseAzureadAuth" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.useAzureadAuth"></a>
+
+```csharp
+public bool UseAzureadAuth { get; set; }
+```
+
+- _Type:_ bool
+
+(Optional) Should AzureAD Authentication be used to access the Blob Storage Account.
+
+This can also be sourced from the ARM_USE_AZUREAD environment
+variable.
+
+Note: When using AzureAD for Authentication to Storage you also need to
+ensure the Storage Blob Data Owner role is assigned.
+
+---
+
+##### `UseMicrosoftGraph`<sup>Optional</sup> <a name="UseMicrosoftGraph" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.useMicrosoftGraph"></a>
+
+```csharp
+public bool UseMicrosoftGraph { get; set; }
+```
+
+- _Type:_ bool
+
+(Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph?
+
+Defaults to true.
+
+Note: In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph)
+rather than ADAL (and Azure Active Directory Graph) for authentication by
+default - you can disable this by setting use_microsoft_graph to false.
+This setting will be removed in Terraform 1.3, due to Microsoft's
+deprecation of ADAL.
+
+---
+
 ##### `UseMsi`<sup>Optional</sup> <a name="UseMsi" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.useMsi"></a>
 
 ```csharp
@@ -13684,6 +13959,21 @@ public bool UseMsi { get; set; }
 (Optional) Should Managed Service Identity authentication be used?
 
 This can also be sourced from the ARM_USE_MSI environment variable.
+
+---
+
+##### `UseOidc`<sup>Optional</sup> <a name="UseOidc" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.useOidc"></a>
+
+```csharp
+public bool UseOidc { get; set; }
+```
+
+- _Type:_ bool
+
+(Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.
+
+Note: When using OIDC for authentication, use_microsoft_graph
+must be set to true (which is the default).
 
 ---
 

--- a/website/docs/cdktf/api-reference/go.mdx
+++ b/website/docs/cdktf/api-reference/go.mdx
@@ -12665,37 +12665,53 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 	Key: *string,
 	StorageAccountName: *string,
 	AccessKey: *string,
+	ClientCertificatePassword: *string,
+	ClientCertificatePath: *string,
 	ClientId: *string,
 	ClientSecret: *string,
 	Endpoint: *string,
 	Environment: *string,
 	MsiEndpoint: *string,
+	OidcRequestToken: *string,
+	OidcRequestUrl: *string,
 	ResourceGroupName: *string,
 	SasToken: *string,
+	Snapshot: *bool,
 	SubscriptionId: *string,
 	TenantId: *string,
+	UseAzureadAuth: *bool,
+	UseMicrosoftGraph: *bool,
 	UseMsi: *bool,
+	UseOidc: *bool,
 }
 ```
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                             | **Type**              | **Description**                                                                                                                 |
-| ---------------------------------------------------------------------------------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.AzurermBackendProps.property.containerName">ContainerName</a></code>           | <code>\*string</code> | (Required) The Name of the Storage Container within the Storage Account.                                                        |
-| <code><a href="#cdktf.AzurermBackendProps.property.key">Key</a></code>                               | <code>\*string</code> | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                     |
-| <code><a href="#cdktf.AzurermBackendProps.property.storageAccountName">StorageAccountName</a></code> | <code>\*string</code> | (Required) The Name of the Storage Account.                                                                                     |
-| <code><a href="#cdktf.AzurermBackendProps.property.accessKey">AccessKey</a></code>                   | <code>\*string</code> | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                 |
-| <code><a href="#cdktf.AzurermBackendProps.property.clientId">ClientId</a></code>                     | <code>\*string</code> | (Optional) The Client ID of the Service Principal.                                                                              |
-| <code><a href="#cdktf.AzurermBackendProps.property.clientSecret">ClientSecret</a></code>             | <code>\*string</code> | (Optional) The Client Secret of the Service Principal.                                                                          |
-| <code><a href="#cdktf.AzurermBackendProps.property.endpoint">Endpoint</a></code>                     | <code>\*string</code> | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable. |
-| <code><a href="#cdktf.AzurermBackendProps.property.environment">Environment</a></code>               | <code>\*string</code> | (Optional) The Azure Environment which should be used.                                                                          |
-| <code><a href="#cdktf.AzurermBackendProps.property.msiEndpoint">MsiEndpoint</a></code>               | <code>\*string</code> | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.           |
-| <code><a href="#cdktf.AzurermBackendProps.property.resourceGroupName">ResourceGroupName</a></code>   | <code>\*string</code> | (Required) The Name of the Resource Group in which the Storage Account exists.                                                  |
-| <code><a href="#cdktf.AzurermBackendProps.property.sasToken">SasToken</a></code>                     | <code>\*string</code> | (Optional) The SAS Token used to access the Blob Storage Account.                                                               |
-| <code><a href="#cdktf.AzurermBackendProps.property.subscriptionId">SubscriptionId</a></code>         | <code>\*string</code> | (Optional) The Subscription ID in which the Storage Account exists.                                                             |
-| <code><a href="#cdktf.AzurermBackendProps.property.tenantId">TenantId</a></code>                     | <code>\*string</code> | (Optional) The Tenant ID in which the Subscription exists.                                                                      |
-| <code><a href="#cdktf.AzurermBackendProps.property.useMsi">UseMsi</a></code>                         | <code>\*bool</code>   | (Optional) Should Managed Service Identity authentication be used?                                                              |
+| **Name**                                                                                                           | **Type**              | **Description**                                                                                                                                |
+| ------------------------------------------------------------------------------------------------------------------ | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.AzurermBackendProps.property.containerName">ContainerName</a></code>                         | <code>\*string</code> | (Required) The Name of the Storage Container within the Storage Account.                                                                       |
+| <code><a href="#cdktf.AzurermBackendProps.property.key">Key</a></code>                                             | <code>\*string</code> | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                                    |
+| <code><a href="#cdktf.AzurermBackendProps.property.storageAccountName">StorageAccountName</a></code>               | <code>\*string</code> | (Required) The Name of the Storage Account.                                                                                                    |
+| <code><a href="#cdktf.AzurermBackendProps.property.accessKey">AccessKey</a></code>                                 | <code>\*string</code> | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                                |
+| <code><a href="#cdktf.AzurermBackendProps.property.clientCertificatePassword">ClientCertificatePassword</a></code> | <code>\*string</code> | (Optional) The password associated with the Client Certificate specified in client_certificate_path.                                           |
+| <code><a href="#cdktf.AzurermBackendProps.property.clientCertificatePath">ClientCertificatePath</a></code>         | <code>\*string</code> | (Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.                                 |
+| <code><a href="#cdktf.AzurermBackendProps.property.clientId">ClientId</a></code>                                   | <code>\*string</code> | (Optional) The Client ID of the Service Principal.                                                                                             |
+| <code><a href="#cdktf.AzurermBackendProps.property.clientSecret">ClientSecret</a></code>                           | <code>\*string</code> | (Optional) The Client Secret of the Service Principal.                                                                                         |
+| <code><a href="#cdktf.AzurermBackendProps.property.endpoint">Endpoint</a></code>                                   | <code>\*string</code> | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable.                |
+| <code><a href="#cdktf.AzurermBackendProps.property.environment">Environment</a></code>                             | <code>\*string</code> | (Optional) The Azure Environment which should be used.                                                                                         |
+| <code><a href="#cdktf.AzurermBackendProps.property.msiEndpoint">MsiEndpoint</a></code>                             | <code>\*string</code> | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.                          |
+| <code><a href="#cdktf.AzurermBackendProps.property.oidcRequestToken">OidcRequestToken</a></code>                   | <code>\*string</code> | (Optional) The bearer token for the request to the OIDC provider.                                                                              |
+| <code><a href="#cdktf.AzurermBackendProps.property.oidcRequestUrl">OidcRequestUrl</a></code>                       | <code>\*string</code> | (Optional) The URL for the OIDC provider from which to request an ID token.                                                                    |
+| <code><a href="#cdktf.AzurermBackendProps.property.resourceGroupName">ResourceGroupName</a></code>                 | <code>\*string</code> | (Required) The Name of the Resource Group in which the Storage Account exists.                                                                 |
+| <code><a href="#cdktf.AzurermBackendProps.property.sasToken">SasToken</a></code>                                   | <code>\*string</code> | (Optional) The SAS Token used to access the Blob Storage Account.                                                                              |
+| <code><a href="#cdktf.AzurermBackendProps.property.snapshot">Snapshot</a></code>                                   | <code>\*bool</code>   | (Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?                                                    |
+| <code><a href="#cdktf.AzurermBackendProps.property.subscriptionId">SubscriptionId</a></code>                       | <code>\*string</code> | (Optional) The Subscription ID in which the Storage Account exists.                                                                            |
+| <code><a href="#cdktf.AzurermBackendProps.property.tenantId">TenantId</a></code>                                   | <code>\*string</code> | (Optional) The Tenant ID in which the Subscription exists.                                                                                     |
+| <code><a href="#cdktf.AzurermBackendProps.property.useAzureadAuth">UseAzureadAuth</a></code>                       | <code>\*bool</code>   | (Optional) Should AzureAD Authentication be used to access the Blob Storage Account.                                                           |
+| <code><a href="#cdktf.AzurermBackendProps.property.useMicrosoftGraph">UseMicrosoftGraph</a></code>                 | <code>\*bool</code>   | (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? |
+| <code><a href="#cdktf.AzurermBackendProps.property.useMsi">UseMsi</a></code>                                       | <code>\*bool</code>   | (Optional) Should Managed Service Identity authentication be used?                                                                             |
+| <code><a href="#cdktf.AzurermBackendProps.property.useOidc">UseOidc</a></code>                                     | <code>\*bool</code>   | (Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.                            |
 
 ---
 
@@ -12746,6 +12762,36 @@ AccessKey *string
 access_key - (Optional) The Access Key used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_ACCESS_KEY environment variable.
+
+---
+
+##### `ClientCertificatePassword`<sup>Optional</sup> <a name="ClientCertificatePassword" id="cdktf.AzurermBackendProps.property.clientCertificatePassword"></a>
+
+```go
+ClientCertificatePassword *string
+```
+
+- _Type:_ \*string
+
+(Optional) The password associated with the Client Certificate specified in client_certificate_path.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PASSWORD environment variable.
+
+---
+
+##### `ClientCertificatePath`<sup>Optional</sup> <a name="ClientCertificatePath" id="cdktf.AzurermBackendProps.property.clientCertificatePath"></a>
+
+```go
+ClientCertificatePath *string
+```
+
+- _Type:_ \*string
+
+(Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PATH environment variable.
 
 ---
 
@@ -12820,6 +12866,37 @@ This can also be sourced from the ARM_MSI_ENDPOINT environment variable.
 
 ---
 
+##### `OidcRequestToken`<sup>Optional</sup> <a name="OidcRequestToken" id="cdktf.AzurermBackendProps.property.oidcRequestToken"></a>
+
+```go
+OidcRequestToken *string
+```
+
+- _Type:_ \*string
+
+(Optional) The bearer token for the request to the OIDC provider.
+
+This can
+also be sourced from the ARM_OIDC_REQUEST_TOKEN or
+ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variables.
+
+---
+
+##### `OidcRequestUrl`<sup>Optional</sup> <a name="OidcRequestUrl" id="cdktf.AzurermBackendProps.property.oidcRequestUrl"></a>
+
+```go
+OidcRequestUrl *string
+```
+
+- _Type:_ \*string
+
+(Optional) The URL for the OIDC provider from which to request an ID token.
+
+This can also be sourced from the ARM_OIDC_REQUEST_URL or
+ACTIONS_ID_TOKEN_REQUEST_URL environment variables.
+
+---
+
 ##### `ResourceGroupName`<sup>Optional</sup> <a name="ResourceGroupName" id="cdktf.AzurermBackendProps.property.resourceGroupName"></a>
 
 ```go
@@ -12843,6 +12920,21 @@ SasToken *string
 (Optional) The SAS Token used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_SAS_TOKEN environment variable.
+
+---
+
+##### `Snapshot`<sup>Optional</sup> <a name="Snapshot" id="cdktf.AzurermBackendProps.property.snapshot"></a>
+
+```go
+Snapshot *bool
+```
+
+- _Type:_ \*bool
+
+(Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?
+
+Defaults to false. This value can also be sourced
+from the ARM_SNAPSHOT environment variable.
 
 ---
 
@@ -12874,6 +12966,44 @@ This can also be sourced from the ARM_TENANT_ID environment variable.
 
 ---
 
+##### `UseAzureadAuth`<sup>Optional</sup> <a name="UseAzureadAuth" id="cdktf.AzurermBackendProps.property.useAzureadAuth"></a>
+
+```go
+UseAzureadAuth *bool
+```
+
+- _Type:_ \*bool
+
+(Optional) Should AzureAD Authentication be used to access the Blob Storage Account.
+
+This can also be sourced from the ARM_USE_AZUREAD environment
+variable.
+
+Note: When using AzureAD for Authentication to Storage you also need to
+ensure the Storage Blob Data Owner role is assigned.
+
+---
+
+##### `UseMicrosoftGraph`<sup>Optional</sup> <a name="UseMicrosoftGraph" id="cdktf.AzurermBackendProps.property.useMicrosoftGraph"></a>
+
+```go
+UseMicrosoftGraph *bool
+```
+
+- _Type:_ \*bool
+
+(Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph?
+
+Defaults to true.
+
+Note: In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph)
+rather than ADAL (and Azure Active Directory Graph) for authentication by
+default - you can disable this by setting use_microsoft_graph to false.
+This setting will be removed in Terraform 1.3, due to Microsoft's
+deprecation of ADAL.
+
+---
+
 ##### `UseMsi`<sup>Optional</sup> <a name="UseMsi" id="cdktf.AzurermBackendProps.property.useMsi"></a>
 
 ```go
@@ -12885,6 +13015,21 @@ UseMsi *bool
 (Optional) Should Managed Service Identity authentication be used?
 
 This can also be sourced from the ARM_USE_MSI environment variable.
+
+---
+
+##### `UseOidc`<sup>Optional</sup> <a name="UseOidc" id="cdktf.AzurermBackendProps.property.useOidc"></a>
+
+```go
+UseOidc *bool
+```
+
+- _Type:_ \*bool
+
+(Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.
+
+Note: When using OIDC for authentication, use_microsoft_graph
+must be set to true (which is the default).
 
 ---
 
@@ -13442,39 +13587,55 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 	Key: *string,
 	StorageAccountName: *string,
 	AccessKey: *string,
+	ClientCertificatePassword: *string,
+	ClientCertificatePath: *string,
 	ClientId: *string,
 	ClientSecret: *string,
 	Endpoint: *string,
 	Environment: *string,
 	MsiEndpoint: *string,
+	OidcRequestToken: *string,
+	OidcRequestUrl: *string,
 	ResourceGroupName: *string,
 	SasToken: *string,
+	Snapshot: *bool,
 	SubscriptionId: *string,
 	TenantId: *string,
+	UseAzureadAuth: *bool,
+	UseMicrosoftGraph: *bool,
 	UseMsi: *bool,
+	UseOidc: *bool,
 }
 ```
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                                               | **Type**                              | **Description**                                                                                                                 |
-| ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.defaults">Defaults</a></code>                     | <code>\*map[string]interface{}</code> | _No description._                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.workspace">Workspace</a></code>                   | <code>\*string</code>                 | _No description._                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.containerName">ContainerName</a></code>           | <code>\*string</code>                 | (Required) The Name of the Storage Container within the Storage Account.                                                        |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.key">Key</a></code>                               | <code>\*string</code>                 | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.storageAccountName">StorageAccountName</a></code> | <code>\*string</code>                 | (Required) The Name of the Storage Account.                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.accessKey">AccessKey</a></code>                   | <code>\*string</code>                 | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                 |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientId">ClientId</a></code>                     | <code>\*string</code>                 | (Optional) The Client ID of the Service Principal.                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientSecret">ClientSecret</a></code>             | <code>\*string</code>                 | (Optional) The Client Secret of the Service Principal.                                                                          |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.endpoint">Endpoint</a></code>                     | <code>\*string</code>                 | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable. |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.environment">Environment</a></code>               | <code>\*string</code>                 | (Optional) The Azure Environment which should be used.                                                                          |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.msiEndpoint">MsiEndpoint</a></code>               | <code>\*string</code>                 | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.           |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.resourceGroupName">ResourceGroupName</a></code>   | <code>\*string</code>                 | (Required) The Name of the Resource Group in which the Storage Account exists.                                                  |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.sasToken">SasToken</a></code>                     | <code>\*string</code>                 | (Optional) The SAS Token used to access the Blob Storage Account.                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.subscriptionId">SubscriptionId</a></code>         | <code>\*string</code>                 | (Optional) The Subscription ID in which the Storage Account exists.                                                             |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.tenantId">TenantId</a></code>                     | <code>\*string</code>                 | (Optional) The Tenant ID in which the Subscription exists.                                                                      |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useMsi">UseMsi</a></code>                         | <code>\*bool</code>                   | (Optional) Should Managed Service Identity authentication be used?                                                              |
+| **Name**                                                                                                                             | **Type**                              | **Description**                                                                                                                                |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.defaults">Defaults</a></code>                                   | <code>\*map[string]interface{}</code> | _No description._                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.workspace">Workspace</a></code>                                 | <code>\*string</code>                 | _No description._                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.containerName">ContainerName</a></code>                         | <code>\*string</code>                 | (Required) The Name of the Storage Container within the Storage Account.                                                                       |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.key">Key</a></code>                                             | <code>\*string</code>                 | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.storageAccountName">StorageAccountName</a></code>               | <code>\*string</code>                 | (Required) The Name of the Storage Account.                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.accessKey">AccessKey</a></code>                                 | <code>\*string</code>                 | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                                |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientCertificatePassword">ClientCertificatePassword</a></code> | <code>\*string</code>                 | (Optional) The password associated with the Client Certificate specified in client_certificate_path.                                           |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientCertificatePath">ClientCertificatePath</a></code>         | <code>\*string</code>                 | (Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.                                 |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientId">ClientId</a></code>                                   | <code>\*string</code>                 | (Optional) The Client ID of the Service Principal.                                                                                             |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientSecret">ClientSecret</a></code>                           | <code>\*string</code>                 | (Optional) The Client Secret of the Service Principal.                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.endpoint">Endpoint</a></code>                                   | <code>\*string</code>                 | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable.                |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.environment">Environment</a></code>                             | <code>\*string</code>                 | (Optional) The Azure Environment which should be used.                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.msiEndpoint">MsiEndpoint</a></code>                             | <code>\*string</code>                 | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.                          |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.oidcRequestToken">OidcRequestToken</a></code>                   | <code>\*string</code>                 | (Optional) The bearer token for the request to the OIDC provider.                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.oidcRequestUrl">OidcRequestUrl</a></code>                       | <code>\*string</code>                 | (Optional) The URL for the OIDC provider from which to request an ID token.                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.resourceGroupName">ResourceGroupName</a></code>                 | <code>\*string</code>                 | (Required) The Name of the Resource Group in which the Storage Account exists.                                                                 |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.sasToken">SasToken</a></code>                                   | <code>\*string</code>                 | (Optional) The SAS Token used to access the Blob Storage Account.                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.snapshot">Snapshot</a></code>                                   | <code>\*bool</code>                   | (Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.subscriptionId">SubscriptionId</a></code>                       | <code>\*string</code>                 | (Optional) The Subscription ID in which the Storage Account exists.                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.tenantId">TenantId</a></code>                                   | <code>\*string</code>                 | (Optional) The Tenant ID in which the Subscription exists.                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useAzureadAuth">UseAzureadAuth</a></code>                       | <code>\*bool</code>                   | (Optional) Should AzureAD Authentication be used to access the Blob Storage Account.                                                           |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useMicrosoftGraph">UseMicrosoftGraph</a></code>                 | <code>\*bool</code>                   | (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useMsi">UseMsi</a></code>                                       | <code>\*bool</code>                   | (Optional) Should Managed Service Identity authentication be used?                                                                             |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useOidc">UseOidc</a></code>                                     | <code>\*bool</code>                   | (Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.                            |
 
 ---
 
@@ -13545,6 +13706,36 @@ AccessKey *string
 access_key - (Optional) The Access Key used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_ACCESS_KEY environment variable.
+
+---
+
+##### `ClientCertificatePassword`<sup>Optional</sup> <a name="ClientCertificatePassword" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.clientCertificatePassword"></a>
+
+```go
+ClientCertificatePassword *string
+```
+
+- _Type:_ \*string
+
+(Optional) The password associated with the Client Certificate specified in client_certificate_path.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PASSWORD environment variable.
+
+---
+
+##### `ClientCertificatePath`<sup>Optional</sup> <a name="ClientCertificatePath" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.clientCertificatePath"></a>
+
+```go
+ClientCertificatePath *string
+```
+
+- _Type:_ \*string
+
+(Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PATH environment variable.
 
 ---
 
@@ -13619,6 +13810,37 @@ This can also be sourced from the ARM_MSI_ENDPOINT environment variable.
 
 ---
 
+##### `OidcRequestToken`<sup>Optional</sup> <a name="OidcRequestToken" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.oidcRequestToken"></a>
+
+```go
+OidcRequestToken *string
+```
+
+- _Type:_ \*string
+
+(Optional) The bearer token for the request to the OIDC provider.
+
+This can
+also be sourced from the ARM_OIDC_REQUEST_TOKEN or
+ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variables.
+
+---
+
+##### `OidcRequestUrl`<sup>Optional</sup> <a name="OidcRequestUrl" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.oidcRequestUrl"></a>
+
+```go
+OidcRequestUrl *string
+```
+
+- _Type:_ \*string
+
+(Optional) The URL for the OIDC provider from which to request an ID token.
+
+This can also be sourced from the ARM_OIDC_REQUEST_URL or
+ACTIONS_ID_TOKEN_REQUEST_URL environment variables.
+
+---
+
 ##### `ResourceGroupName`<sup>Optional</sup> <a name="ResourceGroupName" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.resourceGroupName"></a>
 
 ```go
@@ -13642,6 +13864,21 @@ SasToken *string
 (Optional) The SAS Token used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_SAS_TOKEN environment variable.
+
+---
+
+##### `Snapshot`<sup>Optional</sup> <a name="Snapshot" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.snapshot"></a>
+
+```go
+Snapshot *bool
+```
+
+- _Type:_ \*bool
+
+(Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?
+
+Defaults to false. This value can also be sourced
+from the ARM_SNAPSHOT environment variable.
 
 ---
 
@@ -13673,6 +13910,44 @@ This can also be sourced from the ARM_TENANT_ID environment variable.
 
 ---
 
+##### `UseAzureadAuth`<sup>Optional</sup> <a name="UseAzureadAuth" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.useAzureadAuth"></a>
+
+```go
+UseAzureadAuth *bool
+```
+
+- _Type:_ \*bool
+
+(Optional) Should AzureAD Authentication be used to access the Blob Storage Account.
+
+This can also be sourced from the ARM_USE_AZUREAD environment
+variable.
+
+Note: When using AzureAD for Authentication to Storage you also need to
+ensure the Storage Blob Data Owner role is assigned.
+
+---
+
+##### `UseMicrosoftGraph`<sup>Optional</sup> <a name="UseMicrosoftGraph" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.useMicrosoftGraph"></a>
+
+```go
+UseMicrosoftGraph *bool
+```
+
+- _Type:_ \*bool
+
+(Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph?
+
+Defaults to true.
+
+Note: In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph)
+rather than ADAL (and Azure Active Directory Graph) for authentication by
+default - you can disable this by setting use_microsoft_graph to false.
+This setting will be removed in Terraform 1.3, due to Microsoft's
+deprecation of ADAL.
+
+---
+
 ##### `UseMsi`<sup>Optional</sup> <a name="UseMsi" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.useMsi"></a>
 
 ```go
@@ -13684,6 +13959,21 @@ UseMsi *bool
 (Optional) Should Managed Service Identity authentication be used?
 
 This can also be sourced from the ARM_USE_MSI environment variable.
+
+---
+
+##### `UseOidc`<sup>Optional</sup> <a name="UseOidc" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.useOidc"></a>
+
+```go
+UseOidc *bool
+```
+
+- _Type:_ \*bool
+
+(Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.
+
+Note: When using OIDC for authentication, use_microsoft_graph
+must be set to true (which is the default).
 
 ---
 

--- a/website/docs/cdktf/api-reference/java.mdx
+++ b/website/docs/cdktf/api-reference/java.mdx
@@ -566,36 +566,52 @@ AzurermBackend.Builder.create(Construct scope)
     .key(java.lang.String)
     .storageAccountName(java.lang.String)
 //  .accessKey(java.lang.String)
+//  .clientCertificatePassword(java.lang.String)
+//  .clientCertificatePath(java.lang.String)
 //  .clientId(java.lang.String)
 //  .clientSecret(java.lang.String)
 //  .endpoint(java.lang.String)
 //  .environment(java.lang.String)
 //  .msiEndpoint(java.lang.String)
+//  .oidcRequestToken(java.lang.String)
+//  .oidcRequestUrl(java.lang.String)
 //  .resourceGroupName(java.lang.String)
 //  .sasToken(java.lang.String)
+//  .snapshot(java.lang.Boolean)
 //  .subscriptionId(java.lang.String)
 //  .tenantId(java.lang.String)
+//  .useAzureadAuth(java.lang.Boolean)
+//  .useMicrosoftGraph(java.lang.Boolean)
 //  .useMsi(java.lang.Boolean)
+//  .useOidc(java.lang.Boolean)
     .build();
 ```
 
-| **Name**                                                                                                     | **Type**                                   | **Description**                                                                                                                 |
-| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.scope">scope</a></code>                           | <code>software.constructs.Construct</code> | _No description._                                                                                                               |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.containerName">containerName</a></code>           | <code>java.lang.String</code>              | (Required) The Name of the Storage Container within the Storage Account.                                                        |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.key">key</a></code>                               | <code>java.lang.String</code>              | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                     |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.storageAccountName">storageAccountName</a></code> | <code>java.lang.String</code>              | (Required) The Name of the Storage Account.                                                                                     |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.accessKey">accessKey</a></code>                   | <code>java.lang.String</code>              | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                 |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.clientId">clientId</a></code>                     | <code>java.lang.String</code>              | (Optional) The Client ID of the Service Principal.                                                                              |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.clientSecret">clientSecret</a></code>             | <code>java.lang.String</code>              | (Optional) The Client Secret of the Service Principal.                                                                          |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.endpoint">endpoint</a></code>                     | <code>java.lang.String</code>              | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable. |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.environment">environment</a></code>               | <code>java.lang.String</code>              | (Optional) The Azure Environment which should be used.                                                                          |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.msiEndpoint">msiEndpoint</a></code>               | <code>java.lang.String</code>              | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.           |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.resourceGroupName">resourceGroupName</a></code>   | <code>java.lang.String</code>              | (Required) The Name of the Resource Group in which the Storage Account exists.                                                  |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.sasToken">sasToken</a></code>                     | <code>java.lang.String</code>              | (Optional) The SAS Token used to access the Blob Storage Account.                                                               |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.subscriptionId">subscriptionId</a></code>         | <code>java.lang.String</code>              | (Optional) The Subscription ID in which the Storage Account exists.                                                             |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.tenantId">tenantId</a></code>                     | <code>java.lang.String</code>              | (Optional) The Tenant ID in which the Subscription exists.                                                                      |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.useMsi">useMsi</a></code>                         | <code>java.lang.Boolean</code>             | (Optional) Should Managed Service Identity authentication be used?                                                              |
+| **Name**                                                                                                                   | **Type**                                   | **Description**                                                                                                                                |
+| -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.scope">scope</a></code>                                         | <code>software.constructs.Construct</code> | _No description._                                                                                                                              |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.containerName">containerName</a></code>                         | <code>java.lang.String</code>              | (Required) The Name of the Storage Container within the Storage Account.                                                                       |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.key">key</a></code>                                             | <code>java.lang.String</code>              | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                                    |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.storageAccountName">storageAccountName</a></code>               | <code>java.lang.String</code>              | (Required) The Name of the Storage Account.                                                                                                    |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.accessKey">accessKey</a></code>                                 | <code>java.lang.String</code>              | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                                |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.clientCertificatePassword">clientCertificatePassword</a></code> | <code>java.lang.String</code>              | (Optional) The password associated with the Client Certificate specified in client_certificate_path.                                           |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.clientCertificatePath">clientCertificatePath</a></code>         | <code>java.lang.String</code>              | (Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.                                 |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.clientId">clientId</a></code>                                   | <code>java.lang.String</code>              | (Optional) The Client ID of the Service Principal.                                                                                             |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.clientSecret">clientSecret</a></code>                           | <code>java.lang.String</code>              | (Optional) The Client Secret of the Service Principal.                                                                                         |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.endpoint">endpoint</a></code>                                   | <code>java.lang.String</code>              | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable.                |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.environment">environment</a></code>                             | <code>java.lang.String</code>              | (Optional) The Azure Environment which should be used.                                                                                         |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.msiEndpoint">msiEndpoint</a></code>                             | <code>java.lang.String</code>              | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.                          |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.oidcRequestToken">oidcRequestToken</a></code>                   | <code>java.lang.String</code>              | (Optional) The bearer token for the request to the OIDC provider.                                                                              |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.oidcRequestUrl">oidcRequestUrl</a></code>                       | <code>java.lang.String</code>              | (Optional) The URL for the OIDC provider from which to request an ID token.                                                                    |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.resourceGroupName">resourceGroupName</a></code>                 | <code>java.lang.String</code>              | (Required) The Name of the Resource Group in which the Storage Account exists.                                                                 |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.sasToken">sasToken</a></code>                                   | <code>java.lang.String</code>              | (Optional) The SAS Token used to access the Blob Storage Account.                                                                              |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.snapshot">snapshot</a></code>                                   | <code>java.lang.Boolean</code>             | (Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?                                                    |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.subscriptionId">subscriptionId</a></code>                       | <code>java.lang.String</code>              | (Optional) The Subscription ID in which the Storage Account exists.                                                                            |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.tenantId">tenantId</a></code>                                   | <code>java.lang.String</code>              | (Optional) The Tenant ID in which the Subscription exists.                                                                                     |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.useAzureadAuth">useAzureadAuth</a></code>                       | <code>java.lang.Boolean</code>             | (Optional) Should AzureAD Authentication be used to access the Blob Storage Account.                                                           |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.useMicrosoftGraph">useMicrosoftGraph</a></code>                 | <code>java.lang.Boolean</code>             | (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.useMsi">useMsi</a></code>                                       | <code>java.lang.Boolean</code>             | (Optional) Should Managed Service Identity authentication be used?                                                                             |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.useOidc">useOidc</a></code>                                     | <code>java.lang.Boolean</code>             | (Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.                            |
 
 ---
 
@@ -636,6 +652,28 @@ AzurermBackend.Builder.create(Construct scope)
 access_key - (Optional) The Access Key used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_ACCESS_KEY environment variable.
+
+---
+
+##### `clientCertificatePassword`<sup>Optional</sup> <a name="clientCertificatePassword" id="cdktf.AzurermBackend.Initializer.parameter.clientCertificatePassword"></a>
+
+- _Type:_ java.lang.String
+
+(Optional) The password associated with the Client Certificate specified in client_certificate_path.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PASSWORD environment variable.
+
+---
+
+##### `clientCertificatePath`<sup>Optional</sup> <a name="clientCertificatePath" id="cdktf.AzurermBackend.Initializer.parameter.clientCertificatePath"></a>
+
+- _Type:_ java.lang.String
+
+(Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PATH environment variable.
 
 ---
 
@@ -690,6 +728,29 @@ This can also be sourced from the ARM_MSI_ENDPOINT environment variable.
 
 ---
 
+##### `oidcRequestToken`<sup>Optional</sup> <a name="oidcRequestToken" id="cdktf.AzurermBackend.Initializer.parameter.oidcRequestToken"></a>
+
+- _Type:_ java.lang.String
+
+(Optional) The bearer token for the request to the OIDC provider.
+
+This can
+also be sourced from the ARM_OIDC_REQUEST_TOKEN or
+ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variables.
+
+---
+
+##### `oidcRequestUrl`<sup>Optional</sup> <a name="oidcRequestUrl" id="cdktf.AzurermBackend.Initializer.parameter.oidcRequestUrl"></a>
+
+- _Type:_ java.lang.String
+
+(Optional) The URL for the OIDC provider from which to request an ID token.
+
+This can also be sourced from the ARM_OIDC_REQUEST_URL or
+ACTIONS_ID_TOKEN_REQUEST_URL environment variables.
+
+---
+
 ##### `resourceGroupName`<sup>Optional</sup> <a name="resourceGroupName" id="cdktf.AzurermBackend.Initializer.parameter.resourceGroupName"></a>
 
 - _Type:_ java.lang.String
@@ -705,6 +766,17 @@ This can also be sourced from the ARM_MSI_ENDPOINT environment variable.
 (Optional) The SAS Token used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_SAS_TOKEN environment variable.
+
+---
+
+##### `snapshot`<sup>Optional</sup> <a name="snapshot" id="cdktf.AzurermBackend.Initializer.parameter.snapshot"></a>
+
+- _Type:_ java.lang.Boolean
+
+(Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?
+
+Defaults to false. This value can also be sourced
+from the ARM_SNAPSHOT environment variable.
 
 ---
 
@@ -728,6 +800,36 @@ This can also be sourced from the ARM_TENANT_ID environment variable.
 
 ---
 
+##### `useAzureadAuth`<sup>Optional</sup> <a name="useAzureadAuth" id="cdktf.AzurermBackend.Initializer.parameter.useAzureadAuth"></a>
+
+- _Type:_ java.lang.Boolean
+
+(Optional) Should AzureAD Authentication be used to access the Blob Storage Account.
+
+This can also be sourced from the ARM_USE_AZUREAD environment
+variable.
+
+Note: When using AzureAD for Authentication to Storage you also need to
+ensure the Storage Blob Data Owner role is assigned.
+
+---
+
+##### `useMicrosoftGraph`<sup>Optional</sup> <a name="useMicrosoftGraph" id="cdktf.AzurermBackend.Initializer.parameter.useMicrosoftGraph"></a>
+
+- _Type:_ java.lang.Boolean
+
+(Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph?
+
+Defaults to true.
+
+Note: In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph)
+rather than ADAL (and Azure Active Directory Graph) for authentication by
+default - you can disable this by setting use_microsoft_graph to false.
+This setting will be removed in Terraform 1.3, due to Microsoft's
+deprecation of ADAL.
+
+---
+
 ##### `useMsi`<sup>Optional</sup> <a name="useMsi" id="cdktf.AzurermBackend.Initializer.parameter.useMsi"></a>
 
 - _Type:_ java.lang.Boolean
@@ -735,6 +837,17 @@ This can also be sourced from the ARM_TENANT_ID environment variable.
 (Optional) Should Managed Service Identity authentication be used?
 
 This can also be sourced from the ARM_USE_MSI environment variable.
+
+---
+
+##### `useOidc`<sup>Optional</sup> <a name="useOidc" id="cdktf.AzurermBackend.Initializer.parameter.useOidc"></a>
+
+- _Type:_ java.lang.Boolean
+
+(Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.
+
+Note: When using OIDC for authentication, use_microsoft_graph
+must be set to true (which is the default).
 
 ---
 
@@ -2616,39 +2729,55 @@ DataTerraformRemoteStateAzurerm.Builder.create(Construct scope, java.lang.String
     .key(java.lang.String)
     .storageAccountName(java.lang.String)
 //  .accessKey(java.lang.String)
+//  .clientCertificatePassword(java.lang.String)
+//  .clientCertificatePath(java.lang.String)
 //  .clientId(java.lang.String)
 //  .clientSecret(java.lang.String)
 //  .endpoint(java.lang.String)
 //  .environment(java.lang.String)
 //  .msiEndpoint(java.lang.String)
+//  .oidcRequestToken(java.lang.String)
+//  .oidcRequestUrl(java.lang.String)
 //  .resourceGroupName(java.lang.String)
 //  .sasToken(java.lang.String)
+//  .snapshot(java.lang.Boolean)
 //  .subscriptionId(java.lang.String)
 //  .tenantId(java.lang.String)
+//  .useAzureadAuth(java.lang.Boolean)
+//  .useMicrosoftGraph(java.lang.Boolean)
 //  .useMsi(java.lang.Boolean)
+//  .useOidc(java.lang.Boolean)
     .build();
 ```
 
-| **Name**                                                                                                                      | **Type**                                                         | **Description**                                                                                                                 |
-| ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.scope">scope</a></code>                           | <code>software.constructs.Construct</code>                       | _No description._                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.id">id</a></code>                                 | <code>java.lang.String</code>                                    | _No description._                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.defaults">defaults</a></code>                     | <code>java.util.Map< java.lang.String, java.lang.Object ></code> | _No description._                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.workspace">workspace</a></code>                   | <code>java.lang.String</code>                                    | _No description._                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.containerName">containerName</a></code>           | <code>java.lang.String</code>                                    | (Required) The Name of the Storage Container within the Storage Account.                                                        |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.key">key</a></code>                               | <code>java.lang.String</code>                                    | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.storageAccountName">storageAccountName</a></code> | <code>java.lang.String</code>                                    | (Required) The Name of the Storage Account.                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.accessKey">accessKey</a></code>                   | <code>java.lang.String</code>                                    | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                 |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.clientId">clientId</a></code>                     | <code>java.lang.String</code>                                    | (Optional) The Client ID of the Service Principal.                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.clientSecret">clientSecret</a></code>             | <code>java.lang.String</code>                                    | (Optional) The Client Secret of the Service Principal.                                                                          |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.endpoint">endpoint</a></code>                     | <code>java.lang.String</code>                                    | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable. |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.environment">environment</a></code>               | <code>java.lang.String</code>                                    | (Optional) The Azure Environment which should be used.                                                                          |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.msiEndpoint">msiEndpoint</a></code>               | <code>java.lang.String</code>                                    | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.           |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.resourceGroupName">resourceGroupName</a></code>   | <code>java.lang.String</code>                                    | (Required) The Name of the Resource Group in which the Storage Account exists.                                                  |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.sasToken">sasToken</a></code>                     | <code>java.lang.String</code>                                    | (Optional) The SAS Token used to access the Blob Storage Account.                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.subscriptionId">subscriptionId</a></code>         | <code>java.lang.String</code>                                    | (Optional) The Subscription ID in which the Storage Account exists.                                                             |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.tenantId">tenantId</a></code>                     | <code>java.lang.String</code>                                    | (Optional) The Tenant ID in which the Subscription exists.                                                                      |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.useMsi">useMsi</a></code>                         | <code>java.lang.Boolean</code>                                   | (Optional) Should Managed Service Identity authentication be used?                                                              |
+| **Name**                                                                                                                                    | **Type**                                                         | **Description**                                                                                                                                |
+| ------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.scope">scope</a></code>                                         | <code>software.constructs.Construct</code>                       | _No description._                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.id">id</a></code>                                               | <code>java.lang.String</code>                                    | _No description._                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.defaults">defaults</a></code>                                   | <code>java.util.Map< java.lang.String, java.lang.Object ></code> | _No description._                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.workspace">workspace</a></code>                                 | <code>java.lang.String</code>                                    | _No description._                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.containerName">containerName</a></code>                         | <code>java.lang.String</code>                                    | (Required) The Name of the Storage Container within the Storage Account.                                                                       |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.key">key</a></code>                                             | <code>java.lang.String</code>                                    | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.storageAccountName">storageAccountName</a></code>               | <code>java.lang.String</code>                                    | (Required) The Name of the Storage Account.                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.accessKey">accessKey</a></code>                                 | <code>java.lang.String</code>                                    | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                                |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.clientCertificatePassword">clientCertificatePassword</a></code> | <code>java.lang.String</code>                                    | (Optional) The password associated with the Client Certificate specified in client_certificate_path.                                           |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.clientCertificatePath">clientCertificatePath</a></code>         | <code>java.lang.String</code>                                    | (Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.                                 |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.clientId">clientId</a></code>                                   | <code>java.lang.String</code>                                    | (Optional) The Client ID of the Service Principal.                                                                                             |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.clientSecret">clientSecret</a></code>                           | <code>java.lang.String</code>                                    | (Optional) The Client Secret of the Service Principal.                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.endpoint">endpoint</a></code>                                   | <code>java.lang.String</code>                                    | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable.                |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.environment">environment</a></code>                             | <code>java.lang.String</code>                                    | (Optional) The Azure Environment which should be used.                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.msiEndpoint">msiEndpoint</a></code>                             | <code>java.lang.String</code>                                    | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.                          |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.oidcRequestToken">oidcRequestToken</a></code>                   | <code>java.lang.String</code>                                    | (Optional) The bearer token for the request to the OIDC provider.                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.oidcRequestUrl">oidcRequestUrl</a></code>                       | <code>java.lang.String</code>                                    | (Optional) The URL for the OIDC provider from which to request an ID token.                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.resourceGroupName">resourceGroupName</a></code>                 | <code>java.lang.String</code>                                    | (Required) The Name of the Resource Group in which the Storage Account exists.                                                                 |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.sasToken">sasToken</a></code>                                   | <code>java.lang.String</code>                                    | (Optional) The SAS Token used to access the Blob Storage Account.                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.snapshot">snapshot</a></code>                                   | <code>java.lang.Boolean</code>                                   | (Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.subscriptionId">subscriptionId</a></code>                       | <code>java.lang.String</code>                                    | (Optional) The Subscription ID in which the Storage Account exists.                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.tenantId">tenantId</a></code>                                   | <code>java.lang.String</code>                                    | (Optional) The Tenant ID in which the Subscription exists.                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.useAzureadAuth">useAzureadAuth</a></code>                       | <code>java.lang.Boolean</code>                                   | (Optional) Should AzureAD Authentication be used to access the Blob Storage Account.                                                           |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.useMicrosoftGraph">useMicrosoftGraph</a></code>                 | <code>java.lang.Boolean</code>                                   | (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.useMsi">useMsi</a></code>                                       | <code>java.lang.Boolean</code>                                   | (Optional) Should Managed Service Identity authentication be used?                                                                             |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.useOidc">useOidc</a></code>                                     | <code>java.lang.Boolean</code>                                   | (Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.                            |
 
 ---
 
@@ -2710,6 +2839,28 @@ This can also be sourced from the ARM_ACCESS_KEY environment variable.
 
 ---
 
+##### `clientCertificatePassword`<sup>Optional</sup> <a name="clientCertificatePassword" id="cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.clientCertificatePassword"></a>
+
+- _Type:_ java.lang.String
+
+(Optional) The password associated with the Client Certificate specified in client_certificate_path.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PASSWORD environment variable.
+
+---
+
+##### `clientCertificatePath`<sup>Optional</sup> <a name="clientCertificatePath" id="cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.clientCertificatePath"></a>
+
+- _Type:_ java.lang.String
+
+(Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PATH environment variable.
+
+---
+
 ##### `clientId`<sup>Optional</sup> <a name="clientId" id="cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.clientId"></a>
 
 - _Type:_ java.lang.String
@@ -2761,6 +2912,29 @@ This can also be sourced from the ARM_MSI_ENDPOINT environment variable.
 
 ---
 
+##### `oidcRequestToken`<sup>Optional</sup> <a name="oidcRequestToken" id="cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.oidcRequestToken"></a>
+
+- _Type:_ java.lang.String
+
+(Optional) The bearer token for the request to the OIDC provider.
+
+This can
+also be sourced from the ARM_OIDC_REQUEST_TOKEN or
+ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variables.
+
+---
+
+##### `oidcRequestUrl`<sup>Optional</sup> <a name="oidcRequestUrl" id="cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.oidcRequestUrl"></a>
+
+- _Type:_ java.lang.String
+
+(Optional) The URL for the OIDC provider from which to request an ID token.
+
+This can also be sourced from the ARM_OIDC_REQUEST_URL or
+ACTIONS_ID_TOKEN_REQUEST_URL environment variables.
+
+---
+
 ##### `resourceGroupName`<sup>Optional</sup> <a name="resourceGroupName" id="cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.resourceGroupName"></a>
 
 - _Type:_ java.lang.String
@@ -2776,6 +2950,17 @@ This can also be sourced from the ARM_MSI_ENDPOINT environment variable.
 (Optional) The SAS Token used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_SAS_TOKEN environment variable.
+
+---
+
+##### `snapshot`<sup>Optional</sup> <a name="snapshot" id="cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.snapshot"></a>
+
+- _Type:_ java.lang.Boolean
+
+(Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?
+
+Defaults to false. This value can also be sourced
+from the ARM_SNAPSHOT environment variable.
 
 ---
 
@@ -2799,6 +2984,36 @@ This can also be sourced from the ARM_TENANT_ID environment variable.
 
 ---
 
+##### `useAzureadAuth`<sup>Optional</sup> <a name="useAzureadAuth" id="cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.useAzureadAuth"></a>
+
+- _Type:_ java.lang.Boolean
+
+(Optional) Should AzureAD Authentication be used to access the Blob Storage Account.
+
+This can also be sourced from the ARM_USE_AZUREAD environment
+variable.
+
+Note: When using AzureAD for Authentication to Storage you also need to
+ensure the Storage Blob Data Owner role is assigned.
+
+---
+
+##### `useMicrosoftGraph`<sup>Optional</sup> <a name="useMicrosoftGraph" id="cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.useMicrosoftGraph"></a>
+
+- _Type:_ java.lang.Boolean
+
+(Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph?
+
+Defaults to true.
+
+Note: In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph)
+rather than ADAL (and Azure Active Directory Graph) for authentication by
+default - you can disable this by setting use_microsoft_graph to false.
+This setting will be removed in Terraform 1.3, due to Microsoft's
+deprecation of ADAL.
+
+---
+
 ##### `useMsi`<sup>Optional</sup> <a name="useMsi" id="cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.useMsi"></a>
 
 - _Type:_ java.lang.Boolean
@@ -2806,6 +3021,17 @@ This can also be sourced from the ARM_TENANT_ID environment variable.
 (Optional) Should Managed Service Identity authentication be used?
 
 This can also be sourced from the ARM_USE_MSI environment variable.
+
+---
+
+##### `useOidc`<sup>Optional</sup> <a name="useOidc" id="cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.useOidc"></a>
+
+- _Type:_ java.lang.Boolean
+
+(Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.
+
+Note: When using OIDC for authentication, use_microsoft_graph
+must be set to true (which is the default).
 
 ---
 
@@ -16397,37 +16623,53 @@ AzurermBackendProps.builder()
     .key(java.lang.String)
     .storageAccountName(java.lang.String)
 //  .accessKey(java.lang.String)
+//  .clientCertificatePassword(java.lang.String)
+//  .clientCertificatePath(java.lang.String)
 //  .clientId(java.lang.String)
 //  .clientSecret(java.lang.String)
 //  .endpoint(java.lang.String)
 //  .environment(java.lang.String)
 //  .msiEndpoint(java.lang.String)
+//  .oidcRequestToken(java.lang.String)
+//  .oidcRequestUrl(java.lang.String)
 //  .resourceGroupName(java.lang.String)
 //  .sasToken(java.lang.String)
+//  .snapshot(java.lang.Boolean)
 //  .subscriptionId(java.lang.String)
 //  .tenantId(java.lang.String)
+//  .useAzureadAuth(java.lang.Boolean)
+//  .useMicrosoftGraph(java.lang.Boolean)
 //  .useMsi(java.lang.Boolean)
+//  .useOidc(java.lang.Boolean)
     .build();
 ```
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                             | **Type**                       | **Description**                                                                                                                 |
-| ---------------------------------------------------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.AzurermBackendProps.property.containerName">containerName</a></code>           | <code>java.lang.String</code>  | (Required) The Name of the Storage Container within the Storage Account.                                                        |
-| <code><a href="#cdktf.AzurermBackendProps.property.key">key</a></code>                               | <code>java.lang.String</code>  | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                     |
-| <code><a href="#cdktf.AzurermBackendProps.property.storageAccountName">storageAccountName</a></code> | <code>java.lang.String</code>  | (Required) The Name of the Storage Account.                                                                                     |
-| <code><a href="#cdktf.AzurermBackendProps.property.accessKey">accessKey</a></code>                   | <code>java.lang.String</code>  | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                 |
-| <code><a href="#cdktf.AzurermBackendProps.property.clientId">clientId</a></code>                     | <code>java.lang.String</code>  | (Optional) The Client ID of the Service Principal.                                                                              |
-| <code><a href="#cdktf.AzurermBackendProps.property.clientSecret">clientSecret</a></code>             | <code>java.lang.String</code>  | (Optional) The Client Secret of the Service Principal.                                                                          |
-| <code><a href="#cdktf.AzurermBackendProps.property.endpoint">endpoint</a></code>                     | <code>java.lang.String</code>  | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable. |
-| <code><a href="#cdktf.AzurermBackendProps.property.environment">environment</a></code>               | <code>java.lang.String</code>  | (Optional) The Azure Environment which should be used.                                                                          |
-| <code><a href="#cdktf.AzurermBackendProps.property.msiEndpoint">msiEndpoint</a></code>               | <code>java.lang.String</code>  | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.           |
-| <code><a href="#cdktf.AzurermBackendProps.property.resourceGroupName">resourceGroupName</a></code>   | <code>java.lang.String</code>  | (Required) The Name of the Resource Group in which the Storage Account exists.                                                  |
-| <code><a href="#cdktf.AzurermBackendProps.property.sasToken">sasToken</a></code>                     | <code>java.lang.String</code>  | (Optional) The SAS Token used to access the Blob Storage Account.                                                               |
-| <code><a href="#cdktf.AzurermBackendProps.property.subscriptionId">subscriptionId</a></code>         | <code>java.lang.String</code>  | (Optional) The Subscription ID in which the Storage Account exists.                                                             |
-| <code><a href="#cdktf.AzurermBackendProps.property.tenantId">tenantId</a></code>                     | <code>java.lang.String</code>  | (Optional) The Tenant ID in which the Subscription exists.                                                                      |
-| <code><a href="#cdktf.AzurermBackendProps.property.useMsi">useMsi</a></code>                         | <code>java.lang.Boolean</code> | (Optional) Should Managed Service Identity authentication be used?                                                              |
+| **Name**                                                                                                           | **Type**                       | **Description**                                                                                                                                |
+| ------------------------------------------------------------------------------------------------------------------ | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.AzurermBackendProps.property.containerName">containerName</a></code>                         | <code>java.lang.String</code>  | (Required) The Name of the Storage Container within the Storage Account.                                                                       |
+| <code><a href="#cdktf.AzurermBackendProps.property.key">key</a></code>                                             | <code>java.lang.String</code>  | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                                    |
+| <code><a href="#cdktf.AzurermBackendProps.property.storageAccountName">storageAccountName</a></code>               | <code>java.lang.String</code>  | (Required) The Name of the Storage Account.                                                                                                    |
+| <code><a href="#cdktf.AzurermBackendProps.property.accessKey">accessKey</a></code>                                 | <code>java.lang.String</code>  | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                                |
+| <code><a href="#cdktf.AzurermBackendProps.property.clientCertificatePassword">clientCertificatePassword</a></code> | <code>java.lang.String</code>  | (Optional) The password associated with the Client Certificate specified in client_certificate_path.                                           |
+| <code><a href="#cdktf.AzurermBackendProps.property.clientCertificatePath">clientCertificatePath</a></code>         | <code>java.lang.String</code>  | (Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.                                 |
+| <code><a href="#cdktf.AzurermBackendProps.property.clientId">clientId</a></code>                                   | <code>java.lang.String</code>  | (Optional) The Client ID of the Service Principal.                                                                                             |
+| <code><a href="#cdktf.AzurermBackendProps.property.clientSecret">clientSecret</a></code>                           | <code>java.lang.String</code>  | (Optional) The Client Secret of the Service Principal.                                                                                         |
+| <code><a href="#cdktf.AzurermBackendProps.property.endpoint">endpoint</a></code>                                   | <code>java.lang.String</code>  | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable.                |
+| <code><a href="#cdktf.AzurermBackendProps.property.environment">environment</a></code>                             | <code>java.lang.String</code>  | (Optional) The Azure Environment which should be used.                                                                                         |
+| <code><a href="#cdktf.AzurermBackendProps.property.msiEndpoint">msiEndpoint</a></code>                             | <code>java.lang.String</code>  | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.                          |
+| <code><a href="#cdktf.AzurermBackendProps.property.oidcRequestToken">oidcRequestToken</a></code>                   | <code>java.lang.String</code>  | (Optional) The bearer token for the request to the OIDC provider.                                                                              |
+| <code><a href="#cdktf.AzurermBackendProps.property.oidcRequestUrl">oidcRequestUrl</a></code>                       | <code>java.lang.String</code>  | (Optional) The URL for the OIDC provider from which to request an ID token.                                                                    |
+| <code><a href="#cdktf.AzurermBackendProps.property.resourceGroupName">resourceGroupName</a></code>                 | <code>java.lang.String</code>  | (Required) The Name of the Resource Group in which the Storage Account exists.                                                                 |
+| <code><a href="#cdktf.AzurermBackendProps.property.sasToken">sasToken</a></code>                                   | <code>java.lang.String</code>  | (Optional) The SAS Token used to access the Blob Storage Account.                                                                              |
+| <code><a href="#cdktf.AzurermBackendProps.property.snapshot">snapshot</a></code>                                   | <code>java.lang.Boolean</code> | (Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?                                                    |
+| <code><a href="#cdktf.AzurermBackendProps.property.subscriptionId">subscriptionId</a></code>                       | <code>java.lang.String</code>  | (Optional) The Subscription ID in which the Storage Account exists.                                                                            |
+| <code><a href="#cdktf.AzurermBackendProps.property.tenantId">tenantId</a></code>                                   | <code>java.lang.String</code>  | (Optional) The Tenant ID in which the Subscription exists.                                                                                     |
+| <code><a href="#cdktf.AzurermBackendProps.property.useAzureadAuth">useAzureadAuth</a></code>                       | <code>java.lang.Boolean</code> | (Optional) Should AzureAD Authentication be used to access the Blob Storage Account.                                                           |
+| <code><a href="#cdktf.AzurermBackendProps.property.useMicrosoftGraph">useMicrosoftGraph</a></code>                 | <code>java.lang.Boolean</code> | (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? |
+| <code><a href="#cdktf.AzurermBackendProps.property.useMsi">useMsi</a></code>                                       | <code>java.lang.Boolean</code> | (Optional) Should Managed Service Identity authentication be used?                                                                             |
+| <code><a href="#cdktf.AzurermBackendProps.property.useOidc">useOidc</a></code>                                     | <code>java.lang.Boolean</code> | (Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.                            |
 
 ---
 
@@ -16478,6 +16720,36 @@ public java.lang.String getAccessKey();
 access_key - (Optional) The Access Key used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_ACCESS_KEY environment variable.
+
+---
+
+##### `clientCertificatePassword`<sup>Optional</sup> <a name="clientCertificatePassword" id="cdktf.AzurermBackendProps.property.clientCertificatePassword"></a>
+
+```java
+public java.lang.String getClientCertificatePassword();
+```
+
+- _Type:_ java.lang.String
+
+(Optional) The password associated with the Client Certificate specified in client_certificate_path.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PASSWORD environment variable.
+
+---
+
+##### `clientCertificatePath`<sup>Optional</sup> <a name="clientCertificatePath" id="cdktf.AzurermBackendProps.property.clientCertificatePath"></a>
+
+```java
+public java.lang.String getClientCertificatePath();
+```
+
+- _Type:_ java.lang.String
+
+(Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PATH environment variable.
 
 ---
 
@@ -16552,6 +16824,37 @@ This can also be sourced from the ARM_MSI_ENDPOINT environment variable.
 
 ---
 
+##### `oidcRequestToken`<sup>Optional</sup> <a name="oidcRequestToken" id="cdktf.AzurermBackendProps.property.oidcRequestToken"></a>
+
+```java
+public java.lang.String getOidcRequestToken();
+```
+
+- _Type:_ java.lang.String
+
+(Optional) The bearer token for the request to the OIDC provider.
+
+This can
+also be sourced from the ARM_OIDC_REQUEST_TOKEN or
+ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variables.
+
+---
+
+##### `oidcRequestUrl`<sup>Optional</sup> <a name="oidcRequestUrl" id="cdktf.AzurermBackendProps.property.oidcRequestUrl"></a>
+
+```java
+public java.lang.String getOidcRequestUrl();
+```
+
+- _Type:_ java.lang.String
+
+(Optional) The URL for the OIDC provider from which to request an ID token.
+
+This can also be sourced from the ARM_OIDC_REQUEST_URL or
+ACTIONS_ID_TOKEN_REQUEST_URL environment variables.
+
+---
+
 ##### `resourceGroupName`<sup>Optional</sup> <a name="resourceGroupName" id="cdktf.AzurermBackendProps.property.resourceGroupName"></a>
 
 ```java
@@ -16575,6 +16878,21 @@ public java.lang.String getSasToken();
 (Optional) The SAS Token used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_SAS_TOKEN environment variable.
+
+---
+
+##### `snapshot`<sup>Optional</sup> <a name="snapshot" id="cdktf.AzurermBackendProps.property.snapshot"></a>
+
+```java
+public java.lang.Boolean getSnapshot();
+```
+
+- _Type:_ java.lang.Boolean
+
+(Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?
+
+Defaults to false. This value can also be sourced
+from the ARM_SNAPSHOT environment variable.
 
 ---
 
@@ -16606,6 +16924,44 @@ This can also be sourced from the ARM_TENANT_ID environment variable.
 
 ---
 
+##### `useAzureadAuth`<sup>Optional</sup> <a name="useAzureadAuth" id="cdktf.AzurermBackendProps.property.useAzureadAuth"></a>
+
+```java
+public java.lang.Boolean getUseAzureadAuth();
+```
+
+- _Type:_ java.lang.Boolean
+
+(Optional) Should AzureAD Authentication be used to access the Blob Storage Account.
+
+This can also be sourced from the ARM_USE_AZUREAD environment
+variable.
+
+Note: When using AzureAD for Authentication to Storage you also need to
+ensure the Storage Blob Data Owner role is assigned.
+
+---
+
+##### `useMicrosoftGraph`<sup>Optional</sup> <a name="useMicrosoftGraph" id="cdktf.AzurermBackendProps.property.useMicrosoftGraph"></a>
+
+```java
+public java.lang.Boolean getUseMicrosoftGraph();
+```
+
+- _Type:_ java.lang.Boolean
+
+(Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph?
+
+Defaults to true.
+
+Note: In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph)
+rather than ADAL (and Azure Active Directory Graph) for authentication by
+default - you can disable this by setting use_microsoft_graph to false.
+This setting will be removed in Terraform 1.3, due to Microsoft's
+deprecation of ADAL.
+
+---
+
 ##### `useMsi`<sup>Optional</sup> <a name="useMsi" id="cdktf.AzurermBackendProps.property.useMsi"></a>
 
 ```java
@@ -16617,6 +16973,21 @@ public java.lang.Boolean getUseMsi();
 (Optional) Should Managed Service Identity authentication be used?
 
 This can also be sourced from the ARM_USE_MSI environment variable.
+
+---
+
+##### `useOidc`<sup>Optional</sup> <a name="useOidc" id="cdktf.AzurermBackendProps.property.useOidc"></a>
+
+```java
+public java.lang.Boolean getUseOidc();
+```
+
+- _Type:_ java.lang.Boolean
+
+(Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.
+
+Note: When using OIDC for authentication, use_microsoft_graph
+must be set to true (which is the default).
 
 ---
 
@@ -17175,39 +17546,55 @@ DataTerraformRemoteStateAzurermConfig.builder()
     .key(java.lang.String)
     .storageAccountName(java.lang.String)
 //  .accessKey(java.lang.String)
+//  .clientCertificatePassword(java.lang.String)
+//  .clientCertificatePath(java.lang.String)
 //  .clientId(java.lang.String)
 //  .clientSecret(java.lang.String)
 //  .endpoint(java.lang.String)
 //  .environment(java.lang.String)
 //  .msiEndpoint(java.lang.String)
+//  .oidcRequestToken(java.lang.String)
+//  .oidcRequestUrl(java.lang.String)
 //  .resourceGroupName(java.lang.String)
 //  .sasToken(java.lang.String)
+//  .snapshot(java.lang.Boolean)
 //  .subscriptionId(java.lang.String)
 //  .tenantId(java.lang.String)
+//  .useAzureadAuth(java.lang.Boolean)
+//  .useMicrosoftGraph(java.lang.Boolean)
 //  .useMsi(java.lang.Boolean)
+//  .useOidc(java.lang.Boolean)
     .build();
 ```
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                                               | **Type**                                                         | **Description**                                                                                                                 |
-| ---------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.defaults">defaults</a></code>                     | <code>java.util.Map< java.lang.String, java.lang.Object ></code> | _No description._                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.workspace">workspace</a></code>                   | <code>java.lang.String</code>                                    | _No description._                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.containerName">containerName</a></code>           | <code>java.lang.String</code>                                    | (Required) The Name of the Storage Container within the Storage Account.                                                        |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.key">key</a></code>                               | <code>java.lang.String</code>                                    | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.storageAccountName">storageAccountName</a></code> | <code>java.lang.String</code>                                    | (Required) The Name of the Storage Account.                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.accessKey">accessKey</a></code>                   | <code>java.lang.String</code>                                    | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                 |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientId">clientId</a></code>                     | <code>java.lang.String</code>                                    | (Optional) The Client ID of the Service Principal.                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientSecret">clientSecret</a></code>             | <code>java.lang.String</code>                                    | (Optional) The Client Secret of the Service Principal.                                                                          |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.endpoint">endpoint</a></code>                     | <code>java.lang.String</code>                                    | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable. |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.environment">environment</a></code>               | <code>java.lang.String</code>                                    | (Optional) The Azure Environment which should be used.                                                                          |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.msiEndpoint">msiEndpoint</a></code>               | <code>java.lang.String</code>                                    | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.           |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.resourceGroupName">resourceGroupName</a></code>   | <code>java.lang.String</code>                                    | (Required) The Name of the Resource Group in which the Storage Account exists.                                                  |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.sasToken">sasToken</a></code>                     | <code>java.lang.String</code>                                    | (Optional) The SAS Token used to access the Blob Storage Account.                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.subscriptionId">subscriptionId</a></code>         | <code>java.lang.String</code>                                    | (Optional) The Subscription ID in which the Storage Account exists.                                                             |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.tenantId">tenantId</a></code>                     | <code>java.lang.String</code>                                    | (Optional) The Tenant ID in which the Subscription exists.                                                                      |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useMsi">useMsi</a></code>                         | <code>java.lang.Boolean</code>                                   | (Optional) Should Managed Service Identity authentication be used?                                                              |
+| **Name**                                                                                                                             | **Type**                                                         | **Description**                                                                                                                                |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.defaults">defaults</a></code>                                   | <code>java.util.Map< java.lang.String, java.lang.Object ></code> | _No description._                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.workspace">workspace</a></code>                                 | <code>java.lang.String</code>                                    | _No description._                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.containerName">containerName</a></code>                         | <code>java.lang.String</code>                                    | (Required) The Name of the Storage Container within the Storage Account.                                                                       |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.key">key</a></code>                                             | <code>java.lang.String</code>                                    | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.storageAccountName">storageAccountName</a></code>               | <code>java.lang.String</code>                                    | (Required) The Name of the Storage Account.                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.accessKey">accessKey</a></code>                                 | <code>java.lang.String</code>                                    | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                                |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientCertificatePassword">clientCertificatePassword</a></code> | <code>java.lang.String</code>                                    | (Optional) The password associated with the Client Certificate specified in client_certificate_path.                                           |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientCertificatePath">clientCertificatePath</a></code>         | <code>java.lang.String</code>                                    | (Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.                                 |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientId">clientId</a></code>                                   | <code>java.lang.String</code>                                    | (Optional) The Client ID of the Service Principal.                                                                                             |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientSecret">clientSecret</a></code>                           | <code>java.lang.String</code>                                    | (Optional) The Client Secret of the Service Principal.                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.endpoint">endpoint</a></code>                                   | <code>java.lang.String</code>                                    | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable.                |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.environment">environment</a></code>                             | <code>java.lang.String</code>                                    | (Optional) The Azure Environment which should be used.                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.msiEndpoint">msiEndpoint</a></code>                             | <code>java.lang.String</code>                                    | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.                          |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.oidcRequestToken">oidcRequestToken</a></code>                   | <code>java.lang.String</code>                                    | (Optional) The bearer token for the request to the OIDC provider.                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.oidcRequestUrl">oidcRequestUrl</a></code>                       | <code>java.lang.String</code>                                    | (Optional) The URL for the OIDC provider from which to request an ID token.                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.resourceGroupName">resourceGroupName</a></code>                 | <code>java.lang.String</code>                                    | (Required) The Name of the Resource Group in which the Storage Account exists.                                                                 |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.sasToken">sasToken</a></code>                                   | <code>java.lang.String</code>                                    | (Optional) The SAS Token used to access the Blob Storage Account.                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.snapshot">snapshot</a></code>                                   | <code>java.lang.Boolean</code>                                   | (Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.subscriptionId">subscriptionId</a></code>                       | <code>java.lang.String</code>                                    | (Optional) The Subscription ID in which the Storage Account exists.                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.tenantId">tenantId</a></code>                                   | <code>java.lang.String</code>                                    | (Optional) The Tenant ID in which the Subscription exists.                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useAzureadAuth">useAzureadAuth</a></code>                       | <code>java.lang.Boolean</code>                                   | (Optional) Should AzureAD Authentication be used to access the Blob Storage Account.                                                           |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useMicrosoftGraph">useMicrosoftGraph</a></code>                 | <code>java.lang.Boolean</code>                                   | (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useMsi">useMsi</a></code>                                       | <code>java.lang.Boolean</code>                                   | (Optional) Should Managed Service Identity authentication be used?                                                                             |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useOidc">useOidc</a></code>                                     | <code>java.lang.Boolean</code>                                   | (Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.                            |
 
 ---
 
@@ -17278,6 +17665,36 @@ public java.lang.String getAccessKey();
 access_key - (Optional) The Access Key used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_ACCESS_KEY environment variable.
+
+---
+
+##### `clientCertificatePassword`<sup>Optional</sup> <a name="clientCertificatePassword" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.clientCertificatePassword"></a>
+
+```java
+public java.lang.String getClientCertificatePassword();
+```
+
+- _Type:_ java.lang.String
+
+(Optional) The password associated with the Client Certificate specified in client_certificate_path.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PASSWORD environment variable.
+
+---
+
+##### `clientCertificatePath`<sup>Optional</sup> <a name="clientCertificatePath" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.clientCertificatePath"></a>
+
+```java
+public java.lang.String getClientCertificatePath();
+```
+
+- _Type:_ java.lang.String
+
+(Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PATH environment variable.
 
 ---
 
@@ -17352,6 +17769,37 @@ This can also be sourced from the ARM_MSI_ENDPOINT environment variable.
 
 ---
 
+##### `oidcRequestToken`<sup>Optional</sup> <a name="oidcRequestToken" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.oidcRequestToken"></a>
+
+```java
+public java.lang.String getOidcRequestToken();
+```
+
+- _Type:_ java.lang.String
+
+(Optional) The bearer token for the request to the OIDC provider.
+
+This can
+also be sourced from the ARM_OIDC_REQUEST_TOKEN or
+ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variables.
+
+---
+
+##### `oidcRequestUrl`<sup>Optional</sup> <a name="oidcRequestUrl" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.oidcRequestUrl"></a>
+
+```java
+public java.lang.String getOidcRequestUrl();
+```
+
+- _Type:_ java.lang.String
+
+(Optional) The URL for the OIDC provider from which to request an ID token.
+
+This can also be sourced from the ARM_OIDC_REQUEST_URL or
+ACTIONS_ID_TOKEN_REQUEST_URL environment variables.
+
+---
+
 ##### `resourceGroupName`<sup>Optional</sup> <a name="resourceGroupName" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.resourceGroupName"></a>
 
 ```java
@@ -17375,6 +17823,21 @@ public java.lang.String getSasToken();
 (Optional) The SAS Token used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_SAS_TOKEN environment variable.
+
+---
+
+##### `snapshot`<sup>Optional</sup> <a name="snapshot" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.snapshot"></a>
+
+```java
+public java.lang.Boolean getSnapshot();
+```
+
+- _Type:_ java.lang.Boolean
+
+(Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?
+
+Defaults to false. This value can also be sourced
+from the ARM_SNAPSHOT environment variable.
 
 ---
 
@@ -17406,6 +17869,44 @@ This can also be sourced from the ARM_TENANT_ID environment variable.
 
 ---
 
+##### `useAzureadAuth`<sup>Optional</sup> <a name="useAzureadAuth" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.useAzureadAuth"></a>
+
+```java
+public java.lang.Boolean getUseAzureadAuth();
+```
+
+- _Type:_ java.lang.Boolean
+
+(Optional) Should AzureAD Authentication be used to access the Blob Storage Account.
+
+This can also be sourced from the ARM_USE_AZUREAD environment
+variable.
+
+Note: When using AzureAD for Authentication to Storage you also need to
+ensure the Storage Blob Data Owner role is assigned.
+
+---
+
+##### `useMicrosoftGraph`<sup>Optional</sup> <a name="useMicrosoftGraph" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.useMicrosoftGraph"></a>
+
+```java
+public java.lang.Boolean getUseMicrosoftGraph();
+```
+
+- _Type:_ java.lang.Boolean
+
+(Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph?
+
+Defaults to true.
+
+Note: In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph)
+rather than ADAL (and Azure Active Directory Graph) for authentication by
+default - you can disable this by setting use_microsoft_graph to false.
+This setting will be removed in Terraform 1.3, due to Microsoft's
+deprecation of ADAL.
+
+---
+
 ##### `useMsi`<sup>Optional</sup> <a name="useMsi" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.useMsi"></a>
 
 ```java
@@ -17417,6 +17918,21 @@ public java.lang.Boolean getUseMsi();
 (Optional) Should Managed Service Identity authentication be used?
 
 This can also be sourced from the ARM_USE_MSI environment variable.
+
+---
+
+##### `useOidc`<sup>Optional</sup> <a name="useOidc" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.useOidc"></a>
+
+```java
+public java.lang.Boolean getUseOidc();
+```
+
+- _Type:_ java.lang.Boolean
+
+(Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.
+
+Note: When using OIDC for authentication, use_microsoft_graph
+must be set to true (which is the default).
 
 ---
 

--- a/website/docs/cdktf/api-reference/python.mdx
+++ b/website/docs/cdktf/api-reference/python.mdx
@@ -591,36 +591,52 @@ cdktf.AzurermBackend(
   key: str,
   storage_account_name: str,
   access_key: str = None,
+  client_certificate_password: str = None,
+  client_certificate_path: str = None,
   client_id: str = None,
   client_secret: str = None,
   endpoint: str = None,
   environment: str = None,
   msi_endpoint: str = None,
+  oidc_request_token: str = None,
+  oidc_request_url: str = None,
   resource_group_name: str = None,
   sas_token: str = None,
+  snapshot: bool = None,
   subscription_id: str = None,
   tenant_id: str = None,
-  use_msi: bool = None
+  use_azuread_auth: bool = None,
+  use_microsoft_graph: bool = None,
+  use_msi: bool = None,
+  use_oidc: bool = None
 )
 ```
 
-| **Name**                                                                                                       | **Type**                          | **Description**                                                                                                                 |
-| -------------------------------------------------------------------------------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.scope">scope</a></code>                             | <code>constructs.Construct</code> | _No description._                                                                                                               |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.containerName">container_name</a></code>            | <code>str</code>                  | (Required) The Name of the Storage Container within the Storage Account.                                                        |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.key">key</a></code>                                 | <code>str</code>                  | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                     |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.storageAccountName">storage_account_name</a></code> | <code>str</code>                  | (Required) The Name of the Storage Account.                                                                                     |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.accessKey">access_key</a></code>                    | <code>str</code>                  | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                 |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.clientId">client_id</a></code>                      | <code>str</code>                  | (Optional) The Client ID of the Service Principal.                                                                              |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.clientSecret">client_secret</a></code>              | <code>str</code>                  | (Optional) The Client Secret of the Service Principal.                                                                          |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.endpoint">endpoint</a></code>                       | <code>str</code>                  | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable. |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.environment">environment</a></code>                 | <code>str</code>                  | (Optional) The Azure Environment which should be used.                                                                          |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.msiEndpoint">msi_endpoint</a></code>                | <code>str</code>                  | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.           |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.resourceGroupName">resource_group_name</a></code>   | <code>str</code>                  | (Required) The Name of the Resource Group in which the Storage Account exists.                                                  |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.sasToken">sas_token</a></code>                      | <code>str</code>                  | (Optional) The SAS Token used to access the Blob Storage Account.                                                               |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.subscriptionId">subscription_id</a></code>          | <code>str</code>                  | (Optional) The Subscription ID in which the Storage Account exists.                                                             |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.tenantId">tenant_id</a></code>                      | <code>str</code>                  | (Optional) The Tenant ID in which the Subscription exists.                                                                      |
-| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.useMsi">use_msi</a></code>                          | <code>bool</code>                 | (Optional) Should Managed Service Identity authentication be used?                                                              |
+| **Name**                                                                                                                     | **Type**                          | **Description**                                                                                                                                |
+| ---------------------------------------------------------------------------------------------------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.scope">scope</a></code>                                           | <code>constructs.Construct</code> | _No description._                                                                                                                              |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.containerName">container_name</a></code>                          | <code>str</code>                  | (Required) The Name of the Storage Container within the Storage Account.                                                                       |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.key">key</a></code>                                               | <code>str</code>                  | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                                    |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.storageAccountName">storage_account_name</a></code>               | <code>str</code>                  | (Required) The Name of the Storage Account.                                                                                                    |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.accessKey">access_key</a></code>                                  | <code>str</code>                  | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                                |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.clientCertificatePassword">client_certificate_password</a></code> | <code>str</code>                  | (Optional) The password associated with the Client Certificate specified in client_certificate_path.                                           |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.clientCertificatePath">client_certificate_path</a></code>         | <code>str</code>                  | (Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.                                 |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.clientId">client_id</a></code>                                    | <code>str</code>                  | (Optional) The Client ID of the Service Principal.                                                                                             |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.clientSecret">client_secret</a></code>                            | <code>str</code>                  | (Optional) The Client Secret of the Service Principal.                                                                                         |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.endpoint">endpoint</a></code>                                     | <code>str</code>                  | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable.                |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.environment">environment</a></code>                               | <code>str</code>                  | (Optional) The Azure Environment which should be used.                                                                                         |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.msiEndpoint">msi_endpoint</a></code>                              | <code>str</code>                  | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.                          |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.oidcRequestToken">oidc_request_token</a></code>                   | <code>str</code>                  | (Optional) The bearer token for the request to the OIDC provider.                                                                              |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.oidcRequestUrl">oidc_request_url</a></code>                       | <code>str</code>                  | (Optional) The URL for the OIDC provider from which to request an ID token.                                                                    |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.resourceGroupName">resource_group_name</a></code>                 | <code>str</code>                  | (Required) The Name of the Resource Group in which the Storage Account exists.                                                                 |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.sasToken">sas_token</a></code>                                    | <code>str</code>                  | (Optional) The SAS Token used to access the Blob Storage Account.                                                                              |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.snapshot">snapshot</a></code>                                     | <code>bool</code>                 | (Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?                                                    |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.subscriptionId">subscription_id</a></code>                        | <code>str</code>                  | (Optional) The Subscription ID in which the Storage Account exists.                                                                            |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.tenantId">tenant_id</a></code>                                    | <code>str</code>                  | (Optional) The Tenant ID in which the Subscription exists.                                                                                     |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.useAzureadAuth">use_azuread_auth</a></code>                       | <code>bool</code>                 | (Optional) Should AzureAD Authentication be used to access the Blob Storage Account.                                                           |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.useMicrosoftGraph">use_microsoft_graph</a></code>                 | <code>bool</code>                 | (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.useMsi">use_msi</a></code>                                        | <code>bool</code>                 | (Optional) Should Managed Service Identity authentication be used?                                                                             |
+| <code><a href="#cdktf.AzurermBackend.Initializer.parameter.useOidc">use_oidc</a></code>                                      | <code>bool</code>                 | (Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.                            |
 
 ---
 
@@ -661,6 +677,28 @@ cdktf.AzurermBackend(
 access_key - (Optional) The Access Key used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_ACCESS_KEY environment variable.
+
+---
+
+##### `client_certificate_password`<sup>Optional</sup> <a name="client_certificate_password" id="cdktf.AzurermBackend.Initializer.parameter.clientCertificatePassword"></a>
+
+- _Type:_ str
+
+(Optional) The password associated with the Client Certificate specified in client_certificate_path.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PASSWORD environment variable.
+
+---
+
+##### `client_certificate_path`<sup>Optional</sup> <a name="client_certificate_path" id="cdktf.AzurermBackend.Initializer.parameter.clientCertificatePath"></a>
+
+- _Type:_ str
+
+(Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PATH environment variable.
 
 ---
 
@@ -715,6 +753,29 @@ This can also be sourced from the ARM_MSI_ENDPOINT environment variable.
 
 ---
 
+##### `oidc_request_token`<sup>Optional</sup> <a name="oidc_request_token" id="cdktf.AzurermBackend.Initializer.parameter.oidcRequestToken"></a>
+
+- _Type:_ str
+
+(Optional) The bearer token for the request to the OIDC provider.
+
+This can
+also be sourced from the ARM_OIDC_REQUEST_TOKEN or
+ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variables.
+
+---
+
+##### `oidc_request_url`<sup>Optional</sup> <a name="oidc_request_url" id="cdktf.AzurermBackend.Initializer.parameter.oidcRequestUrl"></a>
+
+- _Type:_ str
+
+(Optional) The URL for the OIDC provider from which to request an ID token.
+
+This can also be sourced from the ARM_OIDC_REQUEST_URL or
+ACTIONS_ID_TOKEN_REQUEST_URL environment variables.
+
+---
+
 ##### `resource_group_name`<sup>Optional</sup> <a name="resource_group_name" id="cdktf.AzurermBackend.Initializer.parameter.resourceGroupName"></a>
 
 - _Type:_ str
@@ -730,6 +791,17 @@ This can also be sourced from the ARM_MSI_ENDPOINT environment variable.
 (Optional) The SAS Token used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_SAS_TOKEN environment variable.
+
+---
+
+##### `snapshot`<sup>Optional</sup> <a name="snapshot" id="cdktf.AzurermBackend.Initializer.parameter.snapshot"></a>
+
+- _Type:_ bool
+
+(Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?
+
+Defaults to false. This value can also be sourced
+from the ARM_SNAPSHOT environment variable.
 
 ---
 
@@ -753,6 +825,36 @@ This can also be sourced from the ARM_TENANT_ID environment variable.
 
 ---
 
+##### `use_azuread_auth`<sup>Optional</sup> <a name="use_azuread_auth" id="cdktf.AzurermBackend.Initializer.parameter.useAzureadAuth"></a>
+
+- _Type:_ bool
+
+(Optional) Should AzureAD Authentication be used to access the Blob Storage Account.
+
+This can also be sourced from the ARM_USE_AZUREAD environment
+variable.
+
+Note: When using AzureAD for Authentication to Storage you also need to
+ensure the Storage Blob Data Owner role is assigned.
+
+---
+
+##### `use_microsoft_graph`<sup>Optional</sup> <a name="use_microsoft_graph" id="cdktf.AzurermBackend.Initializer.parameter.useMicrosoftGraph"></a>
+
+- _Type:_ bool
+
+(Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph?
+
+Defaults to true.
+
+Note: In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph)
+rather than ADAL (and Azure Active Directory Graph) for authentication by
+default - you can disable this by setting use_microsoft_graph to false.
+This setting will be removed in Terraform 1.3, due to Microsoft's
+deprecation of ADAL.
+
+---
+
 ##### `use_msi`<sup>Optional</sup> <a name="use_msi" id="cdktf.AzurermBackend.Initializer.parameter.useMsi"></a>
 
 - _Type:_ bool
@@ -760,6 +862,17 @@ This can also be sourced from the ARM_TENANT_ID environment variable.
 (Optional) Should Managed Service Identity authentication be used?
 
 This can also be sourced from the ARM_USE_MSI environment variable.
+
+---
+
+##### `use_oidc`<sup>Optional</sup> <a name="use_oidc" id="cdktf.AzurermBackend.Initializer.parameter.useOidc"></a>
+
+- _Type:_ bool
+
+(Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.
+
+Note: When using OIDC for authentication, use_microsoft_graph
+must be set to true (which is the default).
 
 ---
 
@@ -2735,39 +2848,55 @@ cdktf.DataTerraformRemoteStateAzurerm(
   key: str,
   storage_account_name: str,
   access_key: str = None,
+  client_certificate_password: str = None,
+  client_certificate_path: str = None,
   client_id: str = None,
   client_secret: str = None,
   endpoint: str = None,
   environment: str = None,
   msi_endpoint: str = None,
+  oidc_request_token: str = None,
+  oidc_request_url: str = None,
   resource_group_name: str = None,
   sas_token: str = None,
+  snapshot: bool = None,
   subscription_id: str = None,
   tenant_id: str = None,
-  use_msi: bool = None
+  use_azuread_auth: bool = None,
+  use_microsoft_graph: bool = None,
+  use_msi: bool = None,
+  use_oidc: bool = None
 )
 ```
 
-| **Name**                                                                                                                        | **Type**                                | **Description**                                                                                                                 |
-| ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.scope">scope</a></code>                             | <code>constructs.Construct</code>       | _No description._                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.id">id</a></code>                                   | <code>str</code>                        | _No description._                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.defaults">defaults</a></code>                       | <code>typing.Mapping[typing.Any]</code> | _No description._                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.workspace">workspace</a></code>                     | <code>str</code>                        | _No description._                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.containerName">container_name</a></code>            | <code>str</code>                        | (Required) The Name of the Storage Container within the Storage Account.                                                        |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.key">key</a></code>                                 | <code>str</code>                        | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.storageAccountName">storage_account_name</a></code> | <code>str</code>                        | (Required) The Name of the Storage Account.                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.accessKey">access_key</a></code>                    | <code>str</code>                        | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                 |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.clientId">client_id</a></code>                      | <code>str</code>                        | (Optional) The Client ID of the Service Principal.                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.clientSecret">client_secret</a></code>              | <code>str</code>                        | (Optional) The Client Secret of the Service Principal.                                                                          |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.endpoint">endpoint</a></code>                       | <code>str</code>                        | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable. |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.environment">environment</a></code>                 | <code>str</code>                        | (Optional) The Azure Environment which should be used.                                                                          |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.msiEndpoint">msi_endpoint</a></code>                | <code>str</code>                        | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.           |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.resourceGroupName">resource_group_name</a></code>   | <code>str</code>                        | (Required) The Name of the Resource Group in which the Storage Account exists.                                                  |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.sasToken">sas_token</a></code>                      | <code>str</code>                        | (Optional) The SAS Token used to access the Blob Storage Account.                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.subscriptionId">subscription_id</a></code>          | <code>str</code>                        | (Optional) The Subscription ID in which the Storage Account exists.                                                             |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.tenantId">tenant_id</a></code>                      | <code>str</code>                        | (Optional) The Tenant ID in which the Subscription exists.                                                                      |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.useMsi">use_msi</a></code>                          | <code>bool</code>                       | (Optional) Should Managed Service Identity authentication be used?                                                              |
+| **Name**                                                                                                                                      | **Type**                                | **Description**                                                                                                                                |
+| --------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.scope">scope</a></code>                                           | <code>constructs.Construct</code>       | _No description._                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.id">id</a></code>                                                 | <code>str</code>                        | _No description._                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.defaults">defaults</a></code>                                     | <code>typing.Mapping[typing.Any]</code> | _No description._                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.workspace">workspace</a></code>                                   | <code>str</code>                        | _No description._                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.containerName">container_name</a></code>                          | <code>str</code>                        | (Required) The Name of the Storage Container within the Storage Account.                                                                       |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.key">key</a></code>                                               | <code>str</code>                        | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.storageAccountName">storage_account_name</a></code>               | <code>str</code>                        | (Required) The Name of the Storage Account.                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.accessKey">access_key</a></code>                                  | <code>str</code>                        | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                                |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.clientCertificatePassword">client_certificate_password</a></code> | <code>str</code>                        | (Optional) The password associated with the Client Certificate specified in client_certificate_path.                                           |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.clientCertificatePath">client_certificate_path</a></code>         | <code>str</code>                        | (Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.                                 |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.clientId">client_id</a></code>                                    | <code>str</code>                        | (Optional) The Client ID of the Service Principal.                                                                                             |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.clientSecret">client_secret</a></code>                            | <code>str</code>                        | (Optional) The Client Secret of the Service Principal.                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.endpoint">endpoint</a></code>                                     | <code>str</code>                        | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable.                |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.environment">environment</a></code>                               | <code>str</code>                        | (Optional) The Azure Environment which should be used.                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.msiEndpoint">msi_endpoint</a></code>                              | <code>str</code>                        | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.                          |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.oidcRequestToken">oidc_request_token</a></code>                   | <code>str</code>                        | (Optional) The bearer token for the request to the OIDC provider.                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.oidcRequestUrl">oidc_request_url</a></code>                       | <code>str</code>                        | (Optional) The URL for the OIDC provider from which to request an ID token.                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.resourceGroupName">resource_group_name</a></code>                 | <code>str</code>                        | (Required) The Name of the Resource Group in which the Storage Account exists.                                                                 |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.sasToken">sas_token</a></code>                                    | <code>str</code>                        | (Optional) The SAS Token used to access the Blob Storage Account.                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.snapshot">snapshot</a></code>                                     | <code>bool</code>                       | (Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.subscriptionId">subscription_id</a></code>                        | <code>str</code>                        | (Optional) The Subscription ID in which the Storage Account exists.                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.tenantId">tenant_id</a></code>                                    | <code>str</code>                        | (Optional) The Tenant ID in which the Subscription exists.                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.useAzureadAuth">use_azuread_auth</a></code>                       | <code>bool</code>                       | (Optional) Should AzureAD Authentication be used to access the Blob Storage Account.                                                           |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.useMicrosoftGraph">use_microsoft_graph</a></code>                 | <code>bool</code>                       | (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.useMsi">use_msi</a></code>                                        | <code>bool</code>                       | (Optional) Should Managed Service Identity authentication be used?                                                                             |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.useOidc">use_oidc</a></code>                                      | <code>bool</code>                       | (Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.                            |
 
 ---
 
@@ -2829,6 +2958,28 @@ This can also be sourced from the ARM_ACCESS_KEY environment variable.
 
 ---
 
+##### `client_certificate_password`<sup>Optional</sup> <a name="client_certificate_password" id="cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.clientCertificatePassword"></a>
+
+- _Type:_ str
+
+(Optional) The password associated with the Client Certificate specified in client_certificate_path.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PASSWORD environment variable.
+
+---
+
+##### `client_certificate_path`<sup>Optional</sup> <a name="client_certificate_path" id="cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.clientCertificatePath"></a>
+
+- _Type:_ str
+
+(Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PATH environment variable.
+
+---
+
 ##### `client_id`<sup>Optional</sup> <a name="client_id" id="cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.clientId"></a>
 
 - _Type:_ str
@@ -2880,6 +3031,29 @@ This can also be sourced from the ARM_MSI_ENDPOINT environment variable.
 
 ---
 
+##### `oidc_request_token`<sup>Optional</sup> <a name="oidc_request_token" id="cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.oidcRequestToken"></a>
+
+- _Type:_ str
+
+(Optional) The bearer token for the request to the OIDC provider.
+
+This can
+also be sourced from the ARM_OIDC_REQUEST_TOKEN or
+ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variables.
+
+---
+
+##### `oidc_request_url`<sup>Optional</sup> <a name="oidc_request_url" id="cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.oidcRequestUrl"></a>
+
+- _Type:_ str
+
+(Optional) The URL for the OIDC provider from which to request an ID token.
+
+This can also be sourced from the ARM_OIDC_REQUEST_URL or
+ACTIONS_ID_TOKEN_REQUEST_URL environment variables.
+
+---
+
 ##### `resource_group_name`<sup>Optional</sup> <a name="resource_group_name" id="cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.resourceGroupName"></a>
 
 - _Type:_ str
@@ -2895,6 +3069,17 @@ This can also be sourced from the ARM_MSI_ENDPOINT environment variable.
 (Optional) The SAS Token used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_SAS_TOKEN environment variable.
+
+---
+
+##### `snapshot`<sup>Optional</sup> <a name="snapshot" id="cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.snapshot"></a>
+
+- _Type:_ bool
+
+(Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?
+
+Defaults to false. This value can also be sourced
+from the ARM_SNAPSHOT environment variable.
 
 ---
 
@@ -2918,6 +3103,36 @@ This can also be sourced from the ARM_TENANT_ID environment variable.
 
 ---
 
+##### `use_azuread_auth`<sup>Optional</sup> <a name="use_azuread_auth" id="cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.useAzureadAuth"></a>
+
+- _Type:_ bool
+
+(Optional) Should AzureAD Authentication be used to access the Blob Storage Account.
+
+This can also be sourced from the ARM_USE_AZUREAD environment
+variable.
+
+Note: When using AzureAD for Authentication to Storage you also need to
+ensure the Storage Blob Data Owner role is assigned.
+
+---
+
+##### `use_microsoft_graph`<sup>Optional</sup> <a name="use_microsoft_graph" id="cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.useMicrosoftGraph"></a>
+
+- _Type:_ bool
+
+(Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph?
+
+Defaults to true.
+
+Note: In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph)
+rather than ADAL (and Azure Active Directory Graph) for authentication by
+default - you can disable this by setting use_microsoft_graph to false.
+This setting will be removed in Terraform 1.3, due to Microsoft's
+deprecation of ADAL.
+
+---
+
 ##### `use_msi`<sup>Optional</sup> <a name="use_msi" id="cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.useMsi"></a>
 
 - _Type:_ bool
@@ -2925,6 +3140,17 @@ This can also be sourced from the ARM_TENANT_ID environment variable.
 (Optional) Should Managed Service Identity authentication be used?
 
 This can also be sourced from the ARM_USE_MSI environment variable.
+
+---
+
+##### `use_oidc`<sup>Optional</sup> <a name="use_oidc" id="cdktf.DataTerraformRemoteStateAzurerm.Initializer.parameter.useOidc"></a>
+
+- _Type:_ bool
+
+(Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.
+
+Note: When using OIDC for authentication, use_microsoft_graph
+must be set to true (which is the default).
 
 ---
 
@@ -17134,37 +17360,53 @@ cdktf.AzurermBackendProps(
   key: str,
   storage_account_name: str,
   access_key: str = None,
+  client_certificate_password: str = None,
+  client_certificate_path: str = None,
   client_id: str = None,
   client_secret: str = None,
   endpoint: str = None,
   environment: str = None,
   msi_endpoint: str = None,
+  oidc_request_token: str = None,
+  oidc_request_url: str = None,
   resource_group_name: str = None,
   sas_token: str = None,
+  snapshot: bool = None,
   subscription_id: str = None,
   tenant_id: str = None,
-  use_msi: bool = None
+  use_azuread_auth: bool = None,
+  use_microsoft_graph: bool = None,
+  use_msi: bool = None,
+  use_oidc: bool = None
 )
 ```
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                               | **Type**          | **Description**                                                                                                                 |
-| ------------------------------------------------------------------------------------------------------ | ----------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.AzurermBackendProps.property.containerName">container_name</a></code>            | <code>str</code>  | (Required) The Name of the Storage Container within the Storage Account.                                                        |
-| <code><a href="#cdktf.AzurermBackendProps.property.key">key</a></code>                                 | <code>str</code>  | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                     |
-| <code><a href="#cdktf.AzurermBackendProps.property.storageAccountName">storage_account_name</a></code> | <code>str</code>  | (Required) The Name of the Storage Account.                                                                                     |
-| <code><a href="#cdktf.AzurermBackendProps.property.accessKey">access_key</a></code>                    | <code>str</code>  | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                 |
-| <code><a href="#cdktf.AzurermBackendProps.property.clientId">client_id</a></code>                      | <code>str</code>  | (Optional) The Client ID of the Service Principal.                                                                              |
-| <code><a href="#cdktf.AzurermBackendProps.property.clientSecret">client_secret</a></code>              | <code>str</code>  | (Optional) The Client Secret of the Service Principal.                                                                          |
-| <code><a href="#cdktf.AzurermBackendProps.property.endpoint">endpoint</a></code>                       | <code>str</code>  | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable. |
-| <code><a href="#cdktf.AzurermBackendProps.property.environment">environment</a></code>                 | <code>str</code>  | (Optional) The Azure Environment which should be used.                                                                          |
-| <code><a href="#cdktf.AzurermBackendProps.property.msiEndpoint">msi_endpoint</a></code>                | <code>str</code>  | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.           |
-| <code><a href="#cdktf.AzurermBackendProps.property.resourceGroupName">resource_group_name</a></code>   | <code>str</code>  | (Required) The Name of the Resource Group in which the Storage Account exists.                                                  |
-| <code><a href="#cdktf.AzurermBackendProps.property.sasToken">sas_token</a></code>                      | <code>str</code>  | (Optional) The SAS Token used to access the Blob Storage Account.                                                               |
-| <code><a href="#cdktf.AzurermBackendProps.property.subscriptionId">subscription_id</a></code>          | <code>str</code>  | (Optional) The Subscription ID in which the Storage Account exists.                                                             |
-| <code><a href="#cdktf.AzurermBackendProps.property.tenantId">tenant_id</a></code>                      | <code>str</code>  | (Optional) The Tenant ID in which the Subscription exists.                                                                      |
-| <code><a href="#cdktf.AzurermBackendProps.property.useMsi">use_msi</a></code>                          | <code>bool</code> | (Optional) Should Managed Service Identity authentication be used?                                                              |
+| **Name**                                                                                                             | **Type**          | **Description**                                                                                                                                |
+| -------------------------------------------------------------------------------------------------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.AzurermBackendProps.property.containerName">container_name</a></code>                          | <code>str</code>  | (Required) The Name of the Storage Container within the Storage Account.                                                                       |
+| <code><a href="#cdktf.AzurermBackendProps.property.key">key</a></code>                                               | <code>str</code>  | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                                    |
+| <code><a href="#cdktf.AzurermBackendProps.property.storageAccountName">storage_account_name</a></code>               | <code>str</code>  | (Required) The Name of the Storage Account.                                                                                                    |
+| <code><a href="#cdktf.AzurermBackendProps.property.accessKey">access_key</a></code>                                  | <code>str</code>  | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                                |
+| <code><a href="#cdktf.AzurermBackendProps.property.clientCertificatePassword">client_certificate_password</a></code> | <code>str</code>  | (Optional) The password associated with the Client Certificate specified in client_certificate_path.                                           |
+| <code><a href="#cdktf.AzurermBackendProps.property.clientCertificatePath">client_certificate_path</a></code>         | <code>str</code>  | (Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.                                 |
+| <code><a href="#cdktf.AzurermBackendProps.property.clientId">client_id</a></code>                                    | <code>str</code>  | (Optional) The Client ID of the Service Principal.                                                                                             |
+| <code><a href="#cdktf.AzurermBackendProps.property.clientSecret">client_secret</a></code>                            | <code>str</code>  | (Optional) The Client Secret of the Service Principal.                                                                                         |
+| <code><a href="#cdktf.AzurermBackendProps.property.endpoint">endpoint</a></code>                                     | <code>str</code>  | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable.                |
+| <code><a href="#cdktf.AzurermBackendProps.property.environment">environment</a></code>                               | <code>str</code>  | (Optional) The Azure Environment which should be used.                                                                                         |
+| <code><a href="#cdktf.AzurermBackendProps.property.msiEndpoint">msi_endpoint</a></code>                              | <code>str</code>  | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.                          |
+| <code><a href="#cdktf.AzurermBackendProps.property.oidcRequestToken">oidc_request_token</a></code>                   | <code>str</code>  | (Optional) The bearer token for the request to the OIDC provider.                                                                              |
+| <code><a href="#cdktf.AzurermBackendProps.property.oidcRequestUrl">oidc_request_url</a></code>                       | <code>str</code>  | (Optional) The URL for the OIDC provider from which to request an ID token.                                                                    |
+| <code><a href="#cdktf.AzurermBackendProps.property.resourceGroupName">resource_group_name</a></code>                 | <code>str</code>  | (Required) The Name of the Resource Group in which the Storage Account exists.                                                                 |
+| <code><a href="#cdktf.AzurermBackendProps.property.sasToken">sas_token</a></code>                                    | <code>str</code>  | (Optional) The SAS Token used to access the Blob Storage Account.                                                                              |
+| <code><a href="#cdktf.AzurermBackendProps.property.snapshot">snapshot</a></code>                                     | <code>bool</code> | (Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?                                                    |
+| <code><a href="#cdktf.AzurermBackendProps.property.subscriptionId">subscription_id</a></code>                        | <code>str</code>  | (Optional) The Subscription ID in which the Storage Account exists.                                                                            |
+| <code><a href="#cdktf.AzurermBackendProps.property.tenantId">tenant_id</a></code>                                    | <code>str</code>  | (Optional) The Tenant ID in which the Subscription exists.                                                                                     |
+| <code><a href="#cdktf.AzurermBackendProps.property.useAzureadAuth">use_azuread_auth</a></code>                       | <code>bool</code> | (Optional) Should AzureAD Authentication be used to access the Blob Storage Account.                                                           |
+| <code><a href="#cdktf.AzurermBackendProps.property.useMicrosoftGraph">use_microsoft_graph</a></code>                 | <code>bool</code> | (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? |
+| <code><a href="#cdktf.AzurermBackendProps.property.useMsi">use_msi</a></code>                                        | <code>bool</code> | (Optional) Should Managed Service Identity authentication be used?                                                                             |
+| <code><a href="#cdktf.AzurermBackendProps.property.useOidc">use_oidc</a></code>                                      | <code>bool</code> | (Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.                            |
 
 ---
 
@@ -17215,6 +17457,36 @@ access_key: str
 access_key - (Optional) The Access Key used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_ACCESS_KEY environment variable.
+
+---
+
+##### `client_certificate_password`<sup>Optional</sup> <a name="client_certificate_password" id="cdktf.AzurermBackendProps.property.clientCertificatePassword"></a>
+
+```python
+client_certificate_password: str
+```
+
+- _Type:_ str
+
+(Optional) The password associated with the Client Certificate specified in client_certificate_path.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PASSWORD environment variable.
+
+---
+
+##### `client_certificate_path`<sup>Optional</sup> <a name="client_certificate_path" id="cdktf.AzurermBackendProps.property.clientCertificatePath"></a>
+
+```python
+client_certificate_path: str
+```
+
+- _Type:_ str
+
+(Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PATH environment variable.
 
 ---
 
@@ -17289,6 +17561,37 @@ This can also be sourced from the ARM_MSI_ENDPOINT environment variable.
 
 ---
 
+##### `oidc_request_token`<sup>Optional</sup> <a name="oidc_request_token" id="cdktf.AzurermBackendProps.property.oidcRequestToken"></a>
+
+```python
+oidc_request_token: str
+```
+
+- _Type:_ str
+
+(Optional) The bearer token for the request to the OIDC provider.
+
+This can
+also be sourced from the ARM_OIDC_REQUEST_TOKEN or
+ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variables.
+
+---
+
+##### `oidc_request_url`<sup>Optional</sup> <a name="oidc_request_url" id="cdktf.AzurermBackendProps.property.oidcRequestUrl"></a>
+
+```python
+oidc_request_url: str
+```
+
+- _Type:_ str
+
+(Optional) The URL for the OIDC provider from which to request an ID token.
+
+This can also be sourced from the ARM_OIDC_REQUEST_URL or
+ACTIONS_ID_TOKEN_REQUEST_URL environment variables.
+
+---
+
 ##### `resource_group_name`<sup>Optional</sup> <a name="resource_group_name" id="cdktf.AzurermBackendProps.property.resourceGroupName"></a>
 
 ```python
@@ -17312,6 +17615,21 @@ sas_token: str
 (Optional) The SAS Token used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_SAS_TOKEN environment variable.
+
+---
+
+##### `snapshot`<sup>Optional</sup> <a name="snapshot" id="cdktf.AzurermBackendProps.property.snapshot"></a>
+
+```python
+snapshot: bool
+```
+
+- _Type:_ bool
+
+(Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?
+
+Defaults to false. This value can also be sourced
+from the ARM_SNAPSHOT environment variable.
 
 ---
 
@@ -17343,6 +17661,44 @@ This can also be sourced from the ARM_TENANT_ID environment variable.
 
 ---
 
+##### `use_azuread_auth`<sup>Optional</sup> <a name="use_azuread_auth" id="cdktf.AzurermBackendProps.property.useAzureadAuth"></a>
+
+```python
+use_azuread_auth: bool
+```
+
+- _Type:_ bool
+
+(Optional) Should AzureAD Authentication be used to access the Blob Storage Account.
+
+This can also be sourced from the ARM_USE_AZUREAD environment
+variable.
+
+Note: When using AzureAD for Authentication to Storage you also need to
+ensure the Storage Blob Data Owner role is assigned.
+
+---
+
+##### `use_microsoft_graph`<sup>Optional</sup> <a name="use_microsoft_graph" id="cdktf.AzurermBackendProps.property.useMicrosoftGraph"></a>
+
+```python
+use_microsoft_graph: bool
+```
+
+- _Type:_ bool
+
+(Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph?
+
+Defaults to true.
+
+Note: In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph)
+rather than ADAL (and Azure Active Directory Graph) for authentication by
+default - you can disable this by setting use_microsoft_graph to false.
+This setting will be removed in Terraform 1.3, due to Microsoft's
+deprecation of ADAL.
+
+---
+
 ##### `use_msi`<sup>Optional</sup> <a name="use_msi" id="cdktf.AzurermBackendProps.property.useMsi"></a>
 
 ```python
@@ -17354,6 +17710,21 @@ use_msi: bool
 (Optional) Should Managed Service Identity authentication be used?
 
 This can also be sourced from the ARM_USE_MSI environment variable.
+
+---
+
+##### `use_oidc`<sup>Optional</sup> <a name="use_oidc" id="cdktf.AzurermBackendProps.property.useOidc"></a>
+
+```python
+use_oidc: bool
+```
+
+- _Type:_ bool
+
+(Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.
+
+Note: When using OIDC for authentication, use_microsoft_graph
+must be set to true (which is the default).
 
 ---
 
@@ -17911,39 +18282,55 @@ cdktf.DataTerraformRemoteStateAzurermConfig(
   key: str,
   storage_account_name: str,
   access_key: str = None,
+  client_certificate_password: str = None,
+  client_certificate_path: str = None,
   client_id: str = None,
   client_secret: str = None,
   endpoint: str = None,
   environment: str = None,
   msi_endpoint: str = None,
+  oidc_request_token: str = None,
+  oidc_request_url: str = None,
   resource_group_name: str = None,
   sas_token: str = None,
+  snapshot: bool = None,
   subscription_id: str = None,
   tenant_id: str = None,
-  use_msi: bool = None
+  use_azuread_auth: bool = None,
+  use_microsoft_graph: bool = None,
+  use_msi: bool = None,
+  use_oidc: bool = None
 )
 ```
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                                                 | **Type**                                | **Description**                                                                                                                 |
-| ------------------------------------------------------------------------------------------------------------------------ | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.defaults">defaults</a></code>                       | <code>typing.Mapping[typing.Any]</code> | _No description._                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.workspace">workspace</a></code>                     | <code>str</code>                        | _No description._                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.containerName">container_name</a></code>            | <code>str</code>                        | (Required) The Name of the Storage Container within the Storage Account.                                                        |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.key">key</a></code>                                 | <code>str</code>                        | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.storageAccountName">storage_account_name</a></code> | <code>str</code>                        | (Required) The Name of the Storage Account.                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.accessKey">access_key</a></code>                    | <code>str</code>                        | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                 |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientId">client_id</a></code>                      | <code>str</code>                        | (Optional) The Client ID of the Service Principal.                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientSecret">client_secret</a></code>              | <code>str</code>                        | (Optional) The Client Secret of the Service Principal.                                                                          |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.endpoint">endpoint</a></code>                       | <code>str</code>                        | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable. |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.environment">environment</a></code>                 | <code>str</code>                        | (Optional) The Azure Environment which should be used.                                                                          |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.msiEndpoint">msi_endpoint</a></code>                | <code>str</code>                        | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.           |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.resourceGroupName">resource_group_name</a></code>   | <code>str</code>                        | (Required) The Name of the Resource Group in which the Storage Account exists.                                                  |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.sasToken">sas_token</a></code>                      | <code>str</code>                        | (Optional) The SAS Token used to access the Blob Storage Account.                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.subscriptionId">subscription_id</a></code>          | <code>str</code>                        | (Optional) The Subscription ID in which the Storage Account exists.                                                             |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.tenantId">tenant_id</a></code>                      | <code>str</code>                        | (Optional) The Tenant ID in which the Subscription exists.                                                                      |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useMsi">use_msi</a></code>                          | <code>bool</code>                       | (Optional) Should Managed Service Identity authentication be used?                                                              |
+| **Name**                                                                                                                               | **Type**                                | **Description**                                                                                                                                |
+| -------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.defaults">defaults</a></code>                                     | <code>typing.Mapping[typing.Any]</code> | _No description._                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.workspace">workspace</a></code>                                   | <code>str</code>                        | _No description._                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.containerName">container_name</a></code>                          | <code>str</code>                        | (Required) The Name of the Storage Container within the Storage Account.                                                                       |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.key">key</a></code>                                               | <code>str</code>                        | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.storageAccountName">storage_account_name</a></code>               | <code>str</code>                        | (Required) The Name of the Storage Account.                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.accessKey">access_key</a></code>                                  | <code>str</code>                        | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                                |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientCertificatePassword">client_certificate_password</a></code> | <code>str</code>                        | (Optional) The password associated with the Client Certificate specified in client_certificate_path.                                           |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientCertificatePath">client_certificate_path</a></code>         | <code>str</code>                        | (Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.                                 |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientId">client_id</a></code>                                    | <code>str</code>                        | (Optional) The Client ID of the Service Principal.                                                                                             |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientSecret">client_secret</a></code>                            | <code>str</code>                        | (Optional) The Client Secret of the Service Principal.                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.endpoint">endpoint</a></code>                                     | <code>str</code>                        | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable.                |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.environment">environment</a></code>                               | <code>str</code>                        | (Optional) The Azure Environment which should be used.                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.msiEndpoint">msi_endpoint</a></code>                              | <code>str</code>                        | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.                          |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.oidcRequestToken">oidc_request_token</a></code>                   | <code>str</code>                        | (Optional) The bearer token for the request to the OIDC provider.                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.oidcRequestUrl">oidc_request_url</a></code>                       | <code>str</code>                        | (Optional) The URL for the OIDC provider from which to request an ID token.                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.resourceGroupName">resource_group_name</a></code>                 | <code>str</code>                        | (Required) The Name of the Resource Group in which the Storage Account exists.                                                                 |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.sasToken">sas_token</a></code>                                    | <code>str</code>                        | (Optional) The SAS Token used to access the Blob Storage Account.                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.snapshot">snapshot</a></code>                                     | <code>bool</code>                       | (Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.subscriptionId">subscription_id</a></code>                        | <code>str</code>                        | (Optional) The Subscription ID in which the Storage Account exists.                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.tenantId">tenant_id</a></code>                                    | <code>str</code>                        | (Optional) The Tenant ID in which the Subscription exists.                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useAzureadAuth">use_azuread_auth</a></code>                       | <code>bool</code>                       | (Optional) Should AzureAD Authentication be used to access the Blob Storage Account.                                                           |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useMicrosoftGraph">use_microsoft_graph</a></code>                 | <code>bool</code>                       | (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useMsi">use_msi</a></code>                                        | <code>bool</code>                       | (Optional) Should Managed Service Identity authentication be used?                                                                             |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useOidc">use_oidc</a></code>                                      | <code>bool</code>                       | (Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.                            |
 
 ---
 
@@ -18014,6 +18401,36 @@ access_key: str
 access_key - (Optional) The Access Key used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_ACCESS_KEY environment variable.
+
+---
+
+##### `client_certificate_password`<sup>Optional</sup> <a name="client_certificate_password" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.clientCertificatePassword"></a>
+
+```python
+client_certificate_password: str
+```
+
+- _Type:_ str
+
+(Optional) The password associated with the Client Certificate specified in client_certificate_path.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PASSWORD environment variable.
+
+---
+
+##### `client_certificate_path`<sup>Optional</sup> <a name="client_certificate_path" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.clientCertificatePath"></a>
+
+```python
+client_certificate_path: str
+```
+
+- _Type:_ str
+
+(Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PATH environment variable.
 
 ---
 
@@ -18088,6 +18505,37 @@ This can also be sourced from the ARM_MSI_ENDPOINT environment variable.
 
 ---
 
+##### `oidc_request_token`<sup>Optional</sup> <a name="oidc_request_token" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.oidcRequestToken"></a>
+
+```python
+oidc_request_token: str
+```
+
+- _Type:_ str
+
+(Optional) The bearer token for the request to the OIDC provider.
+
+This can
+also be sourced from the ARM_OIDC_REQUEST_TOKEN or
+ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variables.
+
+---
+
+##### `oidc_request_url`<sup>Optional</sup> <a name="oidc_request_url" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.oidcRequestUrl"></a>
+
+```python
+oidc_request_url: str
+```
+
+- _Type:_ str
+
+(Optional) The URL for the OIDC provider from which to request an ID token.
+
+This can also be sourced from the ARM_OIDC_REQUEST_URL or
+ACTIONS_ID_TOKEN_REQUEST_URL environment variables.
+
+---
+
 ##### `resource_group_name`<sup>Optional</sup> <a name="resource_group_name" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.resourceGroupName"></a>
 
 ```python
@@ -18111,6 +18559,21 @@ sas_token: str
 (Optional) The SAS Token used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_SAS_TOKEN environment variable.
+
+---
+
+##### `snapshot`<sup>Optional</sup> <a name="snapshot" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.snapshot"></a>
+
+```python
+snapshot: bool
+```
+
+- _Type:_ bool
+
+(Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?
+
+Defaults to false. This value can also be sourced
+from the ARM_SNAPSHOT environment variable.
 
 ---
 
@@ -18142,6 +18605,44 @@ This can also be sourced from the ARM_TENANT_ID environment variable.
 
 ---
 
+##### `use_azuread_auth`<sup>Optional</sup> <a name="use_azuread_auth" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.useAzureadAuth"></a>
+
+```python
+use_azuread_auth: bool
+```
+
+- _Type:_ bool
+
+(Optional) Should AzureAD Authentication be used to access the Blob Storage Account.
+
+This can also be sourced from the ARM_USE_AZUREAD environment
+variable.
+
+Note: When using AzureAD for Authentication to Storage you also need to
+ensure the Storage Blob Data Owner role is assigned.
+
+---
+
+##### `use_microsoft_graph`<sup>Optional</sup> <a name="use_microsoft_graph" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.useMicrosoftGraph"></a>
+
+```python
+use_microsoft_graph: bool
+```
+
+- _Type:_ bool
+
+(Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph?
+
+Defaults to true.
+
+Note: In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph)
+rather than ADAL (and Azure Active Directory Graph) for authentication by
+default - you can disable this by setting use_microsoft_graph to false.
+This setting will be removed in Terraform 1.3, due to Microsoft's
+deprecation of ADAL.
+
+---
+
 ##### `use_msi`<sup>Optional</sup> <a name="use_msi" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.useMsi"></a>
 
 ```python
@@ -18153,6 +18654,21 @@ use_msi: bool
 (Optional) Should Managed Service Identity authentication be used?
 
 This can also be sourced from the ARM_USE_MSI environment variable.
+
+---
+
+##### `use_oidc`<sup>Optional</sup> <a name="use_oidc" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.useOidc"></a>
+
+```python
+use_oidc: bool
+```
+
+- _Type:_ bool
+
+(Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.
+
+Note: When using OIDC for authentication, use_microsoft_graph
+must be set to true (which is the default).
 
 ---
 

--- a/website/docs/cdktf/api-reference/typescript.mdx
+++ b/website/docs/cdktf/api-reference/typescript.mdx
@@ -12654,22 +12654,30 @@ const azurermBackendProps: AzurermBackendProps = { ... }
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                             | **Type**             | **Description**                                                                                                                 |
-| ---------------------------------------------------------------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.AzurermBackendProps.property.containerName">containerName</a></code>           | <code>string</code>  | (Required) The Name of the Storage Container within the Storage Account.                                                        |
-| <code><a href="#cdktf.AzurermBackendProps.property.key">key</a></code>                               | <code>string</code>  | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                     |
-| <code><a href="#cdktf.AzurermBackendProps.property.storageAccountName">storageAccountName</a></code> | <code>string</code>  | (Required) The Name of the Storage Account.                                                                                     |
-| <code><a href="#cdktf.AzurermBackendProps.property.accessKey">accessKey</a></code>                   | <code>string</code>  | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                 |
-| <code><a href="#cdktf.AzurermBackendProps.property.clientId">clientId</a></code>                     | <code>string</code>  | (Optional) The Client ID of the Service Principal.                                                                              |
-| <code><a href="#cdktf.AzurermBackendProps.property.clientSecret">clientSecret</a></code>             | <code>string</code>  | (Optional) The Client Secret of the Service Principal.                                                                          |
-| <code><a href="#cdktf.AzurermBackendProps.property.endpoint">endpoint</a></code>                     | <code>string</code>  | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable. |
-| <code><a href="#cdktf.AzurermBackendProps.property.environment">environment</a></code>               | <code>string</code>  | (Optional) The Azure Environment which should be used.                                                                          |
-| <code><a href="#cdktf.AzurermBackendProps.property.msiEndpoint">msiEndpoint</a></code>               | <code>string</code>  | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.           |
-| <code><a href="#cdktf.AzurermBackendProps.property.resourceGroupName">resourceGroupName</a></code>   | <code>string</code>  | (Required) The Name of the Resource Group in which the Storage Account exists.                                                  |
-| <code><a href="#cdktf.AzurermBackendProps.property.sasToken">sasToken</a></code>                     | <code>string</code>  | (Optional) The SAS Token used to access the Blob Storage Account.                                                               |
-| <code><a href="#cdktf.AzurermBackendProps.property.subscriptionId">subscriptionId</a></code>         | <code>string</code>  | (Optional) The Subscription ID in which the Storage Account exists.                                                             |
-| <code><a href="#cdktf.AzurermBackendProps.property.tenantId">tenantId</a></code>                     | <code>string</code>  | (Optional) The Tenant ID in which the Subscription exists.                                                                      |
-| <code><a href="#cdktf.AzurermBackendProps.property.useMsi">useMsi</a></code>                         | <code>boolean</code> | (Optional) Should Managed Service Identity authentication be used?                                                              |
+| **Name**                                                                                                           | **Type**             | **Description**                                                                                                                                |
+| ------------------------------------------------------------------------------------------------------------------ | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.AzurermBackendProps.property.containerName">containerName</a></code>                         | <code>string</code>  | (Required) The Name of the Storage Container within the Storage Account.                                                                       |
+| <code><a href="#cdktf.AzurermBackendProps.property.key">key</a></code>                                             | <code>string</code>  | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                                    |
+| <code><a href="#cdktf.AzurermBackendProps.property.storageAccountName">storageAccountName</a></code>               | <code>string</code>  | (Required) The Name of the Storage Account.                                                                                                    |
+| <code><a href="#cdktf.AzurermBackendProps.property.accessKey">accessKey</a></code>                                 | <code>string</code>  | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                                |
+| <code><a href="#cdktf.AzurermBackendProps.property.clientCertificatePassword">clientCertificatePassword</a></code> | <code>string</code>  | (Optional) The password associated with the Client Certificate specified in client_certificate_path.                                           |
+| <code><a href="#cdktf.AzurermBackendProps.property.clientCertificatePath">clientCertificatePath</a></code>         | <code>string</code>  | (Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.                                 |
+| <code><a href="#cdktf.AzurermBackendProps.property.clientId">clientId</a></code>                                   | <code>string</code>  | (Optional) The Client ID of the Service Principal.                                                                                             |
+| <code><a href="#cdktf.AzurermBackendProps.property.clientSecret">clientSecret</a></code>                           | <code>string</code>  | (Optional) The Client Secret of the Service Principal.                                                                                         |
+| <code><a href="#cdktf.AzurermBackendProps.property.endpoint">endpoint</a></code>                                   | <code>string</code>  | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable.                |
+| <code><a href="#cdktf.AzurermBackendProps.property.environment">environment</a></code>                             | <code>string</code>  | (Optional) The Azure Environment which should be used.                                                                                         |
+| <code><a href="#cdktf.AzurermBackendProps.property.msiEndpoint">msiEndpoint</a></code>                             | <code>string</code>  | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.                          |
+| <code><a href="#cdktf.AzurermBackendProps.property.oidcRequestToken">oidcRequestToken</a></code>                   | <code>string</code>  | (Optional) The bearer token for the request to the OIDC provider.                                                                              |
+| <code><a href="#cdktf.AzurermBackendProps.property.oidcRequestUrl">oidcRequestUrl</a></code>                       | <code>string</code>  | (Optional) The URL for the OIDC provider from which to request an ID token.                                                                    |
+| <code><a href="#cdktf.AzurermBackendProps.property.resourceGroupName">resourceGroupName</a></code>                 | <code>string</code>  | (Required) The Name of the Resource Group in which the Storage Account exists.                                                                 |
+| <code><a href="#cdktf.AzurermBackendProps.property.sasToken">sasToken</a></code>                                   | <code>string</code>  | (Optional) The SAS Token used to access the Blob Storage Account.                                                                              |
+| <code><a href="#cdktf.AzurermBackendProps.property.snapshot">snapshot</a></code>                                   | <code>boolean</code> | (Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?                                                    |
+| <code><a href="#cdktf.AzurermBackendProps.property.subscriptionId">subscriptionId</a></code>                       | <code>string</code>  | (Optional) The Subscription ID in which the Storage Account exists.                                                                            |
+| <code><a href="#cdktf.AzurermBackendProps.property.tenantId">tenantId</a></code>                                   | <code>string</code>  | (Optional) The Tenant ID in which the Subscription exists.                                                                                     |
+| <code><a href="#cdktf.AzurermBackendProps.property.useAzureadAuth">useAzureadAuth</a></code>                       | <code>boolean</code> | (Optional) Should AzureAD Authentication be used to access the Blob Storage Account.                                                           |
+| <code><a href="#cdktf.AzurermBackendProps.property.useMicrosoftGraph">useMicrosoftGraph</a></code>                 | <code>boolean</code> | (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? |
+| <code><a href="#cdktf.AzurermBackendProps.property.useMsi">useMsi</a></code>                                       | <code>boolean</code> | (Optional) Should Managed Service Identity authentication be used?                                                                             |
+| <code><a href="#cdktf.AzurermBackendProps.property.useOidc">useOidc</a></code>                                     | <code>boolean</code> | (Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.                            |
 
 ---
 
@@ -12720,6 +12728,36 @@ public readonly accessKey: string;
 access_key - (Optional) The Access Key used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_ACCESS_KEY environment variable.
+
+---
+
+##### `clientCertificatePassword`<sup>Optional</sup> <a name="clientCertificatePassword" id="cdktf.AzurermBackendProps.property.clientCertificatePassword"></a>
+
+```typescript
+public readonly clientCertificatePassword: string;
+```
+
+- _Type:_ string
+
+(Optional) The password associated with the Client Certificate specified in client_certificate_path.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PASSWORD environment variable.
+
+---
+
+##### `clientCertificatePath`<sup>Optional</sup> <a name="clientCertificatePath" id="cdktf.AzurermBackendProps.property.clientCertificatePath"></a>
+
+```typescript
+public readonly clientCertificatePath: string;
+```
+
+- _Type:_ string
+
+(Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PATH environment variable.
 
 ---
 
@@ -12794,6 +12832,37 @@ This can also be sourced from the ARM_MSI_ENDPOINT environment variable.
 
 ---
 
+##### `oidcRequestToken`<sup>Optional</sup> <a name="oidcRequestToken" id="cdktf.AzurermBackendProps.property.oidcRequestToken"></a>
+
+```typescript
+public readonly oidcRequestToken: string;
+```
+
+- _Type:_ string
+
+(Optional) The bearer token for the request to the OIDC provider.
+
+This can
+also be sourced from the ARM_OIDC_REQUEST_TOKEN or
+ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variables.
+
+---
+
+##### `oidcRequestUrl`<sup>Optional</sup> <a name="oidcRequestUrl" id="cdktf.AzurermBackendProps.property.oidcRequestUrl"></a>
+
+```typescript
+public readonly oidcRequestUrl: string;
+```
+
+- _Type:_ string
+
+(Optional) The URL for the OIDC provider from which to request an ID token.
+
+This can also be sourced from the ARM_OIDC_REQUEST_URL or
+ACTIONS_ID_TOKEN_REQUEST_URL environment variables.
+
+---
+
 ##### `resourceGroupName`<sup>Optional</sup> <a name="resourceGroupName" id="cdktf.AzurermBackendProps.property.resourceGroupName"></a>
 
 ```typescript
@@ -12817,6 +12886,21 @@ public readonly sasToken: string;
 (Optional) The SAS Token used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_SAS_TOKEN environment variable.
+
+---
+
+##### `snapshot`<sup>Optional</sup> <a name="snapshot" id="cdktf.AzurermBackendProps.property.snapshot"></a>
+
+```typescript
+public readonly snapshot: boolean;
+```
+
+- _Type:_ boolean
+
+(Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?
+
+Defaults to false. This value can also be sourced
+from the ARM_SNAPSHOT environment variable.
 
 ---
 
@@ -12848,6 +12932,44 @@ This can also be sourced from the ARM_TENANT_ID environment variable.
 
 ---
 
+##### `useAzureadAuth`<sup>Optional</sup> <a name="useAzureadAuth" id="cdktf.AzurermBackendProps.property.useAzureadAuth"></a>
+
+```typescript
+public readonly useAzureadAuth: boolean;
+```
+
+- _Type:_ boolean
+
+(Optional) Should AzureAD Authentication be used to access the Blob Storage Account.
+
+This can also be sourced from the ARM_USE_AZUREAD environment
+variable.
+
+Note: When using AzureAD for Authentication to Storage you also need to
+ensure the Storage Blob Data Owner role is assigned.
+
+---
+
+##### `useMicrosoftGraph`<sup>Optional</sup> <a name="useMicrosoftGraph" id="cdktf.AzurermBackendProps.property.useMicrosoftGraph"></a>
+
+```typescript
+public readonly useMicrosoftGraph: boolean;
+```
+
+- _Type:_ boolean
+
+(Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph?
+
+Defaults to true.
+
+Note: In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph)
+rather than ADAL (and Azure Active Directory Graph) for authentication by
+default - you can disable this by setting use_microsoft_graph to false.
+This setting will be removed in Terraform 1.3, due to Microsoft's
+deprecation of ADAL.
+
+---
+
 ##### `useMsi`<sup>Optional</sup> <a name="useMsi" id="cdktf.AzurermBackendProps.property.useMsi"></a>
 
 ```typescript
@@ -12859,6 +12981,21 @@ public readonly useMsi: boolean;
 (Optional) Should Managed Service Identity authentication be used?
 
 This can also be sourced from the ARM_USE_MSI environment variable.
+
+---
+
+##### `useOidc`<sup>Optional</sup> <a name="useOidc" id="cdktf.AzurermBackendProps.property.useOidc"></a>
+
+```typescript
+public readonly useOidc: boolean;
+```
+
+- _Type:_ boolean
+
+(Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.
+
+Note: When using OIDC for authentication, use_microsoft_graph
+must be set to true (which is the default).
 
 ---
 
@@ -13380,24 +13517,32 @@ const dataTerraformRemoteStateAzurermConfig: DataTerraformRemoteStateAzurermConf
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                                               | **Type**                            | **Description**                                                                                                                 |
-| ---------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.defaults">defaults</a></code>                     | <code>{[ key: string ]: any}</code> | _No description._                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.workspace">workspace</a></code>                   | <code>string</code>                 | _No description._                                                                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.containerName">containerName</a></code>           | <code>string</code>                 | (Required) The Name of the Storage Container within the Storage Account.                                                        |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.key">key</a></code>                               | <code>string</code>                 | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.storageAccountName">storageAccountName</a></code> | <code>string</code>                 | (Required) The Name of the Storage Account.                                                                                     |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.accessKey">accessKey</a></code>                   | <code>string</code>                 | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                 |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientId">clientId</a></code>                     | <code>string</code>                 | (Optional) The Client ID of the Service Principal.                                                                              |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientSecret">clientSecret</a></code>             | <code>string</code>                 | (Optional) The Client Secret of the Service Principal.                                                                          |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.endpoint">endpoint</a></code>                     | <code>string</code>                 | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable. |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.environment">environment</a></code>               | <code>string</code>                 | (Optional) The Azure Environment which should be used.                                                                          |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.msiEndpoint">msiEndpoint</a></code>               | <code>string</code>                 | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.           |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.resourceGroupName">resourceGroupName</a></code>   | <code>string</code>                 | (Required) The Name of the Resource Group in which the Storage Account exists.                                                  |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.sasToken">sasToken</a></code>                     | <code>string</code>                 | (Optional) The SAS Token used to access the Blob Storage Account.                                                               |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.subscriptionId">subscriptionId</a></code>         | <code>string</code>                 | (Optional) The Subscription ID in which the Storage Account exists.                                                             |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.tenantId">tenantId</a></code>                     | <code>string</code>                 | (Optional) The Tenant ID in which the Subscription exists.                                                                      |
-| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useMsi">useMsi</a></code>                         | <code>boolean</code>                | (Optional) Should Managed Service Identity authentication be used?                                                              |
+| **Name**                                                                                                                             | **Type**                            | **Description**                                                                                                                                |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.defaults">defaults</a></code>                                   | <code>{[ key: string ]: any}</code> | _No description._                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.workspace">workspace</a></code>                                 | <code>string</code>                 | _No description._                                                                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.containerName">containerName</a></code>                         | <code>string</code>                 | (Required) The Name of the Storage Container within the Storage Account.                                                                       |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.key">key</a></code>                                             | <code>string</code>                 | (Required) The name of the Blob used to retrieve/store Terraform's State file inside the Storage Container.                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.storageAccountName">storageAccountName</a></code>               | <code>string</code>                 | (Required) The Name of the Storage Account.                                                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.accessKey">accessKey</a></code>                                 | <code>string</code>                 | access_key - (Optional) The Access Key used to access the Blob Storage Account.                                                                |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientCertificatePassword">clientCertificatePassword</a></code> | <code>string</code>                 | (Optional) The password associated with the Client Certificate specified in client_certificate_path.                                           |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientCertificatePath">clientCertificatePath</a></code>         | <code>string</code>                 | (Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.                                 |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientId">clientId</a></code>                                   | <code>string</code>                 | (Optional) The Client ID of the Service Principal.                                                                                             |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.clientSecret">clientSecret</a></code>                           | <code>string</code>                 | (Optional) The Client Secret of the Service Principal.                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.endpoint">endpoint</a></code>                                   | <code>string</code>                 | (Optional) The Custom Endpoint for Azure Resource Manager. This can also be sourced from the ARM_ENDPOINT environment variable.                |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.environment">environment</a></code>                             | <code>string</code>                 | (Optional) The Azure Environment which should be used.                                                                                         |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.msiEndpoint">msiEndpoint</a></code>                             | <code>string</code>                 | (Optional) The path to a custom Managed Service Identity endpoint which is automatically determined if not specified.                          |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.oidcRequestToken">oidcRequestToken</a></code>                   | <code>string</code>                 | (Optional) The bearer token for the request to the OIDC provider.                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.oidcRequestUrl">oidcRequestUrl</a></code>                       | <code>string</code>                 | (Optional) The URL for the OIDC provider from which to request an ID token.                                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.resourceGroupName">resourceGroupName</a></code>                 | <code>string</code>                 | (Required) The Name of the Resource Group in which the Storage Account exists.                                                                 |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.sasToken">sasToken</a></code>                                   | <code>string</code>                 | (Optional) The SAS Token used to access the Blob Storage Account.                                                                              |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.snapshot">snapshot</a></code>                                   | <code>boolean</code>                | (Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?                                                    |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.subscriptionId">subscriptionId</a></code>                       | <code>string</code>                 | (Optional) The Subscription ID in which the Storage Account exists.                                                                            |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.tenantId">tenantId</a></code>                                   | <code>string</code>                 | (Optional) The Tenant ID in which the Subscription exists.                                                                                     |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useAzureadAuth">useAzureadAuth</a></code>                       | <code>boolean</code>                | (Optional) Should AzureAD Authentication be used to access the Blob Storage Account.                                                           |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useMicrosoftGraph">useMicrosoftGraph</a></code>                 | <code>boolean</code>                | (Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph? |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useMsi">useMsi</a></code>                                       | <code>boolean</code>                | (Optional) Should Managed Service Identity authentication be used?                                                                             |
+| <code><a href="#cdktf.DataTerraformRemoteStateAzurermConfig.property.useOidc">useOidc</a></code>                                     | <code>boolean</code>                | (Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.                            |
 
 ---
 
@@ -13468,6 +13613,36 @@ public readonly accessKey: string;
 access_key - (Optional) The Access Key used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_ACCESS_KEY environment variable.
+
+---
+
+##### `clientCertificatePassword`<sup>Optional</sup> <a name="clientCertificatePassword" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.clientCertificatePassword"></a>
+
+```typescript
+public readonly clientCertificatePassword: string;
+```
+
+- _Type:_ string
+
+(Optional) The password associated with the Client Certificate specified in client_certificate_path.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PASSWORD environment variable.
+
+---
+
+##### `clientCertificatePath`<sup>Optional</sup> <a name="clientCertificatePath" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.clientCertificatePath"></a>
+
+```typescript
+public readonly clientCertificatePath: string;
+```
+
+- _Type:_ string
+
+(Optional) The path to the PFX file used as the Client Certificate when authenticating as a Service Principal.
+
+This can also be sourced from the
+ARM_CLIENT_CERTIFICATE_PATH environment variable.
 
 ---
 
@@ -13542,6 +13717,37 @@ This can also be sourced from the ARM_MSI_ENDPOINT environment variable.
 
 ---
 
+##### `oidcRequestToken`<sup>Optional</sup> <a name="oidcRequestToken" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.oidcRequestToken"></a>
+
+```typescript
+public readonly oidcRequestToken: string;
+```
+
+- _Type:_ string
+
+(Optional) The bearer token for the request to the OIDC provider.
+
+This can
+also be sourced from the ARM_OIDC_REQUEST_TOKEN or
+ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variables.
+
+---
+
+##### `oidcRequestUrl`<sup>Optional</sup> <a name="oidcRequestUrl" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.oidcRequestUrl"></a>
+
+```typescript
+public readonly oidcRequestUrl: string;
+```
+
+- _Type:_ string
+
+(Optional) The URL for the OIDC provider from which to request an ID token.
+
+This can also be sourced from the ARM_OIDC_REQUEST_URL or
+ACTIONS_ID_TOKEN_REQUEST_URL environment variables.
+
+---
+
 ##### `resourceGroupName`<sup>Optional</sup> <a name="resourceGroupName" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.resourceGroupName"></a>
 
 ```typescript
@@ -13565,6 +13771,21 @@ public readonly sasToken: string;
 (Optional) The SAS Token used to access the Blob Storage Account.
 
 This can also be sourced from the ARM_SAS_TOKEN environment variable.
+
+---
+
+##### `snapshot`<sup>Optional</sup> <a name="snapshot" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.snapshot"></a>
+
+```typescript
+public readonly snapshot: boolean;
+```
+
+- _Type:_ boolean
+
+(Optional) Should the Blob used to store the Terraform Statefile be snapshotted before use?
+
+Defaults to false. This value can also be sourced
+from the ARM_SNAPSHOT environment variable.
 
 ---
 
@@ -13596,6 +13817,44 @@ This can also be sourced from the ARM_TENANT_ID environment variable.
 
 ---
 
+##### `useAzureadAuth`<sup>Optional</sup> <a name="useAzureadAuth" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.useAzureadAuth"></a>
+
+```typescript
+public readonly useAzureadAuth: boolean;
+```
+
+- _Type:_ boolean
+
+(Optional) Should AzureAD Authentication be used to access the Blob Storage Account.
+
+This can also be sourced from the ARM_USE_AZUREAD environment
+variable.
+
+Note: When using AzureAD for Authentication to Storage you also need to
+ensure the Storage Blob Data Owner role is assigned.
+
+---
+
+##### `useMicrosoftGraph`<sup>Optional</sup> <a name="useMicrosoftGraph" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.useMicrosoftGraph"></a>
+
+```typescript
+public readonly useMicrosoftGraph: boolean;
+```
+
+- _Type:_ boolean
+
+(Optional) Should MSAL be used for authentication instead of ADAL, and should Microsoft Graph be used instead of Azure Active Directory Graph?
+
+Defaults to true.
+
+Note: In Terraform 1.2 the Azure Backend uses MSAL (and Microsoft Graph)
+rather than ADAL (and Azure Active Directory Graph) for authentication by
+default - you can disable this by setting use_microsoft_graph to false.
+This setting will be removed in Terraform 1.3, due to Microsoft's
+deprecation of ADAL.
+
+---
+
 ##### `useMsi`<sup>Optional</sup> <a name="useMsi" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.useMsi"></a>
 
 ```typescript
@@ -13607,6 +13866,21 @@ public readonly useMsi: boolean;
 (Optional) Should Managed Service Identity authentication be used?
 
 This can also be sourced from the ARM_USE_MSI environment variable.
+
+---
+
+##### `useOidc`<sup>Optional</sup> <a name="useOidc" id="cdktf.DataTerraformRemoteStateAzurermConfig.property.useOidc"></a>
+
+```typescript
+public readonly useOidc: boolean;
+```
+
+- _Type:_ boolean
+
+(Optional) Should OIDC authentication be used? This can also be sourced from the ARM_USE_OIDC environment variable.
+
+Note: When using OIDC for authentication, use_microsoft_graph
+must be set to true (which is the default).
 
 ---
 


### PR DESCRIPTION
Newly added: snapshot, clientCertificatePassword, clientCertificatePath, useMicrosoftGraph, oidcRequestUrl, oidcRequestToken, useOidc, useAzureadAuth

Resolves #2126
