### PR TITLE
chore(lib): telemetry track tfc usage

### DIFF
--- a/packages/cdktf/lib/backends/cloud-backend.ts
+++ b/packages/cdktf/lib/backends/cloud-backend.ts
@@ -40,6 +40,13 @@ export class CloudBackend extends TerraformBackend {
     };
   }
 
+  public toMetadata() {
+    const cloud = [undefined, "app.terraform.io"].includes(this.props.hostname)
+      ? "tfc"
+      : "tfe";
+    return { ...super.toMetadata(), cloud };
+  }
+
   protected synthesizeAttributes(): { [name: string]: any } {
     return keysToSnakeCase({
       ...this.props,

--- a/packages/cdktf/lib/backends/cloud-backend.ts
+++ b/packages/cdktf/lib/backends/cloud-backend.ts
@@ -9,6 +9,17 @@ import { TerraformBackend } from "../terraform-backend";
 import { ValidateBinaryVersion } from "../validations";
 
 /**
+ * checks whether the given hostname belongs to tfc or (else) to tfe
+ * If no hostname is given, it will return tfc, as that's the default in backends.
+ * @param hostname e.g. app.terraform.io, app.terraform.io:80, tfe.myorg.org
+ * @returns "tfc" or "tfe"
+ */
+export function getHostNameType(hostname?: string): "tfc" | "tfe" {
+  if (!hostname) return "tfc"; // default is tfc when not passing a hostname to backends
+  return hostname.startsWith("app.terraform.io") ? "tfc" : "tfe";
+}
+
+/**
  * The Cloud Backend synthesizes a {@link https://www.terraform.io/cli/cloud/settings#the-cloud-block cloud block}.
  * The cloud block is a nested block within the top-level terraform settings block.
  * It specifies which Terraform Cloud workspaces to use for the current working directory.
@@ -41,13 +52,7 @@ export class CloudBackend extends TerraformBackend {
   }
 
   public toMetadata() {
-    const cloud = [
-      undefined,
-      "app.terraform.io",
-      "app.terraform.io:80",
-    ].includes(this.props.hostname)
-      ? "tfc"
-      : "tfe";
+    const cloud = getHostNameType(this.props.hostname);
     return { ...super.toMetadata(), cloud };
   }
 

--- a/packages/cdktf/lib/backends/cloud-backend.ts
+++ b/packages/cdktf/lib/backends/cloud-backend.ts
@@ -41,7 +41,11 @@ export class CloudBackend extends TerraformBackend {
   }
 
   public toMetadata() {
-    const cloud = [undefined, "app.terraform.io"].includes(this.props.hostname)
+    const cloud = [
+      undefined,
+      "app.terraform.io",
+      "app.terraform.io:80",
+    ].includes(this.props.hostname)
       ? "tfc"
       : "tfe";
     return { ...super.toMetadata(), cloud };

--- a/packages/cdktf/lib/backends/remote-backend.ts
+++ b/packages/cdktf/lib/backends/remote-backend.ts
@@ -19,7 +19,11 @@ export class RemoteBackend extends TerraformBackend {
   }
 
   public toMetadata() {
-    const cloud = [undefined, "app.terraform.io"].includes(this.props.hostname)
+    const cloud = [
+      undefined,
+      "app.terraform.io",
+      "app.terraform.io:80",
+    ].includes(this.props.hostname)
       ? "tfc"
       : "tfe";
     return { ...super.toMetadata(), cloud };

--- a/packages/cdktf/lib/backends/remote-backend.ts
+++ b/packages/cdktf/lib/backends/remote-backend.ts
@@ -7,6 +7,7 @@ import {
   TerraformRemoteState,
   DataTerraformRemoteStateConfig,
 } from "../terraform-remote-state";
+import { getHostNameType } from "./cloud-backend";
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 export class RemoteBackend extends TerraformBackend {
@@ -19,13 +20,7 @@ export class RemoteBackend extends TerraformBackend {
   }
 
   public toMetadata() {
-    const cloud = [
-      undefined,
-      "app.terraform.io",
-      "app.terraform.io:80",
-    ].includes(this.props.hostname)
-      ? "tfc"
-      : "tfe";
+    const cloud = getHostNameType(this.props.hostname);
     return { ...super.toMetadata(), cloud };
   }
 

--- a/packages/cdktf/lib/backends/remote-backend.ts
+++ b/packages/cdktf/lib/backends/remote-backend.ts
@@ -18,6 +18,13 @@ export class RemoteBackend extends TerraformBackend {
     return keysToSnakeCase({ ...this.props });
   }
 
+  public toMetadata() {
+    const cloud = [undefined, "app.terraform.io"].includes(this.props.hostname)
+      ? "tfc"
+      : "tfe";
+    return { ...super.toMetadata(), cloud };
+  }
+
   public getRemoteStateDataSource(
     scope: Construct,
     name: string,

--- a/packages/cdktf/lib/terraform-stack.ts
+++ b/packages/cdktf/lib/terraform-stack.ts
@@ -33,6 +33,7 @@ export interface TerraformStackMetadata {
   readonly stackName: string;
   readonly version: string;
   readonly backend: string;
+  readonly cloud?: string;
 }
 
 // eslint-disable-next-line jsdoc/require-jsdoc
@@ -224,6 +225,7 @@ export class TerraformStack extends Construct {
       version: this.cdktfVersion,
       stackName: this.node.id,
       backend: "local", // overwritten by backend implementations if used
+      cloud: undefined, // overwritten by cloud and remote backend implementations
       ...(Object.keys(this.rawOverrides).length > 0
         ? { overrides: { stack: Object.keys(this.rawOverrides) } }
         : {}),

--- a/website/docs/cdktf/api-reference/csharp.mdx
+++ b/website/docs/cdktf/api-reference/csharp.mdx
@@ -21227,7 +21227,8 @@ using HashiCorp.Cdktf;
 new TerraformStackMetadata {
     string Backend,
     string StackName,
-    string Version
+    string Version,
+    string Cloud = null
 };
 ```
 
@@ -21238,6 +21239,7 @@ new TerraformStackMetadata {
 | <code><a href="#cdktf.TerraformStackMetadata.property.backend">Backend</a></code>     | <code>string</code> | _No description._ |
 | <code><a href="#cdktf.TerraformStackMetadata.property.stackName">StackName</a></code> | <code>string</code> | _No description._ |
 | <code><a href="#cdktf.TerraformStackMetadata.property.version">Version</a></code>     | <code>string</code> | _No description._ |
+| <code><a href="#cdktf.TerraformStackMetadata.property.cloud">Cloud</a></code>         | <code>string</code> | _No description._ |
 
 ---
 
@@ -21265,6 +21267,16 @@ public string StackName { get; set; }
 
 ```csharp
 public string Version { get; set; }
+```
+
+- _Type:_ string
+
+---
+
+##### `Cloud`<sup>Optional</sup> <a name="Cloud" id="cdktf.TerraformStackMetadata.property.cloud"></a>
+
+```csharp
+public string Cloud { get; set; }
 ```
 
 - _Type:_ string

--- a/website/docs/cdktf/api-reference/go.mdx
+++ b/website/docs/cdktf/api-reference/go.mdx
@@ -21228,6 +21228,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 	Backend: *string,
 	StackName: *string,
 	Version: *string,
+	Cloud: *string,
 }
 ```
 
@@ -21238,6 +21239,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 | <code><a href="#cdktf.TerraformStackMetadata.property.backend">Backend</a></code>     | <code>\*string</code> | _No description._ |
 | <code><a href="#cdktf.TerraformStackMetadata.property.stackName">StackName</a></code> | <code>\*string</code> | _No description._ |
 | <code><a href="#cdktf.TerraformStackMetadata.property.version">Version</a></code>     | <code>\*string</code> | _No description._ |
+| <code><a href="#cdktf.TerraformStackMetadata.property.cloud">Cloud</a></code>         | <code>\*string</code> | _No description._ |
 
 ---
 
@@ -21265,6 +21267,16 @@ StackName *string
 
 ```go
 Version *string
+```
+
+- _Type:_ \*string
+
+---
+
+##### `Cloud`<sup>Optional</sup> <a name="Cloud" id="cdktf.TerraformStackMetadata.property.cloud"></a>
+
+```go
+Cloud *string
 ```
 
 - _Type:_ \*string

--- a/website/docs/cdktf/api-reference/java.mdx
+++ b/website/docs/cdktf/api-reference/java.mdx
@@ -25199,6 +25199,7 @@ TerraformStackMetadata.builder()
     .backend(java.lang.String)
     .stackName(java.lang.String)
     .version(java.lang.String)
+//  .cloud(java.lang.String)
     .build();
 ```
 
@@ -25209,6 +25210,7 @@ TerraformStackMetadata.builder()
 | <code><a href="#cdktf.TerraformStackMetadata.property.backend">backend</a></code>     | <code>java.lang.String</code> | _No description._ |
 | <code><a href="#cdktf.TerraformStackMetadata.property.stackName">stackName</a></code> | <code>java.lang.String</code> | _No description._ |
 | <code><a href="#cdktf.TerraformStackMetadata.property.version">version</a></code>     | <code>java.lang.String</code> | _No description._ |
+| <code><a href="#cdktf.TerraformStackMetadata.property.cloud">cloud</a></code>         | <code>java.lang.String</code> | _No description._ |
 
 ---
 
@@ -25236,6 +25238,16 @@ public java.lang.String getStackName();
 
 ```java
 public java.lang.String getVersion();
+```
+
+- _Type:_ java.lang.String
+
+---
+
+##### `cloud`<sup>Optional</sup> <a name="cloud" id="cdktf.TerraformStackMetadata.property.cloud"></a>
+
+```java
+public java.lang.String getCloud();
 ```
 
 - _Type:_ java.lang.String

--- a/website/docs/cdktf/api-reference/python.mdx
+++ b/website/docs/cdktf/api-reference/python.mdx
@@ -26012,7 +26012,8 @@ import cdktf
 cdktf.TerraformStackMetadata(
   backend: str,
   stack_name: str,
-  version: str
+  version: str,
+  cloud: str = None
 )
 ```
 
@@ -26023,6 +26024,7 @@ cdktf.TerraformStackMetadata(
 | <code><a href="#cdktf.TerraformStackMetadata.property.backend">backend</a></code>      | <code>str</code> | _No description._ |
 | <code><a href="#cdktf.TerraformStackMetadata.property.stackName">stack_name</a></code> | <code>str</code> | _No description._ |
 | <code><a href="#cdktf.TerraformStackMetadata.property.version">version</a></code>      | <code>str</code> | _No description._ |
+| <code><a href="#cdktf.TerraformStackMetadata.property.cloud">cloud</a></code>          | <code>str</code> | _No description._ |
 
 ---
 
@@ -26050,6 +26052,16 @@ stack_name: str
 
 ```python
 version: str
+```
+
+- _Type:_ str
+
+---
+
+##### `cloud`<sup>Optional</sup> <a name="cloud" id="cdktf.TerraformStackMetadata.property.cloud"></a>
+
+```python
+cloud: str
 ```
 
 - _Type:_ str

--- a/website/docs/cdktf/api-reference/typescript.mdx
+++ b/website/docs/cdktf/api-reference/typescript.mdx
@@ -20682,6 +20682,7 @@ const terraformStackMetadata: TerraformStackMetadata = { ... }
 | <code><a href="#cdktf.TerraformStackMetadata.property.backend">backend</a></code>     | <code>string</code> | _No description._ |
 | <code><a href="#cdktf.TerraformStackMetadata.property.stackName">stackName</a></code> | <code>string</code> | _No description._ |
 | <code><a href="#cdktf.TerraformStackMetadata.property.version">version</a></code>     | <code>string</code> | _No description._ |
+| <code><a href="#cdktf.TerraformStackMetadata.property.cloud">cloud</a></code>         | <code>string</code> | _No description._ |
 
 ---
 
@@ -20709,6 +20710,16 @@ public readonly stackName: string;
 
 ```typescript
 public readonly version: string;
+```
+
+- _Type:_ string
+
+---
+
+##### `cloud`<sup>Optional</sup> <a name="cloud" id="cdktf.TerraformStackMetadata.property.cloud"></a>
+
+```typescript
+public readonly cloud: string;
 ```
 
 - _Type:_ string


### PR DESCRIPTION
- chore(lib): add cloud = tfc | tfe to synth telemetry events to track usage of either
  BREAKING CHANGE: This changes the signatures of some exported methods and thus is probably a breaking change (at least for Python)
- chore(docs): update docs

Resolves #2206
