### PR TITLE
fix(provider-generator): don't require arrays wrapping variable / output declarations

### DIFF
--- a/packages/@cdktf/provider-generator/lib/get/__tests__/__snapshots__/read-schema.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/__snapshots__/read-schema.test.ts.snap
@@ -1,5 +1,72 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`readSchema generates a local json module 1`] = `
+Object {
+  "local_module": Object {
+    "inputs": Array [
+      Object {
+        "default": "module",
+        "description": "Name of the DigitalOcean static site",
+        "name": "name",
+        "required": false,
+        "type": "any",
+      },
+      Object {
+        "default": "ams",
+        "description": "Region to deploy the app to",
+        "name": "region",
+        "required": false,
+        "type": "any",
+      },
+    ],
+    "name": "local_module",
+    "outputs": Array [
+      Object {
+        "description": undefined,
+        "name": "uri",
+      },
+    ],
+  },
+}
+`;
+
+exports[`readSchema generates a local module 1`] = `
+Object {
+  "local_module": Object {
+    "inputs": Array [
+      Object {
+        "description": "Name of the s3 bucket. Must be unique.",
+        "name": "bucket_name",
+        "required": true,
+        "type": "string",
+      },
+      Object {
+        "default": Object {},
+        "description": "Tags to set on the bucket.",
+        "name": "tags",
+        "required": false,
+        "type": "map(string)",
+      },
+    ],
+    "name": "local_module",
+    "outputs": Array [
+      Object {
+        "description": "ARN of the bucket",
+        "name": "arn",
+      },
+      Object {
+        "description": "Domain name of the bucket",
+        "name": "domain",
+      },
+      Object {
+        "description": "Name (id) of the bucket",
+        "name": "name",
+      },
+    ],
+  },
+}
+`;
+
 exports[`readSchema generates a more complex schema 1`] = `
 Object {
   "terraform-aws-modules_eks_aws": Object {

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/fixtures/local-json-module/module.tf.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/fixtures/local-json-module/module.tf.json
@@ -1,0 +1,17 @@
+{
+  "output": {
+    "uri": {
+      "value": "${digitalocean_app.static_site}"
+    }
+  },
+  "variable": {
+    "name": {
+      "default": "module",
+      "description": "Name of the DigitalOcean static site"
+    },
+    "region": {
+      "default": "ams",
+      "description": "Region to deploy the app to"
+    }
+  }
+}

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/fixtures/local-module/module.tf
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/fixtures/local-module/module.tf
@@ -1,0 +1,30 @@
+# https://learn.hashicorp.com/tutorials/terraform/module-create
+
+# Input variable definitions
+
+variable "bucket_name" {
+  description = "Name of the s3 bucket. Must be unique."
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to set on the bucket."
+  type        = map(string)
+  default     = {}
+}
+# Output variable definitions
+
+output "arn" {
+  description = "ARN of the bucket"
+  value       = aws_s3_bucket.s3_bucket.arn
+}
+
+output "name" {
+  description = "Name (id) of the bucket"
+  value       = aws_s3_bucket.s3_bucket.id
+}
+
+output "domain" {
+  description = "Domain name of the bucket"
+  value       = aws_s3_bucket_website_configuration.s3_bucket.website_domain
+}

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/read-schema.test.ts
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/read-schema.test.ts
@@ -1,3 +1,4 @@
+import * as path from "path";
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
 import {
@@ -54,6 +55,28 @@ describe("readSchema", () => {
     const module = new TerraformModuleConstraint(
       "terraform-aws-modules/eks/aws@7.0.1"
     );
+    const target = new ConstructsMakerModuleTarget(module, Language.TYPESCRIPT);
+    const result = await readModuleSchema(target);
+    expect(result).toMatchSnapshot();
+  });
+
+  it("generates a local module", async () => {
+    const module = new TerraformModuleConstraint({
+      name: "local_module",
+      fqn: "local_module",
+      source: path.resolve(__dirname, "fixtures", "local-module"),
+    });
+    const target = new ConstructsMakerModuleTarget(module, Language.TYPESCRIPT);
+    const result = await readModuleSchema(target);
+    expect(result).toMatchSnapshot();
+  });
+
+  it("generates a local json module", async () => {
+    const module = new TerraformModuleConstraint({
+      name: "local_module",
+      fqn: "local_module",
+      source: path.resolve(__dirname, "fixtures", "local-json-module"),
+    });
     const target = new ConstructsMakerModuleTarget(module, Language.TYPESCRIPT);
     const result = await readModuleSchema(target);
     expect(result).toMatchSnapshot();

--- a/packages/@cdktf/provider-generator/lib/get/generator/provider-schema.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/provider-schema.ts
@@ -132,13 +132,16 @@ interface ModuleIndex {
   Modules: ModuleIndexItem[];
 }
 
+const unwrapIfArray = <T>(item: T | T[]): T =>
+  Array.isArray(item) ? item[0] : item;
+
 const transformVariables = (variables: any) => {
   const result: Input[] = [];
 
   if (!variables) return result;
 
   for (const name of Object.keys(variables)) {
-    const variable = variables[name][0];
+    const variable = unwrapIfArray(variables[name]);
     let variableType: string;
 
     if (
@@ -185,7 +188,7 @@ const transformOutputs = (outputs: any) => {
 
   if (outputs) {
     for (const name of Object.keys(outputs)) {
-      const output = outputs[name][0];
+      const output = unwrapIfArray(outputs[name]);
 
       const item: any = {
         name,


### PR DESCRIPTION
While terraform gives us this format, a hand-written or generated .tf.json file might not have
extra arrays around the values of variables and outputs. This leads to errors when parsing, so
when cdktf get is invoked.
