### PR TITLE
chore(docs): rewrite internal redirects

### DIFF
--- a/website/docs/cdktf/cli-reference/commands.mdx
+++ b/website/docs/cdktf/cli-reference/commands.mdx
@@ -153,7 +153,7 @@ Options:
   -h, --help                                    Show help  [boolean]
 ```
 
-~> **Note:** The `parallelism` flag has a different behavior than the [terraform parallelism flag](https://www.terraform.io/cli/commands/apply#parallelism-n). To set the custom terraform parallelism flag, please use the `--terraform-parallelism` flag instead.
+~> **Note:** The `parallelism` flag has a different behavior than the [terraform parallelism flag](/cli/commands/apply#parallelism-n). To set the custom terraform parallelism flag, please use the `--terraform-parallelism` flag instead.
 
 **Examples**
 
@@ -222,7 +222,7 @@ Options:
   -h, --help                               Show help  [boolean]
 ```
 
-~> **Note:** The `parallelism` flag has a different behavior than the [terraform parallelism flag](https://www.terraform.io/cli/commands/apply#parallelism-n). To set the custom terraform parallelism flag, please use the `--terraform-parallelism` flag instead.
+~> **Note:** The `parallelism` flag has a different behavior than the [terraform parallelism flag](/cli/commands/apply#parallelism-n). To set the custom terraform parallelism flag, please use the `--terraform-parallelism` flag instead.
 
 **Examples**
 
@@ -287,7 +287,7 @@ Options:
   -h, --help                      Show help  [boolean]
 ```
 
-~> **Note:** The `parallelism` flag has a different behavior than the [terraform parallelism flag](https://www.terraform.io/cli/commands/plan#parallelism-n). To set the custom terraform parallelism flag, please use the `--terraform-parallelism` flag instead.
+~> **Note:** The `parallelism` flag has a different behavior than the [terraform parallelism flag](/cli/commands/plan#parallelism-n). To set the custom terraform parallelism flag, please use the `--terraform-parallelism` flag instead.
 
 Examples:
 
@@ -516,7 +516,7 @@ Options:
   -h, --help                      Show help  [boolean]
 ```
 
-~> **Note:** The `parallelism` flag has a different behavior than the [terraform parallelism flag](https://www.terraform.io/cli/commands/apply#parallelism-n). To set the custom terraform parallelism flag, please use the `--terraform-parallelism` flag instead.
+~> **Note:** The `parallelism` flag has a different behavior than the [terraform parallelism flag](/cli/commands/apply#parallelism-n). To set the custom terraform parallelism flag, please use the `--terraform-parallelism` flag instead.
 
 **Examples**
 

--- a/website/docs/cdktf/concepts/data-sources.mdx
+++ b/website/docs/cdktf/concepts/data-sources.mdx
@@ -37,7 +37,7 @@ export class HelloTerraform extends TerraformStack {
 
 ## Remote State Data Source
 
-The [`terraform_remote_state` data source](/language/state/remote-state-data) retrieves state data from a remote [Terraform backend](/language/settings/backends). This allows you to use the root-level outputs of one or more Terraform configurations as input data for another configuration. For example, a core infrastructure team can handle building the core machines, networking, etc. and then expose some information to other teams that allows them to run their own infrastructure. Refer to the [Remote Backends page](/cdktf/concepts/remote-backends) for more details.
+The [`terraform_remote_state` data source](/language/state/remote-state-data) retrieves state data from a remote [Terraform backend](/language/settings/backends/configuration). This allows you to use the root-level outputs of one or more Terraform configurations as input data for another configuration. For example, a core infrastructure team can handle building the core machines, networking, etc. and then expose some information to other teams that allows them to run their own infrastructure. Refer to the [Remote Backends page](/cdktf/concepts/remote-backends) for more details.
 
 The following TypeScript example uses the global `DataTerraformRemoteState` to reference a Terraform Output of another Terraform configuration.
 

--- a/website/docs/cdktf/concepts/remote-backends.mdx
+++ b/website/docs/cdktf/concepts/remote-backends.mdx
@@ -11,7 +11,7 @@ Terraform stores [state](/language/state) about managed infrastructure to map re
 
 By default, `cdktf init` will configure a Terraform Cloud workspace and a corresponding remote backend to store state for the new project. If you run `cdktf init --local` to configure your new project to use a local backend to store state, you can still [migrate the state](#migrate-local-state-storage-to-remote) to a remote backend later.
 
-You can configure your CDK for Terraform (CDKTF) remote backend to be [Terraform Cloud](/cloud), another Terraform [supported backend](#supported-backends), or a custom location.
+You can configure your CDK for Terraform (CDKTF) remote backend to be [Terraform Cloud](https://cloud.hashicorp.com/products/terraform), another Terraform [supported backend](#supported-backends), or a custom location.
 
 ## When to Use Remote Backends
 
@@ -167,7 +167,7 @@ In addition to Terraform Cloud, Terraform and CDKTF support the following backen
   ```typescript
   new LocalBackend(stack, {...});
   ```
-- [artifactory](/language/settings/backends/artifactory)
+- [artifactory](/language/v1.2.x/settings/backends/artifactory)
   ```typescript
   new ArtifactoryBackend(stack, {...});
   ```
@@ -183,11 +183,11 @@ In addition to Terraform Cloud, Terraform and CDKTF support the following backen
   ```typescript
   new CosBackend(stack, {...});
   ```
-- [etcd](/language/settings/backends/etcd)
+- [etcd](/language/v1.2.x/settings/backends/etcd)
   ```typescript
   new EtcdBackend(stack, {...});
   ```
-- [etcdv3](/language/settings/backends/etcdv3)
+- [etcdv3](/language/v1.2.x/settings/backends/etcdv3)
   ```typescript
   new EtcdV3Backend(stack, {...});
   ```
@@ -199,7 +199,7 @@ In addition to Terraform Cloud, Terraform and CDKTF support the following backen
   ```typescript
   new HttpBackend(stack, {...});
   ```
-- [manta](/language/settings/backends/manta)
+- [manta](/language/v1.2.x/settings/backends/manta)
   ```typescript
   new MantaBackend(stack, {...});
   ```
@@ -215,7 +215,7 @@ In addition to Terraform Cloud, Terraform and CDKTF support the following backen
   ```typescript
   new S3Backend(stack, {...});
   ```
-- [swift](/language/settings/backends/swift)
+- [swift](/language/v1.2.x/settings/backends/swift)
   ```typescript
   new SwiftBackend(stack, {...});
   ```

--- a/website/docs/cdktf/concepts/resources.mdx
+++ b/website/docs/cdktf/concepts/resources.mdx
@@ -73,9 +73,9 @@ new Deployment(this, "nginx-deployment", {
 
 ## Provisioners
 
-Provisioners can be used to model specific actions on the local machine or on a remote machine in order to prepare servers or other infrastructure objects for service. You can find more information on the concept of provisioners in the [Terraform docs](https://www.terraform.io/language/resources/provisioners/syntax). You can pass the `provisioners` key to define a list of provisioners, connections can be configured with the `connection` key. A working example can be found at [examples/typescript/provisioner](https://github.com/hashicorp/terraform-cdk/blob/main/examples/typescript/provisioner/main.ts).
+Provisioners can be used to model specific actions on the local machine or on a remote machine in order to prepare servers or other infrastructure objects for service. You can find more information on the concept of provisioners in the [Terraform docs](/language/resources/provisioners/syntax). You can pass the `provisioners` key to define a list of provisioners, connections can be configured with the `connection` key. A working example can be found at [examples/typescript/provisioner](https://github.com/hashicorp/terraform-cdk/blob/main/examples/typescript/provisioner/main.ts).
 
-If you need to use the special [`self` object](https://www.terraform.io/language/resources/provisioners/syntax#the-self-object) that can only be used in `provisioner` and `connection` blocks to refer to the parent resource you can use the `TerraformSelf` class like this: `TerraformSelf.getString("public_ip")`.
+If you need to use the special [`self` object](/language/resources/provisioners/syntax#the-self-object) that can only be used in `provisioner` and `connection` blocks to refer to the parent resource you can use the `TerraformSelf` class like this: `TerraformSelf.getString("public_ip")`.
 
 ## Escape Hatch
 

--- a/website/docs/cdktf/concepts/variables-and-outputs.mdx
+++ b/website/docs/cdktf/concepts/variables-and-outputs.mdx
@@ -21,7 +21,7 @@ You can define [Terraform variables](/language/values/variables) as input parame
 
 ### When to use Input Variables
 
-Variables are useful when you plan to synthesize your CDKTF application into a JSON configuration file for Terraform. For example, when you are planning to store configurations and run Terraform inside [Terraform Cloud](/cloud).
+Variables are useful when you plan to synthesize your CDKTF application into a JSON configuration file for Terraform. For example, when you are planning to store configurations and run Terraform inside [Terraform Cloud](https://cloud.hashicorp.com/products/terraform).
 
 If you plan to use CDKTF to manage your infrastructure, we recommend using your language's APIs to consume the data you would normally pass through Terraform variables. You can read from disk (synchronously) or from the environment variables, just as you would in any normal program.
 

--- a/website/docs/cdktf/create-and-deploy/best-practices.mdx
+++ b/website/docs/cdktf/create-and-deploy/best-practices.mdx
@@ -27,7 +27,7 @@ new MyResource(this, "hello", {
 
 To pass a [Terraform variable through environment variables](/cli/config/environment-variables#tf_var_name), name the environment variable `TF_VAR_NAME`. For example, set `TF_VAR_adminPasword='<your password>'` in the execution environment.
 
-If you use Terraform Cloud with [remote execution](/cloud-docs/run#remote-operations), you can store your secrets in Terraform Cloud. Refer to the Terraform Cloud documentation about [workspace variables](/cloud-docs/workspaces/variables/managing-variables#workspace-specific-variables) for more details.
+If you use Terraform Cloud with [remote execution](/cloud-docs/run/remote-operations#remote-operations), you can store your secrets in Terraform Cloud. Refer to the Terraform Cloud documentation about [workspace variables](/cloud-docs/workspaces/variables/managing-variables#workspace-specific-variables) for more details.
 
 We recommend using `TerraformVariable` only at the Stack level. Nesting them in custom constructs makes the interface unclear because some information may be passed into the constructor of the construct, while other data may be passed through a `TerraformVariable`. Nesting also changes the logical ID and makes it difficult to understand which `TerraformVariable` instances you must configure for the CDKTF program to run.
 

--- a/website/docs/cdktf/create-and-deploy/deployment-patterns.mdx
+++ b/website/docs/cdktf/create-and-deploy/deployment-patterns.mdx
@@ -53,7 +53,7 @@ You can use the [Terraform CDK GitHub Action](https://github.com/marketplace/act
 
 ### GitHub Actions CI and Terraform Cloud
 
-Set the `TERRAFORM_CLOUD_TOKEN` environment variable to the [Terraform Cloud API token](https://www.terraform.io/cloud-docs/users-teams-organizations/api-tokens). This allows the CDKTF stacks `CloudBackend` to connect to Terraform Cloud.
+Set the `TERRAFORM_CLOUD_TOKEN` environment variable to the [Terraform Cloud API token](/cloud-docs/users-teams-organizations/api-tokens). This allows the CDKTF stacks `CloudBackend` to connect to Terraform Cloud.
 
 You must create a job like this for every stack so that you can pass the stack name into `cdktf diff <stack name>`. None of the stacks can depend on each other because Terraform cannot reason about which stacks must be launched first to respect these dependencies.
 

--- a/website/docs/cdktf/create-and-deploy/terraform-cloud.mdx
+++ b/website/docs/cdktf/create-and-deploy/terraform-cloud.mdx
@@ -147,6 +147,6 @@ To run Terraform Cloud in a CI workflow, you can either use [Terraform Cloud's V
 
 -> **Note:** Sentinel policies and run tasks are available in the **Team & Governance** package. Refer to [Terraform Cloud pricing](https://www.hashicorp.com/products/terraform/pricing) for details.
 
-You can define [Sentinel policies](/cloud-docs/sentinel) for one or multiple Terraform Cloud workspaces to ensure that your infrastructure follows company-wide security standards and best practices. You can use Sentinel policies with CDKTF if Terraform Cloud is configured as a [Remote Backend](/concepts/remote-backends).
+You can define [Sentinel policies](/cloud-docs/policy-enforcement) for one or multiple Terraform Cloud workspaces to ensure that your infrastructure follows company-wide security standards and best practices. You can use Sentinel policies with CDKTF if Terraform Cloud is configured as a [Remote Backend](/concepts/remote-backends).
 
 You can also use [Run Tasks](/cloud-docs/workspaces/settings/run-tasks) to directly integrate third-party tools and services at certain stages in the Terraform Cloud run lifecycle. Terraform Cloud uses the status response from the third-party tool to determine if a run should proceed.

--- a/website/docs/cdktf/examples.mdx
+++ b/website/docs/cdktf/examples.mdx
@@ -44,7 +44,7 @@ Follow these hands-on tutorials:
 
 #### Backends
 
-Each CDK for Terraform project can specify a [backend](/language/settings/backends) that defines where and how Terraform operations are performed, where Terraform [state snapshots](/language/state) are stored, etc.
+Each CDK for Terraform project can specify a [backend](/language/settings/backends/configuration) that defines where and how Terraform operations are performed, where Terraform [state snapshots](/language/state) are stored, etc.
 
 | Example                                                                                              | Description                                                                                                                         | Complexity |
 | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ---------- |

--- a/website/docs/cdktf/index.mdx
+++ b/website/docs/cdktf/index.mdx
@@ -23,7 +23,7 @@ At a high level, you will:
 1. **Define Infrastructure:** Use your chosen language to define the infrastructure you want to provision on one or more providers. CDKTF automatically extracts the schema from Terraform providers and modules to generate the necessary classes for your application.
 1. **Deploy**: Use `cdktf` CLI commands to provision infrastructure with Terraform or synthesize your code into a JSON configuration file that others can use with Terraform directly.
 
-You can use every Terraform provider and module available on the [Terraform Registry](https://registry.terraform.io/), and you can use CDKTF with [Terraform Cloud](/cloud), [Terraform Enterprise](/enterprise), and HashiCorp's policy as code framework, [Sentinel](https://www.hashicorp.com/sentinel).
+You can use every Terraform provider and module available on the [Terraform Registry](https://registry.terraform.io/), and you can use CDKTF with [Terraform Cloud](https://cloud.hashicorp.com/products/terraform), [Terraform Enterprise](/enterprise), and HashiCorp's policy as code framework, [Sentinel](https://www.hashicorp.com/sentinel).
 
 ## When to use CDK for Terraform
 

--- a/website/docs/cdktf/release/upgrade-guide-v0-11.mdx
+++ b/website/docs/cdktf/release/upgrade-guide-v0-11.mdx
@@ -11,7 +11,7 @@ Both lists and maps now allow accessing all computed attributes of an assignable
 
 ### `TF_VAR_` prefixed environment variables can no longer be accessed at synth time
 
-These environment variables will now be filtered out in the synth phase since they are only intended to be used during diff (plan) and deploy (apply) phases to supply values for [`TerraformVariable`s](https://www.terraform.io/cdktf/concepts/variables-and-outputs#input-variables). This inhibits accidentally inlining those values into the generated `cdk.tf.json` config.
+These environment variables will now be filtered out in the synth phase since they are only intended to be used during diff (plan) and deploy (apply) phases to supply values for [`TerraformVariable`s](/cdktf/concepts/variables-and-outputs#input-variables). This inhibits accidentally inlining those values into the generated `cdk.tf.json` config.
 
 ### Environment variable and CLI option changes
 


### PR DESCRIPTION
# Description 

This rewrites some markdown links to be their final redirect destinations.
This is in support of the GA Rollout to developer.hashicorp.com