### PR TITLE
feat(lib): adds failed process output to test matcher APIs #1953

### DIFF
--- a/packages/cdktf/lib/testing/__tests__/matchers.test.ts
+++ b/packages/cdktf/lib/testing/__tests__/matchers.test.ts
@@ -239,6 +239,11 @@ describe("matchers", () => {
           "Expected subject to be a valid terraform stack"
         )
       );
+      expect(res.message).toEqual(
+        expect.stringContaining(
+          "There are some problems with the configuration, described below."
+        )
+      );
     });
   });
 
@@ -259,6 +264,7 @@ describe("matchers", () => {
       new DockerImage(stack, "test", { name: "test" });
 
       const res = toPlanSuccessfully(Testing.fullSynth(stack));
+
       expect(res.pass).toBeTruthy();
       expect(res.message).toMatchInlineSnapshot(
         `"Expected subject not to plan successfully"`

--- a/packages/cdktf/lib/testing/__tests__/matchers.test.ts
+++ b/packages/cdktf/lib/testing/__tests__/matchers.test.ts
@@ -245,7 +245,9 @@ describe("matchers", () => {
         )
       );
       expect(res.message).toEqual(
-        expect.stringContaining("Error: Extraneous data after value")
+        expect.stringContaining(
+          "Expected subject to be a valid terraform stack"
+        )
       );
     });
   });

--- a/packages/cdktf/lib/testing/__tests__/matchers.test.ts
+++ b/packages/cdktf/lib/testing/__tests__/matchers.test.ts
@@ -244,6 +244,9 @@ describe("matchers", () => {
           "There are some problems with the configuration, described below."
         )
       );
+      expect(res.message).toEqual(
+        expect.stringContaining("Error: Extraneous data after value")
+      );
     });
   });
 

--- a/packages/cdktf/lib/testing/matchers.ts
+++ b/packages/cdktf/lib/testing/matchers.ts
@@ -221,7 +221,7 @@ export function getToHaveResourceWithProperties(
 const isExecSpawnError = (err: any): err is Error & SpawnSyncReturns<any> =>
   "output" in err &&
   Array.isArray(err.output) &&
-  err.output.some((buf: any) => buf instanceof Buffer);
+  err.output.some((buf: any) => Buffer.isBuffer(buf));
 
 /**
  * A helper util to append `process.spawn` output to assertion messages to improve developer expirience.

--- a/packages/cdktf/lib/testing/matchers.ts
+++ b/packages/cdktf/lib/testing/matchers.ts
@@ -212,13 +212,24 @@ export function getToHaveResourceWithProperties(
   };
 }
 
-// eslint-disable-next-line jsdoc/require-jsdoc
+/**
+ * A helper util to verify wether an Error was caused by the Nodejs `process.spawn` API.
+ *
+ * @param   {Error}   err The Error object to verify
+ * @returns {Boolean}     A bool indicating wether the input Error is containing process.spawn output.
+ */
 const isExecSpawnError = (err: any): err is Error & SpawnSyncReturns<any> =>
   "output" in err &&
   Array.isArray(err.output) &&
   err.output.some((buf: any) => buf instanceof Buffer);
 
-// eslint-disable-next-line jsdoc/require-jsdoc
+/**
+ * A helper util to append `process.spawn` output to assertion messages to improve developer expirience.
+ *
+ * @param   {String} message The message to optionally append process output to.
+ * @param   {Error}  err     The error from which the `process.spawn` output should be retreived from.
+ * @returns {String}         The finalized assertion message decorated with the `process.spawn` output.
+ */
 const withProcessOutput = (message: string, err: unknown) => {
   let output = "";
 


### PR DESCRIPTION
This commit appends the process output to the error message of test matchers such as `.toPlanSuccessfully()` or `.toBeValidTerraform()` if available. 

Prior to this commit the developer faced a more generic error message and had to manually execute `terraform validate -json` in the output directory of CDKTF to receive more details on why the test failed.

-> **Nevermind: Did not saw that there is an PR already open to tackle this issue... This PR can be closed if preferred!**

Closes #1953 
