### PR TITLE
chore(deps): Update docker image to use new jsii/superchain tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.mirror.hashicorp.services/jsii/superchain:node14
+FROM docker.mirror.hashicorp.services/jsii/superchain:1-buster-slim-node14
 
 ARG DEFAULT_TERRAFORM_VERSION
 ARG AVAILABLE_TERRAFORM_VERSIONS


### PR DESCRIPTION
The old `node14` docker image tag is [now deprecated](https://hub.docker.com/r/jsii/superchain). This PR replaces it with the new recommended docker image tag.

### Background
We're seeing errors like the following image in our PRs:

<img width="1215" alt="image" src="https://user-images.githubusercontent.com/573531/197174003-d8319763-6a4d-4227-9d22-57ed0827e39e.png">

From [this issue](https://github.com/golang/go/issues/51436) it seems like it's related to Go 1.16, which our `hashicorp/jsii-terraform` image was using. Since `jsii/superchain` was already on Go 1.18 already, we realized something's wrong with our docker image, leading us to the discontinued tags.