### PR TITLE
feat: [Proposal] Enable non-escaping mode for tokens

### DIFF
--- a/packages/cdktf/lib/tfExpression.ts
+++ b/packages/cdktf/lib/tfExpression.ts
@@ -58,7 +58,11 @@ class TFExpression extends Intrinsic implements IResolvable {
     }
 
     // Only a token reference
-    if (tokenList.literals.length === 0 && numberOfTokens === 1) {
+    if (
+      tokenList.literals.length === 0 &&
+      tokenList.escapes.length === 0 &&
+      numberOfTokens === 1
+    ) {
       return resolvedArg;
     }
 

--- a/packages/cdktf/lib/tfExpression.ts
+++ b/packages/cdktf/lib/tfExpression.ts
@@ -6,7 +6,6 @@ import { Tokenization, Token } from "./tokens/token";
 import { App } from "./app";
 import { TerraformStack } from "./terraform-stack";
 import { ITerraformDependable } from "./terraform-dependable";
-import { TokenString } from "./tokens/private/encoding";
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 class TFExpression extends Intrinsic implements IResolvable {
@@ -322,17 +321,11 @@ class FunctionCall extends TFExpression {
   public resolve(context: IResolveContext): string {
     const suppressBraces = context.suppressBraces;
     context.suppressBraces = true;
+    context.ignoreEscapes = true;
 
     const serializedArgs = this.args
       .map((arg) => this.resolveArg(context, arg))
       .join(", ");
-
-    const escapeRegex = TokenString.forEscape(serializedArgs);
-    if (escapeRegex.test()) {
-      throw new Error(
-        "Cannot use terraform escape sequences within CDKTF Functions. Please use the escape sequence at the beginning and use terraform functions directly"
-      );
-    }
 
     const expr = `${this.name}(${serializedArgs})`;
 

--- a/packages/cdktf/lib/tfExpression.ts
+++ b/packages/cdktf/lib/tfExpression.ts
@@ -85,13 +85,23 @@ class TFExpression extends Intrinsic implements IResolvable {
         }
 
         // if left is only a token, needs to be wrapped as terraform expression
-        if (leftTokenList.literals.length === 0 && leftTokenCount === 1) {
+        if (
+          leftTokenList.literals.length === 0 &&
+          leftTokenList.escapes.length === 0 &&
+          leftTokenCount === 1
+        ) {
           leftValue = `\${${leftTokens[0]}}`;
+        }
+
+        if (leftTokenList.escapes.length === 1 && leftTokenCount === 0) {
+          leftValue = `${leftTokenList.escapes[0]}`;
         }
 
         const rightValue =
           rightTokens.length === 0
             ? this.escapeString(right)
+            : leftTokenList.escapes.length > 0
+            ? rightTokens[0]
             : `\${${rightTokens[0]}}`;
 
         return `${leftValue}${rightValue}`;

--- a/packages/cdktf/lib/tfExpression.ts
+++ b/packages/cdktf/lib/tfExpression.ts
@@ -6,6 +6,7 @@ import { Tokenization, Token } from "./tokens/token";
 import { App } from "./app";
 import { TerraformStack } from "./terraform-stack";
 import { ITerraformDependable } from "./terraform-dependable";
+import { TokenString } from "./tokens/private/encoding";
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 class TFExpression extends Intrinsic implements IResolvable {
@@ -85,23 +86,13 @@ class TFExpression extends Intrinsic implements IResolvable {
         }
 
         // if left is only a token, needs to be wrapped as terraform expression
-        if (
-          leftTokenList.literals.length === 0 &&
-          leftTokenList.escapes.length === 0 &&
-          leftTokenCount === 1
-        ) {
+        if (leftTokenList.literals.length === 0 && leftTokenCount === 1) {
           leftValue = `\${${leftTokens[0]}}`;
-        }
-
-        if (leftTokenList.escapes.length === 1 && leftTokenCount === 0) {
-          leftValue = `${leftTokenList.escapes[0]}`;
         }
 
         const rightValue =
           rightTokens.length === 0
             ? this.escapeString(right)
-            : leftTokenList.escapes.length > 0
-            ? rightTokens[0]
             : `\${${rightTokens[0]}}`;
 
         return `${leftValue}${rightValue}`;
@@ -335,6 +326,13 @@ class FunctionCall extends TFExpression {
     const serializedArgs = this.args
       .map((arg) => this.resolveArg(context, arg))
       .join(", ");
+
+    const escapeRegex = TokenString.forEscape(serializedArgs);
+    if (escapeRegex.test()) {
+      throw new Error(
+        "Cannot use terraform escape sequences within CDKTF Functions. Please use the escape sequence at the beginning and use terraform functions directly"
+      );
+    }
 
     const expr = `${this.name}(${serializedArgs})`;
 

--- a/packages/cdktf/lib/tfExpression.ts
+++ b/packages/cdktf/lib/tfExpression.ts
@@ -320,14 +320,21 @@ class FunctionCall extends TFExpression {
 
   public resolve(context: IResolveContext): string {
     const suppressBraces = context.suppressBraces;
+    const originalIgnoreEscapes = context.ignoreEscapes;
+    const originalWarnEscapes = context.warnEscapes;
+
     context.suppressBraces = true;
     context.ignoreEscapes = true;
+    context.warnEscapes = true;
 
     const serializedArgs = this.args
       .map((arg) => this.resolveArg(context, arg))
       .join(", ");
 
     const expr = `${this.name}(${serializedArgs})`;
+
+    context.ignoreEscapes = originalIgnoreEscapes;
+    context.warnEscapes = originalWarnEscapes;
 
     return suppressBraces ? expr : `\${${expr}}`;
   }

--- a/packages/cdktf/lib/tokens/private/encoding.ts
+++ b/packages/cdktf/lib/tokens/private/encoding.ts
@@ -54,6 +54,13 @@ export class TokenString {
   }
 
   /**
+   * Returns a `TokenString` for this string that has escape sequences.
+   */
+  public static forEscape(s: string) {
+    return new TokenString(s, ESCAPE_TOKEN_BEGIN_REGEX, 1, true);
+  }
+
+  /**
    * Returns a `TokenString` for this string (must be the first string element of the list)
    */
   public static forListToken(s: string) {

--- a/packages/cdktf/lib/tokens/private/resolve.ts
+++ b/packages/cdktf/lib/tokens/private/resolve.ts
@@ -65,6 +65,7 @@ export function resolve(obj: any, options: IResolveOptions): any {
       preparing: options.preparing,
       scope: options.scope,
       suppressBraces: options.previousContext?.suppressBraces,
+      ignoreEscapes: options.previousContext?.ignoreEscapes,
       iteratorContext: options.previousContext?.iteratorContext,
       registerPostProcessor(pp) {
         postProcessor = pp;
@@ -143,7 +144,10 @@ export function resolve(obj: any, options: IResolveOptions): any {
 
     let str: string = obj;
 
-    const tokenStr = TokenString.forString(str, true);
+    const tokenStr = TokenString.forString(
+      str,
+      !makeContext()[0].ignoreEscapes
+    );
     if (tokenStr.test()) {
       const fragments = tokenStr.split(tokenMap.lookupToken.bind(tokenMap));
       str = options.resolver.resolveString(fragments, makeContext()[0]);

--- a/packages/cdktf/lib/tokens/private/resolve.ts
+++ b/packages/cdktf/lib/tokens/private/resolve.ts
@@ -143,7 +143,7 @@ export function resolve(obj: any, options: IResolveOptions): any {
 
     let str: string = obj;
 
-    const tokenStr = TokenString.forString(str);
+    const tokenStr = TokenString.forString(str, true);
     if (tokenStr.test()) {
       const fragments = tokenStr.split(tokenMap.lookupToken.bind(tokenMap));
       str = options.resolver.resolveString(fragments, makeContext()[0]);
@@ -156,12 +156,8 @@ export function resolve(obj: any, options: IResolveOptions): any {
         return TokenMap.instance().lookupNumberToken(parseFloat(id));
       });
 
-      str = fragments
-        .mapTokens({
-          mapToken: (resolvable: IResolvable) =>
-            makeContext()[0].resolve(resolvable),
-        })
-        .join(new StringConcat());
+      const context = makeContext()[0];
+      str = fragments.mapTokens(context).join(new StringConcat());
     }
 
     return str;

--- a/packages/cdktf/lib/tokens/private/resolve.ts
+++ b/packages/cdktf/lib/tokens/private/resolve.ts
@@ -66,6 +66,7 @@ export function resolve(obj: any, options: IResolveOptions): any {
       scope: options.scope,
       suppressBraces: options.previousContext?.suppressBraces,
       ignoreEscapes: options.previousContext?.ignoreEscapes,
+      warnEscapes: options.previousContext?.warnEscapes,
       iteratorContext: options.previousContext?.iteratorContext,
       registerPostProcessor(pp) {
         postProcessor = pp;
@@ -144,9 +145,11 @@ export function resolve(obj: any, options: IResolveOptions): any {
 
     let str: string = obj;
 
+    const context = makeContext()[0];
     const tokenStr = TokenString.forString(
       str,
-      !makeContext()[0].ignoreEscapes
+      !context.ignoreEscapes,
+      context.warnEscapes
     );
     if (tokenStr.test()) {
       const fragments = tokenStr.split(tokenMap.lookupToken.bind(tokenMap));

--- a/packages/cdktf/lib/tokens/private/token-map.ts
+++ b/packages/cdktf/lib/tokens/private/token-map.ts
@@ -155,7 +155,7 @@ export class TokenMap {
    * Split a string into literals and Tokens
    */
   public splitString(s: string): TokenizedStringFragments {
-    const str = TokenString.forString(s, true);
+    const str = TokenString.forString(s);
     return str.split(this.lookupToken.bind(this));
   }
 

--- a/packages/cdktf/lib/tokens/private/token-map.ts
+++ b/packages/cdktf/lib/tokens/private/token-map.ts
@@ -155,7 +155,7 @@ export class TokenMap {
    * Split a string into literals and Tokens
    */
   public splitString(s: string): TokenizedStringFragments {
-    const str = TokenString.forString(s);
+    const str = TokenString.forString(s, true);
     return str.split(this.lookupToken.bind(this));
   }
 

--- a/packages/cdktf/lib/tokens/resolvable.ts
+++ b/packages/cdktf/lib/tokens/resolvable.ts
@@ -199,7 +199,7 @@ export class DefaultTokenResolver implements ITokenResolver {
     fragments: TokenizedStringFragments,
     context: IResolveContext
   ) {
-    return fragments.mapTokens({ mapToken: context.resolve }).join(this.concat);
+    return fragments.mapTokens(context).join(this.concat);
   }
 
   /**
@@ -222,7 +222,7 @@ export class DefaultTokenResolver implements ITokenResolver {
       );
     }
 
-    return fragments.mapTokens({ mapToken: context.resolve }).firstValue;
+    return fragments.mapTokens(context).firstValue;
   }
 
   /**
@@ -265,6 +265,6 @@ export class DefaultTokenResolver implements ITokenResolver {
       );
     }
 
-    return fragments.mapTokens({ mapToken: context.resolve }).firstValue;
+    return fragments.mapTokens(context).firstValue;
   }
 }

--- a/packages/cdktf/lib/tokens/resolvable.ts
+++ b/packages/cdktf/lib/tokens/resolvable.ts
@@ -26,6 +26,11 @@ export interface IResolveContext {
   suppressBraces?: boolean;
 
   /**
+   * True when ${} should not be parsed, and treated as literals
+   */
+  ignoreEscapes?: boolean;
+
+  /**
    * TerraformIterators can be passed for block attributes and normal list attributes
    * both require different handling when the iterable variable is accessed
    * e.g. a dynamic block needs each.key while a for expression just needs key

--- a/packages/cdktf/lib/tokens/resolvable.ts
+++ b/packages/cdktf/lib/tokens/resolvable.ts
@@ -31,6 +31,12 @@ export interface IResolveContext {
   ignoreEscapes?: boolean;
 
   /**
+   * True when ${} should not be included in the string to be resolved, outputs a warning.
+   * Default: false
+   */
+  warnEscapes?: boolean;
+
+  /**
    * TerraformIterators can be passed for block attributes and normal list attributes
    * both require different handling when the iterable variable is accessed
    * e.g. a dynamic block needs each.key while a for expression just needs key

--- a/packages/cdktf/lib/tokens/string-fragments.ts
+++ b/packages/cdktf/lib/tokens/string-fragments.ts
@@ -12,7 +12,12 @@ import { Tokenization } from "./token";
 type LiteralFragment = { type: "literal"; lit: any };
 type TokenFragment = { type: "token"; token: IResolvable };
 type IntrinsicFragment = { type: "intrinsic"; value: any };
-type Fragment = LiteralFragment | TokenFragment | IntrinsicFragment;
+type EscapeFragment = { type: "escape"; kind: "open" | "close" };
+type Fragment =
+  | LiteralFragment
+  | TokenFragment
+  | IntrinsicFragment
+  | EscapeFragment;
 
 /**
  * Fragments of a concatenated string containing stringified Tokens
@@ -73,6 +78,10 @@ export class TokenizedStringFragments {
     this.fragments.push({ type: "intrinsic", value });
   }
 
+  public addEscape(kind: "open" | "close") {
+    this.fragments.push({ type: "escape", kind });
+  }
+
   /**
    * Return all Tokens from this string
    */
@@ -107,6 +116,19 @@ export class TokenizedStringFragments {
     for (const f of this.fragments) {
       if (f.type === "intrinsic") {
         ret.push(f.value);
+      }
+    }
+    return ret;
+  }
+
+  /**
+   * Return all escape fragments from this string
+   */
+  public get escapes(): IResolvable[] {
+    const ret = new Array<IResolvable>();
+    for (const f of this.fragments) {
+      if (f.type === "escape") {
+        ret.push(f.kind as any);
       }
     }
     return ret;

--- a/packages/cdktf/lib/tokens/string-fragments.ts
+++ b/packages/cdktf/lib/tokens/string-fragments.ts
@@ -86,6 +86,10 @@ export class TokenizedStringFragments {
     this.fragments.push({ type: "escape", kind });
   }
 
+  public concat(other: TokenizedStringFragments): void {
+    this.fragments.concat(other.fragments);
+  }
+
   /**
    * Return all Tokens from this string
    */

--- a/packages/cdktf/test/encoding.test.ts
+++ b/packages/cdktf/test/encoding.test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { IResolvable, IResolveContext } from "../lib";
+import { TokenString } from "../lib/tokens/private/encoding";
+
+class TestResolvable implements IResolvable {
+  creationStack: string[];
+  resolve(_context: IResolveContext) {}
+  toString(): string {
+    return "test";
+  }
+
+  constructor() {
+    this.creationStack = [];
+  }
+}
+
+test("extract one token", () => {
+  const tokenString = TokenString.forString("${TfToken[TOKEN.0]}", false);
+  const resolvable = new TestResolvable();
+
+  const splitTokens = tokenString.split(() => resolvable);
+  expect(splitTokens.firstToken).toEqual(resolvable);
+});
+
+test("extract literals and token", () => {
+  const tokenString = TokenString.forString(
+    "foo-${TfToken[TOKEN.0]}-bar",
+    false
+  );
+  const resolvable = new TestResolvable();
+
+  const splitTokens = tokenString.split(() => resolvable);
+
+  expect(splitTokens.tokens[0]).toEqual(resolvable);
+  expect(splitTokens.literals).toEqual(
+    expect.arrayContaining(["foo-", "-bar"])
+  );
+});
+
+test("extract escapes without tokens", () => {
+  const tokenString = TokenString.forString("${10}", true);
+  const resolvable = new TestResolvable();
+
+  const splitTokens = tokenString.split(() => resolvable);
+
+  expect(splitTokens.tokens).toHaveLength(0);
+  expect(splitTokens.escapes).toEqual(
+    expect.arrayContaining(["open", "close"])
+  );
+  expect(splitTokens.literals).toEqual(expect.arrayContaining(["10"]));
+});
+
+test("extract multiple escapes without tokens", () => {
+  const tokenString = TokenString.forString('${"test-${10}"}', true);
+  const resolvable = new TestResolvable();
+
+  const splitTokens = tokenString.split(() => resolvable);
+
+  expect(splitTokens.tokens).toHaveLength(0);
+  expect(splitTokens.escapes).toEqual(
+    expect.arrayContaining(["open", "open", "close", "close"])
+  );
+  expect(splitTokens.literals).toEqual(
+    expect.arrayContaining(['"test-', "10", '"'])
+  );
+});
+
+test("extract escape sequences", () => {
+  const tokenString = TokenString.forString(
+    "${foo-${TfToken[TOKEN.0]}-bar}",
+    true
+  );
+  const resolvable = new TestResolvable();
+
+  const splitTokens = tokenString.split(() => resolvable);
+
+  expect(splitTokens.tokens[0]).toEqual(resolvable);
+  expect(splitTokens.literals).toEqual(
+    expect.arrayContaining(["foo-", "-bar"])
+  );
+});

--- a/packages/cdktf/test/encoding.test.ts
+++ b/packages/cdktf/test/encoding.test.ts
@@ -80,3 +80,13 @@ test("extract escape sequences", () => {
     expect.arrayContaining(["foo-", "-bar"])
   );
 });
+
+test("extract escape sequences followed directly by tokens", () => {
+  const tokenString = TokenString.forString("${${TfToken[TOKEN.0]}-bar}", true);
+  const resolvable = new TestResolvable();
+
+  const splitTokens = tokenString.split(() => resolvable);
+
+  expect(splitTokens.tokens[0]).toEqual(resolvable);
+  expect(splitTokens.literals).toEqual(expect.arrayContaining(["-bar"]));
+});

--- a/packages/cdktf/test/encoding.test.ts
+++ b/packages/cdktf/test/encoding.test.ts
@@ -45,9 +45,7 @@ test("extract escapes without tokens", () => {
   const splitTokens = tokenString.split(() => resolvable);
 
   expect(splitTokens.tokens).toHaveLength(0);
-  expect(splitTokens.escapes).toEqual(
-    expect.arrayContaining(["open", "close"])
-  );
+  expect(splitTokens.escapes).toEqual(expect.arrayContaining(["${", "}"]));
   expect(splitTokens.literals).toEqual(expect.arrayContaining(["10"]));
 });
 
@@ -59,7 +57,7 @@ test("extract multiple escapes without tokens", () => {
 
   expect(splitTokens.tokens).toHaveLength(0);
   expect(splitTokens.escapes).toEqual(
-    expect.arrayContaining(["open", "open", "close", "close"])
+    expect.arrayContaining(["${", "${", "}", "}"])
   );
   expect(splitTokens.literals).toEqual(
     expect.arrayContaining(['"test-', "10", '"'])

--- a/packages/cdktf/test/fqn.test.ts
+++ b/packages/cdktf/test/fqn.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import { Testing, TerraformStack } from "../lib";
+import { Testing, TerraformStack, Fn } from "../lib";
 import { TestProvider, TestResource } from "./helper";
 
 test("able to use fqn on an element", () => {
@@ -66,6 +66,273 @@ test("able to append to resource", () => {
     name: "${test_resource.first-resource}-second",
     tags: {
       firstResourceName: "${test_resource.first-resource.name}",
+    },
+  };
+
+  expect(res).toHaveProperty(
+    "resource.test_resource.second-resource",
+    expected
+  );
+});
+
+test("works when escape is mid-way", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+  new TestProvider(stack, "provider", {});
+
+  const firstResource = new TestResource(stack, "first-resource", {
+    name: "foo",
+  });
+  const otherResource = new TestResource(stack, "other-resource", {
+    name: "baz",
+  });
+
+  const secondResource = new TestResource(stack, "second-resource", {
+    name: "bar",
+    tags: {
+      firstResourceName: `simple-test-${Fn.lookup(
+        otherResource.fqn,
+        "name",
+        ""
+      )}-$\{${firstResource.fqn}.name}`,
+    },
+  });
+
+  secondResource.addOverride("name", `${firstResource.fqn}-second`);
+
+  const res = JSON.parse(Testing.synth(stack));
+
+  const expected = {
+    name: "${test_resource.first-resource}-second",
+    tags: {
+      firstResourceName:
+        'simple-test-${lookup(test_resource.other-resource, "name", "")}-${test_resource.first-resource.name}',
+    },
+  };
+
+  expect(res).toHaveProperty(
+    "resource.test_resource.second-resource",
+    expected
+  );
+});
+
+test("after escape, reverts to normal", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+  new TestProvider(stack, "provider", {});
+
+  const firstResource = new TestResource(stack, "first-resource", {
+    name: "foo",
+  });
+  const otherResource = new TestResource(stack, "other-resource", {
+    name: "baz",
+  });
+
+  const secondResource = new TestResource(stack, "second-resource", {
+    name: "bar",
+    tags: {
+      firstResourceName: `simple-test-$\{${firstResource.fqn}.name}-${Fn.lookup(
+        otherResource.fqn,
+        "name",
+        ""
+      )}`,
+    },
+  });
+
+  secondResource.addOverride("name", `${firstResource.fqn}-second`);
+
+  const res = JSON.parse(Testing.synth(stack));
+
+  const expected = {
+    name: "${test_resource.first-resource}-second",
+    tags: {
+      firstResourceName:
+        'simple-test-${test_resource.first-resource.name}-${lookup(test_resource.other-resource, "name", "")}',
+    },
+  };
+
+  expect(res).toHaveProperty(
+    "resource.test_resource.second-resource",
+    expected
+  );
+});
+
+test("can have multiple escapes", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+  new TestProvider(stack, "provider", {});
+
+  const firstResource = new TestResource(stack, "first-resource", {
+    name: "foo",
+  });
+  const otherResource = new TestResource(stack, "other-resource", {
+    name: "baz",
+  });
+
+  const secondResource = new TestResource(stack, "second-resource", {
+    name: "bar",
+    tags: {
+      firstResourceName: `simple-test-$\{${
+        firstResource.fqn
+      }.name}-$\{${Fn.lookup(otherResource.fqn, "name", "")}}`,
+    },
+  });
+
+  secondResource.addOverride("name", `${firstResource.fqn}-second`);
+
+  const res = JSON.parse(Testing.synth(stack));
+
+  const expected = {
+    name: "${test_resource.first-resource}-second",
+    tags: {
+      firstResourceName:
+        'simple-test-${test_resource.first-resource.name}-${lookup(test_resource.other-resource, "name", "")}',
+    },
+  };
+
+  expect(res).toHaveProperty(
+    "resource.test_resource.second-resource",
+    expected
+  );
+});
+
+test("can have literals within escapes", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+  new TestProvider(stack, "provider", {});
+
+  const firstResource = new TestResource(stack, "first-resource", {
+    name: "foo",
+  });
+
+  const secondResource = new TestResource(stack, "second-resource", {
+    name: "bar",
+    tags: {
+      firstResourceName: `simple-test-$\{"hello"}`,
+    },
+  });
+
+  secondResource.addOverride("name", `${firstResource.fqn}-second`);
+
+  const res = JSON.parse(Testing.synth(stack));
+
+  const expected = {
+    name: "${test_resource.first-resource}-second",
+    tags: {
+      firstResourceName: 'simple-test-${"hello"}',
+    },
+  };
+
+  expect(res).toHaveProperty(
+    "resource.test_resource.second-resource",
+    expected
+  );
+});
+
+test("can extract tokens within escapes", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+  new TestProvider(stack, "provider", {});
+
+  const firstResource = new TestResource(stack, "first-resource", {
+    name: "foo",
+  });
+
+  const secondResource = new TestResource(stack, "second-resource", {
+    name: "bar",
+    tags: {
+      firstResourceName: `$\{${firstResource.fqn}.name}`,
+    },
+  });
+
+  secondResource.addOverride("name", `${firstResource.fqn}-second`);
+
+  const res = JSON.parse(Testing.synth(stack));
+
+  const expected = {
+    name: "${test_resource.first-resource}-second",
+    tags: {
+      firstResourceName: "${test_resource.first-resource.name}",
+    },
+  };
+
+  expect(res).toHaveProperty(
+    "resource.test_resource.second-resource",
+    expected
+  );
+});
+
+test("works with functions", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+  new TestProvider(stack, "provider", {});
+
+  const firstResource = new TestResource(stack, "first-resource", {
+    name: "foo",
+  });
+  const otherResource = new TestResource(stack, "other-resource", {
+    name: "baz",
+  });
+
+  const secondResource = new TestResource(stack, "second-resource", {
+    name: "bar",
+    tags: {
+      firstResourceName: `simple-test-$\{${
+        firstResource.fqn
+      }.name}-$\{${Fn.lookup(otherResource.fqn, "name", "")}}`,
+    },
+  });
+
+  secondResource.addOverride("name", `${firstResource.fqn}-second`);
+
+  const res = JSON.parse(Testing.synth(stack));
+
+  const expected = {
+    name: "${test_resource.first-resource}-second",
+    tags: {
+      firstResourceName:
+        'simple-test-${test_resource.first-resource.name}-${lookup(test_resource.other-resource, "name", "")}',
+    },
+  };
+
+  expect(res).toHaveProperty(
+    "resource.test_resource.second-resource",
+    expected
+  );
+});
+
+test("works with functions containing escapes", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+  new TestProvider(stack, "provider", {});
+
+  const firstResource = new TestResource(stack, "first-resource", {
+    name: "foo",
+  });
+  const otherResource = new TestResource(stack, "other-resource", {
+    name: "baz",
+  });
+
+  const secondResource = new TestResource(stack, "second-resource", {
+    name: "bar",
+    tags: {
+      firstResourceName: Fn.lookup(
+        otherResource.fqn,
+        "name",
+        `$\{${firstResource.fqn}.name}`
+      ),
+    },
+  });
+
+  secondResource.addOverride("name", `${firstResource.fqn}-second`);
+
+  const res = JSON.parse(Testing.synth(stack));
+
+  const expected = {
+    name: "${test_resource.first-resource}-second",
+    tags: {
+      firstResourceName:
+        'simple-test-${test_resource.first-resource.name}-${lookup(test_resource.other-resource, "name", "")}',
     },
   };
 

--- a/packages/cdktf/test/fqn.test.ts
+++ b/packages/cdktf/test/fqn.test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { Testing, TerraformStack } from "../lib";
+import { TestProvider, TestResource } from "./helper";
+
+test("able to use fqn on an element", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+  new TestProvider(stack, "provider", {});
+
+  const firstResource = new TestResource(stack, "first-resource", {
+    name: "foo",
+  });
+
+  new TestResource(stack, "second-resource", {
+    name: "bar",
+    tags: {
+      other: firstResource.fqn,
+    },
+  });
+
+  const res = JSON.parse(Testing.synth(stack));
+
+  const expectedFirst = {
+    name: "foo",
+  };
+
+  const expectedSecond = {
+    name: "bar",
+    tags: {
+      other: "${test_resource.first-resource}",
+    },
+  };
+
+  expect(res).toHaveProperty(
+    "resource.test_resource.first-resource",
+    expectedFirst
+  );
+  expect(res).toHaveProperty(
+    "resource.test_resource.second-resource",
+    expectedSecond
+  );
+});
+
+test("able to append to resource", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+  new TestProvider(stack, "provider", {});
+
+  const firstResource = new TestResource(stack, "first-resource", {
+    name: "foo",
+  });
+
+  const secondResource = new TestResource(stack, "second-resource", {
+    name: "bar",
+    tags: {
+      firstResourceName: `$\{${firstResource.fqn}.name}`,
+    },
+  });
+
+  secondResource.addOverride("name", `${firstResource.fqn}-second`);
+
+  const res = JSON.parse(Testing.synth(stack));
+
+  const expected = {
+    name: "${test_resource.first-resource}-second",
+    tags: {
+      firstResourceName: "${test_resource.first-resource.name}",
+    },
+  };
+
+  expect(res).toHaveProperty(
+    "resource.test_resource.second-resource",
+    expected
+  );
+});

--- a/packages/cdktf/test/fqn.test.ts
+++ b/packages/cdktf/test/fqn.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import { Testing, TerraformStack, Fn, mulOperation } from "../lib";
+import { Testing, TerraformStack, Fn } from "../lib";
 import { TestProvider, TestResource } from "./helper";
 
 test("able to use fqn on an element", () => {
@@ -361,7 +361,7 @@ test("does not throw error when tokens are nested with functions", () => {
   );
 });
 
-test("allows interpolation within functions", () => {
+test("allows functions within functions", () => {
   const app = Testing.app();
   const stack = new TerraformStack(app, "test");
   new TestProvider(stack, "provider", {});
@@ -376,7 +376,7 @@ test("allows interpolation within functions", () => {
       firstResourceName: Fn.lookup(
         otherResource.fqn,
         "name",
-        mulOperation(2, 33)
+        Fn.upper(Fn.lookup(otherResource.fqn, "name", ""))
       ),
     },
   });
@@ -387,7 +387,7 @@ test("allows interpolation within functions", () => {
     name: "bar",
     tags: {
       firstResourceName:
-        '${lookup(test_resource.other-resource, "name", "--")}',
+        '${lookup(test_resource.other-resource, "name", upper(lookup(test_resource.other-resource, "name", "")))}',
     },
   };
 

--- a/packages/cdktf/test/fqn.test.ts
+++ b/packages/cdktf/test/fqn.test.ts
@@ -313,7 +313,7 @@ test("works with functions containing escapes", () => {
     name: "baz",
   });
 
-  const secondResource = new TestResource(stack, "second-resource", {
+  new TestResource(stack, "second-resource", {
     name: "bar",
     tags: {
       firstResourceName: Fn.lookup(
@@ -324,7 +324,7 @@ test("works with functions containing escapes", () => {
     },
   });
 
-  secondResource.addOverride("name", `${firstResource.fqn}-second`);
+  // secondResource.addOverride("name", `${firstResource.fqn}-second`);
 
   const res = JSON.parse(Testing.synth(stack));
 
@@ -332,7 +332,7 @@ test("works with functions containing escapes", () => {
     name: "${test_resource.first-resource}-second",
     tags: {
       firstResourceName:
-        'simple-test-${test_resource.first-resource.name}-${lookup(test_resource.other-resource, "name", "")}',
+        '${lookup(test_resource.other-resource, "name", test_resource.other-resource.name)}',
     },
   };
 

--- a/packages/cdktf/test/fqn.test.ts
+++ b/packages/cdktf/test/fqn.test.ts
@@ -301,7 +301,7 @@ test("works with functions", () => {
   );
 });
 
-test("throws error when escapes are nested with functions", () => {
+test("doesn't throw error when escapes are nested with functions", () => {
   const app = Testing.app();
   const stack = new TerraformStack(app, "test");
   new TestProvider(stack, "provider", {});
@@ -324,9 +324,20 @@ test("throws error when escapes are nested with functions", () => {
     },
   });
 
-  expect(() => {
-    Testing.synth(stack);
-  }).toThrow();
+  const res = JSON.parse(Testing.synth(stack));
+
+  const expected = {
+    name: "bar",
+    tags: {
+      firstResourceName:
+        '${lookup(test_resource.other-resource, "name", "$${${test_resource.first-resource}.name}")}',
+    },
+  };
+
+  expect(res).toHaveProperty(
+    "resource.test_resource.second-resource",
+    expected
+  );
 });
 
 test("does not throw error when tokens are nested with functions", () => {

--- a/packages/cdktf/test/fqn.test.ts
+++ b/packages/cdktf/test/fqn.test.ts
@@ -318,6 +318,7 @@ test("doesn't throw error when escapes are nested with functions", () => {
   const app = Testing.app();
   const stack = new TerraformStack(app, "test");
   new TestProvider(stack, "provider", {});
+  jest.spyOn(console, "warn").mockImplementation(() => {});
 
   const firstResource = new TestResource(stack, "first-resource", {
     name: "foo",
@@ -347,6 +348,9 @@ test("doesn't throw error when escapes are nested with functions", () => {
         '${lookup(test_resource.other-resource, "name", "$${${test_resource.first-resource}.name}")}',
     },
   };
+
+  expect(console.warn).toHaveBeenCalled();
+  (console.warn as jest.Mock).mockRestore();
 
   expect(res).toHaveProperty(
     "resource.test_resource.second-resource",

--- a/packages/cdktf/test/fqn.test.ts
+++ b/packages/cdktf/test/fqn.test.ts
@@ -302,6 +302,19 @@ test("works with functions", () => {
 });
 
 test("doesn't throw error when escapes are nested with functions", () => {
+  /*
+    This test is a bit weird. The test shows the inability of the existing system
+    to handle both Fn.* methods as well as escapes. However, it's here to ensure that the
+    expectation that this is failing / awkward.
+
+    The reason for the inability is because we don't have quotes set up as a first class
+    syntax element during processing of input. Dealing with nested escapes and quotes is 
+    quite hard and awkward with just regexes, and requires a bit more context, which we don't have yet. 
+
+    As a follow up, depending on the customer feedback / requirements discovered, we can 
+    move the string parsing process to an actual parser that will understand the concept of 
+    nested quotes (multiple types) and interpolations.
+  */
   const app = Testing.app();
   const stack = new TerraformStack(app, "test");
   new TestProvider(stack, "provider", {});
@@ -330,6 +343,7 @@ test("doesn't throw error when escapes are nested with functions", () => {
     name: "bar",
     tags: {
       firstResourceName:
+        // Note: This is not valid terraform
         '${lookup(test_resource.other-resource, "name", "$${${test_resource.first-resource}.name}")}',
     },
   };

--- a/packages/cdktf/test/fqn.test.ts
+++ b/packages/cdktf/test/fqn.test.ts
@@ -421,3 +421,34 @@ test("allows functions within functions", () => {
     expected
   );
 });
+
+test("allows operators within functions", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+  new TestProvider(stack, "provider", {});
+
+  const otherResource = new TestResource(stack, "other-resource", {
+    name: "baz",
+  });
+
+  new TestResource(stack, "second-resource", {
+    name: "bar",
+    tags: {
+      halfNameLength: `\${length(${otherResource.fqn}.name) / 2}`,
+    },
+  });
+
+  const res = JSON.parse(Testing.synth(stack));
+
+  const expected = {
+    name: "bar",
+    tags: {
+      halfNameLength: "${length(test_resource.other-resource.name) / 2}",
+    },
+  };
+
+  expect(res).toHaveProperty(
+    "resource.test_resource.second-resource",
+    expected
+  );
+});

--- a/tools/documentation-generation/yarn.lock
+++ b/tools/documentation-generation/yarn.lock
@@ -180,7 +180,8 @@ case@^1.6.3:
   version "0.0.0"
   dependencies:
     archiver "5.3.1"
-    json-stable-stringify "^1.0.1"
+    json-stable-stringify "^1.0.2"
+    semver "^7.3.8"
 
 chalk@^4, chalk@^4.1.2:
   version "4.1.2"
@@ -513,12 +514,12 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-json-stable-stringify@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
-  integrity sha512-i/J297TW6xyj7sDFa7AmBPkQvLIxWr2kKPWI26tXydnZrzVAocNqn5DMNT1Mzk0vit1V5UkRM7C1KdVNp7Lmcg==
+json-stable-stringify@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz#e06f23128e0bbe342dc996ed5a19e28b57b580e0"
+  integrity sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==
   dependencies:
-    jsonify "~0.0.0"
+    jsonify "^0.0.1"
 
 jsonfile@^6.0.1:
   version "6.1.0"
@@ -529,10 +530,10 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonify@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
-  integrity sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA==
+jsonify@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.1.tgz#2aa3111dae3d34a0f151c63f3a45d995d9420978"
+  integrity sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==
 
 lazystream@^1.0.0:
   version "1.0.1"
@@ -750,6 +751,13 @@ semver@^7.3.7:
   version "7.3.7"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
   integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.3.8:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
   dependencies:
     lru-cache "^6.0.0"
 

--- a/website/docs/cdktf/api-reference/csharp.mdx
+++ b/website/docs/cdktf/api-reference/csharp.mdx
@@ -29169,6 +29169,7 @@ new TokenizedStringFragments();
 | <code><a href="#cdktf.TokenizedStringFragments.addIntrinsic">AddIntrinsic</a></code> | Adds an intrinsic fragment.                                  |
 | <code><a href="#cdktf.TokenizedStringFragments.addLiteral">AddLiteral</a></code>     | Adds a literal fragment.                                     |
 | <code><a href="#cdktf.TokenizedStringFragments.addToken">AddToken</a></code>         | Adds a token fragment.                                       |
+| <code><a href="#cdktf.TokenizedStringFragments.concat">Concat</a></code>             | _No description._                                            |
 | <code><a href="#cdktf.TokenizedStringFragments.join">Join</a></code>                 | Combine the string fragments using the given joiner.         |
 | <code><a href="#cdktf.TokenizedStringFragments.mapTokens">MapTokens</a></code>       | Apply a transformation function to all tokens in the string. |
 
@@ -29231,6 +29232,18 @@ Adds a token fragment.
 - _Type:_ <a href="#cdktf.IResolvable">IResolvable</a>
 
 the token to add.
+
+---
+
+##### `Concat` <a name="Concat" id="cdktf.TokenizedStringFragments.concat"></a>
+
+```csharp
+private void Concat(TokenizedStringFragments Other)
+```
+
+###### `Other`<sup>Required</sup> <a name="Other" id="cdktf.TokenizedStringFragments.concat.parameter.other"></a>
+
+- _Type:_ <a href="#cdktf.TokenizedStringFragments">TokenizedStringFragments</a>
 
 ---
 
@@ -30002,6 +30015,7 @@ Resolve an inner object.
 | <code><a href="#cdktf.IResolveContext.property.ignoreEscapes">IgnoreEscapes</a></code>     | <code>bool</code>                  | True when ${} should not be parsed, and treated as literals.                                                                                                                                                                       |
 | <code><a href="#cdktf.IResolveContext.property.iteratorContext">IteratorContext</a></code> | <code>string</code>                | TerraformIterators can be passed for block attributes and normal list attributes both require different handling when the iterable variable is accessed e.g. a dynamic block needs each.key while a for expression just needs key. |
 | <code><a href="#cdktf.IResolveContext.property.suppressBraces">SuppressBraces</a></code>   | <code>bool</code>                  | True when ${} should be ommitted (because already inside them), false otherwise.                                                                                                                                                   |
+| <code><a href="#cdktf.IResolveContext.property.warnEscapes">WarnEscapes</a></code>         | <code>bool</code>                  | True when ${} should not be included in the string to be resolved, outputs a warning.                                                                                                                                              |
 
 ---
 
@@ -30062,6 +30076,20 @@ public bool SuppressBraces { get; set; }
 - _Type:_ bool
 
 True when ${} should be ommitted (because already inside them), false otherwise.
+
+---
+
+##### `WarnEscapes`<sup>Optional</sup> <a name="WarnEscapes" id="cdktf.IResolveContext.property.warnEscapes"></a>
+
+```csharp
+public bool WarnEscapes { get; set; }
+```
+
+- _Type:_ bool
+
+True when ${} should not be included in the string to be resolved, outputs a warning.
+
+Default: false
 
 ---
 

--- a/website/docs/cdktf/api-reference/csharp.mdx
+++ b/website/docs/cdktf/api-reference/csharp.mdx
@@ -29165,11 +29165,24 @@ new TokenizedStringFragments();
 
 | **Name**                                                                             | **Description**                                              |
 | ------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
+| <code><a href="#cdktf.TokenizedStringFragments.addEscape">AddEscape</a></code>       | _No description._                                            |
 | <code><a href="#cdktf.TokenizedStringFragments.addIntrinsic">AddIntrinsic</a></code> | Adds an intrinsic fragment.                                  |
 | <code><a href="#cdktf.TokenizedStringFragments.addLiteral">AddLiteral</a></code>     | Adds a literal fragment.                                     |
 | <code><a href="#cdktf.TokenizedStringFragments.addToken">AddToken</a></code>         | Adds a token fragment.                                       |
 | <code><a href="#cdktf.TokenizedStringFragments.join">Join</a></code>                 | Combine the string fragments using the given joiner.         |
 | <code><a href="#cdktf.TokenizedStringFragments.mapTokens">MapTokens</a></code>       | Apply a transformation function to all tokens in the string. |
+
+---
+
+##### `AddEscape` <a name="AddEscape" id="cdktf.TokenizedStringFragments.addEscape"></a>
+
+```csharp
+private void AddEscape(string Kind)
+```
+
+###### `Kind`<sup>Required</sup> <a name="Kind" id="cdktf.TokenizedStringFragments.addEscape.parameter.kind"></a>
+
+- _Type:_ string
 
 ---
 
@@ -29255,12 +29268,25 @@ Apply a transformation function to all tokens in the string.
 
 | **Name**                                                                                  | **Type**                                                    | **Description**                                  |
 | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------ |
+| <code><a href="#cdktf.TokenizedStringFragments.property.escapes">Escapes</a></code>       | <code><a href="#cdktf.IResolvable">IResolvable</a>[]</code> | Return all escape fragments from this string.    |
 | <code><a href="#cdktf.TokenizedStringFragments.property.firstValue">FirstValue</a></code> | <code>object</code>                                         | Returns the first value.                         |
 | <code><a href="#cdktf.TokenizedStringFragments.property.intrinsic">Intrinsic</a></code>   | <code><a href="#cdktf.IResolvable">IResolvable</a>[]</code> | Return all intrinsic fragments from this string. |
 | <code><a href="#cdktf.TokenizedStringFragments.property.length">Length</a></code>         | <code>double</code>                                         | Returns the number of fragments.                 |
 | <code><a href="#cdktf.TokenizedStringFragments.property.literals">Literals</a></code>     | <code><a href="#cdktf.IResolvable">IResolvable</a>[]</code> | Return all literals from this string.            |
 | <code><a href="#cdktf.TokenizedStringFragments.property.tokens">Tokens</a></code>         | <code><a href="#cdktf.IResolvable">IResolvable</a>[]</code> | Return all Tokens from this string.              |
 | <code><a href="#cdktf.TokenizedStringFragments.property.firstToken">FirstToken</a></code> | <code><a href="#cdktf.IResolvable">IResolvable</a></code>   | Returns the first token.                         |
+
+---
+
+##### `Escapes`<sup>Required</sup> <a name="Escapes" id="cdktf.TokenizedStringFragments.property.escapes"></a>
+
+```csharp
+public IResolvable[] Escapes { get; }
+```
+
+- _Type:_ <a href="#cdktf.IResolvable">IResolvable</a>[]
+
+Return all escape fragments from this string.
 
 ---
 

--- a/website/docs/cdktf/api-reference/csharp.mdx
+++ b/website/docs/cdktf/api-reference/csharp.mdx
@@ -29999,6 +29999,7 @@ Resolve an inner object.
 | ------------------------------------------------------------------------------------------ | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | <code><a href="#cdktf.IResolveContext.property.preparing">Preparing</a></code>             | <code>bool</code>                  | True when we are still preparing, false if we're rendering the final output.                                                                                                                                                       |
 | <code><a href="#cdktf.IResolveContext.property.scope">Scope</a></code>                     | <code>Constructs.IConstruct</code> | The scope from which resolution has been initiated.                                                                                                                                                                                |
+| <code><a href="#cdktf.IResolveContext.property.ignoreEscapes">IgnoreEscapes</a></code>     | <code>bool</code>                  | True when ${} should not be parsed, and treated as literals.                                                                                                                                                                       |
 | <code><a href="#cdktf.IResolveContext.property.iteratorContext">IteratorContext</a></code> | <code>string</code>                | TerraformIterators can be passed for block attributes and normal list attributes both require different handling when the iterable variable is accessed e.g. a dynamic block needs each.key while a for expression just needs key. |
 | <code><a href="#cdktf.IResolveContext.property.suppressBraces">SuppressBraces</a></code>   | <code>bool</code>                  | True when ${} should be ommitted (because already inside them), false otherwise.                                                                                                                                                   |
 
@@ -30025,6 +30026,18 @@ public IConstruct Scope { get; }
 - _Type:_ Constructs.IConstruct
 
 The scope from which resolution has been initiated.
+
+---
+
+##### `IgnoreEscapes`<sup>Optional</sup> <a name="IgnoreEscapes" id="cdktf.IResolveContext.property.ignoreEscapes"></a>
+
+```csharp
+public bool IgnoreEscapes { get; set; }
+```
+
+- _Type:_ bool
+
+True when ${} should not be parsed, and treated as literals.
 
 ---
 

--- a/website/docs/cdktf/api-reference/csharp.mdx
+++ b/website/docs/cdktf/api-reference/csharp.mdx
@@ -29253,14 +29253,14 @@ If there are any
 ##### `MapTokens` <a name="MapTokens" id="cdktf.TokenizedStringFragments.mapTokens"></a>
 
 ```csharp
-private TokenizedStringFragments MapTokens(ITokenMapper Mapper)
+private TokenizedStringFragments MapTokens(IResolveContext Context)
 ```
 
 Apply a transformation function to all tokens in the string.
 
-###### `Mapper`<sup>Required</sup> <a name="Mapper" id="cdktf.TokenizedStringFragments.mapTokens.parameter.mapper"></a>
+###### `Context`<sup>Required</sup> <a name="Context" id="cdktf.TokenizedStringFragments.mapTokens.parameter.context"></a>
 
-- _Type:_ <a href="#cdktf.ITokenMapper">ITokenMapper</a>
+- _Type:_ <a href="#cdktf.IResolveContext">IResolveContext</a>
 
 ---
 

--- a/website/docs/cdktf/api-reference/go.mdx
+++ b/website/docs/cdktf/api-reference/go.mdx
@@ -29253,14 +29253,14 @@ If there are any
 ##### `MapTokens` <a name="MapTokens" id="cdktf.TokenizedStringFragments.mapTokens"></a>
 
 ```go
-func MapTokens(mapper ITokenMapper) TokenizedStringFragments
+func MapTokens(context IResolveContext) TokenizedStringFragments
 ```
 
 Apply a transformation function to all tokens in the string.
 
-###### `mapper`<sup>Required</sup> <a name="mapper" id="cdktf.TokenizedStringFragments.mapTokens.parameter.mapper"></a>
+###### `context`<sup>Required</sup> <a name="context" id="cdktf.TokenizedStringFragments.mapTokens.parameter.context"></a>
 
-- _Type:_ <a href="#cdktf.ITokenMapper">ITokenMapper</a>
+- _Type:_ <a href="#cdktf.IResolveContext">IResolveContext</a>
 
 ---
 

--- a/website/docs/cdktf/api-reference/go.mdx
+++ b/website/docs/cdktf/api-reference/go.mdx
@@ -29999,6 +29999,7 @@ Resolve an inner object.
 | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | <code><a href="#cdktf.IResolveContext.property.preparing">Preparing</a></code>             | <code>\*bool</code>                                                 | True when we are still preparing, false if we're rendering the final output.                                                                                                                                                       |
 | <code><a href="#cdktf.IResolveContext.property.scope">Scope</a></code>                     | <code>github.com/aws/constructs-go/constructs/v10.IConstruct</code> | The scope from which resolution has been initiated.                                                                                                                                                                                |
+| <code><a href="#cdktf.IResolveContext.property.ignoreEscapes">IgnoreEscapes</a></code>     | <code>\*bool</code>                                                 | True when ${} should not be parsed, and treated as literals.                                                                                                                                                                       |
 | <code><a href="#cdktf.IResolveContext.property.iteratorContext">IteratorContext</a></code> | <code>\*string</code>                                               | TerraformIterators can be passed for block attributes and normal list attributes both require different handling when the iterable variable is accessed e.g. a dynamic block needs each.key while a for expression just needs key. |
 | <code><a href="#cdktf.IResolveContext.property.suppressBraces">SuppressBraces</a></code>   | <code>\*bool</code>                                                 | True when ${} should be ommitted (because already inside them), false otherwise.                                                                                                                                                   |
 
@@ -30025,6 +30026,18 @@ func Scope() IConstruct
 - _Type:_ github.com/aws/constructs-go/constructs/v10.IConstruct
 
 The scope from which resolution has been initiated.
+
+---
+
+##### `IgnoreEscapes`<sup>Optional</sup> <a name="IgnoreEscapes" id="cdktf.IResolveContext.property.ignoreEscapes"></a>
+
+```go
+func IgnoreEscapes() *bool
+```
+
+- _Type:_ \*bool
+
+True when ${} should not be parsed, and treated as literals.
 
 ---
 

--- a/website/docs/cdktf/api-reference/go.mdx
+++ b/website/docs/cdktf/api-reference/go.mdx
@@ -29165,11 +29165,24 @@ cdktf.NewTokenizedStringFragments() TokenizedStringFragments
 
 | **Name**                                                                             | **Description**                                              |
 | ------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
+| <code><a href="#cdktf.TokenizedStringFragments.addEscape">AddEscape</a></code>       | _No description._                                            |
 | <code><a href="#cdktf.TokenizedStringFragments.addIntrinsic">AddIntrinsic</a></code> | Adds an intrinsic fragment.                                  |
 | <code><a href="#cdktf.TokenizedStringFragments.addLiteral">AddLiteral</a></code>     | Adds a literal fragment.                                     |
 | <code><a href="#cdktf.TokenizedStringFragments.addToken">AddToken</a></code>         | Adds a token fragment.                                       |
 | <code><a href="#cdktf.TokenizedStringFragments.join">Join</a></code>                 | Combine the string fragments using the given joiner.         |
 | <code><a href="#cdktf.TokenizedStringFragments.mapTokens">MapTokens</a></code>       | Apply a transformation function to all tokens in the string. |
+
+---
+
+##### `AddEscape` <a name="AddEscape" id="cdktf.TokenizedStringFragments.addEscape"></a>
+
+```go
+func AddEscape(kind *string)
+```
+
+###### `kind`<sup>Required</sup> <a name="kind" id="cdktf.TokenizedStringFragments.addEscape.parameter.kind"></a>
+
+- _Type:_ \*string
 
 ---
 
@@ -29255,12 +29268,25 @@ Apply a transformation function to all tokens in the string.
 
 | **Name**                                                                                  | **Type**                                                      | **Description**                                  |
 | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------ |
+| <code><a href="#cdktf.TokenizedStringFragments.property.escapes">Escapes</a></code>       | <code>\*[]<a href="#cdktf.IResolvable">IResolvable</a></code> | Return all escape fragments from this string.    |
 | <code><a href="#cdktf.TokenizedStringFragments.property.firstValue">FirstValue</a></code> | <code>interface{}</code>                                      | Returns the first value.                         |
 | <code><a href="#cdktf.TokenizedStringFragments.property.intrinsic">Intrinsic</a></code>   | <code>\*[]<a href="#cdktf.IResolvable">IResolvable</a></code> | Return all intrinsic fragments from this string. |
 | <code><a href="#cdktf.TokenizedStringFragments.property.length">Length</a></code>         | <code>\*f64</code>                                            | Returns the number of fragments.                 |
 | <code><a href="#cdktf.TokenizedStringFragments.property.literals">Literals</a></code>     | <code>\*[]<a href="#cdktf.IResolvable">IResolvable</a></code> | Return all literals from this string.            |
 | <code><a href="#cdktf.TokenizedStringFragments.property.tokens">Tokens</a></code>         | <code>\*[]<a href="#cdktf.IResolvable">IResolvable</a></code> | Return all Tokens from this string.              |
 | <code><a href="#cdktf.TokenizedStringFragments.property.firstToken">FirstToken</a></code> | <code><a href="#cdktf.IResolvable">IResolvable</a></code>     | Returns the first token.                         |
+
+---
+
+##### `Escapes`<sup>Required</sup> <a name="Escapes" id="cdktf.TokenizedStringFragments.property.escapes"></a>
+
+```go
+func Escapes() *[]IResolvable
+```
+
+- _Type:_ \*[]<a href="#cdktf.IResolvable">IResolvable</a>
+
+Return all escape fragments from this string.
 
 ---
 

--- a/website/docs/cdktf/api-reference/go.mdx
+++ b/website/docs/cdktf/api-reference/go.mdx
@@ -29169,6 +29169,7 @@ cdktf.NewTokenizedStringFragments() TokenizedStringFragments
 | <code><a href="#cdktf.TokenizedStringFragments.addIntrinsic">AddIntrinsic</a></code> | Adds an intrinsic fragment.                                  |
 | <code><a href="#cdktf.TokenizedStringFragments.addLiteral">AddLiteral</a></code>     | Adds a literal fragment.                                     |
 | <code><a href="#cdktf.TokenizedStringFragments.addToken">AddToken</a></code>         | Adds a token fragment.                                       |
+| <code><a href="#cdktf.TokenizedStringFragments.concat">Concat</a></code>             | _No description._                                            |
 | <code><a href="#cdktf.TokenizedStringFragments.join">Join</a></code>                 | Combine the string fragments using the given joiner.         |
 | <code><a href="#cdktf.TokenizedStringFragments.mapTokens">MapTokens</a></code>       | Apply a transformation function to all tokens in the string. |
 
@@ -29231,6 +29232,18 @@ Adds a token fragment.
 - _Type:_ <a href="#cdktf.IResolvable">IResolvable</a>
 
 the token to add.
+
+---
+
+##### `Concat` <a name="Concat" id="cdktf.TokenizedStringFragments.concat"></a>
+
+```go
+func Concat(other TokenizedStringFragments)
+```
+
+###### `other`<sup>Required</sup> <a name="other" id="cdktf.TokenizedStringFragments.concat.parameter.other"></a>
+
+- _Type:_ <a href="#cdktf.TokenizedStringFragments">TokenizedStringFragments</a>
 
 ---
 
@@ -30002,6 +30015,7 @@ Resolve an inner object.
 | <code><a href="#cdktf.IResolveContext.property.ignoreEscapes">IgnoreEscapes</a></code>     | <code>\*bool</code>                                                 | True when ${} should not be parsed, and treated as literals.                                                                                                                                                                       |
 | <code><a href="#cdktf.IResolveContext.property.iteratorContext">IteratorContext</a></code> | <code>\*string</code>                                               | TerraformIterators can be passed for block attributes and normal list attributes both require different handling when the iterable variable is accessed e.g. a dynamic block needs each.key while a for expression just needs key. |
 | <code><a href="#cdktf.IResolveContext.property.suppressBraces">SuppressBraces</a></code>   | <code>\*bool</code>                                                 | True when ${} should be ommitted (because already inside them), false otherwise.                                                                                                                                                   |
+| <code><a href="#cdktf.IResolveContext.property.warnEscapes">WarnEscapes</a></code>         | <code>\*bool</code>                                                 | True when ${} should not be included in the string to be resolved, outputs a warning.                                                                                                                                              |
 
 ---
 
@@ -30062,6 +30076,20 @@ func SuppressBraces() *bool
 - _Type:_ \*bool
 
 True when ${} should be ommitted (because already inside them), false otherwise.
+
+---
+
+##### `WarnEscapes`<sup>Optional</sup> <a name="WarnEscapes" id="cdktf.IResolveContext.property.warnEscapes"></a>
+
+```go
+func WarnEscapes() *bool
+```
+
+- _Type:_ \*bool
+
+True when ${} should not be included in the string to be resolved, outputs a warning.
+
+Default: false
 
 ---
 

--- a/website/docs/cdktf/api-reference/java.mdx
+++ b/website/docs/cdktf/api-reference/java.mdx
@@ -33452,14 +33452,14 @@ If there are any
 ##### `mapTokens` <a name="mapTokens" id="cdktf.TokenizedStringFragments.mapTokens"></a>
 
 ```java
-public TokenizedStringFragments mapTokens(ITokenMapper mapper)
+public TokenizedStringFragments mapTokens(IResolveContext context)
 ```
 
 Apply a transformation function to all tokens in the string.
 
-###### `mapper`<sup>Required</sup> <a name="mapper" id="cdktf.TokenizedStringFragments.mapTokens.parameter.mapper"></a>
+###### `context`<sup>Required</sup> <a name="context" id="cdktf.TokenizedStringFragments.mapTokens.parameter.context"></a>
 
-- _Type:_ <a href="#cdktf.ITokenMapper">ITokenMapper</a>
+- _Type:_ <a href="#cdktf.IResolveContext">IResolveContext</a>
 
 ---
 

--- a/website/docs/cdktf/api-reference/java.mdx
+++ b/website/docs/cdktf/api-reference/java.mdx
@@ -34198,6 +34198,7 @@ Resolve an inner object.
 | ------------------------------------------------------------------------------------------ | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | <code><a href="#cdktf.IResolveContext.property.preparing">preparing</a></code>             | <code>java.lang.Boolean</code>              | True when we are still preparing, false if we're rendering the final output.                                                                                                                                                       |
 | <code><a href="#cdktf.IResolveContext.property.scope">scope</a></code>                     | <code>software.constructs.IConstruct</code> | The scope from which resolution has been initiated.                                                                                                                                                                                |
+| <code><a href="#cdktf.IResolveContext.property.ignoreEscapes">ignoreEscapes</a></code>     | <code>java.lang.Boolean</code>              | True when ${} should not be parsed, and treated as literals.                                                                                                                                                                       |
 | <code><a href="#cdktf.IResolveContext.property.iteratorContext">iteratorContext</a></code> | <code>java.lang.String</code>               | TerraformIterators can be passed for block attributes and normal list attributes both require different handling when the iterable variable is accessed e.g. a dynamic block needs each.key while a for expression just needs key. |
 | <code><a href="#cdktf.IResolveContext.property.suppressBraces">suppressBraces</a></code>   | <code>java.lang.Boolean</code>              | True when ${} should be ommitted (because already inside them), false otherwise.                                                                                                                                                   |
 
@@ -34224,6 +34225,18 @@ public IConstruct getScope();
 - _Type:_ software.constructs.IConstruct
 
 The scope from which resolution has been initiated.
+
+---
+
+##### `ignoreEscapes`<sup>Optional</sup> <a name="ignoreEscapes" id="cdktf.IResolveContext.property.ignoreEscapes"></a>
+
+```java
+public java.lang.Boolean getIgnoreEscapes();
+```
+
+- _Type:_ java.lang.Boolean
+
+True when ${} should not be parsed, and treated as literals.
 
 ---
 

--- a/website/docs/cdktf/api-reference/java.mdx
+++ b/website/docs/cdktf/api-reference/java.mdx
@@ -33364,11 +33364,24 @@ new TokenizedStringFragments();
 
 | **Name**                                                                             | **Description**                                              |
 | ------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
+| <code><a href="#cdktf.TokenizedStringFragments.addEscape">addEscape</a></code>       | _No description._                                            |
 | <code><a href="#cdktf.TokenizedStringFragments.addIntrinsic">addIntrinsic</a></code> | Adds an intrinsic fragment.                                  |
 | <code><a href="#cdktf.TokenizedStringFragments.addLiteral">addLiteral</a></code>     | Adds a literal fragment.                                     |
 | <code><a href="#cdktf.TokenizedStringFragments.addToken">addToken</a></code>         | Adds a token fragment.                                       |
 | <code><a href="#cdktf.TokenizedStringFragments.join">join</a></code>                 | Combine the string fragments using the given joiner.         |
 | <code><a href="#cdktf.TokenizedStringFragments.mapTokens">mapTokens</a></code>       | Apply a transformation function to all tokens in the string. |
+
+---
+
+##### `addEscape` <a name="addEscape" id="cdktf.TokenizedStringFragments.addEscape"></a>
+
+```java
+public void addEscape(java.lang.String kind)
+```
+
+###### `kind`<sup>Required</sup> <a name="kind" id="cdktf.TokenizedStringFragments.addEscape.parameter.kind"></a>
+
+- _Type:_ java.lang.String
 
 ---
 
@@ -33454,12 +33467,25 @@ Apply a transformation function to all tokens in the string.
 
 | **Name**                                                                                  | **Type**                                                                   | **Description**                                  |
 | ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------ |
+| <code><a href="#cdktf.TokenizedStringFragments.property.escapes">escapes</a></code>       | <code>java.util.List< <a href="#cdktf.IResolvable">IResolvable</a>></code> | Return all escape fragments from this string.    |
 | <code><a href="#cdktf.TokenizedStringFragments.property.firstValue">firstValue</a></code> | <code>java.lang.Object</code>                                              | Returns the first value.                         |
 | <code><a href="#cdktf.TokenizedStringFragments.property.intrinsic">intrinsic</a></code>   | <code>java.util.List< <a href="#cdktf.IResolvable">IResolvable</a>></code> | Return all intrinsic fragments from this string. |
 | <code><a href="#cdktf.TokenizedStringFragments.property.length">length</a></code>         | <code>java.lang.Number</code>                                              | Returns the number of fragments.                 |
 | <code><a href="#cdktf.TokenizedStringFragments.property.literals">literals</a></code>     | <code>java.util.List< <a href="#cdktf.IResolvable">IResolvable</a>></code> | Return all literals from this string.            |
 | <code><a href="#cdktf.TokenizedStringFragments.property.tokens">tokens</a></code>         | <code>java.util.List< <a href="#cdktf.IResolvable">IResolvable</a>></code> | Return all Tokens from this string.              |
 | <code><a href="#cdktf.TokenizedStringFragments.property.firstToken">firstToken</a></code> | <code><a href="#cdktf.IResolvable">IResolvable</a></code>                  | Returns the first token.                         |
+
+---
+
+##### `escapes`<sup>Required</sup> <a name="escapes" id="cdktf.TokenizedStringFragments.property.escapes"></a>
+
+```java
+public java.util.List< IResolvable > getEscapes();
+```
+
+- _Type:_ java.util.List< <a href="#cdktf.IResolvable">IResolvable</a>>
+
+Return all escape fragments from this string.
 
 ---
 

--- a/website/docs/cdktf/api-reference/java.mdx
+++ b/website/docs/cdktf/api-reference/java.mdx
@@ -33368,6 +33368,7 @@ new TokenizedStringFragments();
 | <code><a href="#cdktf.TokenizedStringFragments.addIntrinsic">addIntrinsic</a></code> | Adds an intrinsic fragment.                                  |
 | <code><a href="#cdktf.TokenizedStringFragments.addLiteral">addLiteral</a></code>     | Adds a literal fragment.                                     |
 | <code><a href="#cdktf.TokenizedStringFragments.addToken">addToken</a></code>         | Adds a token fragment.                                       |
+| <code><a href="#cdktf.TokenizedStringFragments.concat">concat</a></code>             | _No description._                                            |
 | <code><a href="#cdktf.TokenizedStringFragments.join">join</a></code>                 | Combine the string fragments using the given joiner.         |
 | <code><a href="#cdktf.TokenizedStringFragments.mapTokens">mapTokens</a></code>       | Apply a transformation function to all tokens in the string. |
 
@@ -33430,6 +33431,18 @@ Adds a token fragment.
 - _Type:_ <a href="#cdktf.IResolvable">IResolvable</a>
 
 the token to add.
+
+---
+
+##### `concat` <a name="concat" id="cdktf.TokenizedStringFragments.concat"></a>
+
+```java
+public void concat(TokenizedStringFragments other)
+```
+
+###### `other`<sup>Required</sup> <a name="other" id="cdktf.TokenizedStringFragments.concat.parameter.other"></a>
+
+- _Type:_ <a href="#cdktf.TokenizedStringFragments">TokenizedStringFragments</a>
 
 ---
 
@@ -34201,6 +34214,7 @@ Resolve an inner object.
 | <code><a href="#cdktf.IResolveContext.property.ignoreEscapes">ignoreEscapes</a></code>     | <code>java.lang.Boolean</code>              | True when ${} should not be parsed, and treated as literals.                                                                                                                                                                       |
 | <code><a href="#cdktf.IResolveContext.property.iteratorContext">iteratorContext</a></code> | <code>java.lang.String</code>               | TerraformIterators can be passed for block attributes and normal list attributes both require different handling when the iterable variable is accessed e.g. a dynamic block needs each.key while a for expression just needs key. |
 | <code><a href="#cdktf.IResolveContext.property.suppressBraces">suppressBraces</a></code>   | <code>java.lang.Boolean</code>              | True when ${} should be ommitted (because already inside them), false otherwise.                                                                                                                                                   |
+| <code><a href="#cdktf.IResolveContext.property.warnEscapes">warnEscapes</a></code>         | <code>java.lang.Boolean</code>              | True when ${} should not be included in the string to be resolved, outputs a warning.                                                                                                                                              |
 
 ---
 
@@ -34261,6 +34275,20 @@ public java.lang.Boolean getSuppressBraces();
 - _Type:_ java.lang.Boolean
 
 True when ${} should be ommitted (because already inside them), false otherwise.
+
+---
+
+##### `warnEscapes`<sup>Optional</sup> <a name="warnEscapes" id="cdktf.IResolveContext.property.warnEscapes"></a>
+
+```java
+public java.lang.Boolean getWarnEscapes();
+```
+
+- _Type:_ java.lang.Boolean
+
+True when ${} should not be included in the string to be resolved, outputs a warning.
+
+Default: false
 
 ---
 

--- a/website/docs/cdktf/api-reference/python.mdx
+++ b/website/docs/cdktf/api-reference/python.mdx
@@ -35834,6 +35834,7 @@ Resolve an inner object.
 | ------------------------------------------------------------------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | <code><a href="#cdktf.IResolveContext.property.preparing">preparing</a></code>              | <code>bool</code>                  | True when we are still preparing, false if we're rendering the final output.                                                                                                                                                       |
 | <code><a href="#cdktf.IResolveContext.property.scope">scope</a></code>                      | <code>constructs.IConstruct</code> | The scope from which resolution has been initiated.                                                                                                                                                                                |
+| <code><a href="#cdktf.IResolveContext.property.ignoreEscapes">ignore_escapes</a></code>     | <code>bool</code>                  | True when ${} should not be parsed, and treated as literals.                                                                                                                                                                       |
 | <code><a href="#cdktf.IResolveContext.property.iteratorContext">iterator_context</a></code> | <code>str</code>                   | TerraformIterators can be passed for block attributes and normal list attributes both require different handling when the iterable variable is accessed e.g. a dynamic block needs each.key while a for expression just needs key. |
 | <code><a href="#cdktf.IResolveContext.property.suppressBraces">suppress_braces</a></code>   | <code>bool</code>                  | True when ${} should be ommitted (because already inside them), false otherwise.                                                                                                                                                   |
 
@@ -35860,6 +35861,18 @@ scope: IConstruct
 - _Type:_ constructs.IConstruct
 
 The scope from which resolution has been initiated.
+
+---
+
+##### `ignore_escapes`<sup>Optional</sup> <a name="ignore_escapes" id="cdktf.IResolveContext.property.ignoreEscapes"></a>
+
+```python
+ignore_escapes: bool
+```
+
+- _Type:_ bool
+
+True when ${} should not be parsed, and treated as literals.
 
 ---
 

--- a/website/docs/cdktf/api-reference/python.mdx
+++ b/website/docs/cdktf/api-reference/python.mdx
@@ -34956,11 +34956,26 @@ cdktf.TokenizedStringFragments()
 
 | **Name**                                                                              | **Description**                                              |
 | ------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| <code><a href="#cdktf.TokenizedStringFragments.addEscape">add_escape</a></code>       | _No description._                                            |
 | <code><a href="#cdktf.TokenizedStringFragments.addIntrinsic">add_intrinsic</a></code> | Adds an intrinsic fragment.                                  |
 | <code><a href="#cdktf.TokenizedStringFragments.addLiteral">add_literal</a></code>     | Adds a literal fragment.                                     |
 | <code><a href="#cdktf.TokenizedStringFragments.addToken">add_token</a></code>         | Adds a token fragment.                                       |
 | <code><a href="#cdktf.TokenizedStringFragments.join">join</a></code>                  | Combine the string fragments using the given joiner.         |
 | <code><a href="#cdktf.TokenizedStringFragments.mapTokens">map_tokens</a></code>       | Apply a transformation function to all tokens in the string. |
+
+---
+
+##### `add_escape` <a name="add_escape" id="cdktf.TokenizedStringFragments.addEscape"></a>
+
+```python
+def add_escape(
+  kind: str
+) - > None
+```
+
+###### `kind`<sup>Required</sup> <a name="kind" id="cdktf.TokenizedStringFragments.addEscape.parameter.kind"></a>
+
+- _Type:_ str
 
 ---
 
@@ -35056,12 +35071,25 @@ Apply a transformation function to all tokens in the string.
 
 | **Name**                                                                                   | **Type**                                                               | **Description**                                  |
 | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- | ------------------------------------------------ |
+| <code><a href="#cdktf.TokenizedStringFragments.property.escapes">escapes</a></code>        | <code>typing.List[<a href="#cdktf.IResolvable">IResolvable</a>]</code> | Return all escape fragments from this string.    |
 | <code><a href="#cdktf.TokenizedStringFragments.property.firstValue">first_value</a></code> | <code>typing.Any</code>                                                | Returns the first value.                         |
 | <code><a href="#cdktf.TokenizedStringFragments.property.intrinsic">intrinsic</a></code>    | <code>typing.List[<a href="#cdktf.IResolvable">IResolvable</a>]</code> | Return all intrinsic fragments from this string. |
 | <code><a href="#cdktf.TokenizedStringFragments.property.length">length</a></code>          | <code>typing.Union[int, float]</code>                                  | Returns the number of fragments.                 |
 | <code><a href="#cdktf.TokenizedStringFragments.property.literals">literals</a></code>      | <code>typing.List[<a href="#cdktf.IResolvable">IResolvable</a>]</code> | Return all literals from this string.            |
 | <code><a href="#cdktf.TokenizedStringFragments.property.tokens">tokens</a></code>          | <code>typing.List[<a href="#cdktf.IResolvable">IResolvable</a>]</code> | Return all Tokens from this string.              |
 | <code><a href="#cdktf.TokenizedStringFragments.property.firstToken">first_token</a></code> | <code><a href="#cdktf.IResolvable">IResolvable</a></code>              | Returns the first token.                         |
+
+---
+
+##### `escapes`<sup>Required</sup> <a name="escapes" id="cdktf.TokenizedStringFragments.property.escapes"></a>
+
+```python
+escapes: typing.List[IResolvable]
+```
+
+- _Type:_ typing.List[<a href="#cdktf.IResolvable">IResolvable</a>]
+
+Return all escape fragments from this string.
 
 ---
 

--- a/website/docs/cdktf/api-reference/python.mdx
+++ b/website/docs/cdktf/api-reference/python.mdx
@@ -35055,15 +35055,15 @@ If there are any
 
 ```python
 def map_tokens(
-  mapper: ITokenMapper
+  context: IResolveContext
 ) - > TokenizedStringFragments
 ```
 
 Apply a transformation function to all tokens in the string.
 
-###### `mapper`<sup>Required</sup> <a name="mapper" id="cdktf.TokenizedStringFragments.mapTokens.parameter.mapper"></a>
+###### `context`<sup>Required</sup> <a name="context" id="cdktf.TokenizedStringFragments.mapTokens.parameter.context"></a>
 
-- _Type:_ <a href="#cdktf.ITokenMapper">ITokenMapper</a>
+- _Type:_ <a href="#cdktf.IResolveContext">IResolveContext</a>
 
 ---
 

--- a/website/docs/cdktf/api-reference/python.mdx
+++ b/website/docs/cdktf/api-reference/python.mdx
@@ -34960,6 +34960,7 @@ cdktf.TokenizedStringFragments()
 | <code><a href="#cdktf.TokenizedStringFragments.addIntrinsic">add_intrinsic</a></code> | Adds an intrinsic fragment.                                  |
 | <code><a href="#cdktf.TokenizedStringFragments.addLiteral">add_literal</a></code>     | Adds a literal fragment.                                     |
 | <code><a href="#cdktf.TokenizedStringFragments.addToken">add_token</a></code>         | Adds a token fragment.                                       |
+| <code><a href="#cdktf.TokenizedStringFragments.concat">concat</a></code>              | _No description._                                            |
 | <code><a href="#cdktf.TokenizedStringFragments.join">join</a></code>                  | Combine the string fragments using the given joiner.         |
 | <code><a href="#cdktf.TokenizedStringFragments.mapTokens">map_tokens</a></code>       | Apply a transformation function to all tokens in the string. |
 
@@ -35030,6 +35031,20 @@ Adds a token fragment.
 - _Type:_ <a href="#cdktf.IResolvable">IResolvable</a>
 
 the token to add.
+
+---
+
+##### `concat` <a name="concat" id="cdktf.TokenizedStringFragments.concat"></a>
+
+```python
+def concat(
+  other: TokenizedStringFragments
+) - > None
+```
+
+###### `other`<sup>Required</sup> <a name="other" id="cdktf.TokenizedStringFragments.concat.parameter.other"></a>
+
+- _Type:_ <a href="#cdktf.TokenizedStringFragments">TokenizedStringFragments</a>
 
 ---
 
@@ -35837,6 +35852,7 @@ Resolve an inner object.
 | <code><a href="#cdktf.IResolveContext.property.ignoreEscapes">ignore_escapes</a></code>     | <code>bool</code>                  | True when ${} should not be parsed, and treated as literals.                                                                                                                                                                       |
 | <code><a href="#cdktf.IResolveContext.property.iteratorContext">iterator_context</a></code> | <code>str</code>                   | TerraformIterators can be passed for block attributes and normal list attributes both require different handling when the iterable variable is accessed e.g. a dynamic block needs each.key while a for expression just needs key. |
 | <code><a href="#cdktf.IResolveContext.property.suppressBraces">suppress_braces</a></code>   | <code>bool</code>                  | True when ${} should be ommitted (because already inside them), false otherwise.                                                                                                                                                   |
+| <code><a href="#cdktf.IResolveContext.property.warnEscapes">warn_escapes</a></code>         | <code>bool</code>                  | True when ${} should not be included in the string to be resolved, outputs a warning.                                                                                                                                              |
 
 ---
 
@@ -35897,6 +35913,20 @@ suppress_braces: bool
 - _Type:_ bool
 
 True when ${} should be ommitted (because already inside them), false otherwise.
+
+---
+
+##### `warn_escapes`<sup>Optional</sup> <a name="warn_escapes" id="cdktf.IResolveContext.property.warnEscapes"></a>
+
+```python
+warn_escapes: bool
+```
+
+- _Type:_ bool
+
+True when ${} should not be included in the string to be resolved, outputs a warning.
+
+Default: false
 
 ---
 

--- a/website/docs/cdktf/api-reference/typescript.mdx
+++ b/website/docs/cdktf/api-reference/typescript.mdx
@@ -29414,6 +29414,7 @@ Resolve an inner object.
 | ------------------------------------------------------------------------------------------ | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | <code><a href="#cdktf.IResolveContext.property.preparing">preparing</a></code>             | <code>boolean</code>               | True when we are still preparing, false if we're rendering the final output.                                                                                                                                                       |
 | <code><a href="#cdktf.IResolveContext.property.scope">scope</a></code>                     | <code>constructs.IConstruct</code> | The scope from which resolution has been initiated.                                                                                                                                                                                |
+| <code><a href="#cdktf.IResolveContext.property.ignoreEscapes">ignoreEscapes</a></code>     | <code>boolean</code>               | True when ${} should not be parsed, and treated as literals.                                                                                                                                                                       |
 | <code><a href="#cdktf.IResolveContext.property.iteratorContext">iteratorContext</a></code> | <code>string</code>                | TerraformIterators can be passed for block attributes and normal list attributes both require different handling when the iterable variable is accessed e.g. a dynamic block needs each.key while a for expression just needs key. |
 | <code><a href="#cdktf.IResolveContext.property.suppressBraces">suppressBraces</a></code>   | <code>boolean</code>               | True when ${} should be ommitted (because already inside them), false otherwise.                                                                                                                                                   |
 
@@ -29440,6 +29441,18 @@ public readonly scope: IConstruct;
 - _Type:_ constructs.IConstruct
 
 The scope from which resolution has been initiated.
+
+---
+
+##### `ignoreEscapes`<sup>Optional</sup> <a name="ignoreEscapes" id="cdktf.IResolveContext.property.ignoreEscapes"></a>
+
+```typescript
+public readonly ignoreEscapes: boolean;
+```
+
+- _Type:_ boolean
+
+True when ${} should not be parsed, and treated as literals.
 
 ---
 

--- a/website/docs/cdktf/api-reference/typescript.mdx
+++ b/website/docs/cdktf/api-reference/typescript.mdx
@@ -28668,14 +28668,14 @@ If there are any
 ##### `mapTokens` <a name="mapTokens" id="cdktf.TokenizedStringFragments.mapTokens"></a>
 
 ```typescript
-public mapTokens(mapper: ITokenMapper): TokenizedStringFragments
+public mapTokens(context: IResolveContext): TokenizedStringFragments
 ```
 
 Apply a transformation function to all tokens in the string.
 
-###### `mapper`<sup>Required</sup> <a name="mapper" id="cdktf.TokenizedStringFragments.mapTokens.parameter.mapper"></a>
+###### `context`<sup>Required</sup> <a name="context" id="cdktf.TokenizedStringFragments.mapTokens.parameter.context"></a>
 
-- _Type:_ <a href="#cdktf.ITokenMapper">ITokenMapper</a>
+- _Type:_ <a href="#cdktf.IResolveContext">IResolveContext</a>
 
 ---
 

--- a/website/docs/cdktf/api-reference/typescript.mdx
+++ b/website/docs/cdktf/api-reference/typescript.mdx
@@ -28584,6 +28584,7 @@ new TokenizedStringFragments();
 | <code><a href="#cdktf.TokenizedStringFragments.addIntrinsic">addIntrinsic</a></code> | Adds an intrinsic fragment.                                  |
 | <code><a href="#cdktf.TokenizedStringFragments.addLiteral">addLiteral</a></code>     | Adds a literal fragment.                                     |
 | <code><a href="#cdktf.TokenizedStringFragments.addToken">addToken</a></code>         | Adds a token fragment.                                       |
+| <code><a href="#cdktf.TokenizedStringFragments.concat">concat</a></code>             | _No description._                                            |
 | <code><a href="#cdktf.TokenizedStringFragments.join">join</a></code>                 | Combine the string fragments using the given joiner.         |
 | <code><a href="#cdktf.TokenizedStringFragments.mapTokens">mapTokens</a></code>       | Apply a transformation function to all tokens in the string. |
 
@@ -28646,6 +28647,18 @@ Adds a token fragment.
 - _Type:_ <a href="#cdktf.IResolvable">IResolvable</a>
 
 the token to add.
+
+---
+
+##### `concat` <a name="concat" id="cdktf.TokenizedStringFragments.concat"></a>
+
+```typescript
+public concat(other: TokenizedStringFragments): void
+```
+
+###### `other`<sup>Required</sup> <a name="other" id="cdktf.TokenizedStringFragments.concat.parameter.other"></a>
+
+- _Type:_ <a href="#cdktf.TokenizedStringFragments">TokenizedStringFragments</a>
 
 ---
 
@@ -29417,6 +29430,7 @@ Resolve an inner object.
 | <code><a href="#cdktf.IResolveContext.property.ignoreEscapes">ignoreEscapes</a></code>     | <code>boolean</code>               | True when ${} should not be parsed, and treated as literals.                                                                                                                                                                       |
 | <code><a href="#cdktf.IResolveContext.property.iteratorContext">iteratorContext</a></code> | <code>string</code>                | TerraformIterators can be passed for block attributes and normal list attributes both require different handling when the iterable variable is accessed e.g. a dynamic block needs each.key while a for expression just needs key. |
 | <code><a href="#cdktf.IResolveContext.property.suppressBraces">suppressBraces</a></code>   | <code>boolean</code>               | True when ${} should be ommitted (because already inside them), false otherwise.                                                                                                                                                   |
+| <code><a href="#cdktf.IResolveContext.property.warnEscapes">warnEscapes</a></code>         | <code>boolean</code>               | True when ${} should not be included in the string to be resolved, outputs a warning.                                                                                                                                              |
 
 ---
 
@@ -29477,6 +29491,20 @@ public readonly suppressBraces: boolean;
 - _Type:_ boolean
 
 True when ${} should be ommitted (because already inside them), false otherwise.
+
+---
+
+##### `warnEscapes`<sup>Optional</sup> <a name="warnEscapes" id="cdktf.IResolveContext.property.warnEscapes"></a>
+
+```typescript
+public readonly warnEscapes: boolean;
+```
+
+- _Type:_ boolean
+
+True when ${} should not be included in the string to be resolved, outputs a warning.
+
+Default: false
 
 ---
 

--- a/website/docs/cdktf/api-reference/typescript.mdx
+++ b/website/docs/cdktf/api-reference/typescript.mdx
@@ -28580,11 +28580,24 @@ new TokenizedStringFragments();
 
 | **Name**                                                                             | **Description**                                              |
 | ------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
+| <code><a href="#cdktf.TokenizedStringFragments.addEscape">addEscape</a></code>       | _No description._                                            |
 | <code><a href="#cdktf.TokenizedStringFragments.addIntrinsic">addIntrinsic</a></code> | Adds an intrinsic fragment.                                  |
 | <code><a href="#cdktf.TokenizedStringFragments.addLiteral">addLiteral</a></code>     | Adds a literal fragment.                                     |
 | <code><a href="#cdktf.TokenizedStringFragments.addToken">addToken</a></code>         | Adds a token fragment.                                       |
 | <code><a href="#cdktf.TokenizedStringFragments.join">join</a></code>                 | Combine the string fragments using the given joiner.         |
 | <code><a href="#cdktf.TokenizedStringFragments.mapTokens">mapTokens</a></code>       | Apply a transformation function to all tokens in the string. |
+
+---
+
+##### `addEscape` <a name="addEscape" id="cdktf.TokenizedStringFragments.addEscape"></a>
+
+```typescript
+public addEscape(kind: string): void
+```
+
+###### `kind`<sup>Required</sup> <a name="kind" id="cdktf.TokenizedStringFragments.addEscape.parameter.kind"></a>
+
+- _Type:_ string
 
 ---
 
@@ -28670,12 +28683,25 @@ Apply a transformation function to all tokens in the string.
 
 | **Name**                                                                                  | **Type**                                                    | **Description**                                  |
 | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------ |
+| <code><a href="#cdktf.TokenizedStringFragments.property.escapes">escapes</a></code>       | <code><a href="#cdktf.IResolvable">IResolvable</a>[]</code> | Return all escape fragments from this string.    |
 | <code><a href="#cdktf.TokenizedStringFragments.property.firstValue">firstValue</a></code> | <code>any</code>                                            | Returns the first value.                         |
 | <code><a href="#cdktf.TokenizedStringFragments.property.intrinsic">intrinsic</a></code>   | <code><a href="#cdktf.IResolvable">IResolvable</a>[]</code> | Return all intrinsic fragments from this string. |
 | <code><a href="#cdktf.TokenizedStringFragments.property.length">length</a></code>         | <code>number</code>                                         | Returns the number of fragments.                 |
 | <code><a href="#cdktf.TokenizedStringFragments.property.literals">literals</a></code>     | <code><a href="#cdktf.IResolvable">IResolvable</a>[]</code> | Return all literals from this string.            |
 | <code><a href="#cdktf.TokenizedStringFragments.property.tokens">tokens</a></code>         | <code><a href="#cdktf.IResolvable">IResolvable</a>[]</code> | Return all Tokens from this string.              |
 | <code><a href="#cdktf.TokenizedStringFragments.property.firstToken">firstToken</a></code> | <code><a href="#cdktf.IResolvable">IResolvable</a></code>   | Returns the first token.                         |
+
+---
+
+##### `escapes`<sup>Required</sup> <a name="escapes" id="cdktf.TokenizedStringFragments.property.escapes"></a>
+
+```typescript
+public readonly escapes: IResolvable[];
+```
+
+- _Type:_ <a href="#cdktf.IResolvable">IResolvable</a>[]
+
+Return all escape fragments from this string.
 
 ---
 

--- a/website/docs/cdktf/concepts/functions.mdx
+++ b/website/docs/cdktf/concepts/functions.mdx
@@ -138,3 +138,22 @@ new TerraformOutput(this, "half-of-the-zone", {
   value: Op.div(Fn.length(zones.names), 2),
 });
 ```
+
+# Using Terraform built-in functions directly within strings
+
+It is also possible to use all built-in Terraform functions without using CDKTF's `Fn.*` functions described above. To write Terraform built-in functions the same as you would in HCL, simply wrap the desired string within the HCL `${` and `}` syntax. **Note:** CDKTF doesn't do any further processing within the escaped syntax (`${` and `}`), and thus is unable to handle nested escape syntaxes yet.
+
+```typescript
+import { Fn, Op, TerraformOutput } from "cdktf";
+import { DataAwsAvailabilityZones } from "@cdktf/provider-aws/lib/data-aws-availability-zones";
+
+// ...
+
+const const zones = new DataAwsAvailabilityZones(this, "zones", {
+  state: "available",
+});
+
+new TerraformOutput(this, "half-of-the-zone", {
+  value: `\${length(${zones.fqn}.names) / 2}`
+});
+```


### PR DESCRIPTION
Relates to: https://github.com/hashicorp/terraform-cdk/issues/1641

This PR proposes to use the HCL syntax for string interpolation (`${}`) to alter how CDKTF outputs [Tokens](https://developer.hashicorp.com/terraform/cdktf/concepts/tokens). What I'm looking for right now is some feedback around what kinds of potential problems this introduces that I may not have thought about and the relative usefulness of such things pertaining to its ease of use with [escape hatches](https://developer.hashicorp.com/terraform/cdktf/concepts/resources#escape-hatch) and overrides.

### Problem
As the above issue mentions, working with FQN is hard currently, and the root cause seems to be the resolution of tokens. The easiest example is from the above issue, where a user tried the following:

```typescript
efsMountTarget.addOverride(
      "count",
      `\${length(${dataAwsAvailabilityZonesAll.fqn}.names)}`
    );
```
Here's the expectation is that the value of `count` in the output would be: `${length(data.allAvailableZones.name)}`, however, earlier to this PR, we would output:

```tf
"${length(${data.allAvailableZones}.name)}"
```

This then trips up Terraform because `${}` is only valid within a string and not within normal HCL, causing errors like: `Error: Invalid character` or `Error: Invalid expression` etc.

### Current workarounds / preferred ways
As already mentioned in the above issue, a few work arounds for this would be to use CDKTF's [Terraform functions](https://developer.hashicorp.com/terraform/cdktf/concepts/functions). If we were to use those, the above example could become:

```typescript
   const zoneNames = Fn.lookup(dataAwsAvailabilityZonesAll.fqn, "names", undefined)
   efsMountTarget.addOverride(
     "count",
     Fn.lengthOf(zoneNames)
   );
```

While this is a pretty nice example where I think using Terraform functions is recommended, there are times when using them is a bit more difficult / cumbersome. From the original issue:

```
const webappService = new Service(this, 'k8s-service-webapp', {
  ...
  waitForLoadBalancer: true,
});

new DnsRecordSet(this, `webapp-dns-zone-record`, {
  ...
  rrdatas: [(webappService?.status.fqn as any)[0]?.load_balancer?.ingress?.ip], // won't be resolved properly
});
```

The solution using Terraform functions is:

```typescript
Fn.lookup(Fn.lookup(Fn.lookup(Fn.element(webappService.status.fqn, 0), "load_balancer"), "ingress"), "ip")
```

which can be a bit complicated to figure out.

### Proposal
With this PR, I'd like to make a proposal with adding something like a 'raw' mode where the user can signal CDKTF to stop adding any additional string interpolation syntax (`${}`) in it's output. Here's how this would look like for the first example:

```typescript
efsMountTarget.addOverride(
      "count",
      `\${length(${dataAwsAvailabilityZonesAll.fqn}.names)}`
    );
```

This example would no longer create an error because the output will be: 

```tf
"${length(data.allAvailableZones.name)}"
```

The second example becomes:

```typescript
const webappService = new Service(this, 'k8s-service-webapp', {
  ...
  waitForLoadBalancer: true,
});

new DnsRecordSet(this, `webapp-dns-zone-record`, {
  ...
  rrdatas: [`$\{${webappService?.status.fqn}[0].load_balancer[0].ingress[0].ip}`],
});
```

> **Warning**
> Within the top-level interpolation sequence, CDKTF will continue suppressing the interpolation syntax, so things like `` `$\{"test-${resource.fqn}"}` `` would not have the intended effect. However, there can be multiple top-level interpolation sequences, like: `` `$\{${resource1.fqn}.name}-${Fn.lookup(resource2.fqn, "names", undefined)}` `` that would do the right thing.


### TODOs
- [ ] Update [functions.mdx documentation](https://github.com/hashicorp/terraform-cdk/blob/main/website/docs/cdktf/concepts/functions.mdx)
- [ ] More tests for edge cases
