### PR TITLE
fix: Graceful failures when using `cdktf` with non-admin tokens

### DIFF
--- a/packages/cdktf-cli/src/lib/models/terraform-cloud.ts
+++ b/packages/cdktf-cli/src/lib/models/terraform-cloud.ts
@@ -386,8 +386,6 @@ export class TerraformCloud implements Terraform {
           plan = await this.client.Plans.show(
             result.relationships.plan.data.id
           );
-
-          console.log(JSON.stringify(plan, null, 2));
         } catch (e) {
           if (isPermissionLackingError(e)) {
             // This shouldn't happen, since we had enough permissions to create a plan

--- a/packages/cdktf-cli/src/lib/models/terraform-cloud.ts
+++ b/packages/cdktf-cli/src/lib/models/terraform-cloud.ts
@@ -377,7 +377,7 @@ export class TerraformCloud implements Terraform {
       );
     } catch (e) {
       if (isPermissionLackingError(e)) {
-        // We may have a token without admin privileges
+        // We may have a token without admin permissions
         sendLog(
           `Cannot get plan output due to token without administator scope. To view plan output visit:\n\n${url}`
         );
@@ -450,7 +450,7 @@ export class TerraformCloud implements Terraform {
       await this.client.Runs.action("apply", runId);
     } catch (e) {
       if (isPermissionLackingError(e)) {
-        // We may have a token without admin privileges
+        // We may have a token without apply permissions
         sendLog(
           `Failed to apply Terraform run. This may be due to lacking permissions.`
         );
@@ -543,6 +543,9 @@ export class TerraformCloud implements Terraform {
       return outputs;
     } catch (e) {
       if (isPermissionLackingError(e)) {
+        logger.info(
+          "Unable to obtain state versions since the token supplied lacks permission, proceeding without outputs"
+        );
         return {};
       }
 

--- a/packages/cdktf-cli/src/lib/models/terraform-cloud.ts
+++ b/packages/cdktf-cli/src/lib/models/terraform-cloud.ts
@@ -354,9 +354,22 @@ export class TerraformCloud implements Terraform {
     }
 
     sendLog(`Getting plan output`);
-    const plan = await this.client.Plans.jsonOutput(
-      result.relationships.plan.data.id
-    );
+    let plan;
+    try {
+      plan = await this.client.Plans.jsonOutput(
+        result.relationships.plan.data.id
+      );
+    } catch (e) {
+      if (
+        e.response &&
+        (e.response.status === 404 || e.response.status === 401)
+      ) {
+        // We may have a token without admin privileges
+        sendLog(
+          `Cannot get plan output due to token without administator scope. To view plan output visit:\n\n${url}`
+        );
+      }
+    }
 
     this.run = result;
     return new TerraformCloudPlan(

--- a/test/typescript/feature-flags/__snapshots__/test.ts.snap
+++ b/test/typescript/feature-flags/__snapshots__/test.ts.snap
@@ -45,7 +45,7 @@ exports[`full integration test with allowSepCharsInLogicalIds feature 1`] = `
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"null\\",
-        \\"version\\": \\"3.2.0\\"
+        \\"version\\": \\"3.2.1\\"
       }
     }
   }
@@ -97,7 +97,7 @@ exports[`full integration test with excludeStackIdFromLogicalIds feature 1`] = `
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"null\\",
-        \\"version\\": \\"3.2.0\\"
+        \\"version\\": \\"3.2.1\\"
       }
     }
   }
@@ -149,7 +149,7 @@ exports[`full integration test without features 1`] = `
     \\"required_providers\\": {
       \\"null\\": {
         \\"source\\": \\"null\\",
-        \\"version\\": \\"3.2.0\\"
+        \\"version\\": \\"3.2.1\\"
       }
     }
   }


### PR DESCRIPTION
Closes: #2236

I'm still not really comfortable with the big-picture understanding of how we use `json-output`. While this PR works well enough, please let me know if there are certain scenarios that are broken because of this. Especially around cross-stack references and so on. 