### PR TITLE
fix(cli): handle missing package versions for non-npm packages

### DIFF
--- a/packages/cdktf-cli/lib/dependencies/dependency-manager.ts
+++ b/packages/cdktf-cli/lib/dependencies/dependency-manager.ts
@@ -248,7 +248,7 @@ export class DependencyManager {
 
     for (const version of prebuiltProviderNpmVersions) {
       try {
-        const isAvailable = await this.packageManager.isVersionAvailable(
+        const isAvailable = await this.packageManager.isNpmVersionAvailable(
           packageName,
           version
         );

--- a/packages/cdktf-cli/lib/dependencies/package-manager.ts
+++ b/packages/cdktf-cli/lib/dependencies/package-manager.ts
@@ -171,14 +171,18 @@ class PythonPackageManager extends PackageManager {
     packageName: string,
     packageVersion: string
   ): Promise<boolean> {
-    logger.debug(`Checking if ${packageName}@${packageVersion} is available for Python`);
+    logger.debug(
+      `Checking if ${packageName}@${packageVersion} is available for Python`
+    );
     const url = `https://pypi.org/pypi/${packageName}/${packageVersion}/json`;
     logger.debug(`Fetching package information for ${packageName} from ${url}`);
 
     const response = await fetch(url);
     const json = await response.json();
     logger.debug(
-      `Got response from PyPI for ${packageName}@${packageVersion}: ${JSON.stringify(json)}`
+      `Got response from PyPI for ${packageName}@${packageVersion}: ${JSON.stringify(
+        json
+      )}`
     );
 
     if (json.info) {
@@ -221,7 +225,7 @@ class NugetPackageManager extends PackageManager {
     logger.debug(`Checking if ${packageName}@${packageVersion} is available`);
 
     const [owner, ...rest] = packageName.split(".");
-    const id = rest.join(".");
+    const id = rest[rest.length - 1];
     const url = `https://azuresearch-usnc.nuget.org/query?q=owner:${owner}%20id:${id}&prerelease=false&semVerLevel=2.0.0`;
     logger.debug(`Fetching package metadata from Nuget: '${url}'`);
 
@@ -237,7 +241,8 @@ class NugetPackageManager extends PackageManager {
       return false; // No package found
     }
 
-    const packageVersions = json.data.find((p) => p.id === id)?.versions ?? [];
+    const packageVersions =
+      json.data.find((p) => p.id === packageName)?.versions ?? [];
 
     if (!packageVersions.length) {
       return false; // No package release matching the id found

--- a/packages/cdktf-cli/lib/dependencies/package-manager.ts
+++ b/packages/cdktf-cli/lib/dependencies/package-manager.ts
@@ -171,14 +171,14 @@ class PythonPackageManager extends PackageManager {
     packageName: string,
     packageVersion: string
   ): Promise<boolean> {
-    logger.debug(`Checking if ${packageName}@${packageVersion} is available`);
+    logger.debug(`Checking if ${packageName}@${packageVersion} is available for Python`);
     const url = `https://pypi.org/pypi/${packageName}/${packageVersion}/json`;
     logger.debug(`Fetching package information for ${packageName} from ${url}`);
 
     const response = await fetch(url);
     const json = await response.json();
     logger.debug(
-      `Got response fron Pypi for ${packageName}: ${JSON.stringify(json)}`
+      `Got response from PyPI for ${packageName}@${packageVersion}: ${JSON.stringify(json)}`
     );
 
     if (json.info) {
@@ -186,7 +186,7 @@ class PythonPackageManager extends PackageManager {
       return true;
     } else {
       logger.debug(
-        `Could not get pypi package info, got: ${JSON.stringify(json)}`
+        `Could not get PyPI package info, got: ${JSON.stringify(json)}`
       );
       return false;
     }
@@ -220,9 +220,8 @@ class NugetPackageManager extends PackageManager {
   ): Promise<boolean> {
     logger.debug(`Checking if ${packageName}@${packageVersion} is available`);
 
-    const parts = packageName.split(".");
-    const owner = parts[0];
-    const id = parts.slice(1).join(".");
+    const [owner, ...rest] = packageName.split(".");
+    const id = rest.join(".");
     const url = `https://azuresearch-usnc.nuget.org/query?q=owner:${owner}%20id:${id}&prerelease=false&semVerLevel=2.0.0`;
     logger.debug(`Fetching package metadata from Nuget: '${url}'`);
 
@@ -231,7 +230,7 @@ class NugetPackageManager extends PackageManager {
       data: { id: string; versions: { version: string }[] }[];
     };
     logger.debug(
-      `Got response from Nuget for ${packageName} : ${JSON.stringify(json)}`
+      `Got response from NuGet for ${packageName} : ${JSON.stringify(json)}`
     );
 
     if (!json?.data?.length) {
@@ -309,13 +308,13 @@ class MavenPackageManager extends PackageManager {
 
     const url = `https://search.maven.org/solrsearch/select?q=g:${groupId}+AND+a:${packageIdentifier}+AND+v:${packageVersion}&rows=5&wt=json`;
     logger.debug(
-      `Trying to find package version by querying maven central under '${url}'`
+      `Trying to find package version by querying Maven Central under '${url}'`
     );
     const response = await fetch(url);
 
     const json = await response.json();
     logger.debug(
-      `Got response from the maven package search for ${packageName}: ${JSON.stringify(
+      `Got response from the Maven package search for ${packageName}: ${JSON.stringify(
         json
       )}`
     );

--- a/packages/cdktf-cli/lib/dependencies/package-manager.ts
+++ b/packages/cdktf-cli/lib/dependencies/package-manager.ts
@@ -46,7 +46,7 @@ export abstract class PackageManager {
   // public abstract listPackages(): Promise<todo>; future stuff..
   // add check if package exists already. might query version in the future and offer to upgrade?
 
-  public abstract isVersionAvailable(
+  public abstract isNpmVersionAvailable(
     packageName: string,
     packageVersion: string
   ): Promise<boolean>;
@@ -84,7 +84,7 @@ class NodePackageManager extends PackageManager {
     console.log("Package installed.");
   }
 
-  public async isVersionAvailable(
+  public async isNpmVersionAvailable(
     _packageName: string,
     _packageVersion: string
   ): Promise<boolean> {
@@ -167,7 +167,7 @@ class PythonPackageManager extends PackageManager {
     }
   }
 
-  public async isVersionAvailable(
+  public async isNpmVersionAvailable(
     packageName: string,
     packageVersion: string
   ): Promise<boolean> {
@@ -214,7 +214,7 @@ class NugetPackageManager extends PackageManager {
     console.log("Package installed.");
   }
 
-  public async isVersionAvailable(
+  public async isNpmVersionAvailable(
     packageName: string,
     packageVersion: string
   ): Promise<boolean> {
@@ -291,7 +291,7 @@ class MavenPackageManager extends PackageManager {
     console.log("Package installed.");
   }
 
-  public async isVersionAvailable(
+  public async isNpmVersionAvailable(
     packageName: string,
     packageVersion: string
   ): Promise<boolean> {
@@ -352,7 +352,7 @@ class GoPackageManager extends PackageManager {
     console.log("Package installed.");
   }
 
-  public async isVersionAvailable(
+  public async isNpmVersionAvailable(
     packageName: string,
     packageVersion: string
   ): Promise<boolean> {

--- a/packages/cdktf-cli/lib/dependencies/package-manager.ts
+++ b/packages/cdktf-cli/lib/dependencies/package-manager.ts
@@ -8,6 +8,8 @@ import { xml2js, js2xml, Element } from "xml-js";
 import { Errors } from "../errors";
 import * as fs from "fs-extra";
 import * as semver from "semver";
+import fetch from "node-fetch";
+import { logger } from "../logging";
 
 /**
  * manages installing, updating, and removing dependencies
@@ -43,6 +45,11 @@ export abstract class PackageManager {
   ): Promise<void>;
   // public abstract listPackages(): Promise<todo>; future stuff..
   // add check if package exists already. might query version in the future and offer to upgrade?
+
+  public abstract isVersionAvailable(
+    packageName: string,
+    packageVersion: string
+  ): Promise<boolean>;
 }
 
 class NodePackageManager extends PackageManager {
@@ -75,6 +82,14 @@ class NodePackageManager extends PackageManager {
     await exec(command, args, { cwd: this.workingDirectory });
 
     console.log("Package installed.");
+  }
+
+  public async isVersionAvailable(
+    _packageName: string,
+    _packageVersion: string
+  ): Promise<boolean> {
+    // We get the list of available versions from npm, no need to check here
+    return true;
   }
 }
 
@@ -151,6 +166,31 @@ class PythonPackageManager extends PackageManager {
       console.log("Package installed.");
     }
   }
+
+  public async isVersionAvailable(
+    packageName: string,
+    packageVersion: string
+  ): Promise<boolean> {
+    logger.debug(`Checking if ${packageName}@${packageVersion} is available`);
+    const url = `https://pypi.org/pypi/${packageName}/${packageVersion}/json`;
+    logger.debug(`Fetching package information for ${packageName} from ${url}`);
+
+    const response = await fetch(url);
+    const json = await response.json();
+    logger.debug(
+      `Got response fron Pypi for ${packageName}: ${JSON.stringify(json)}`
+    );
+
+    if (json.info) {
+      // We found the version, so it exists
+      return true;
+    } else {
+      logger.debug(
+        `Could not get pypi package info, got: ${JSON.stringify(json)}`
+      );
+      return false;
+    }
+  }
 }
 
 class NugetPackageManager extends PackageManager {
@@ -172,6 +212,39 @@ class NugetPackageManager extends PackageManager {
     await exec(command, args, { cwd: this.workingDirectory });
 
     console.log("Package installed.");
+  }
+
+  public async isVersionAvailable(
+    packageName: string,
+    packageVersion: string
+  ): Promise<boolean> {
+    logger.debug(`Checking if ${packageName}@${packageVersion} is available`);
+
+    const parts = packageName.split(".");
+    const owner = parts[0];
+    const id = parts.slice(1).join(".");
+    const url = `https://azuresearch-usnc.nuget.org/query?q=owner:${owner}%20id:${id}&prerelease=false&semVerLevel=2.0.0`;
+    logger.debug(`Fetching package metadata from Nuget: '${url}'`);
+
+    const response = await fetch(url);
+    const json = (await response.json()) as {
+      data: { id: string; versions: { version: string }[] }[];
+    };
+    logger.debug(
+      `Got response from Nuget for ${packageName} : ${JSON.stringify(json)}`
+    );
+
+    if (!json?.data?.length) {
+      return false; // No package found
+    }
+
+    const packageVersions = json.data.find((p) => p.id === id)?.versions ?? [];
+
+    if (!packageVersions.length) {
+      return false; // No package release matching the id found
+    }
+
+    return packageVersions.some((v) => v.version === packageVersion);
   }
 }
 
@@ -217,6 +290,38 @@ class MavenPackageManager extends PackageManager {
     await exec("mvn", ["install"], { cwd: this.workingDirectory });
     console.log("Package installed.");
   }
+
+  public async isVersionAvailable(
+    packageName: string,
+    packageVersion: string
+  ): Promise<boolean> {
+    logger.debug(`Checking if ${packageName}@${packageVersion} is available`);
+
+    const parts = packageName.split(".");
+    if (parts.length !== 3) {
+      throw Errors.Internal(
+        `Expected package name to be in format "group.artifact", e.g. "com.hashicorp.cdktf-provider-google", got: ${packageName}`
+      );
+    }
+
+    const packageIdentifier = parts.pop();
+    const groupId = parts.join(".");
+
+    const url = `https://search.maven.org/solrsearch/select?q=g:${groupId}+AND+a:${packageIdentifier}+AND+v:${packageVersion}&rows=5&wt=json`;
+    logger.debug(
+      `Trying to find package version by querying maven central under '${url}'`
+    );
+    const response = await fetch(url);
+
+    const json = await response.json();
+    logger.debug(
+      `Got response from the maven package search for ${packageName}: ${JSON.stringify(
+        json
+      )}`
+    );
+
+    return (json?.response?.numFound ?? 0) > 0;
+  }
 }
 
 class GoPackageManager extends PackageManager {
@@ -245,5 +350,51 @@ class GoPackageManager extends PackageManager {
     );
 
     console.log("Package installed.");
+  }
+
+  public async isVersionAvailable(
+    packageName: string,
+    packageVersion: string
+  ): Promise<boolean> {
+    logger.debug(`Checking if ${packageName}@${packageVersion} is available`);
+
+    // e.g. github.com/cdktf/cdktf-provider-google-go/google
+    const parts = packageName.split("/");
+    if (parts.length !== 4) {
+      throw Errors.Internal(
+        `Expecting Go package name to be in the format of github.com/<org>/<repo>/<package>, got ${packageName}`
+      );
+    }
+
+    const org = parts[1];
+    const repo = parts[2];
+    const packagePath = parts[3];
+
+    const url = `https://api.github.com/repos/${org}/${repo}/git/ref/tags/${packagePath}/v${packageVersion}`;
+    logger.debug(`Fetching tags for ${org}/${repo} from '${url}'`);
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+      },
+    });
+
+    const json = await response.json();
+    logger.debug(
+      `Got response from GitHubs repository tag endpoint for ${packageName}: ${JSON.stringify(
+        json
+      )}`
+    );
+
+    if (json && json.ref) {
+      return true;
+    }
+
+    logger.info(
+      `Could not find the tag ${packagePath}/v${packageVersion} in the repository ${org}/${repo}: ${JSON.stringify(
+        json
+      )}}`
+    );
+
+    return false;
   }
 }

--- a/packages/cdktf-cli/lib/dependencies/prebuilt-providers.ts
+++ b/packages/cdktf-cli/lib/dependencies/prebuilt-providers.ts
@@ -233,6 +233,7 @@ export async function getPrebuiltProviderVersions(
   }
   const npmPackageVersions = matchingVersions
     .map((matchingVersion) => matchingVersion.packageVersion)
-    .sort(semver.compare);
+    .sort(semver.compare)
+    .reverse();
   return npmPackageVersions;
 }

--- a/packages/cdktf-cli/test/lib/dependencies/prebuilt-providers.test.ts
+++ b/packages/cdktf-cli/test/lib/dependencies/prebuilt-providers.test.ts
@@ -225,7 +225,7 @@ describe("prebuilt-providers", () => {
           ProviderConstraint.fromConfigEntry("test"),
           "0.12.2"
         )
-      ).resolves.toEqual("2.3.0");
+      ).resolves.toEqual(["2.3.0"]);
     });
   });
 });

