### PR TITLE
chore: Update Go to version 1.18 on windows workflows

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.18.x
       - name: Download dist
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -166,7 +166,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.18.x
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path


### PR DESCRIPTION
Follow up of: https://github.com/hashicorp/terraform-cdk/pull/2214

Upgrades the version of Go in the windows platform integration tests.