### PR TITLE
fix: correctly denote all of our redirects as temporary because they might change

### DIFF
--- a/cdk.tf/vercel.json
+++ b/cdk.tf/vercel.json
@@ -5,199 +5,248 @@
   "redirects": [
     {
       "source": "/",
-      "destination": "https://github.com/hashicorp/terraform-cdk"
+      "destination": "https://github.com/hashicorp/terraform-cdk",
+      "permanent": false
     },
     {
       "source": "/launch",
-      "destination": "https://www.hashicorp.com/blog/cdk-for-terraform-enabling-python-and-typescript-support/"
+      "destination": "https://www.hashicorp.com/blog/cdk-for-terraform-enabling-python-and-typescript-support/",
+      "permanent": false
     },
     {
       "source": "/launch-aws",
-      "destination": "https://aws.amazon.com/blogs/developer/introducing-the-cloud-development-kit-for-terraform-preview/"
+      "destination": "https://aws.amazon.com/blogs/developer/introducing-the-cloud-development-kit-for-terraform-preview/",
+      "permanent": false
     },
     {
       "source": "/learn",
-      "destination": "https://learn.hashicorp.com/terraform/cdktf/cdktf-intro"
+      "destination": "https://learn.hashicorp.com/terraform/cdktf/cdktf-intro",
+      "permanent": false
     },
     {
       "source": "/discuss",
-      "destination": "https://discuss.hashicorp.com/c/terraform-core/cdk-for-terraform/47"
+      "destination": "https://discuss.hashicorp.com/c/terraform-core/cdk-for-terraform/47",
+      "permanent": false
     },
     {
       "source": "/issues/:id",
-      "destination": "https://github.com/hashicorp/terraform-cdk/issues/:id"
+      "destination": "https://github.com/hashicorp/terraform-cdk/issues/:id",
+      "permanent": false
     },
     {
       "source": "/feature",
-      "destination": "https://github.com/hashicorp/terraform-cdk/issues/new?assignees=&labels=enhancement&template=feature-request.md&title="
+      "destination": "https://github.com/hashicorp/terraform-cdk/issues/new?assignees=&labels=enhancement&template=feature-request.md&title=",
+      "permanent": false
     },
     {
       "source": "/bug",
-      "destination": "https://github.com/hashicorp/terraform-cdk/issues/new?assignees=&labels=bug&template=bug-report.md&title="
+      "destination": "https://github.com/hashicorp/terraform-cdk/issues/new?assignees=&labels=bug&template=bug-report.md&title=",
+      "permanent": false
     },
     {
       "source": "/escape-hatch",
-      "destination": "https://www.terraform.io/docs/cdktf/concepts/providers-and-resources.html#escape-hatch"
+      "destination": "https://www.terraform.io/docs/cdktf/concepts/providers-and-resources.html#escape-hatch",
+      "permanent": false
     },
     {
       "source": "/jsii",
-      "destination": "https://github.com/aws/jsii"
+      "destination": "https://github.com/aws/jsii",
+      "permanent": false
     },
     {
       "source": "/constructs",
-      "destination": "https://www.terraform.io/cdktf/concepts/constructs"
+      "destination": "https://www.terraform.io/cdktf/concepts/constructs",
+      "permanent": false
     },
     {
       "source": "/awesome",
-      "destination": "https://github.com/skorfmann/awesome-terraform-cdk"
+      "destination": "https://github.com/skorfmann/awesome-terraform-cdk",
+      "permanent": false
     },
     {
       "source": "/imports",
-      "destination": "https://www.terraform.io/docs/cdktf/concepts/providers-and-resources.html"
+      "destination": "https://www.terraform.io/docs/cdktf/concepts/providers-and-resources.html",
+      "permanent": false
     },
     {
       "source": "/dev",
-      "destination": "https://cdk.dev"
+      "destination": "https://cdk.dev",
+      "permanent": false
     },
     {
       "source": "/provider/:name",
-      "destination": "https://github.com/cdktf/cdktf-provider-:name"
+      "destination": "https://github.com/cdktf/cdktf-provider-:name",
+      "permanent": false
     },
     {
       "source": "/provider",
-      "destination": "https://github.com/orgs/hashicorp/repositories?q=pre-built-provider&type=&language=&sort="
+      "destination": "https://github.com/orgs/hashicorp/repositories?q=pre-built-provider&type=&language=&sort=",
+      "permanent": false
     },
     {
       "source": "/interop",
-      "destination": "https://github.com/skorfmann/cfn2tf"
+      "destination": "https://github.com/skorfmann/cfn2tf",
+      "permanent": false
     },
     {
       "source": "/cfn2tf",
-      "destination": "https://github.com/skorfmann/cfn2tf"
+      "destination": "https://github.com/skorfmann/cfn2tf",
+      "permanent": false
     },
     {
       "source": "/job-us",
-      "destination": "https://www.hashicorp.com/job/2545021"
+      "destination": "https://www.hashicorp.com/job/2545021",
+      "permanent": false
     },
     {
       "source": "/job-eu",
-      "destination": "https://www.hashicorp.com/job/2548521"
+      "destination": "https://www.hashicorp.com/job/2548521",
+      "permanent": false
     },
     {
       "source": "/we-are-hiring",
-      "destination": "https://www.hashicorp.com/job/2545021"
+      "destination": "https://www.hashicorp.com/job/2545021",
+      "permanent": false
     },
     {
       "source": "/migrate-state",
-      "destination": "https://www.terraform.io/docs/cdktf/concepts/remote-backends.html#migrate-local-state-storage-to-remote"
+      "destination": "https://www.terraform.io/docs/cdktf/concepts/remote-backends.html#migrate-local-state-storage-to-remote",
+      "permanent": false
     },
     {
       "source": "/0.1",
-      "destination": "https://www.hashicorp.com/blog/announcing-cdk-for-terraform-0-1"
+      "destination": "https://www.hashicorp.com/blog/announcing-cdk-for-terraform-0-1",
+      "permanent": false
     },
     {
       "source": "/0.13",
-      "destination": "https://www.hashicorp.com/blog/cdk-for-terraform-0-13-significantly-improves-performance"
+      "destination": "https://www.hashicorp.com/blog/cdk-for-terraform-0-13-significantly-improves-performance",
+      "permanent": false
     },
     {
       "source": "/github-nuget",
-      "destination": "https://docs.github.com/en/free-pro-team@latest/packages/guides/configuring-dotnet-cli-for-use-with-github-packages#authenticating-to-github-packages"
+      "destination": "https://docs.github.com/en/free-pro-team@latest/packages/guides/configuring-dotnet-cli-for-use-with-github-packages#authenticating-to-github-packages",
+      "permanent": false
     },
     {
       "source": "/modules-and-providers",
-      "destination": "https://www.terraform.io/docs/cdktf/concepts/providers-and-resources.html"
+      "destination": "https://www.terraform.io/docs/cdktf/concepts/providers-and-resources.html",
+      "permanent": false
     },
     {
       "source": "/office-hours",
-      "destination": "https://www.youtube.com/watch?v=BkypHylJcgs&ab_channel=HashiCorp"
+      "destination": "https://www.youtube.com/watch?v=BkypHylJcgs&ab_channel=HashiCorp",
+      "permanent": false
     },
     {
       "source": "/multiple-stacks",
-      "destination": "https://www.terraform.io/docs/cdktf/concepts/stacks.html#multiple-stacks"
+      "destination": "https://www.terraform.io/docs/cdktf/concepts/stacks.html#multiple-stacks",
+      "permanent": false
     },
     {
       "source": "/plus",
-      "destination": "https://github.com/cdktf-plus/cdktf-plus"
+      "destination": "https://github.com/cdktf-plus/cdktf-plus",
+      "permanent": false
     },
     {
       "source": "/watch",
-      "destination": "https://www.terraform.io/docs/cdktf/cli-reference/commands.html#watch"
+      "destination": "https://www.terraform.io/docs/cdktf/cli-reference/commands.html#watch",
+      "permanent": false
     },
     {
       "source": "/links",
-      "destination": "https://github.com/skorfmann/cdktf-redirects/blob/master/_redirects"
+      "destination": "https://github.com/skorfmann/cdktf-redirects/blob/master/_redirects",
+      "permanent": false
     },
     {
       "source": "/prebuilt-providers",
-      "destination": "https://www.terraform.io/docs/cdktf/concepts/providers-and-resources.html#install-pre-built-providers"
+      "destination": "https://www.terraform.io/docs/cdktf/concepts/providers-and-resources.html#install-pre-built-providers",
+      "permanent": false
     },
     {
       "source": "/upgrade-constructs-v10",
-      "destination": "https://www.terraform.io/cdktf/release/upgrade-guide-v0-6"
+      "destination": "https://www.terraform.io/cdktf/release/upgrade-guide-v0-6",
+      "permanent": false
     },
     {
       "source": "/testing",
-      "destination": "https://www.terraform.io/docs/cdktf/test/unit-tests.html"
+      "destination": "https://www.terraform.io/docs/cdktf/test/unit-tests.html",
+      "permanent": false
     },
     {
       "source": "/bugs/convert-expressions",
-      "destination": "https://github.com/hashicorp/terraform-cdk/issues/842"
+      "destination": "https://github.com/hashicorp/terraform-cdk/issues/842",
+      "permanent": false
     },
     {
       "source": "/bugs/new/convert",
-      "destination": "https://github.com/hashicorp/terraform-cdk/issues/new?assignees=&labels=bug%2C+new%2C+feature%2Fconvert&template=bug-report.md&title="
+      "destination": "https://github.com/hashicorp/terraform-cdk/issues/new?assignees=&labels=bug%2C+new%2C+feature%2Fconvert&template=bug-report.md&title=",
+      "permanent": false
     },
     {
       "source": "/variables",
-      "destination": "https://www.terraform.io/docs/cdktf/concepts/variables-and-outputs.html#input-variables"
+      "destination": "https://www.terraform.io/docs/cdktf/concepts/variables-and-outputs.html#input-variables",
+      "permanent": false
     },
     {
       "source": "/provider-generation",
-      "destination": "https://www.terraform.io/docs/cdktf/concepts/providers-and-resources.html#providers"
+      "destination": "https://www.terraform.io/docs/cdktf/concepts/providers-and-resources.html#providers",
+      "permanent": false
     },
     {
       "source": "/telemetry",
-      "destination": "https://www.terraform.io/docs/cdktf/telemetry.html"
+      "destination": "https://www.terraform.io/docs/cdktf/telemetry.html",
+      "permanent": false
     },
     {
       "source": "/convert-limitations",
-      "destination": "https://github.com/hashicorp/terraform-cdk/blob/main/packages/@cdktf/hcl2cdk/README.md#known-limitations"
+      "destination": "https://github.com/hashicorp/terraform-cdk/blob/main/packages/@cdktf/hcl2cdk/README.md#known-limitations",
+      "permanent": false
     },
     {
       "source": "/complex-object-as-configuration",
-      "destination": "https://www.terraform.io/cdktf/concepts/providers-and-resources#references"
+      "destination": "https://www.terraform.io/cdktf/concepts/providers-and-resources#references",
+      "permanent": false
     },
     {
       "source": "/docs",
-      "destination": "https://www.terraform.io/cdktf"
+      "destination": "https://www.terraform.io/cdktf",
+      "permanent": false
     },
     {
       "source": "/adapter",
-      "destination": "https://github.com/hashicorp/cdktf-aws-cdk"
+      "destination": "https://github.com/hashicorp/cdktf-aws-cdk",
+      "permanent": false
     },
     {
       "source": "/module-map-inputs",
-      "destination": "https://www.terraform.io/cdktf/concepts/modules#configure-modules"
+      "destination": "https://www.terraform.io/cdktf/concepts/modules#configure-modules",
+      "permanent": false
     },
     {
       "source": "/registry-providers",
-      "destination": "https://registry.terraform.io/browse/providers"
+      "destination": "https://registry.terraform.io/browse/providers",
+      "permanent": false
     },
     {
       "source": "/cdk-day-2022-hybrid-modules",
-      "destination": "https://www.youtube.com/watch?v=7Dt_zJbDmso"
+      "destination": "https://www.youtube.com/watch?v=7Dt_zJbDmso",
+      "permanent": false
     },
     {
       "source": "/crash-reporting",
-      "destination": "https://www.terraform.io/cdktf/telemetry#crash-reporting"
+      "destination": "https://www.terraform.io/cdktf/telemetry#crash-reporting",
+      "permanent": false
     },
     {
       "source": "/.well-known/prebuilt-providers.json",
-      "destination": "https://raw.githubusercontent.com/hashicorp/cdktf-repository-manager/main/provider.json"
+      "destination": "https://raw.githubusercontent.com/hashicorp/cdktf-repository-manager/main/provider.json",
+      "permanent": false
     },
     {
       "source": "/troubleshooting/cdktf-version-mismatch",
-      "destination": "https://developer.hashicorp.com/terraform/cdktf/test/debugging#cdktf-cli-and-library-on-different-versions" 
+      "destination": "https://developer.hashicorp.com/terraform/cdktf/test/debugging#cdktf-cli-and-library-on-different-versions",
+      "permanent": false
     }
   ]
 }


### PR DESCRIPTION
Apparently not having a `permanent` property defaults to `true`. So currently all of our redirects do a permanent redirect (308).

### before this PR
```
> curl https://www.cdk.tf
Redirecting to https://github.com/hashicorp/terraform-cdk (308)
```
### after this PR
```
> curl curl https://terraform-cdk-redirects-1gul8nt9t-hashicorp.vercel.app/
Redirecting to https://github.com/hashicorp/terraform-cdk (307)
```