--- a/packages/cdktf-cli/test/lib/dependencies/prebuilt-providers.test.ts
+++ b/packages/cdktf-cli/test/lib/dependencies/prebuilt-providers.test.ts
@@ -4,7 +4,7 @@ import nock from "nock";
 import { ProviderConstraint } from "../../../lib/dependencies/dependency-manager";
 import {
   getNpmPackageName,
-  getPrebuiltProviderVersion,
+  getPrebuiltProviderVersions,
   getAllPrebuiltProviderVersions,
   getPrebuiltProviderRepositoryName,
   resetFetchCache,
@@ -184,7 +184,7 @@ describe("prebuilt-providers", () => {
         .replyWithError({ code: "ETIMEDOUT" });
 
       await expect(
-        getPrebuiltProviderVersion(
+        getPrebuiltProviderVersions(
           ProviderConstraint.fromConfigEntry("test"),
           "0.12.2"
         )
@@ -203,7 +203,7 @@ describe("prebuilt-providers", () => {
         .replyWithError({ code: "ETIMEDOUT" });
 
       await expect(
-        getPrebuiltProviderVersion(
+        getPrebuiltProviderVersions(
           ProviderConstraint.fromConfigEntry("test"),
           "0.12.2"
         )
@@ -221,7 +221,7 @@ describe("prebuilt-providers", () => {
         .reply(200, buildNpmResponse("2.3.0"));
 
       await expect(
-        getPrebuiltProviderVersion(
+        getPrebuiltProviderVersions(
           ProviderConstraint.fromConfigEntry("test"),
           "0.12.2"
         )

--- a/test/csharp/provider-add-command/test.ts
+++ b/test/csharp/provider-add-command/test.ts
@@ -11,13 +11,13 @@ describe("provider add command", () => {
         DISABLE_VERSION_CHECK: "true",
       }); // reset CDKTF_DIST set by run-against-dist script & disable version check as we have to use an older version of cdktf-cli
       await driver.setupCsharpProject({
-        init: { additionalOptions: "--cdktf-version 0.10.4" },
+        init: { additionalOptions: "--cdktf-version 0.12.2" },
       });
     }, 500_000);
 
     it("detects correct cdktf version", async () => {
       const res = await driver.exec("cdktf", ["debug"]);
-      expect(res.stdout).toContain("cdktf: 0.10.4");
+      expect(res.stdout).toContain("cdktf: 0.12.2");
     });
 
     onPosix(
@@ -26,29 +26,29 @@ describe("provider add command", () => {
         const res = await driver.exec("cdktf", [
           "provider",
           "add",
-          "random@=3.1.3", // this is not the latest version, but theres v0.2.55 of the pre-built provider resulting in exactly this package
+          "random@=3.4.2", // this is not the latest version, but theres v3.0.52 of the pre-built provider resulting in exactly this package
         ]);
         expect(res.stdout).toMatchInlineSnapshot(`
-                  "Checking whether pre-built provider exists for the following constraints:
-                    provider: random
-                    version : =3.1.3
-                    language: csharp
-                    cdktf   : 0.10.4
+          "Checking whether pre-built provider exists for the following constraints:
+            provider: random
+            version : =3.4.2
+            language: csharp
+            cdktf   : 0.12.2
 
 
-                  Found pre-built provider.
+          Found pre-built provider.
 
-                  Installing package HashiCorp.Cdktf.Providers.Random @ 0.2.55 using \\"dotnet add package HashiCorp.Cdktf.Providers.Random --version 0.2.55\\".
+          Installing package HashiCorp.Cdktf.Providers.Random @ 2.0.52 using \\"dotnet add package HashiCorp.Cdktf.Providers.Random --version 2.0.52\\".
 
-                  Package installed.
-                  "
-              `);
+          Package installed.
+          "
+        `);
         expect(res.stderr).toBe("");
 
         const proj = driver.readLocalFile("MyTerraformStack.csproj");
 
         expect(proj).toContain(
-          '<PackageReference Include="HashiCorp.Cdktf.Providers.Random" Version="0.2.55" />'
+          '<PackageReference Include="HashiCorp.Cdktf.Providers.Random" Version="2.0.52" />'
         );
       },
       500_000
@@ -60,19 +60,19 @@ describe("provider add command", () => {
         const res = await driver.exec("cdktf", [
           "provider",
           "add",
-          "random@=3.1.3", // this is not the latest version, but theres v0.2.55 of the pre-built provider resulting in exactly this package
+          "random@=3.4.2", // this is not the latest version, but theres v2.0.52 of the pre-built provider resulting in exactly this package
         ]);
         expect(res.stdout).toMatchInlineSnapshot(`
                   "Checking whether pre-built provider exists for the following constraints:
                     provider: random
-                    version : =3.1.3
+                    version : =3.4.2
                     language: csharp
-                    cdktf   : 0.10.4
+                    cdktf   : 0.12.2
 
 
                   Found pre-built provider.
 
-                  Installing package HashiCorp.Cdktf.Providers.Random @ 0.2.55 using \\"dotnet add package HashiCorp.Cdktf.Providers.Random --version 0.2.55\\".
+                  Installing package HashiCorp.Cdktf.Providers.Random @ 2.0.52 using \\"dotnet add package HashiCorp.Cdktf.Providers.Random --version 2.0.52\\".
 
                   Package installed.
                   "
@@ -82,7 +82,7 @@ describe("provider add command", () => {
         const proj = driver.readLocalFile("MyTerraformStack.csproj");
 
         expect(proj).toContain(
-          '<PackageReference Include="HashiCorp.Cdktf.Providers.Random" Version="0.2.55" />'
+          '<PackageReference Include="HashiCorp.Cdktf.Providers.Random" Version="2.0.52" />'
         );
       },
       500_000


### PR DESCRIPTION
The previous implementation assumes that for every released npm version
there is an matching release on the other package managers. This sometimes
is not true, mostly by errors in the publishing process. To hide this and make
the UX of provider add nicer we will deploy the latest compatible matching version.

Closes #2065
