### PR TITLE
fix(cli): Ignore local obj/ dir in C# template

### DIFF
--- a/packages/cdktf-cli/templates/csharp/.gitignore
+++ b/packages/cdktf-cli/templates/csharp/.gitignore
@@ -1,0 +1,5 @@
+# This gitignore file is used for development
+#
+# The "{{}}.gitignore" file is the one used in the
+# new CDKTF project created from this template
+obj/


### PR DESCRIPTION
Some C# plugin in my VSCode setup started building the template project which resulted in an obj directory being created 😅 This PR adds a Gitignore to ignore this untracked directory for good
