### PR TITLE
fix(deps): Use apt instead of yum, since base image is debian based now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 FROM docker.mirror.hashicorp.services/jsii/superchain:1-buster-slim-node14
 
+USER root
+
 ARG DEFAULT_TERRAFORM_VERSION
 ARG AVAILABLE_TERRAFORM_VERSIONS
 
-RUN yum install -y unzip jq gcc gcc-c++ time && curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python3
+
+RUN apt-get update -y && apt-get install -y unzip jq build-essential time
+RUN curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python3
 RUN npm install -g @sentry/cli --unsafe-perm
 
 ENV TF_PLUGIN_CACHE_DIR="/root/.terraform.d/plugin-cache"           \


### PR DESCRIPTION
After #2214, we found out that JSII Superchain image [moved from using Amazon Linux 2 to Debian](https://github.com/aws/jsii/pull/2949). This caused our docker image [build process to fail](https://github.com/hashicorp/terraform-cdk/actions/runs/3296963070/jobs/5437224948#step:7:629). This PR updates to use the package manager `apt` used in Debian instead of `yum`.