### PR TITLE
fix: Prevent any release jobs from triggering if no release is required

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
     outputs:
       tests: ${{ steps.build-test-matrix.outputs.tests }}
       version: ${{ steps.get_version.outputs.version }}
+      release_status: ${{ steps.get_release_status.outputs.release }}
     container:
       image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     env:
@@ -82,6 +83,7 @@ jobs:
   integration_test:
     needs:
       - prepare-release
+    if: jobs.prepare-release.outputs.release_status == 'unreleased'
     uses: ./.github/workflows/integration.yml
     with:
       skip_setup: true
@@ -102,6 +104,7 @@ jobs:
 
   unit_test:
     uses: ./.github/workflows/unit.yml
+    if: jobs.prepare-release.outputs.release_status == 'unreleased'
     strategy:
       fail-fast: false
       matrix:
@@ -124,6 +127,7 @@ jobs:
 
   release_github:
     name: Release to Github
+    if: jobs.prepare-release.outputs.release_status == 'unreleased'
     needs:
       - prepare-release
       - integration_test
@@ -152,6 +156,7 @@ jobs:
       - integration_test
       - unit_test
     runs-on: ubuntu-latest
+    if: jobs.prepare-release.outputs.release_status == 'unreleased'
     container:
       image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     steps:
@@ -171,6 +176,7 @@ jobs:
       - integration_test
       - unit_test
     runs-on: ubuntu-latest
+    if: jobs.prepare-release.outputs.release_status == 'unreleased'
     container:
       image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     steps:
@@ -191,6 +197,7 @@ jobs:
       - integration_test
       - unit_test
     runs-on: ubuntu-latest
+    if: jobs.prepare-release.outputs.release_status == 'unreleased'
     container:
       image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     steps:
@@ -216,6 +223,7 @@ jobs:
       - integration_test
       - unit_test
     runs-on: ubuntu-latest
+    if: jobs.prepare-release.outputs.release_status == 'unreleased'
     container:
       image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     steps:
@@ -236,6 +244,7 @@ jobs:
       - integration_test
       - unit_test
     runs-on: ubuntu-latest
+    if: jobs.prepare-release.outputs.release_status == 'unreleased'
     container:
       image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     steps:
@@ -258,6 +267,7 @@ jobs:
       - integration_test
       - unit_test
     runs-on: ubuntu-latest
+    if: jobs.prepare-release.outputs.release_status == 'unreleased'
     container:
       image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     steps:
@@ -283,8 +293,7 @@ jobs:
 
   release_homebrew:
     name: Release to Homebrew
-    # The branch or tag ref that triggered the workflow run.
-    if: startsWith(github.event.head_commit.message, 'Bump version')
+    if: jobs.prepare-release.outputs.release_status == 'unreleased'
     needs: release_npm
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -291,6 +291,20 @@ Most of our tests are automated but there are some workflows we need to manually
 - Update the learn examples and the end to end examples
 - Check if there are PRs left behind on our [triage board](https://github.com/orgs/hashicorp/projects/125/views/4)
 
+#### Retrying a broken deployment
+
+The release workflow uses sentry as the source of truth for releases. The downside of that, however, is that if the release is broken at some point and a new release is required, it will not be possible to run the release workflow. In order to work around that, the sentry release needs to be reverted.
+
+```sh
+# Install Sentry CLI and login
+npm i -g @sentry/cli
+sentry-cli login
+# List all releases (optional)
+sentry-cli releases list --org hashicorp
+# Delete the release, Note: there will be no confirmation for deleting the release!
+sentry-cli releases delete --org hashicorp <release> # e.g. cdktf-cli-0.14.0
+```
+
 ### Repositories to update
 
 - [Docker E2E](https://github.com/hashicorp/docker-on-aws-ecs-with-terraform-cdk-using-typescript)


### PR DESCRIPTION
This updates the `release` workflow, to:

- Short-circuit the workflow is no new release needs to be made
- Enable publishing version to homebrew when new release is made