### PR TITLE
chore: install pre-built provider with exact version

### DIFF
--- a/packages/cdktf-cli/src/lib/dependencies/package-manager.ts
+++ b/packages/cdktf-cli/src/lib/dependencies/package-manager.ts
@@ -145,6 +145,11 @@ class NodePackageManager extends PackageManager {
       packageVersion ? packageName + "@" + packageVersion : packageName
     );
 
+    // Install exact version
+    // Yarn: https://classic.yarnpkg.com/lang/en/docs/cli/add/#toc-yarn-add-exact-e
+    // Npm: https://docs.npmjs.com/cli/v8/commands/npm-install#save-exact
+    args.push("-E");
+
     console.log(
       `Installing package ${packageName} @ ${packageVersion} using ${command}.`
     );

--- a/test/typescript/provider-upgrade-command/test.ts
+++ b/test/typescript/provider-upgrade-command/test.ts
@@ -31,26 +31,26 @@ describe("provider upgrade command", () => {
 
     it("can update withing the same cdktf version to a specific version", async () => {
       expect(driver.packageJson()).toEqual(
-        packageJsonWithDependency("@cdktf/provider-random", "^0.2.55")
+        packageJsonWithDependency("@cdktf/provider-random", "0.2.55")
       );
 
       await driver.exec("cdktf", ["provider", "upgrade", "random@=3.2.0"]);
 
       expect(driver.packageJson()).toEqual(
-        packageJsonWithDependency("@cdktf/provider-random", "^0.2.64")
+        packageJsonWithDependency("@cdktf/provider-random", "0.2.64")
       );
     });
 
     it("can update within the same cdktf version to the latest version", async () => {
       expect(driver.packageJson()).toEqual(
-        packageJsonWithDependency("@cdktf/provider-random", "^0.2.55")
+        packageJsonWithDependency("@cdktf/provider-random", "0.2.55")
       );
 
       await driver.exec("cdktf", ["provider", "upgrade", "random"]);
 
       // Assert that we have version 0.2.64
       expect(driver.packageJson()).toEqual(
-        packageJsonWithDependency("@cdktf/provider-random", "^0.2.64")
+        packageJsonWithDependency("@cdktf/provider-random", "0.2.64")
       );
     });
 


### PR DESCRIPTION
Closes #2205

Updated the NodeJS package manager to always use the `-E` flag. This flag translates into `--save-exact` for npm, and `--exact` on yarn.