### PR TITLE
feat(examples): add upcloud-server python example

### DIFF
--- a/examples/python/upcloud-server/.gitignore
+++ b/examples/python/upcloud-server/.gitignore
@@ -1,0 +1,7 @@
+dist/
+imports/*
+!imports/__init__.py
+.terraform
+cdktf.out
+cdktf.log
+*terraform.*.tfstate*

--- a/examples/python/upcloud-server/Pipfile
+++ b/examples/python/upcloud-server/Pipfile
@@ -1,0 +1,10 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[requires]
+python_version = "3"
+
+[packages]
+cdktf = {path = "./../../../dist/python/cdktf-0.0.0-py3-none-any.whl"}

--- a/examples/python/upcloud-server/Pipfile.lock
+++ b/examples/python/upcloud-server/Pipfile.lock
@@ -1,0 +1,107 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "8ce1cced7669974baf5c84fe8064722114b821f5f858cb872e69efe69307c759"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "attrs": {
+            "hashes": [
+                "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6",
+                "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==22.1.0"
+        },
+        "cattrs": {
+            "hashes": [
+                "sha256:bc12b1f0d000b9f9bee83335887d532a1d3e99a833d1bf0882151c97d3e68c21",
+                "sha256:f0eed5642399423cf656e7b66ce92cdc5b963ecafd041d1b24d136fdde7acf6d"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==22.2.0"
+        },
+        "cdktf": {
+            "hashes": [
+                "sha256:657bd637e5bd8d79a1c9b4d98d18df2633d884ea09e6b6823b7e2560d44b143e"
+            ],
+            "path": "./../../../dist/python/cdktf-0.0.0-py3-none-any.whl",
+            "version": "==0.0.0"
+        },
+        "constructs": {
+            "hashes": [
+                "sha256:1c886bf74540d89fe0f2f5722af63111b3b67aedb1c3a90e019b64dd645ad851",
+                "sha256:8030129518d0a433922f1e12fa8ad5666b26977d6a5331b1304801415aba46f5"
+            ],
+            "markers": "python_version ~= '3.7'",
+            "version": "==10.1.145"
+        },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:2ac84b496be68464a2da60da518af3785fff8b7ec0d090a581604bc870bdee41",
+                "sha256:affbabf13fb6e98988c38d9c5650e701569fe3c1de3233cfb61c5f33774690ad"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.0.0"
+        },
+        "jsii": {
+            "hashes": [
+                "sha256:9fc57ff37868364ba3417b26dc97189cd0cc71282196a3f4765768c067354be0",
+                "sha256:d0867c0d2f60ceda1664c026033ae34ea36178c7027315e577ded13043827664"
+            ],
+            "markers": "python_version ~= '3.7'",
+            "version": "==1.70.0"
+        },
+        "publication": {
+            "hashes": [
+                "sha256:0248885351febc11d8a1098d5c8e3ab2dabcf3e8c0c96db1e17ecd12b53afbe6",
+                "sha256:68416a0de76dddcdd2930d1c8ef853a743cc96c82416c4e4d3b5d901c6276dc4"
+            ],
+            "version": "==0.0.3"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==2.8.2"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==1.16.0"
+        },
+        "typeguard": {
+            "hashes": [
+                "sha256:00edaa8da3a133674796cf5ea87d9f4b4c367d77476e185e80251cc13dfbb8c4",
+                "sha256:5e3e3be01e887e7eafae5af63d1f36c849aaa94e3a0112097312aabfa16284f1"
+            ],
+            "markers": "python_full_version >= '3.5.3'",
+            "version": "==2.13.3"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa",
+                "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==4.4.0"
+        }
+    },
+    "develop": {}
+}

--- a/examples/python/upcloud-server/README.md
+++ b/examples/python/upcloud-server/README.md
@@ -1,0 +1,67 @@
+# python-upcloud-server
+
+A CDK for Terraform application in Python to create a server with UpCloud CDK for Terraform provider.
+
+To get started with this example, you need to:
+
+- [Install `pipenv` and project dependencies](#install-pipenv-and-project-dependencies)
+- [Configure your UpCloud credentials](#configure-your-upcloud-credentials)
+- [Deploy the example stack](#deploy-the-example-stack)
+
+## Install `pipenv` and project dependencies
+
+First, if you do not have `pipenv` installed on your system, install it with `pip install --user pipenv`. See [pipenv website](https://pipenv.pypa.io/en/latest/) for alternative installation methods.
+
+```sh
+pip install --user pipenv
+```
+
+Then, to install the project dependencies, run `pipenv install`.
+
+```sh
+pipenv install
+```
+
+Finally, generate CDK for Terraform constructs for Terraform providers and modules used in the project by running `cdktf get`.
+
+```sh
+cdktf get
+```
+
+See also [repository](https://github.com/cdktf/cdktf-provider-upcloud.git) with pre-built UpCloud CDK for Terraform provider.
+
+## Configure your UpCloud credentials
+
+This example project looks for UpCloud credentials in `UPCLOUD_USERNAME` and `UPCLOUD_PASSWORD` environment variables, similarly than UpCloud Terraform provider. Configure these environment variables, for example, by sourcing a file that contains suitable `export` commands.
+
+```sh
+. upcloud-credentials.sh
+```
+
+Example credential file content:
+
+```sh
+# upcloud-credentials.sh
+export UPCLOUD_USERNAME="your-username"
+export UPCLOUD_PASSWORD="your-password"
+```
+
+## Deploy the example stack
+
+To deploy our stack defined in [main.py](./main.py), run `cdktf deploy`.
+
+```sh
+# With one-time password delivered to your email
+cdktf deploy
+
+# With ssh-key
+PUBLIC_KEY_PATH=$(ls ~/.ssh/*.pub) cdktf deploy
+```
+
+After the server has been deployed, you can use `example` username and `server_ip` stack output value to SSH into the server.
+
+If you want to cleanup the created resources, run `cdktf destroy` to destroy the stack.
+
+```sh
+cdktf destroy
+```

--- a/examples/python/upcloud-server/cdktf.json
+++ b/examples/python/upcloud-server/cdktf.json
@@ -1,0 +1,14 @@
+{
+  "language": "python",
+  "app": "pipenv run python main.py",
+  "sendCrashReports": "false",
+  "terraformProviders": [
+    "UpCloudLtd/upcloud@~> 2.6"
+  ],
+  "terraformModules": [],
+  "codeMakerOutput": "imports",
+  "context": {
+    "excludeStackIdFromLogicalIds": "true",
+    "allowSepCharsInLogicalIds": "true"
+  }
+}

--- a/examples/python/upcloud-server/help
+++ b/examples/python/upcloud-server/help
@@ -1,0 +1,24 @@
+========================================================================================================
+
+  Your cdktf Python project is ready!
+
+  cat help                Prints this message
+
+  Compile:
+    pipenv run ./main.py  Compile and run the python code.
+
+  Synthesize:
+    cdktf synth [stack]   Synthesize Terraform resources to cdktf.out/
+
+  Diff:
+    cdktf diff [stack]    Perform a diff (terraform plan) for the given stack
+
+  Deploy:
+    cdktf deploy [stack]  Deploy the given stack
+
+  Destroy:
+    cdktf destroy [stack] Destroy the given stack
+
+  Learn more about using modules and providers https://cdk.tf/modules-and-providers
+
+========================================================================================================

--- a/examples/python/upcloud-server/main.py
+++ b/examples/python/upcloud-server/main.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+from os import getenv
+
+from constructs import Construct
+from cdktf import App, TerraformOutput, TerraformStack
+
+from imports.upcloud.provider import UpcloudProvider
+from imports.upcloud.server import Server, ServerLogin, ServerNetworkInterface, ServerTemplate
+
+
+def get_server_login(user=None):
+    """Get ServerLogin with ssh-key from PUBLIC_KEY_PATH environment variable
+
+    As a fallback, create one-time password, if PUBLIC_KEY_PATH is undefined or its value is an empty string.
+    """
+    public_key_path = getenv("PUBLIC_KEY_PATH")
+
+    if public_key_path:
+        with open(public_key_path) as f:
+            ssh_key = f.read()
+        return ServerLogin(user=user, keys=[ssh_key])
+    else:
+        return ServerLogin(
+            user=user,
+            create_password=True,
+            password_delivery="email")
+
+
+class ExampleStack(TerraformStack):
+    def __init__(self, scope: Construct, ns: str):
+        super().__init__(scope, ns)
+
+        UpcloudProvider(self, "upcloud")
+
+        # If there are no SSH keys avaivable, we will have to use older
+        # template as one-time passwords are not supported by the most recent
+        # templates.
+        login = get_server_login("example")
+        template_name = "Ubuntu Server 22.04 LTS (Jammy Jellyfish)" if login.keys else "Ubuntu Server 20.04 LTS (Focal Fossa)"
+
+        server = Server(
+            self,
+            "server",
+            hostname="cdktf-example-python-upcloud-server-vm",
+            login=login,
+            network_interface=[
+                ServerNetworkInterface(
+                    type="public",
+                    ip_address_family="IPv4",
+                ),
+                ServerNetworkInterface(
+                    type="utility",
+                    ip_address_family="IPv4",
+                ),
+            ],
+            plan="1xCPU-1GB",
+            metadata=True,
+            template=ServerTemplate(
+                size=25,
+                storage=template_name
+            ),
+            zone="pl-waw1",
+        )
+
+        TerraformOutput(
+            self,
+            "server_ip",
+            value=server.network_interface.get(0).ip_address
+        )
+
+
+app = App()
+ExampleStack(app, "python-upcloud-server")
+
+app.synth()

--- a/examples/python/upcloud-server/package.json
+++ b/examples/python/upcloud-server/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@examples/python-upcloud-server",
+  "version": "0.0.0",
+  "license": "MPL-2.0",
+  "scripts": {
+    "reinstall": "rm Pipfile.lock && pipenv --rm && pipenv install",
+    "build": "cdktf get",
+    "synth": "cdktf synth"
+  }
+}


### PR DESCRIPTION
This PR adds first example for UpCloud provider.

See also:
- [upcloud.com](https://upcloud.com/)
- [Terraform provider](https://registry.terraform.io/providers/UpCloudLtd/upcloud)
- [Pre-built cdktf provider repo](https://github.com/cdktf/cdktf-provider-upcloud)