### PR TITLE
chore(cli): Use the npm package's repository field for generating go package name

### DIFF
--- a/packages/cdktf-cli/lib/dependencies/dependency-manager.ts
+++ b/packages/cdktf-cli/lib/dependencies/dependency-manager.ts
@@ -9,6 +9,7 @@ import { CdktfConfigManager } from "./cdktf-config-manager";
 import { PackageManager } from "./package-manager";
 import {
   getNpmPackageName,
+  getPrebuiltProviderRepositoryName,
   getPrebuiltProviderVersion,
 } from "./prebuilt-providers";
 import { getLatestVersion } from "./registry-api";
@@ -197,7 +198,6 @@ export class DependencyManager {
       );
     }
 
-    const packageName = this.convertPackageName(npmPackageName);
     const prebuiltProviderVersion = await getPrebuiltProviderVersion(
       constraint,
       this.cdktfVersion
@@ -209,6 +209,13 @@ export class DependencyManager {
     }
 
     const packageVersion = prebuiltProviderVersion;
+    const prebuiltProviderRepository = await getPrebuiltProviderRepositoryName(
+      npmPackageName
+    );
+    const packageName = this.convertPackageName(
+      npmPackageName,
+      prebuiltProviderRepository
+    );
 
     await this.packageManager.addPackage(packageName, packageVersion);
 
@@ -241,10 +248,14 @@ export class DependencyManager {
   /**
    * Converts an NPM package name of a pre-built provider package to the name in the target language
    */
-  private convertPackageName(name: string): string {
+  private convertPackageName(name: string, repository: string): string {
     const providerName = name.replace("@cdktf/provider-", "");
     switch (this.targetLanguage) {
       case Language.GO: // e.g. github.com/hashicorp/cdktf-provider-opentelekomcloud-go/opentelekomcloud
+        if (repository) {
+          return `${repository}-go/${providerName}`;
+        }
+
         return `github.com/hashicorp/cdktf-provider-${providerName}-go/${providerName}`;
       case Language.TYPESCRIPT: // e.g. @cdktf/provider-random
         return name; // already the correct name

--- a/packages/cdktf-cli/lib/dependencies/dependency-manager.ts
+++ b/packages/cdktf-cli/lib/dependencies/dependency-manager.ts
@@ -251,12 +251,12 @@ export class DependencyManager {
   private convertPackageName(name: string, repository: string): string {
     const providerName = name.replace("@cdktf/provider-", "");
     switch (this.targetLanguage) {
-      case Language.GO: // e.g. github.com/hashicorp/cdktf-provider-opentelekomcloud-go/opentelekomcloud
+      case Language.GO: // e.g. github.com/cdktf/cdktf-provider-opentelekomcloud-go/opentelekomcloud
         if (repository) {
           return `${repository}-go/${providerName}`;
         }
 
-        return `github.com/hashicorp/cdktf-provider-${providerName}-go/${providerName}`;
+        return `github.com/cdktf/cdktf-provider-${providerName}-go/${providerName}`;
       case Language.TYPESCRIPT: // e.g. @cdktf/provider-random
         return name; // already the correct name
       case Language.CSHARP: // e.g. HashiCorp.Cdktf.Providers.Opentelekomcloud

--- a/packages/cdktf-cli/lib/dependencies/prebuilt-providers.ts
+++ b/packages/cdktf-cli/lib/dependencies/prebuilt-providers.ts
@@ -80,7 +80,7 @@ type PrebuiltProviderVersion = {
   cdktfPeerDependencyConstraint: string; // e.g. "^10.0.0"
 };
 
-export async function getPrebuiltProviderVersions(
+export async function getAllPrebuiltProviderVersions(
   packageName: string
 ): Promise<PrebuiltProviderVersion[]> {
   const url = `https://registry.npmjs.org/${packageName}`;
@@ -141,7 +141,7 @@ export async function getPrebuiltProviderVersion(
     return null;
   }
 
-  const versions = await getPrebuiltProviderVersions(providerName);
+  const versions = await getAllPrebuiltProviderVersions(providerName);
 
   // find first the version that matches the requested provider version and cdktf version
   const matchingVersion = versions.find((v) => {

--- a/packages/cdktf-cli/lib/dependencies/prebuilt-providers.ts
+++ b/packages/cdktf-cli/lib/dependencies/prebuilt-providers.ts
@@ -79,7 +79,8 @@ type PrebuiltProviderVersion = {
   providerVersion: string; // e.g. "4.12.1"
   cdktfPeerDependencyConstraint: string; // e.g. "^10.0.0"
 };
-async function getPrebuiltProviderVersions(
+
+export async function getPrebuiltProviderVersions(
   packageName: string
 ): Promise<PrebuiltProviderVersion[]> {
   const url = `https://registry.npmjs.org/${packageName}`;

--- a/packages/cdktf-cli/test/lib/dependencies/prebuilt-providers.test.ts
+++ b/packages/cdktf-cli/test/lib/dependencies/prebuilt-providers.test.ts
@@ -48,7 +48,7 @@ describe("network issues", () => {
 
       await expect(
         getAllPrebuiltProviderVersions("@cdktf/test")
-      ).rejects.toThrowError(/failed, reason:/);
+      ).rejects.toThrowError("Connection error");
     });
 
     it("succeeds when package found", async () => {
@@ -122,7 +122,7 @@ describe("network issues", () => {
           ProviderConstraint.fromConfigEntry("test"),
           "0.12.2"
         )
-      ).rejects.toThrowError(/@cdktf\/provider-test failed, reason/);
+      ).rejects.toThrowError("Connection error");
     });
 
     it("succeeds when both github and npm work", async () => {

--- a/packages/cdktf-cli/test/lib/dependencies/prebuilt-providers.test.ts
+++ b/packages/cdktf-cli/test/lib/dependencies/prebuilt-providers.test.ts
@@ -5,7 +5,7 @@ import { ProviderConstraint } from "../../../lib/dependencies/dependency-manager
 import {
   getNpmPackageName,
   getPrebuiltProviderVersion,
-  getPrebuiltProviderVersions,
+  getAllPrebuiltProviderVersions,
 } from "../../../lib/dependencies/prebuilt-providers";
 
 function buildNpmResponse(
@@ -47,7 +47,7 @@ describe("network issues", () => {
         .replyWithError({ code: "ETIMEDOUT" });
 
       await expect(
-        getPrebuiltProviderVersions("@cdktf/test")
+        getAllPrebuiltProviderVersions("@cdktf/test")
       ).rejects.toThrowError(/failed, reason:/);
     });
 
@@ -56,7 +56,9 @@ describe("network issues", () => {
         .get(new RegExp("/@cdktf/.*"))
         .reply(200, buildNpmResponse("2.3.0"));
 
-      await expect(getPrebuiltProviderVersions("@cdktf/test")).resolves.toEqual(
+      await expect(
+        getAllPrebuiltProviderVersions("@cdktf/test")
+      ).resolves.toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             packageVersion: "2.3.0",

--- a/packages/cdktf-cli/test/lib/dependencies/prebuilt-providers.test.ts
+++ b/packages/cdktf-cli/test/lib/dependencies/prebuilt-providers.test.ts
@@ -1,0 +1,144 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import nock from "nock";
+import { ProviderConstraint } from "../../../lib/dependencies/dependency-manager";
+import {
+  getNpmPackageName,
+  getPrebuiltProviderVersion,
+  getPrebuiltProviderVersions,
+} from "../../../lib/dependencies/prebuilt-providers";
+
+function buildNpmResponse(
+  version = "0.0.0",
+  name = "test",
+  cdktfVersion = "^0.12.2"
+): any {
+  return {
+    versions: {
+      [version]: {
+        cdktf: {
+          provider: {
+            name: `registry.terraform.io/hashicorp/${name}`,
+            version: "0.3.1",
+          },
+        },
+        peerDependencies: {
+          cdktf: cdktfVersion,
+        },
+      },
+    },
+  };
+}
+
+describe("network issues", () => {
+  beforeAll(() => {
+    nock.disableNetConnect();
+  });
+
+  afterAll(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
+  });
+
+  describe("getPrebuiltProviderVersions", () => {
+    it("fails when connection error", async () => {
+      nock("https://registry.npmjs.org/")
+        .get(new RegExp("/@cdktf/.*"))
+        .replyWithError({ code: "ETIMEDOUT" });
+
+      await expect(
+        getPrebuiltProviderVersions("@cdktf/test")
+      ).rejects.toThrowError(/failed, reason:/);
+    });
+
+    it("succeeds when package found", async () => {
+      nock("https://registry.npmjs.org/")
+        .get(new RegExp("/@cdktf/.*"))
+        .reply(200, buildNpmResponse("2.3.0"));
+
+      await expect(getPrebuiltProviderVersions("@cdktf/test")).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            packageVersion: "2.3.0",
+          }),
+        ])
+      );
+    });
+  });
+
+  describe("getNpmPackageName", () => {
+    it("fails when connection error", async () => {
+      nock("https://raw.githubusercontent.com/")
+        .get("/hashicorp/cdktf-repository-manager/main/provider.json")
+        .replyWithError({ code: "ETIMEDOUT" });
+
+      await expect(
+        getNpmPackageName(ProviderConstraint.fromConfigEntry("test"))
+      ).rejects.toThrowError(/failed, reason:/);
+    });
+
+    it("succeeds when connection works", async () => {
+      nock("https://raw.githubusercontent.com/")
+        .get("/hashicorp/cdktf-repository-manager/main/provider.json")
+        .reply(200, {
+          test: "hashicorp/test@~> 0.3.3",
+        });
+
+      await expect(
+        getNpmPackageName(ProviderConstraint.fromConfigEntry("test"))
+      ).resolves.toEqual("@cdktf/provider-test");
+    });
+  });
+
+  describe("getPrebuiltProviderVersion", () => {
+    it("returns null on connection error with github", async () => {
+      nock("https://raw.githubusercontent.com/")
+        .get("/hashicorp/cdktf-repository-manager/main/provider.json")
+        .replyWithError({ code: "ETIMEDOUT" });
+
+      await expect(
+        getPrebuiltProviderVersion(
+          ProviderConstraint.fromConfigEntry("test"),
+          "0.12.2"
+        )
+      ).rejects.toThrowError(/provider.json failed, reason:/);
+    });
+
+    it("returns null on connection error with npm", async () => {
+      nock("https://raw.githubusercontent.com/")
+        .get("/hashicorp/cdktf-repository-manager/main/provider.json")
+        .reply(200, {
+          test: "hashicorp/test@~> 0.3.3",
+        });
+
+      nock("https://registry.npmjs.org/")
+        .get(new RegExp("/@cdktf/.*"))
+        .replyWithError({ code: "ETIMEDOUT" });
+
+      await expect(
+        getPrebuiltProviderVersion(
+          ProviderConstraint.fromConfigEntry("test"),
+          "0.12.2"
+        )
+      ).rejects.toThrowError(/@cdktf\/provider-test failed, reason/);
+    });
+
+    it("succeeds when both github and npm work", async () => {
+      nock("https://raw.githubusercontent.com/")
+        .get("/hashicorp/cdktf-repository-manager/main/provider.json")
+        .reply(200, {
+          test: "hashicorp/test@~> 0.3.3",
+        });
+      nock("https://registry.npmjs.org/")
+        .get(new RegExp("/@cdktf/.*"))
+        .reply(200, buildNpmResponse("2.3.0"));
+
+      await expect(
+        getPrebuiltProviderVersion(
+          ProviderConstraint.fromConfigEntry("test"),
+          "0.12.2"
+        )
+      ).resolves.toEqual("2.3.0");
+    });
+  });
+});


### PR DESCRIPTION
Related to the move of our pre-built providers to the `cdktf` github organization.
Also fixes https://github.com/hashicorp/terraform-cdk/issues/1815

The core intention of the PR is to use some of the information published by projen on the pre-built provider's package.json, especially the 'repository' field, to generate the package module path for Go. This will prevent `cdktf provider add` to be broken as we move the providers to the `cdktf` organization.