### PR TITLE
chore(lib): Add deprecation notices to backends that were deprecated in Terraform v1.2.3 and removed in TF 1.3

### DIFF
--- a/packages/cdktf/lib/backends/artifactory-backend.ts
+++ b/packages/cdktf/lib/backends/artifactory-backend.ts
@@ -9,7 +9,7 @@ import {
 } from "../terraform-remote-state";
 
 /**
- * @deprecated the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ * @deprecated CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
  */
 export class ArtifactoryBackend extends TerraformBackend {
   constructor(
@@ -33,7 +33,7 @@ export class ArtifactoryBackend extends TerraformBackend {
 }
 
 /**
- * @deprecated the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ * @deprecated CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
  */
 export class DataTerraformRemoteStateArtifactory extends TerraformRemoteState {
   constructor(
@@ -57,7 +57,7 @@ export class DataTerraformRemoteStateArtifactory extends TerraformRemoteState {
  * Read more about this backend in the Terraform docs:
  * https://www.terraform.io/language/settings/backends/artifactory
  *
- * @deprecated the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ * @deprecated CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
  */
 export interface ArtifactoryBackendProps {
   /**
@@ -85,7 +85,7 @@ export interface ArtifactoryBackendProps {
 }
 
 /**
- * @deprecated the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ * @deprecated CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
  */
 export interface DataTerraformRemoteStateArtifactoryConfig
   extends DataTerraformRemoteStateConfig,

--- a/packages/cdktf/lib/backends/artifactory-backend.ts
+++ b/packages/cdktf/lib/backends/artifactory-backend.ts
@@ -8,7 +8,9 @@ import {
   DataTerraformRemoteStateConfig,
 } from "../terraform-remote-state";
 
-// eslint-disable-next-line jsdoc/require-jsdoc
+/**
+ * @deprecated the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ */
 export class ArtifactoryBackend extends TerraformBackend {
   constructor(
     scope: Construct,
@@ -30,7 +32,9 @@ export class ArtifactoryBackend extends TerraformBackend {
   }
 }
 
-// eslint-disable-next-line jsdoc/require-jsdoc
+/**
+ * @deprecated the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ */
 export class DataTerraformRemoteStateArtifactory extends TerraformRemoteState {
   constructor(
     scope: Construct,
@@ -52,6 +56,8 @@ export class DataTerraformRemoteStateArtifactory extends TerraformRemoteState {
  *
  * Read more about this backend in the Terraform docs:
  * https://www.terraform.io/language/settings/backends/artifactory
+ *
+ * @deprecated the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
  */
 export interface ArtifactoryBackendProps {
   /**
@@ -78,6 +84,9 @@ export interface ArtifactoryBackendProps {
   readonly subpath: string;
 }
 
+/**
+ * @deprecated the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ */
 export interface DataTerraformRemoteStateArtifactoryConfig
   extends DataTerraformRemoteStateConfig,
     ArtifactoryBackendProps {}

--- a/packages/cdktf/lib/backends/etcd-backend.ts
+++ b/packages/cdktf/lib/backends/etcd-backend.ts
@@ -8,7 +8,9 @@ import {
   DataTerraformRemoteStateConfig,
 } from "../terraform-remote-state";
 
-// eslint-disable-next-line jsdoc/require-jsdoc
+/**
+ * @deprecated the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ */
 export class EtcdBackend extends TerraformBackend {
   constructor(scope: Construct, private readonly props: EtcdBackendProps) {
     super(scope, "backend", "etcd");
@@ -27,7 +29,9 @@ export class EtcdBackend extends TerraformBackend {
   }
 }
 
-// eslint-disable-next-line jsdoc/require-jsdoc
+/**
+ * @deprecated the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ */
 export class DataTerraformRemoteStateEtcd extends TerraformRemoteState {
   constructor(
     scope: Construct,
@@ -44,6 +48,8 @@ export class DataTerraformRemoteStateEtcd extends TerraformRemoteState {
  *
  * Read more about this backend in the Terraform docs:
  * https://www.terraform.io/language/settings/backends/etcd
+ *
+ * @deprecated the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
  */
 export interface EtcdBackendProps {
   /**
@@ -64,6 +70,9 @@ export interface EtcdBackendProps {
   readonly password?: string;
 }
 
+/**
+ * @deprecated the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ */
 export interface DataTerraformRemoteStateEtcdConfig
   extends DataTerraformRemoteStateConfig,
     EtcdBackendProps {}

--- a/packages/cdktf/lib/backends/etcd-backend.ts
+++ b/packages/cdktf/lib/backends/etcd-backend.ts
@@ -9,7 +9,7 @@ import {
 } from "../terraform-remote-state";
 
 /**
- * @deprecated the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ * @deprecated CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
  */
 export class EtcdBackend extends TerraformBackend {
   constructor(scope: Construct, private readonly props: EtcdBackendProps) {
@@ -30,7 +30,7 @@ export class EtcdBackend extends TerraformBackend {
 }
 
 /**
- * @deprecated the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ * @deprecated CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
  */
 export class DataTerraformRemoteStateEtcd extends TerraformRemoteState {
   constructor(
@@ -49,7 +49,7 @@ export class DataTerraformRemoteStateEtcd extends TerraformRemoteState {
  * Read more about this backend in the Terraform docs:
  * https://www.terraform.io/language/settings/backends/etcd
  *
- * @deprecated the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ * @deprecated CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
  */
 export interface EtcdBackendProps {
   /**
@@ -71,7 +71,7 @@ export interface EtcdBackendProps {
 }
 
 /**
- * @deprecated the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ * @deprecated CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
  */
 export interface DataTerraformRemoteStateEtcdConfig
   extends DataTerraformRemoteStateConfig,

--- a/packages/cdktf/lib/backends/etcdv3-backend.ts
+++ b/packages/cdktf/lib/backends/etcdv3-backend.ts
@@ -9,7 +9,7 @@ import {
 } from "../terraform-remote-state";
 
 /**
- * @deprecated the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ * @deprecated CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
  */
 export class EtcdV3Backend extends TerraformBackend {
   constructor(scope: Construct, private readonly props: EtcdV3BackendProps) {
@@ -33,7 +33,7 @@ export class EtcdV3Backend extends TerraformBackend {
 }
 
 /**
- * @deprecated the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ * @deprecated CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
  */
 export class DataTerraformRemoteStateEtcdV3 extends TerraformRemoteState {
   constructor(
@@ -52,7 +52,7 @@ export class DataTerraformRemoteStateEtcdV3 extends TerraformRemoteState {
  * Read more about this backend in the Terraform docs:
  * https://www.terraform.io/language/settings/backends/etcdv3
  *
- * @deprecated the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ * @deprecated CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
  */
 export interface EtcdV3BackendProps {
   /**
@@ -93,7 +93,7 @@ export interface EtcdV3BackendProps {
 }
 
 /**
- * @deprecated the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ * @deprecated CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
  */
 export interface DataTerraformRemoteStateEtcdV3Config
   extends DataTerraformRemoteStateConfig,

--- a/packages/cdktf/lib/backends/etcdv3-backend.ts
+++ b/packages/cdktf/lib/backends/etcdv3-backend.ts
@@ -8,7 +8,9 @@ import {
   DataTerraformRemoteStateConfig,
 } from "../terraform-remote-state";
 
-// eslint-disable-next-line jsdoc/require-jsdoc
+/**
+ * @deprecated the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ */
 export class EtcdV3Backend extends TerraformBackend {
   constructor(scope: Construct, private readonly props: EtcdV3BackendProps) {
     super(scope, "backend", "etcdv3");
@@ -30,7 +32,9 @@ export class EtcdV3Backend extends TerraformBackend {
   }
 }
 
-// eslint-disable-next-line jsdoc/require-jsdoc
+/**
+ * @deprecated the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ */
 export class DataTerraformRemoteStateEtcdV3 extends TerraformRemoteState {
   constructor(
     scope: Construct,
@@ -47,6 +51,8 @@ export class DataTerraformRemoteStateEtcdV3 extends TerraformRemoteState {
  *
  * Read more about this backend in the Terraform docs:
  * https://www.terraform.io/language/settings/backends/etcdv3
+ *
+ * @deprecated the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
  */
 export interface EtcdV3BackendProps {
   /**
@@ -86,6 +92,9 @@ export interface EtcdV3BackendProps {
   readonly keyPath?: string;
 }
 
+/**
+ * @deprecated the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ */
 export interface DataTerraformRemoteStateEtcdV3Config
   extends DataTerraformRemoteStateConfig,
     EtcdV3BackendProps {}

--- a/packages/cdktf/lib/backends/manta-backend.ts
+++ b/packages/cdktf/lib/backends/manta-backend.ts
@@ -8,7 +8,9 @@ import {
   DataTerraformRemoteStateConfig,
 } from "../terraform-remote-state";
 
-// eslint-disable-next-line jsdoc/require-jsdoc
+/**
+ * @deprecated the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ */
 export class MantaBackend extends TerraformBackend {
   constructor(scope: Construct, private readonly props: MantaBackendProps) {
     super(scope, "backend", "manta");
@@ -30,7 +32,9 @@ export class MantaBackend extends TerraformBackend {
   }
 }
 
-// eslint-disable-next-line jsdoc/require-jsdoc
+/**
+ * @deprecated the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ */
 export class DataTerraformRemoteStateManta extends TerraformRemoteState {
   constructor(
     scope: Construct,
@@ -41,6 +45,9 @@ export class DataTerraformRemoteStateManta extends TerraformRemoteState {
   }
 }
 
+/**
+ * @deprecated the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ */
 export interface MantaBackendProps {
   readonly account: string;
   readonly user?: string;
@@ -52,6 +59,9 @@ export interface MantaBackendProps {
   readonly objectName?: string;
 }
 
+/**
+ * @deprecated the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ */
 export interface DataTerraformRemoteStateMantaConfig
   extends DataTerraformRemoteStateConfig,
     MantaBackendProps {}

--- a/packages/cdktf/lib/backends/manta-backend.ts
+++ b/packages/cdktf/lib/backends/manta-backend.ts
@@ -9,7 +9,7 @@ import {
 } from "../terraform-remote-state";
 
 /**
- * @deprecated the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ * @deprecated CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
  */
 export class MantaBackend extends TerraformBackend {
   constructor(scope: Construct, private readonly props: MantaBackendProps) {
@@ -33,7 +33,7 @@ export class MantaBackend extends TerraformBackend {
 }
 
 /**
- * @deprecated the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ * @deprecated CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
  */
 export class DataTerraformRemoteStateManta extends TerraformRemoteState {
   constructor(
@@ -46,7 +46,7 @@ export class DataTerraformRemoteStateManta extends TerraformRemoteState {
 }
 
 /**
- * @deprecated the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ * @deprecated CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
  */
 export interface MantaBackendProps {
   readonly account: string;
@@ -60,7 +60,7 @@ export interface MantaBackendProps {
 }
 
 /**
- * @deprecated the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ * @deprecated CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
  */
 export interface DataTerraformRemoteStateMantaConfig
   extends DataTerraformRemoteStateConfig,

--- a/packages/cdktf/lib/backends/swift-backend.ts
+++ b/packages/cdktf/lib/backends/swift-backend.ts
@@ -8,7 +8,9 @@ import {
   DataTerraformRemoteStateConfig,
 } from "../terraform-remote-state";
 
-// eslint-disable-next-line jsdoc/require-jsdoc
+/**
+ * @deprecated the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ */
 export class SwiftBackend extends TerraformBackend {
   constructor(scope: Construct, private readonly props: SwiftBackendProps) {
     super(scope, "backend", "swift");
@@ -27,7 +29,9 @@ export class SwiftBackend extends TerraformBackend {
   }
 }
 
-// eslint-disable-next-line jsdoc/require-jsdoc
+/**
+ * @deprecated the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ */
 export class DataTerraformRemoteStateSwift extends TerraformRemoteState {
   constructor(
     scope: Construct,
@@ -38,6 +42,9 @@ export class DataTerraformRemoteStateSwift extends TerraformRemoteState {
   }
 }
 
+/**
+ * @deprecated the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ */
 export interface SwiftBackendProps {
   readonly authUrl?: string;
   readonly cloud?: string;
@@ -68,6 +75,9 @@ export interface SwiftBackendProps {
   readonly expireAfter?: string;
 }
 
+/**
+ * @deprecated the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ */
 export interface DataTerraformRemoteStateSwiftConfig
   extends DataTerraformRemoteStateConfig,
     SwiftBackendProps {}

--- a/packages/cdktf/lib/backends/swift-backend.ts
+++ b/packages/cdktf/lib/backends/swift-backend.ts
@@ -9,7 +9,7 @@ import {
 } from "../terraform-remote-state";
 
 /**
- * @deprecated the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ * @deprecated CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
  */
 export class SwiftBackend extends TerraformBackend {
   constructor(scope: Construct, private readonly props: SwiftBackendProps) {
@@ -30,7 +30,7 @@ export class SwiftBackend extends TerraformBackend {
 }
 
 /**
- * @deprecated the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ * @deprecated CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
  */
 export class DataTerraformRemoteStateSwift extends TerraformRemoteState {
   constructor(
@@ -43,7 +43,7 @@ export class DataTerraformRemoteStateSwift extends TerraformRemoteState {
 }
 
 /**
- * @deprecated the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ * @deprecated CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
  */
 export interface SwiftBackendProps {
   readonly authUrl?: string;
@@ -76,7 +76,7 @@ export interface SwiftBackendProps {
 }
 
 /**
- * @deprecated the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+ * @deprecated CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
  */
 export interface DataTerraformRemoteStateSwiftConfig
   extends DataTerraformRemoteStateConfig,

--- a/website/docs/cdktf/api-reference/csharp.mdx
+++ b/website/docs/cdktf/api-reference/csharp.mdx
@@ -273,7 +273,7 @@ new ArtifactoryBackend(Construct Scope, ArtifactoryBackendProps Props);
 
 ---
 
-##### `ToString` <a name="ToString" id="cdktf.ArtifactoryBackend.toString"></a>
+##### ~~`ToString`~~ <a name="ToString" id="cdktf.ArtifactoryBackend.toString"></a>
 
 ```csharp
 private string ToString()
@@ -281,7 +281,7 @@ private string ToString()
 
 Returns a string representation of this construct.
 
-##### `AddOverride` <a name="AddOverride" id="cdktf.ArtifactoryBackend.addOverride"></a>
+##### ~~`AddOverride`~~ <a name="AddOverride" id="cdktf.ArtifactoryBackend.addOverride"></a>
 
 ```csharp
 private void AddOverride(string Path, object Value)
@@ -299,7 +299,7 @@ private void AddOverride(string Path, object Value)
 
 ---
 
-##### `OverrideLogicalId` <a name="OverrideLogicalId" id="cdktf.ArtifactoryBackend.overrideLogicalId"></a>
+##### ~~`OverrideLogicalId`~~ <a name="OverrideLogicalId" id="cdktf.ArtifactoryBackend.overrideLogicalId"></a>
 
 ```csharp
 private void OverrideLogicalId(string NewLogicalId)
@@ -315,7 +315,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `ResetOverrideLogicalId` <a name="ResetOverrideLogicalId" id="cdktf.ArtifactoryBackend.resetOverrideLogicalId"></a>
+##### ~~`ResetOverrideLogicalId`~~ <a name="ResetOverrideLogicalId" id="cdktf.ArtifactoryBackend.resetOverrideLogicalId"></a>
 
 ```csharp
 private void ResetOverrideLogicalId()
@@ -323,13 +323,13 @@ private void ResetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `ToMetadata` <a name="ToMetadata" id="cdktf.ArtifactoryBackend.toMetadata"></a>
+##### ~~`ToMetadata`~~ <a name="ToMetadata" id="cdktf.ArtifactoryBackend.toMetadata"></a>
 
 ```csharp
 private object ToMetadata()
 ```
 
-##### `ToTerraform` <a name="ToTerraform" id="cdktf.ArtifactoryBackend.toTerraform"></a>
+##### ~~`ToTerraform`~~ <a name="ToTerraform" id="cdktf.ArtifactoryBackend.toTerraform"></a>
 
 ```csharp
 private object ToTerraform()
@@ -337,7 +337,7 @@ private object ToTerraform()
 
 Adds this resource to the terraform JSON output.
 
-##### `GetRemoteStateDataSource` <a name="GetRemoteStateDataSource" id="cdktf.ArtifactoryBackend.getRemoteStateDataSource"></a>
+##### ~~`GetRemoteStateDataSource`~~ <a name="GetRemoteStateDataSource" id="cdktf.ArtifactoryBackend.getRemoteStateDataSource"></a>
 
 ```csharp
 private TerraformRemoteState GetRemoteStateDataSource(Construct Scope, string Name, string FromStack)
@@ -373,7 +373,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `IsConstruct` <a name="IsConstruct" id="cdktf.ArtifactoryBackend.isConstruct"></a>
+##### ~~`IsConstruct`~~ <a name="IsConstruct" id="cdktf.ArtifactoryBackend.isConstruct"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -405,7 +405,7 @@ Any object.
 
 ---
 
-##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.ArtifactoryBackend.isTerraformElement"></a>
+##### ~~`IsTerraformElement`~~ <a name="IsTerraformElement" id="cdktf.ArtifactoryBackend.isTerraformElement"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -419,7 +419,7 @@ ArtifactoryBackend.IsTerraformElement(object X);
 
 ---
 
-##### `IsBackend` <a name="IsBackend" id="cdktf.ArtifactoryBackend.isBackend"></a>
+##### ~~`IsBackend`~~ <a name="IsBackend" id="cdktf.ArtifactoryBackend.isBackend"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -444,7 +444,9 @@ ArtifactoryBackend.IsBackend(object X);
 
 ---
 
-##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.ArtifactoryBackend.property.node"></a>
+##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.ArtifactoryBackend.property.node"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public Node Node { get; }
@@ -456,7 +458,9 @@ The tree node.
 
 ---
 
-##### `CdktfStack`<sup>Required</sup> <a name="CdktfStack" id="cdktf.ArtifactoryBackend.property.cdktfStack"></a>
+##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.ArtifactoryBackend.property.cdktfStack"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public TerraformStack CdktfStack { get; }
@@ -466,7 +470,9 @@ public TerraformStack CdktfStack { get; }
 
 ---
 
-##### `Fqn`<sup>Required</sup> <a name="Fqn" id="cdktf.ArtifactoryBackend.property.fqn"></a>
+##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.ArtifactoryBackend.property.fqn"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Fqn { get; }
@@ -476,7 +482,9 @@ public string Fqn { get; }
 
 ---
 
-##### `FriendlyUniqueId`<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.ArtifactoryBackend.property.friendlyUniqueId"></a>
+##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.ArtifactoryBackend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string FriendlyUniqueId { get; }
@@ -1870,7 +1878,7 @@ new DataTerraformRemoteStateArtifactory(Construct Scope, string Id, DataTerrafor
 
 ---
 
-##### `ToString` <a name="ToString" id="cdktf.DataTerraformRemoteStateArtifactory.toString"></a>
+##### ~~`ToString`~~ <a name="ToString" id="cdktf.DataTerraformRemoteStateArtifactory.toString"></a>
 
 ```csharp
 private string ToString()
@@ -1878,7 +1886,7 @@ private string ToString()
 
 Returns a string representation of this construct.
 
-##### `AddOverride` <a name="AddOverride" id="cdktf.DataTerraformRemoteStateArtifactory.addOverride"></a>
+##### ~~`AddOverride`~~ <a name="AddOverride" id="cdktf.DataTerraformRemoteStateArtifactory.addOverride"></a>
 
 ```csharp
 private void AddOverride(string Path, object Value)
@@ -1896,7 +1904,7 @@ private void AddOverride(string Path, object Value)
 
 ---
 
-##### `OverrideLogicalId` <a name="OverrideLogicalId" id="cdktf.DataTerraformRemoteStateArtifactory.overrideLogicalId"></a>
+##### ~~`OverrideLogicalId`~~ <a name="OverrideLogicalId" id="cdktf.DataTerraformRemoteStateArtifactory.overrideLogicalId"></a>
 
 ```csharp
 private void OverrideLogicalId(string NewLogicalId)
@@ -1912,7 +1920,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `ResetOverrideLogicalId` <a name="ResetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateArtifactory.resetOverrideLogicalId"></a>
+##### ~~`ResetOverrideLogicalId`~~ <a name="ResetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateArtifactory.resetOverrideLogicalId"></a>
 
 ```csharp
 private void ResetOverrideLogicalId()
@@ -1920,13 +1928,13 @@ private void ResetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `ToMetadata` <a name="ToMetadata" id="cdktf.DataTerraformRemoteStateArtifactory.toMetadata"></a>
+##### ~~`ToMetadata`~~ <a name="ToMetadata" id="cdktf.DataTerraformRemoteStateArtifactory.toMetadata"></a>
 
 ```csharp
 private object ToMetadata()
 ```
 
-##### `ToTerraform` <a name="ToTerraform" id="cdktf.DataTerraformRemoteStateArtifactory.toTerraform"></a>
+##### ~~`ToTerraform`~~ <a name="ToTerraform" id="cdktf.DataTerraformRemoteStateArtifactory.toTerraform"></a>
 
 ```csharp
 private object ToTerraform()
@@ -1934,7 +1942,7 @@ private object ToTerraform()
 
 Adds this resource to the terraform JSON output.
 
-##### `Get` <a name="Get" id="cdktf.DataTerraformRemoteStateArtifactory.get"></a>
+##### ~~`Get`~~ <a name="Get" id="cdktf.DataTerraformRemoteStateArtifactory.get"></a>
 
 ```csharp
 private IResolvable Get(string Output)
@@ -1946,7 +1954,7 @@ private IResolvable Get(string Output)
 
 ---
 
-##### `GetBoolean` <a name="GetBoolean" id="cdktf.DataTerraformRemoteStateArtifactory.getBoolean"></a>
+##### ~~`GetBoolean`~~ <a name="GetBoolean" id="cdktf.DataTerraformRemoteStateArtifactory.getBoolean"></a>
 
 ```csharp
 private IResolvable GetBoolean(string Output)
@@ -1958,7 +1966,7 @@ private IResolvable GetBoolean(string Output)
 
 ---
 
-##### `GetList` <a name="GetList" id="cdktf.DataTerraformRemoteStateArtifactory.getList"></a>
+##### ~~`GetList`~~ <a name="GetList" id="cdktf.DataTerraformRemoteStateArtifactory.getList"></a>
 
 ```csharp
 private string[] GetList(string Output)
@@ -1970,7 +1978,7 @@ private string[] GetList(string Output)
 
 ---
 
-##### `GetNumber` <a name="GetNumber" id="cdktf.DataTerraformRemoteStateArtifactory.getNumber"></a>
+##### ~~`GetNumber`~~ <a name="GetNumber" id="cdktf.DataTerraformRemoteStateArtifactory.getNumber"></a>
 
 ```csharp
 private double GetNumber(string Output)
@@ -1982,7 +1990,7 @@ private double GetNumber(string Output)
 
 ---
 
-##### `GetString` <a name="GetString" id="cdktf.DataTerraformRemoteStateArtifactory.getString"></a>
+##### ~~`GetString`~~ <a name="GetString" id="cdktf.DataTerraformRemoteStateArtifactory.getString"></a>
 
 ```csharp
 private string GetString(string Output)
@@ -2003,7 +2011,7 @@ private string GetString(string Output)
 
 ---
 
-##### `IsConstruct` <a name="IsConstruct" id="cdktf.DataTerraformRemoteStateArtifactory.isConstruct"></a>
+##### ~~`IsConstruct`~~ <a name="IsConstruct" id="cdktf.DataTerraformRemoteStateArtifactory.isConstruct"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -2035,7 +2043,7 @@ Any object.
 
 ---
 
-##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement"></a>
+##### ~~`IsTerraformElement`~~ <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -2060,7 +2068,9 @@ DataTerraformRemoteStateArtifactory.IsTerraformElement(object X);
 
 ---
 
-##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateArtifactory.property.node"></a>
+##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateArtifactory.property.node"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public Node Node { get; }
@@ -2072,7 +2082,9 @@ The tree node.
 
 ---
 
-##### `CdktfStack`<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateArtifactory.property.cdktfStack"></a>
+##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateArtifactory.property.cdktfStack"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public TerraformStack CdktfStack { get; }
@@ -2082,7 +2094,9 @@ public TerraformStack CdktfStack { get; }
 
 ---
 
-##### `Fqn`<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateArtifactory.property.fqn"></a>
+##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateArtifactory.property.fqn"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Fqn { get; }
@@ -2092,7 +2106,9 @@ public string Fqn { get; }
 
 ---
 
-##### `FriendlyUniqueId`<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateArtifactory.property.friendlyUniqueId"></a>
+##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateArtifactory.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string FriendlyUniqueId { get; }
@@ -2110,7 +2126,9 @@ public string FriendlyUniqueId { get; }
 
 ---
 
-##### `TfResourceType`<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateArtifactory.property.tfResourceType"></a>
+##### ~~`TfResourceType`~~<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateArtifactory.property.tfResourceType"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string TfResourceType { get; }
@@ -3086,7 +3104,7 @@ new DataTerraformRemoteStateEtcd(Construct Scope, string Id, DataTerraformRemote
 
 ---
 
-##### `ToString` <a name="ToString" id="cdktf.DataTerraformRemoteStateEtcd.toString"></a>
+##### ~~`ToString`~~ <a name="ToString" id="cdktf.DataTerraformRemoteStateEtcd.toString"></a>
 
 ```csharp
 private string ToString()
@@ -3094,7 +3112,7 @@ private string ToString()
 
 Returns a string representation of this construct.
 
-##### `AddOverride` <a name="AddOverride" id="cdktf.DataTerraformRemoteStateEtcd.addOverride"></a>
+##### ~~`AddOverride`~~ <a name="AddOverride" id="cdktf.DataTerraformRemoteStateEtcd.addOverride"></a>
 
 ```csharp
 private void AddOverride(string Path, object Value)
@@ -3112,7 +3130,7 @@ private void AddOverride(string Path, object Value)
 
 ---
 
-##### `OverrideLogicalId` <a name="OverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcd.overrideLogicalId"></a>
+##### ~~`OverrideLogicalId`~~ <a name="OverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcd.overrideLogicalId"></a>
 
 ```csharp
 private void OverrideLogicalId(string NewLogicalId)
@@ -3128,7 +3146,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `ResetOverrideLogicalId` <a name="ResetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcd.resetOverrideLogicalId"></a>
+##### ~~`ResetOverrideLogicalId`~~ <a name="ResetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcd.resetOverrideLogicalId"></a>
 
 ```csharp
 private void ResetOverrideLogicalId()
@@ -3136,13 +3154,13 @@ private void ResetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `ToMetadata` <a name="ToMetadata" id="cdktf.DataTerraformRemoteStateEtcd.toMetadata"></a>
+##### ~~`ToMetadata`~~ <a name="ToMetadata" id="cdktf.DataTerraformRemoteStateEtcd.toMetadata"></a>
 
 ```csharp
 private object ToMetadata()
 ```
 
-##### `ToTerraform` <a name="ToTerraform" id="cdktf.DataTerraformRemoteStateEtcd.toTerraform"></a>
+##### ~~`ToTerraform`~~ <a name="ToTerraform" id="cdktf.DataTerraformRemoteStateEtcd.toTerraform"></a>
 
 ```csharp
 private object ToTerraform()
@@ -3150,7 +3168,7 @@ private object ToTerraform()
 
 Adds this resource to the terraform JSON output.
 
-##### `Get` <a name="Get" id="cdktf.DataTerraformRemoteStateEtcd.get"></a>
+##### ~~`Get`~~ <a name="Get" id="cdktf.DataTerraformRemoteStateEtcd.get"></a>
 
 ```csharp
 private IResolvable Get(string Output)
@@ -3162,7 +3180,7 @@ private IResolvable Get(string Output)
 
 ---
 
-##### `GetBoolean` <a name="GetBoolean" id="cdktf.DataTerraformRemoteStateEtcd.getBoolean"></a>
+##### ~~`GetBoolean`~~ <a name="GetBoolean" id="cdktf.DataTerraformRemoteStateEtcd.getBoolean"></a>
 
 ```csharp
 private IResolvable GetBoolean(string Output)
@@ -3174,7 +3192,7 @@ private IResolvable GetBoolean(string Output)
 
 ---
 
-##### `GetList` <a name="GetList" id="cdktf.DataTerraformRemoteStateEtcd.getList"></a>
+##### ~~`GetList`~~ <a name="GetList" id="cdktf.DataTerraformRemoteStateEtcd.getList"></a>
 
 ```csharp
 private string[] GetList(string Output)
@@ -3186,7 +3204,7 @@ private string[] GetList(string Output)
 
 ---
 
-##### `GetNumber` <a name="GetNumber" id="cdktf.DataTerraformRemoteStateEtcd.getNumber"></a>
+##### ~~`GetNumber`~~ <a name="GetNumber" id="cdktf.DataTerraformRemoteStateEtcd.getNumber"></a>
 
 ```csharp
 private double GetNumber(string Output)
@@ -3198,7 +3216,7 @@ private double GetNumber(string Output)
 
 ---
 
-##### `GetString` <a name="GetString" id="cdktf.DataTerraformRemoteStateEtcd.getString"></a>
+##### ~~`GetString`~~ <a name="GetString" id="cdktf.DataTerraformRemoteStateEtcd.getString"></a>
 
 ```csharp
 private string GetString(string Output)
@@ -3219,7 +3237,7 @@ private string GetString(string Output)
 
 ---
 
-##### `IsConstruct` <a name="IsConstruct" id="cdktf.DataTerraformRemoteStateEtcd.isConstruct"></a>
+##### ~~`IsConstruct`~~ <a name="IsConstruct" id="cdktf.DataTerraformRemoteStateEtcd.isConstruct"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -3251,7 +3269,7 @@ Any object.
 
 ---
 
-##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateEtcd.isTerraformElement"></a>
+##### ~~`IsTerraformElement`~~ <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateEtcd.isTerraformElement"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -3276,7 +3294,9 @@ DataTerraformRemoteStateEtcd.IsTerraformElement(object X);
 
 ---
 
-##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateEtcd.property.node"></a>
+##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateEtcd.property.node"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public Node Node { get; }
@@ -3288,7 +3308,9 @@ The tree node.
 
 ---
 
-##### `CdktfStack`<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateEtcd.property.cdktfStack"></a>
+##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateEtcd.property.cdktfStack"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public TerraformStack CdktfStack { get; }
@@ -3298,7 +3320,9 @@ public TerraformStack CdktfStack { get; }
 
 ---
 
-##### `Fqn`<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateEtcd.property.fqn"></a>
+##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateEtcd.property.fqn"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Fqn { get; }
@@ -3308,7 +3332,9 @@ public string Fqn { get; }
 
 ---
 
-##### `FriendlyUniqueId`<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcd.property.friendlyUniqueId"></a>
+##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcd.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string FriendlyUniqueId { get; }
@@ -3326,7 +3352,9 @@ public string FriendlyUniqueId { get; }
 
 ---
 
-##### `TfResourceType`<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateEtcd.property.tfResourceType"></a>
+##### ~~`TfResourceType`~~<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateEtcd.property.tfResourceType"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string TfResourceType { get; }
@@ -3390,7 +3418,7 @@ new DataTerraformRemoteStateEtcdV3(Construct Scope, string Id, DataTerraformRemo
 
 ---
 
-##### `ToString` <a name="ToString" id="cdktf.DataTerraformRemoteStateEtcdV3.toString"></a>
+##### ~~`ToString`~~ <a name="ToString" id="cdktf.DataTerraformRemoteStateEtcdV3.toString"></a>
 
 ```csharp
 private string ToString()
@@ -3398,7 +3426,7 @@ private string ToString()
 
 Returns a string representation of this construct.
 
-##### `AddOverride` <a name="AddOverride" id="cdktf.DataTerraformRemoteStateEtcdV3.addOverride"></a>
+##### ~~`AddOverride`~~ <a name="AddOverride" id="cdktf.DataTerraformRemoteStateEtcdV3.addOverride"></a>
 
 ```csharp
 private void AddOverride(string Path, object Value)
@@ -3416,7 +3444,7 @@ private void AddOverride(string Path, object Value)
 
 ---
 
-##### `OverrideLogicalId` <a name="OverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcdV3.overrideLogicalId"></a>
+##### ~~`OverrideLogicalId`~~ <a name="OverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcdV3.overrideLogicalId"></a>
 
 ```csharp
 private void OverrideLogicalId(string NewLogicalId)
@@ -3432,7 +3460,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `ResetOverrideLogicalId` <a name="ResetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcdV3.resetOverrideLogicalId"></a>
+##### ~~`ResetOverrideLogicalId`~~ <a name="ResetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcdV3.resetOverrideLogicalId"></a>
 
 ```csharp
 private void ResetOverrideLogicalId()
@@ -3440,13 +3468,13 @@ private void ResetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `ToMetadata` <a name="ToMetadata" id="cdktf.DataTerraformRemoteStateEtcdV3.toMetadata"></a>
+##### ~~`ToMetadata`~~ <a name="ToMetadata" id="cdktf.DataTerraformRemoteStateEtcdV3.toMetadata"></a>
 
 ```csharp
 private object ToMetadata()
 ```
 
-##### `ToTerraform` <a name="ToTerraform" id="cdktf.DataTerraformRemoteStateEtcdV3.toTerraform"></a>
+##### ~~`ToTerraform`~~ <a name="ToTerraform" id="cdktf.DataTerraformRemoteStateEtcdV3.toTerraform"></a>
 
 ```csharp
 private object ToTerraform()
@@ -3454,7 +3482,7 @@ private object ToTerraform()
 
 Adds this resource to the terraform JSON output.
 
-##### `Get` <a name="Get" id="cdktf.DataTerraformRemoteStateEtcdV3.get"></a>
+##### ~~`Get`~~ <a name="Get" id="cdktf.DataTerraformRemoteStateEtcdV3.get"></a>
 
 ```csharp
 private IResolvable Get(string Output)
@@ -3466,7 +3494,7 @@ private IResolvable Get(string Output)
 
 ---
 
-##### `GetBoolean` <a name="GetBoolean" id="cdktf.DataTerraformRemoteStateEtcdV3.getBoolean"></a>
+##### ~~`GetBoolean`~~ <a name="GetBoolean" id="cdktf.DataTerraformRemoteStateEtcdV3.getBoolean"></a>
 
 ```csharp
 private IResolvable GetBoolean(string Output)
@@ -3478,7 +3506,7 @@ private IResolvable GetBoolean(string Output)
 
 ---
 
-##### `GetList` <a name="GetList" id="cdktf.DataTerraformRemoteStateEtcdV3.getList"></a>
+##### ~~`GetList`~~ <a name="GetList" id="cdktf.DataTerraformRemoteStateEtcdV3.getList"></a>
 
 ```csharp
 private string[] GetList(string Output)
@@ -3490,7 +3518,7 @@ private string[] GetList(string Output)
 
 ---
 
-##### `GetNumber` <a name="GetNumber" id="cdktf.DataTerraformRemoteStateEtcdV3.getNumber"></a>
+##### ~~`GetNumber`~~ <a name="GetNumber" id="cdktf.DataTerraformRemoteStateEtcdV3.getNumber"></a>
 
 ```csharp
 private double GetNumber(string Output)
@@ -3502,7 +3530,7 @@ private double GetNumber(string Output)
 
 ---
 
-##### `GetString` <a name="GetString" id="cdktf.DataTerraformRemoteStateEtcdV3.getString"></a>
+##### ~~`GetString`~~ <a name="GetString" id="cdktf.DataTerraformRemoteStateEtcdV3.getString"></a>
 
 ```csharp
 private string GetString(string Output)
@@ -3523,7 +3551,7 @@ private string GetString(string Output)
 
 ---
 
-##### `IsConstruct` <a name="IsConstruct" id="cdktf.DataTerraformRemoteStateEtcdV3.isConstruct"></a>
+##### ~~`IsConstruct`~~ <a name="IsConstruct" id="cdktf.DataTerraformRemoteStateEtcdV3.isConstruct"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -3555,7 +3583,7 @@ Any object.
 
 ---
 
-##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement"></a>
+##### ~~`IsTerraformElement`~~ <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -3580,7 +3608,9 @@ DataTerraformRemoteStateEtcdV3.IsTerraformElement(object X);
 
 ---
 
-##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateEtcdV3.property.node"></a>
+##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateEtcdV3.property.node"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public Node Node { get; }
@@ -3592,7 +3622,9 @@ The tree node.
 
 ---
 
-##### `CdktfStack`<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateEtcdV3.property.cdktfStack"></a>
+##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateEtcdV3.property.cdktfStack"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public TerraformStack CdktfStack { get; }
@@ -3602,7 +3634,9 @@ public TerraformStack CdktfStack { get; }
 
 ---
 
-##### `Fqn`<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateEtcdV3.property.fqn"></a>
+##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateEtcdV3.property.fqn"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Fqn { get; }
@@ -3612,7 +3646,9 @@ public string Fqn { get; }
 
 ---
 
-##### `FriendlyUniqueId`<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcdV3.property.friendlyUniqueId"></a>
+##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcdV3.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string FriendlyUniqueId { get; }
@@ -3630,7 +3666,9 @@ public string FriendlyUniqueId { get; }
 
 ---
 
-##### `TfResourceType`<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateEtcdV3.property.tfResourceType"></a>
+##### ~~`TfResourceType`~~<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateEtcdV3.property.tfResourceType"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string TfResourceType { get; }
@@ -4606,7 +4644,7 @@ new DataTerraformRemoteStateManta(Construct Scope, string Id, DataTerraformRemot
 
 ---
 
-##### `ToString` <a name="ToString" id="cdktf.DataTerraformRemoteStateManta.toString"></a>
+##### ~~`ToString`~~ <a name="ToString" id="cdktf.DataTerraformRemoteStateManta.toString"></a>
 
 ```csharp
 private string ToString()
@@ -4614,7 +4652,7 @@ private string ToString()
 
 Returns a string representation of this construct.
 
-##### `AddOverride` <a name="AddOverride" id="cdktf.DataTerraformRemoteStateManta.addOverride"></a>
+##### ~~`AddOverride`~~ <a name="AddOverride" id="cdktf.DataTerraformRemoteStateManta.addOverride"></a>
 
 ```csharp
 private void AddOverride(string Path, object Value)
@@ -4632,7 +4670,7 @@ private void AddOverride(string Path, object Value)
 
 ---
 
-##### `OverrideLogicalId` <a name="OverrideLogicalId" id="cdktf.DataTerraformRemoteStateManta.overrideLogicalId"></a>
+##### ~~`OverrideLogicalId`~~ <a name="OverrideLogicalId" id="cdktf.DataTerraformRemoteStateManta.overrideLogicalId"></a>
 
 ```csharp
 private void OverrideLogicalId(string NewLogicalId)
@@ -4648,7 +4686,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `ResetOverrideLogicalId` <a name="ResetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateManta.resetOverrideLogicalId"></a>
+##### ~~`ResetOverrideLogicalId`~~ <a name="ResetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateManta.resetOverrideLogicalId"></a>
 
 ```csharp
 private void ResetOverrideLogicalId()
@@ -4656,13 +4694,13 @@ private void ResetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `ToMetadata` <a name="ToMetadata" id="cdktf.DataTerraformRemoteStateManta.toMetadata"></a>
+##### ~~`ToMetadata`~~ <a name="ToMetadata" id="cdktf.DataTerraformRemoteStateManta.toMetadata"></a>
 
 ```csharp
 private object ToMetadata()
 ```
 
-##### `ToTerraform` <a name="ToTerraform" id="cdktf.DataTerraformRemoteStateManta.toTerraform"></a>
+##### ~~`ToTerraform`~~ <a name="ToTerraform" id="cdktf.DataTerraformRemoteStateManta.toTerraform"></a>
 
 ```csharp
 private object ToTerraform()
@@ -4670,7 +4708,7 @@ private object ToTerraform()
 
 Adds this resource to the terraform JSON output.
 
-##### `Get` <a name="Get" id="cdktf.DataTerraformRemoteStateManta.get"></a>
+##### ~~`Get`~~ <a name="Get" id="cdktf.DataTerraformRemoteStateManta.get"></a>
 
 ```csharp
 private IResolvable Get(string Output)
@@ -4682,7 +4720,7 @@ private IResolvable Get(string Output)
 
 ---
 
-##### `GetBoolean` <a name="GetBoolean" id="cdktf.DataTerraformRemoteStateManta.getBoolean"></a>
+##### ~~`GetBoolean`~~ <a name="GetBoolean" id="cdktf.DataTerraformRemoteStateManta.getBoolean"></a>
 
 ```csharp
 private IResolvable GetBoolean(string Output)
@@ -4694,7 +4732,7 @@ private IResolvable GetBoolean(string Output)
 
 ---
 
-##### `GetList` <a name="GetList" id="cdktf.DataTerraformRemoteStateManta.getList"></a>
+##### ~~`GetList`~~ <a name="GetList" id="cdktf.DataTerraformRemoteStateManta.getList"></a>
 
 ```csharp
 private string[] GetList(string Output)
@@ -4706,7 +4744,7 @@ private string[] GetList(string Output)
 
 ---
 
-##### `GetNumber` <a name="GetNumber" id="cdktf.DataTerraformRemoteStateManta.getNumber"></a>
+##### ~~`GetNumber`~~ <a name="GetNumber" id="cdktf.DataTerraformRemoteStateManta.getNumber"></a>
 
 ```csharp
 private double GetNumber(string Output)
@@ -4718,7 +4756,7 @@ private double GetNumber(string Output)
 
 ---
 
-##### `GetString` <a name="GetString" id="cdktf.DataTerraformRemoteStateManta.getString"></a>
+##### ~~`GetString`~~ <a name="GetString" id="cdktf.DataTerraformRemoteStateManta.getString"></a>
 
 ```csharp
 private string GetString(string Output)
@@ -4739,7 +4777,7 @@ private string GetString(string Output)
 
 ---
 
-##### `IsConstruct` <a name="IsConstruct" id="cdktf.DataTerraformRemoteStateManta.isConstruct"></a>
+##### ~~`IsConstruct`~~ <a name="IsConstruct" id="cdktf.DataTerraformRemoteStateManta.isConstruct"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -4771,7 +4809,7 @@ Any object.
 
 ---
 
-##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateManta.isTerraformElement"></a>
+##### ~~`IsTerraformElement`~~ <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateManta.isTerraformElement"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -4796,7 +4834,9 @@ DataTerraformRemoteStateManta.IsTerraformElement(object X);
 
 ---
 
-##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateManta.property.node"></a>
+##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateManta.property.node"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public Node Node { get; }
@@ -4808,7 +4848,9 @@ The tree node.
 
 ---
 
-##### `CdktfStack`<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateManta.property.cdktfStack"></a>
+##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateManta.property.cdktfStack"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public TerraformStack CdktfStack { get; }
@@ -4818,7 +4860,9 @@ public TerraformStack CdktfStack { get; }
 
 ---
 
-##### `Fqn`<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateManta.property.fqn"></a>
+##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateManta.property.fqn"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Fqn { get; }
@@ -4828,7 +4872,9 @@ public string Fqn { get; }
 
 ---
 
-##### `FriendlyUniqueId`<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateManta.property.friendlyUniqueId"></a>
+##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateManta.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string FriendlyUniqueId { get; }
@@ -4846,7 +4892,9 @@ public string FriendlyUniqueId { get; }
 
 ---
 
-##### `TfResourceType`<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateManta.property.tfResourceType"></a>
+##### ~~`TfResourceType`~~<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateManta.property.tfResourceType"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string TfResourceType { get; }
@@ -5822,7 +5870,7 @@ new DataTerraformRemoteStateSwift(Construct Scope, string Id, DataTerraformRemot
 
 ---
 
-##### `ToString` <a name="ToString" id="cdktf.DataTerraformRemoteStateSwift.toString"></a>
+##### ~~`ToString`~~ <a name="ToString" id="cdktf.DataTerraformRemoteStateSwift.toString"></a>
 
 ```csharp
 private string ToString()
@@ -5830,7 +5878,7 @@ private string ToString()
 
 Returns a string representation of this construct.
 
-##### `AddOverride` <a name="AddOverride" id="cdktf.DataTerraformRemoteStateSwift.addOverride"></a>
+##### ~~`AddOverride`~~ <a name="AddOverride" id="cdktf.DataTerraformRemoteStateSwift.addOverride"></a>
 
 ```csharp
 private void AddOverride(string Path, object Value)
@@ -5848,7 +5896,7 @@ private void AddOverride(string Path, object Value)
 
 ---
 
-##### `OverrideLogicalId` <a name="OverrideLogicalId" id="cdktf.DataTerraformRemoteStateSwift.overrideLogicalId"></a>
+##### ~~`OverrideLogicalId`~~ <a name="OverrideLogicalId" id="cdktf.DataTerraformRemoteStateSwift.overrideLogicalId"></a>
 
 ```csharp
 private void OverrideLogicalId(string NewLogicalId)
@@ -5864,7 +5912,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `ResetOverrideLogicalId` <a name="ResetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateSwift.resetOverrideLogicalId"></a>
+##### ~~`ResetOverrideLogicalId`~~ <a name="ResetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateSwift.resetOverrideLogicalId"></a>
 
 ```csharp
 private void ResetOverrideLogicalId()
@@ -5872,13 +5920,13 @@ private void ResetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `ToMetadata` <a name="ToMetadata" id="cdktf.DataTerraformRemoteStateSwift.toMetadata"></a>
+##### ~~`ToMetadata`~~ <a name="ToMetadata" id="cdktf.DataTerraformRemoteStateSwift.toMetadata"></a>
 
 ```csharp
 private object ToMetadata()
 ```
 
-##### `ToTerraform` <a name="ToTerraform" id="cdktf.DataTerraformRemoteStateSwift.toTerraform"></a>
+##### ~~`ToTerraform`~~ <a name="ToTerraform" id="cdktf.DataTerraformRemoteStateSwift.toTerraform"></a>
 
 ```csharp
 private object ToTerraform()
@@ -5886,7 +5934,7 @@ private object ToTerraform()
 
 Adds this resource to the terraform JSON output.
 
-##### `Get` <a name="Get" id="cdktf.DataTerraformRemoteStateSwift.get"></a>
+##### ~~`Get`~~ <a name="Get" id="cdktf.DataTerraformRemoteStateSwift.get"></a>
 
 ```csharp
 private IResolvable Get(string Output)
@@ -5898,7 +5946,7 @@ private IResolvable Get(string Output)
 
 ---
 
-##### `GetBoolean` <a name="GetBoolean" id="cdktf.DataTerraformRemoteStateSwift.getBoolean"></a>
+##### ~~`GetBoolean`~~ <a name="GetBoolean" id="cdktf.DataTerraformRemoteStateSwift.getBoolean"></a>
 
 ```csharp
 private IResolvable GetBoolean(string Output)
@@ -5910,7 +5958,7 @@ private IResolvable GetBoolean(string Output)
 
 ---
 
-##### `GetList` <a name="GetList" id="cdktf.DataTerraformRemoteStateSwift.getList"></a>
+##### ~~`GetList`~~ <a name="GetList" id="cdktf.DataTerraformRemoteStateSwift.getList"></a>
 
 ```csharp
 private string[] GetList(string Output)
@@ -5922,7 +5970,7 @@ private string[] GetList(string Output)
 
 ---
 
-##### `GetNumber` <a name="GetNumber" id="cdktf.DataTerraformRemoteStateSwift.getNumber"></a>
+##### ~~`GetNumber`~~ <a name="GetNumber" id="cdktf.DataTerraformRemoteStateSwift.getNumber"></a>
 
 ```csharp
 private double GetNumber(string Output)
@@ -5934,7 +5982,7 @@ private double GetNumber(string Output)
 
 ---
 
-##### `GetString` <a name="GetString" id="cdktf.DataTerraformRemoteStateSwift.getString"></a>
+##### ~~`GetString`~~ <a name="GetString" id="cdktf.DataTerraformRemoteStateSwift.getString"></a>
 
 ```csharp
 private string GetString(string Output)
@@ -5955,7 +6003,7 @@ private string GetString(string Output)
 
 ---
 
-##### `IsConstruct` <a name="IsConstruct" id="cdktf.DataTerraformRemoteStateSwift.isConstruct"></a>
+##### ~~`IsConstruct`~~ <a name="IsConstruct" id="cdktf.DataTerraformRemoteStateSwift.isConstruct"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -5987,7 +6035,7 @@ Any object.
 
 ---
 
-##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateSwift.isTerraformElement"></a>
+##### ~~`IsTerraformElement`~~ <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateSwift.isTerraformElement"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -6012,7 +6060,9 @@ DataTerraformRemoteStateSwift.IsTerraformElement(object X);
 
 ---
 
-##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateSwift.property.node"></a>
+##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateSwift.property.node"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public Node Node { get; }
@@ -6024,7 +6074,9 @@ The tree node.
 
 ---
 
-##### `CdktfStack`<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateSwift.property.cdktfStack"></a>
+##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateSwift.property.cdktfStack"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public TerraformStack CdktfStack { get; }
@@ -6034,7 +6086,9 @@ public TerraformStack CdktfStack { get; }
 
 ---
 
-##### `Fqn`<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateSwift.property.fqn"></a>
+##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateSwift.property.fqn"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Fqn { get; }
@@ -6044,7 +6098,9 @@ public string Fqn { get; }
 
 ---
 
-##### `FriendlyUniqueId`<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateSwift.property.friendlyUniqueId"></a>
+##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateSwift.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string FriendlyUniqueId { get; }
@@ -6062,7 +6118,9 @@ public string FriendlyUniqueId { get; }
 
 ---
 
-##### `TfResourceType`<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateSwift.property.tfResourceType"></a>
+##### ~~`TfResourceType`~~<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateSwift.property.tfResourceType"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string TfResourceType { get; }
@@ -6115,7 +6173,7 @@ new EtcdBackend(Construct Scope, EtcdBackendProps Props);
 
 ---
 
-##### `ToString` <a name="ToString" id="cdktf.EtcdBackend.toString"></a>
+##### ~~`ToString`~~ <a name="ToString" id="cdktf.EtcdBackend.toString"></a>
 
 ```csharp
 private string ToString()
@@ -6123,7 +6181,7 @@ private string ToString()
 
 Returns a string representation of this construct.
 
-##### `AddOverride` <a name="AddOverride" id="cdktf.EtcdBackend.addOverride"></a>
+##### ~~`AddOverride`~~ <a name="AddOverride" id="cdktf.EtcdBackend.addOverride"></a>
 
 ```csharp
 private void AddOverride(string Path, object Value)
@@ -6141,7 +6199,7 @@ private void AddOverride(string Path, object Value)
 
 ---
 
-##### `OverrideLogicalId` <a name="OverrideLogicalId" id="cdktf.EtcdBackend.overrideLogicalId"></a>
+##### ~~`OverrideLogicalId`~~ <a name="OverrideLogicalId" id="cdktf.EtcdBackend.overrideLogicalId"></a>
 
 ```csharp
 private void OverrideLogicalId(string NewLogicalId)
@@ -6157,7 +6215,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `ResetOverrideLogicalId` <a name="ResetOverrideLogicalId" id="cdktf.EtcdBackend.resetOverrideLogicalId"></a>
+##### ~~`ResetOverrideLogicalId`~~ <a name="ResetOverrideLogicalId" id="cdktf.EtcdBackend.resetOverrideLogicalId"></a>
 
 ```csharp
 private void ResetOverrideLogicalId()
@@ -6165,13 +6223,13 @@ private void ResetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `ToMetadata` <a name="ToMetadata" id="cdktf.EtcdBackend.toMetadata"></a>
+##### ~~`ToMetadata`~~ <a name="ToMetadata" id="cdktf.EtcdBackend.toMetadata"></a>
 
 ```csharp
 private object ToMetadata()
 ```
 
-##### `ToTerraform` <a name="ToTerraform" id="cdktf.EtcdBackend.toTerraform"></a>
+##### ~~`ToTerraform`~~ <a name="ToTerraform" id="cdktf.EtcdBackend.toTerraform"></a>
 
 ```csharp
 private object ToTerraform()
@@ -6179,7 +6237,7 @@ private object ToTerraform()
 
 Adds this resource to the terraform JSON output.
 
-##### `GetRemoteStateDataSource` <a name="GetRemoteStateDataSource" id="cdktf.EtcdBackend.getRemoteStateDataSource"></a>
+##### ~~`GetRemoteStateDataSource`~~ <a name="GetRemoteStateDataSource" id="cdktf.EtcdBackend.getRemoteStateDataSource"></a>
 
 ```csharp
 private TerraformRemoteState GetRemoteStateDataSource(Construct Scope, string Name, string FromStack)
@@ -6215,7 +6273,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `IsConstruct` <a name="IsConstruct" id="cdktf.EtcdBackend.isConstruct"></a>
+##### ~~`IsConstruct`~~ <a name="IsConstruct" id="cdktf.EtcdBackend.isConstruct"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -6247,7 +6305,7 @@ Any object.
 
 ---
 
-##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.EtcdBackend.isTerraformElement"></a>
+##### ~~`IsTerraformElement`~~ <a name="IsTerraformElement" id="cdktf.EtcdBackend.isTerraformElement"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -6261,7 +6319,7 @@ EtcdBackend.IsTerraformElement(object X);
 
 ---
 
-##### `IsBackend` <a name="IsBackend" id="cdktf.EtcdBackend.isBackend"></a>
+##### ~~`IsBackend`~~ <a name="IsBackend" id="cdktf.EtcdBackend.isBackend"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -6286,7 +6344,9 @@ EtcdBackend.IsBackend(object X);
 
 ---
 
-##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.EtcdBackend.property.node"></a>
+##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.EtcdBackend.property.node"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public Node Node { get; }
@@ -6298,7 +6358,9 @@ The tree node.
 
 ---
 
-##### `CdktfStack`<sup>Required</sup> <a name="CdktfStack" id="cdktf.EtcdBackend.property.cdktfStack"></a>
+##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.EtcdBackend.property.cdktfStack"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public TerraformStack CdktfStack { get; }
@@ -6308,7 +6370,9 @@ public TerraformStack CdktfStack { get; }
 
 ---
 
-##### `Fqn`<sup>Required</sup> <a name="Fqn" id="cdktf.EtcdBackend.property.fqn"></a>
+##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.EtcdBackend.property.fqn"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Fqn { get; }
@@ -6318,7 +6382,9 @@ public string Fqn { get; }
 
 ---
 
-##### `FriendlyUniqueId`<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.EtcdBackend.property.friendlyUniqueId"></a>
+##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.EtcdBackend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string FriendlyUniqueId { get; }
@@ -6371,7 +6437,7 @@ new EtcdV3Backend(Construct Scope, EtcdV3BackendProps Props);
 
 ---
 
-##### `ToString` <a name="ToString" id="cdktf.EtcdV3Backend.toString"></a>
+##### ~~`ToString`~~ <a name="ToString" id="cdktf.EtcdV3Backend.toString"></a>
 
 ```csharp
 private string ToString()
@@ -6379,7 +6445,7 @@ private string ToString()
 
 Returns a string representation of this construct.
 
-##### `AddOverride` <a name="AddOverride" id="cdktf.EtcdV3Backend.addOverride"></a>
+##### ~~`AddOverride`~~ <a name="AddOverride" id="cdktf.EtcdV3Backend.addOverride"></a>
 
 ```csharp
 private void AddOverride(string Path, object Value)
@@ -6397,7 +6463,7 @@ private void AddOverride(string Path, object Value)
 
 ---
 
-##### `OverrideLogicalId` <a name="OverrideLogicalId" id="cdktf.EtcdV3Backend.overrideLogicalId"></a>
+##### ~~`OverrideLogicalId`~~ <a name="OverrideLogicalId" id="cdktf.EtcdV3Backend.overrideLogicalId"></a>
 
 ```csharp
 private void OverrideLogicalId(string NewLogicalId)
@@ -6413,7 +6479,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `ResetOverrideLogicalId` <a name="ResetOverrideLogicalId" id="cdktf.EtcdV3Backend.resetOverrideLogicalId"></a>
+##### ~~`ResetOverrideLogicalId`~~ <a name="ResetOverrideLogicalId" id="cdktf.EtcdV3Backend.resetOverrideLogicalId"></a>
 
 ```csharp
 private void ResetOverrideLogicalId()
@@ -6421,13 +6487,13 @@ private void ResetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `ToMetadata` <a name="ToMetadata" id="cdktf.EtcdV3Backend.toMetadata"></a>
+##### ~~`ToMetadata`~~ <a name="ToMetadata" id="cdktf.EtcdV3Backend.toMetadata"></a>
 
 ```csharp
 private object ToMetadata()
 ```
 
-##### `ToTerraform` <a name="ToTerraform" id="cdktf.EtcdV3Backend.toTerraform"></a>
+##### ~~`ToTerraform`~~ <a name="ToTerraform" id="cdktf.EtcdV3Backend.toTerraform"></a>
 
 ```csharp
 private object ToTerraform()
@@ -6435,7 +6501,7 @@ private object ToTerraform()
 
 Adds this resource to the terraform JSON output.
 
-##### `GetRemoteStateDataSource` <a name="GetRemoteStateDataSource" id="cdktf.EtcdV3Backend.getRemoteStateDataSource"></a>
+##### ~~`GetRemoteStateDataSource`~~ <a name="GetRemoteStateDataSource" id="cdktf.EtcdV3Backend.getRemoteStateDataSource"></a>
 
 ```csharp
 private TerraformRemoteState GetRemoteStateDataSource(Construct Scope, string Name, string FromStack)
@@ -6471,7 +6537,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `IsConstruct` <a name="IsConstruct" id="cdktf.EtcdV3Backend.isConstruct"></a>
+##### ~~`IsConstruct`~~ <a name="IsConstruct" id="cdktf.EtcdV3Backend.isConstruct"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -6503,7 +6569,7 @@ Any object.
 
 ---
 
-##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.EtcdV3Backend.isTerraformElement"></a>
+##### ~~`IsTerraformElement`~~ <a name="IsTerraformElement" id="cdktf.EtcdV3Backend.isTerraformElement"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -6517,7 +6583,7 @@ EtcdV3Backend.IsTerraformElement(object X);
 
 ---
 
-##### `IsBackend` <a name="IsBackend" id="cdktf.EtcdV3Backend.isBackend"></a>
+##### ~~`IsBackend`~~ <a name="IsBackend" id="cdktf.EtcdV3Backend.isBackend"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -6542,7 +6608,9 @@ EtcdV3Backend.IsBackend(object X);
 
 ---
 
-##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.EtcdV3Backend.property.node"></a>
+##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.EtcdV3Backend.property.node"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public Node Node { get; }
@@ -6554,7 +6622,9 @@ The tree node.
 
 ---
 
-##### `CdktfStack`<sup>Required</sup> <a name="CdktfStack" id="cdktf.EtcdV3Backend.property.cdktfStack"></a>
+##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.EtcdV3Backend.property.cdktfStack"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public TerraformStack CdktfStack { get; }
@@ -6564,7 +6634,9 @@ public TerraformStack CdktfStack { get; }
 
 ---
 
-##### `Fqn`<sup>Required</sup> <a name="Fqn" id="cdktf.EtcdV3Backend.property.fqn"></a>
+##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.EtcdV3Backend.property.fqn"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Fqn { get; }
@@ -6574,7 +6646,9 @@ public string Fqn { get; }
 
 ---
 
-##### `FriendlyUniqueId`<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.EtcdV3Backend.property.friendlyUniqueId"></a>
+##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.EtcdV3Backend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string FriendlyUniqueId { get; }
@@ -7395,7 +7469,7 @@ new MantaBackend(Construct Scope, MantaBackendProps Props);
 
 ---
 
-##### `ToString` <a name="ToString" id="cdktf.MantaBackend.toString"></a>
+##### ~~`ToString`~~ <a name="ToString" id="cdktf.MantaBackend.toString"></a>
 
 ```csharp
 private string ToString()
@@ -7403,7 +7477,7 @@ private string ToString()
 
 Returns a string representation of this construct.
 
-##### `AddOverride` <a name="AddOverride" id="cdktf.MantaBackend.addOverride"></a>
+##### ~~`AddOverride`~~ <a name="AddOverride" id="cdktf.MantaBackend.addOverride"></a>
 
 ```csharp
 private void AddOverride(string Path, object Value)
@@ -7421,7 +7495,7 @@ private void AddOverride(string Path, object Value)
 
 ---
 
-##### `OverrideLogicalId` <a name="OverrideLogicalId" id="cdktf.MantaBackend.overrideLogicalId"></a>
+##### ~~`OverrideLogicalId`~~ <a name="OverrideLogicalId" id="cdktf.MantaBackend.overrideLogicalId"></a>
 
 ```csharp
 private void OverrideLogicalId(string NewLogicalId)
@@ -7437,7 +7511,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `ResetOverrideLogicalId` <a name="ResetOverrideLogicalId" id="cdktf.MantaBackend.resetOverrideLogicalId"></a>
+##### ~~`ResetOverrideLogicalId`~~ <a name="ResetOverrideLogicalId" id="cdktf.MantaBackend.resetOverrideLogicalId"></a>
 
 ```csharp
 private void ResetOverrideLogicalId()
@@ -7445,13 +7519,13 @@ private void ResetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `ToMetadata` <a name="ToMetadata" id="cdktf.MantaBackend.toMetadata"></a>
+##### ~~`ToMetadata`~~ <a name="ToMetadata" id="cdktf.MantaBackend.toMetadata"></a>
 
 ```csharp
 private object ToMetadata()
 ```
 
-##### `ToTerraform` <a name="ToTerraform" id="cdktf.MantaBackend.toTerraform"></a>
+##### ~~`ToTerraform`~~ <a name="ToTerraform" id="cdktf.MantaBackend.toTerraform"></a>
 
 ```csharp
 private object ToTerraform()
@@ -7459,7 +7533,7 @@ private object ToTerraform()
 
 Adds this resource to the terraform JSON output.
 
-##### `GetRemoteStateDataSource` <a name="GetRemoteStateDataSource" id="cdktf.MantaBackend.getRemoteStateDataSource"></a>
+##### ~~`GetRemoteStateDataSource`~~ <a name="GetRemoteStateDataSource" id="cdktf.MantaBackend.getRemoteStateDataSource"></a>
 
 ```csharp
 private TerraformRemoteState GetRemoteStateDataSource(Construct Scope, string Name, string FromStack)
@@ -7495,7 +7569,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `IsConstruct` <a name="IsConstruct" id="cdktf.MantaBackend.isConstruct"></a>
+##### ~~`IsConstruct`~~ <a name="IsConstruct" id="cdktf.MantaBackend.isConstruct"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -7527,7 +7601,7 @@ Any object.
 
 ---
 
-##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.MantaBackend.isTerraformElement"></a>
+##### ~~`IsTerraformElement`~~ <a name="IsTerraformElement" id="cdktf.MantaBackend.isTerraformElement"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -7541,7 +7615,7 @@ MantaBackend.IsTerraformElement(object X);
 
 ---
 
-##### `IsBackend` <a name="IsBackend" id="cdktf.MantaBackend.isBackend"></a>
+##### ~~`IsBackend`~~ <a name="IsBackend" id="cdktf.MantaBackend.isBackend"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -7566,7 +7640,9 @@ MantaBackend.IsBackend(object X);
 
 ---
 
-##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.MantaBackend.property.node"></a>
+##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.MantaBackend.property.node"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public Node Node { get; }
@@ -7578,7 +7654,9 @@ The tree node.
 
 ---
 
-##### `CdktfStack`<sup>Required</sup> <a name="CdktfStack" id="cdktf.MantaBackend.property.cdktfStack"></a>
+##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.MantaBackend.property.cdktfStack"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public TerraformStack CdktfStack { get; }
@@ -7588,7 +7666,9 @@ public TerraformStack CdktfStack { get; }
 
 ---
 
-##### `Fqn`<sup>Required</sup> <a name="Fqn" id="cdktf.MantaBackend.property.fqn"></a>
+##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.MantaBackend.property.fqn"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Fqn { get; }
@@ -7598,7 +7678,9 @@ public string Fqn { get; }
 
 ---
 
-##### `FriendlyUniqueId`<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.MantaBackend.property.friendlyUniqueId"></a>
+##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.MantaBackend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string FriendlyUniqueId { get; }
@@ -8801,7 +8883,7 @@ new SwiftBackend(Construct Scope, SwiftBackendProps Props);
 
 ---
 
-##### `ToString` <a name="ToString" id="cdktf.SwiftBackend.toString"></a>
+##### ~~`ToString`~~ <a name="ToString" id="cdktf.SwiftBackend.toString"></a>
 
 ```csharp
 private string ToString()
@@ -8809,7 +8891,7 @@ private string ToString()
 
 Returns a string representation of this construct.
 
-##### `AddOverride` <a name="AddOverride" id="cdktf.SwiftBackend.addOverride"></a>
+##### ~~`AddOverride`~~ <a name="AddOverride" id="cdktf.SwiftBackend.addOverride"></a>
 
 ```csharp
 private void AddOverride(string Path, object Value)
@@ -8827,7 +8909,7 @@ private void AddOverride(string Path, object Value)
 
 ---
 
-##### `OverrideLogicalId` <a name="OverrideLogicalId" id="cdktf.SwiftBackend.overrideLogicalId"></a>
+##### ~~`OverrideLogicalId`~~ <a name="OverrideLogicalId" id="cdktf.SwiftBackend.overrideLogicalId"></a>
 
 ```csharp
 private void OverrideLogicalId(string NewLogicalId)
@@ -8843,7 +8925,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `ResetOverrideLogicalId` <a name="ResetOverrideLogicalId" id="cdktf.SwiftBackend.resetOverrideLogicalId"></a>
+##### ~~`ResetOverrideLogicalId`~~ <a name="ResetOverrideLogicalId" id="cdktf.SwiftBackend.resetOverrideLogicalId"></a>
 
 ```csharp
 private void ResetOverrideLogicalId()
@@ -8851,13 +8933,13 @@ private void ResetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `ToMetadata` <a name="ToMetadata" id="cdktf.SwiftBackend.toMetadata"></a>
+##### ~~`ToMetadata`~~ <a name="ToMetadata" id="cdktf.SwiftBackend.toMetadata"></a>
 
 ```csharp
 private object ToMetadata()
 ```
 
-##### `ToTerraform` <a name="ToTerraform" id="cdktf.SwiftBackend.toTerraform"></a>
+##### ~~`ToTerraform`~~ <a name="ToTerraform" id="cdktf.SwiftBackend.toTerraform"></a>
 
 ```csharp
 private object ToTerraform()
@@ -8865,7 +8947,7 @@ private object ToTerraform()
 
 Adds this resource to the terraform JSON output.
 
-##### `GetRemoteStateDataSource` <a name="GetRemoteStateDataSource" id="cdktf.SwiftBackend.getRemoteStateDataSource"></a>
+##### ~~`GetRemoteStateDataSource`~~ <a name="GetRemoteStateDataSource" id="cdktf.SwiftBackend.getRemoteStateDataSource"></a>
 
 ```csharp
 private TerraformRemoteState GetRemoteStateDataSource(Construct Scope, string Name, string FromStack)
@@ -8901,7 +8983,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `IsConstruct` <a name="IsConstruct" id="cdktf.SwiftBackend.isConstruct"></a>
+##### ~~`IsConstruct`~~ <a name="IsConstruct" id="cdktf.SwiftBackend.isConstruct"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -8933,7 +9015,7 @@ Any object.
 
 ---
 
-##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.SwiftBackend.isTerraformElement"></a>
+##### ~~`IsTerraformElement`~~ <a name="IsTerraformElement" id="cdktf.SwiftBackend.isTerraformElement"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -8947,7 +9029,7 @@ SwiftBackend.IsTerraformElement(object X);
 
 ---
 
-##### `IsBackend` <a name="IsBackend" id="cdktf.SwiftBackend.isBackend"></a>
+##### ~~`IsBackend`~~ <a name="IsBackend" id="cdktf.SwiftBackend.isBackend"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
@@ -8972,7 +9054,9 @@ SwiftBackend.IsBackend(object X);
 
 ---
 
-##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.SwiftBackend.property.node"></a>
+##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.SwiftBackend.property.node"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public Node Node { get; }
@@ -8984,7 +9068,9 @@ The tree node.
 
 ---
 
-##### `CdktfStack`<sup>Required</sup> <a name="CdktfStack" id="cdktf.SwiftBackend.property.cdktfStack"></a>
+##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.SwiftBackend.property.cdktfStack"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public TerraformStack CdktfStack { get; }
@@ -8994,7 +9080,9 @@ public TerraformStack CdktfStack { get; }
 
 ---
 
-##### `Fqn`<sup>Required</sup> <a name="Fqn" id="cdktf.SwiftBackend.property.fqn"></a>
+##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.SwiftBackend.property.fqn"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Fqn { get; }
@@ -9004,7 +9092,9 @@ public string Fqn { get; }
 
 ---
 
-##### `FriendlyUniqueId`<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.SwiftBackend.property.friendlyUniqueId"></a>
+##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.SwiftBackend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string FriendlyUniqueId { get; }
@@ -13253,7 +13343,9 @@ new ArtifactoryBackendProps {
 
 ---
 
-##### `Password`<sup>Required</sup> <a name="Password" id="cdktf.ArtifactoryBackendProps.property.password"></a>
+##### ~~`Password`~~<sup>Required</sup> <a name="Password" id="cdktf.ArtifactoryBackendProps.property.password"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Password { get; set; }
@@ -13265,7 +13357,9 @@ public string Password { get; set; }
 
 ---
 
-##### `Repo`<sup>Required</sup> <a name="Repo" id="cdktf.ArtifactoryBackendProps.property.repo"></a>
+##### ~~`Repo`~~<sup>Required</sup> <a name="Repo" id="cdktf.ArtifactoryBackendProps.property.repo"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Repo { get; set; }
@@ -13277,7 +13371,9 @@ public string Repo { get; set; }
 
 ---
 
-##### `Subpath`<sup>Required</sup> <a name="Subpath" id="cdktf.ArtifactoryBackendProps.property.subpath"></a>
+##### ~~`Subpath`~~<sup>Required</sup> <a name="Subpath" id="cdktf.ArtifactoryBackendProps.property.subpath"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Subpath { get; set; }
@@ -13289,7 +13385,9 @@ public string Subpath { get; set; }
 
 ---
 
-##### `Url`<sup>Required</sup> <a name="Url" id="cdktf.ArtifactoryBackendProps.property.url"></a>
+##### ~~`Url`~~<sup>Required</sup> <a name="Url" id="cdktf.ArtifactoryBackendProps.property.url"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Url { get; set; }
@@ -13303,7 +13401,9 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ---
 
-##### `Username`<sup>Required</sup> <a name="Username" id="cdktf.ArtifactoryBackendProps.property.username"></a>
+##### ~~`Username`~~<sup>Required</sup> <a name="Username" id="cdktf.ArtifactoryBackendProps.property.username"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Username { get; set; }
@@ -14166,7 +14266,9 @@ new DataTerraformRemoteStateArtifactoryConfig {
 
 ---
 
-##### `Defaults`<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.defaults"></a>
+##### ~~`Defaults`~~<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.defaults"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public System.Collections.Generic.IDictionary< string, object > Defaults { get; set; }
@@ -14176,7 +14278,9 @@ public System.Collections.Generic.IDictionary< string, object > Defaults { get; 
 
 ---
 
-##### `Workspace`<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.workspace"></a>
+##### ~~`Workspace`~~<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.workspace"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Workspace { get; set; }
@@ -14186,7 +14290,9 @@ public string Workspace { get; set; }
 
 ---
 
-##### `Password`<sup>Required</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.password"></a>
+##### ~~`Password`~~<sup>Required</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.password"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Password { get; set; }
@@ -14198,7 +14304,9 @@ public string Password { get; set; }
 
 ---
 
-##### `Repo`<sup>Required</sup> <a name="Repo" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.repo"></a>
+##### ~~`Repo`~~<sup>Required</sup> <a name="Repo" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.repo"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Repo { get; set; }
@@ -14210,7 +14318,9 @@ public string Repo { get; set; }
 
 ---
 
-##### `Subpath`<sup>Required</sup> <a name="Subpath" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.subpath"></a>
+##### ~~`Subpath`~~<sup>Required</sup> <a name="Subpath" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.subpath"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Subpath { get; set; }
@@ -14222,7 +14332,9 @@ public string Subpath { get; set; }
 
 ---
 
-##### `Url`<sup>Required</sup> <a name="Url" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.url"></a>
+##### ~~`Url`~~<sup>Required</sup> <a name="Url" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.url"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Url { get; set; }
@@ -14236,7 +14348,9 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ---
 
-##### `Username`<sup>Required</sup> <a name="Username" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.username"></a>
+##### ~~`Username`~~<sup>Required</sup> <a name="Username" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.username"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Username { get; set; }
@@ -15101,7 +15215,9 @@ new DataTerraformRemoteStateEtcdConfig {
 
 ---
 
-##### `Defaults`<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.defaults"></a>
+##### ~~`Defaults`~~<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.defaults"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public System.Collections.Generic.IDictionary< string, object > Defaults { get; set; }
@@ -15111,7 +15227,9 @@ public System.Collections.Generic.IDictionary< string, object > Defaults { get; 
 
 ---
 
-##### `Workspace`<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.workspace"></a>
+##### ~~`Workspace`~~<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.workspace"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Workspace { get; set; }
@@ -15121,7 +15239,9 @@ public string Workspace { get; set; }
 
 ---
 
-##### `Endpoints`<sup>Required</sup> <a name="Endpoints" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.endpoints"></a>
+##### ~~`Endpoints`~~<sup>Required</sup> <a name="Endpoints" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.endpoints"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Endpoints { get; set; }
@@ -15133,7 +15253,9 @@ public string Endpoints { get; set; }
 
 ---
 
-##### `Path`<sup>Required</sup> <a name="Path" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.path"></a>
+##### ~~`Path`~~<sup>Required</sup> <a name="Path" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.path"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Path { get; set; }
@@ -15145,7 +15267,9 @@ public string Path { get; set; }
 
 ---
 
-##### `Password`<sup>Optional</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.password"></a>
+##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.password"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Password { get; set; }
@@ -15157,7 +15281,9 @@ public string Password { get; set; }
 
 ---
 
-##### `Username`<sup>Optional</sup> <a name="Username" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.username"></a>
+##### ~~`Username`~~<sup>Optional</sup> <a name="Username" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.username"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Username { get; set; }
@@ -15207,7 +15333,9 @@ new DataTerraformRemoteStateEtcdV3Config {
 
 ---
 
-##### `Defaults`<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.defaults"></a>
+##### ~~`Defaults`~~<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.defaults"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public System.Collections.Generic.IDictionary< string, object > Defaults { get; set; }
@@ -15217,7 +15345,9 @@ public System.Collections.Generic.IDictionary< string, object > Defaults { get; 
 
 ---
 
-##### `Workspace`<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.workspace"></a>
+##### ~~`Workspace`~~<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.workspace"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Workspace { get; set; }
@@ -15227,7 +15357,9 @@ public string Workspace { get; set; }
 
 ---
 
-##### `Endpoints`<sup>Required</sup> <a name="Endpoints" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.endpoints"></a>
+##### ~~`Endpoints`~~<sup>Required</sup> <a name="Endpoints" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.endpoints"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string[] Endpoints { get; set; }
@@ -15239,7 +15371,9 @@ public string[] Endpoints { get; set; }
 
 ---
 
-##### `CacertPath`<sup>Optional</sup> <a name="CacertPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.cacertPath"></a>
+##### ~~`CacertPath`~~<sup>Optional</sup> <a name="CacertPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.cacertPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string CacertPath { get; set; }
@@ -15251,7 +15385,9 @@ public string CacertPath { get; set; }
 
 ---
 
-##### `CertPath`<sup>Optional</sup> <a name="CertPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.certPath"></a>
+##### ~~`CertPath`~~<sup>Optional</sup> <a name="CertPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.certPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string CertPath { get; set; }
@@ -15263,7 +15399,9 @@ public string CertPath { get; set; }
 
 ---
 
-##### `KeyPath`<sup>Optional</sup> <a name="KeyPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.keyPath"></a>
+##### ~~`KeyPath`~~<sup>Optional</sup> <a name="KeyPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.keyPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string KeyPath { get; set; }
@@ -15275,7 +15413,9 @@ public string KeyPath { get; set; }
 
 ---
 
-##### `Lock`<sup>Optional</sup> <a name="Lock" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.lock"></a>
+##### ~~`Lock`~~<sup>Optional</sup> <a name="Lock" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.lock"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public bool Lock { get; set; }
@@ -15289,7 +15429,9 @@ Defaults to true.
 
 ---
 
-##### `Password`<sup>Optional</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.password"></a>
+##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.password"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Password { get; set; }
@@ -15301,7 +15443,9 @@ public string Password { get; set; }
 
 ---
 
-##### `Prefix`<sup>Optional</sup> <a name="Prefix" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.prefix"></a>
+##### ~~`Prefix`~~<sup>Optional</sup> <a name="Prefix" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.prefix"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Prefix { get; set; }
@@ -15315,7 +15459,9 @@ Defaults to "".
 
 ---
 
-##### `Username`<sup>Optional</sup> <a name="Username" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.username"></a>
+##### ~~`Username`~~<sup>Optional</sup> <a name="Username" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.username"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Username { get; set; }
@@ -15818,7 +15964,9 @@ new DataTerraformRemoteStateMantaConfig {
 
 ---
 
-##### `Defaults`<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateMantaConfig.property.defaults"></a>
+##### ~~`Defaults`~~<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateMantaConfig.property.defaults"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public System.Collections.Generic.IDictionary< string, object > Defaults { get; set; }
@@ -15828,7 +15976,9 @@ public System.Collections.Generic.IDictionary< string, object > Defaults { get; 
 
 ---
 
-##### `Workspace`<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateMantaConfig.property.workspace"></a>
+##### ~~`Workspace`~~<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateMantaConfig.property.workspace"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Workspace { get; set; }
@@ -15838,7 +15988,9 @@ public string Workspace { get; set; }
 
 ---
 
-##### `Account`<sup>Required</sup> <a name="Account" id="cdktf.DataTerraformRemoteStateMantaConfig.property.account"></a>
+##### ~~`Account`~~<sup>Required</sup> <a name="Account" id="cdktf.DataTerraformRemoteStateMantaConfig.property.account"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Account { get; set; }
@@ -15848,7 +16000,9 @@ public string Account { get; set; }
 
 ---
 
-##### `KeyId`<sup>Required</sup> <a name="KeyId" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyId"></a>
+##### ~~`KeyId`~~<sup>Required</sup> <a name="KeyId" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string KeyId { get; set; }
@@ -15858,7 +16012,9 @@ public string KeyId { get; set; }
 
 ---
 
-##### `Path`<sup>Required</sup> <a name="Path" id="cdktf.DataTerraformRemoteStateMantaConfig.property.path"></a>
+##### ~~`Path`~~<sup>Required</sup> <a name="Path" id="cdktf.DataTerraformRemoteStateMantaConfig.property.path"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Path { get; set; }
@@ -15868,7 +16024,9 @@ public string Path { get; set; }
 
 ---
 
-##### `InsecureSkipTlsVerify`<sup>Optional</sup> <a name="InsecureSkipTlsVerify" id="cdktf.DataTerraformRemoteStateMantaConfig.property.insecureSkipTlsVerify"></a>
+##### ~~`InsecureSkipTlsVerify`~~<sup>Optional</sup> <a name="InsecureSkipTlsVerify" id="cdktf.DataTerraformRemoteStateMantaConfig.property.insecureSkipTlsVerify"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public bool InsecureSkipTlsVerify { get; set; }
@@ -15878,7 +16036,9 @@ public bool InsecureSkipTlsVerify { get; set; }
 
 ---
 
-##### `KeyMaterial`<sup>Optional</sup> <a name="KeyMaterial" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyMaterial"></a>
+##### ~~`KeyMaterial`~~<sup>Optional</sup> <a name="KeyMaterial" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyMaterial"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string KeyMaterial { get; set; }
@@ -15888,7 +16048,9 @@ public string KeyMaterial { get; set; }
 
 ---
 
-##### `ObjectName`<sup>Optional</sup> <a name="ObjectName" id="cdktf.DataTerraformRemoteStateMantaConfig.property.objectName"></a>
+##### ~~`ObjectName`~~<sup>Optional</sup> <a name="ObjectName" id="cdktf.DataTerraformRemoteStateMantaConfig.property.objectName"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string ObjectName { get; set; }
@@ -15898,7 +16060,9 @@ public string ObjectName { get; set; }
 
 ---
 
-##### `Url`<sup>Optional</sup> <a name="Url" id="cdktf.DataTerraformRemoteStateMantaConfig.property.url"></a>
+##### ~~`Url`~~<sup>Optional</sup> <a name="Url" id="cdktf.DataTerraformRemoteStateMantaConfig.property.url"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Url { get; set; }
@@ -15908,7 +16072,9 @@ public string Url { get; set; }
 
 ---
 
-##### `User`<sup>Optional</sup> <a name="User" id="cdktf.DataTerraformRemoteStateMantaConfig.property.user"></a>
+##### ~~`User`~~<sup>Optional</sup> <a name="User" id="cdktf.DataTerraformRemoteStateMantaConfig.property.user"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string User { get; set; }
@@ -16903,7 +17069,9 @@ new DataTerraformRemoteStateSwiftConfig {
 
 ---
 
-##### `Defaults`<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaults"></a>
+##### ~~`Defaults`~~<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaults"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public System.Collections.Generic.IDictionary< string, object > Defaults { get; set; }
@@ -16913,7 +17081,9 @@ public System.Collections.Generic.IDictionary< string, object > Defaults { get; 
 
 ---
 
-##### `Workspace`<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.workspace"></a>
+##### ~~`Workspace`~~<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.workspace"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Workspace { get; set; }
@@ -16923,7 +17093,9 @@ public string Workspace { get; set; }
 
 ---
 
-##### `Container`<sup>Required</sup> <a name="Container" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.container"></a>
+##### ~~`Container`~~<sup>Required</sup> <a name="Container" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.container"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Container { get; set; }
@@ -16933,7 +17105,9 @@ public string Container { get; set; }
 
 ---
 
-##### `ApplicationCredentialId`<sup>Optional</sup> <a name="ApplicationCredentialId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialId"></a>
+##### ~~`ApplicationCredentialId`~~<sup>Optional</sup> <a name="ApplicationCredentialId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string ApplicationCredentialId { get; set; }
@@ -16943,7 +17117,9 @@ public string ApplicationCredentialId { get; set; }
 
 ---
 
-##### `ApplicationCredentialName`<sup>Optional</sup> <a name="ApplicationCredentialName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialName"></a>
+##### ~~`ApplicationCredentialName`~~<sup>Optional</sup> <a name="ApplicationCredentialName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string ApplicationCredentialName { get; set; }
@@ -16953,7 +17129,9 @@ public string ApplicationCredentialName { get; set; }
 
 ---
 
-##### `ApplicationCredentialSecret`<sup>Optional</sup> <a name="ApplicationCredentialSecret" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialSecret"></a>
+##### ~~`ApplicationCredentialSecret`~~<sup>Optional</sup> <a name="ApplicationCredentialSecret" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialSecret"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string ApplicationCredentialSecret { get; set; }
@@ -16963,7 +17141,9 @@ public string ApplicationCredentialSecret { get; set; }
 
 ---
 
-##### `ArchiveContainer`<sup>Optional</sup> <a name="ArchiveContainer" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.archiveContainer"></a>
+##### ~~`ArchiveContainer`~~<sup>Optional</sup> <a name="ArchiveContainer" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.archiveContainer"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string ArchiveContainer { get; set; }
@@ -16973,7 +17153,9 @@ public string ArchiveContainer { get; set; }
 
 ---
 
-##### `AuthUrl`<sup>Optional</sup> <a name="AuthUrl" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.authUrl"></a>
+##### ~~`AuthUrl`~~<sup>Optional</sup> <a name="AuthUrl" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.authUrl"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string AuthUrl { get; set; }
@@ -16983,7 +17165,9 @@ public string AuthUrl { get; set; }
 
 ---
 
-##### `CacertFile`<sup>Optional</sup> <a name="CacertFile" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cacertFile"></a>
+##### ~~`CacertFile`~~<sup>Optional</sup> <a name="CacertFile" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cacertFile"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string CacertFile { get; set; }
@@ -16993,7 +17177,9 @@ public string CacertFile { get; set; }
 
 ---
 
-##### `Cert`<sup>Optional</sup> <a name="Cert" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cert"></a>
+##### ~~`Cert`~~<sup>Optional</sup> <a name="Cert" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cert"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Cert { get; set; }
@@ -17003,7 +17189,9 @@ public string Cert { get; set; }
 
 ---
 
-##### `Cloud`<sup>Optional</sup> <a name="Cloud" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cloud"></a>
+##### ~~`Cloud`~~<sup>Optional</sup> <a name="Cloud" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cloud"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Cloud { get; set; }
@@ -17013,7 +17201,9 @@ public string Cloud { get; set; }
 
 ---
 
-##### `DefaultDomain`<sup>Optional</sup> <a name="DefaultDomain" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaultDomain"></a>
+##### ~~`DefaultDomain`~~<sup>Optional</sup> <a name="DefaultDomain" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaultDomain"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string DefaultDomain { get; set; }
@@ -17023,7 +17213,9 @@ public string DefaultDomain { get; set; }
 
 ---
 
-##### `DomainId`<sup>Optional</sup> <a name="DomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainId"></a>
+##### ~~`DomainId`~~<sup>Optional</sup> <a name="DomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string DomainId { get; set; }
@@ -17033,7 +17225,9 @@ public string DomainId { get; set; }
 
 ---
 
-##### `DomainName`<sup>Optional</sup> <a name="DomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainName"></a>
+##### ~~`DomainName`~~<sup>Optional</sup> <a name="DomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string DomainName { get; set; }
@@ -17043,7 +17237,9 @@ public string DomainName { get; set; }
 
 ---
 
-##### `ExpireAfter`<sup>Optional</sup> <a name="ExpireAfter" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.expireAfter"></a>
+##### ~~`ExpireAfter`~~<sup>Optional</sup> <a name="ExpireAfter" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.expireAfter"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string ExpireAfter { get; set; }
@@ -17053,7 +17249,9 @@ public string ExpireAfter { get; set; }
 
 ---
 
-##### `Insecure`<sup>Optional</sup> <a name="Insecure" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.insecure"></a>
+##### ~~`Insecure`~~<sup>Optional</sup> <a name="Insecure" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.insecure"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public bool Insecure { get; set; }
@@ -17063,7 +17261,9 @@ public bool Insecure { get; set; }
 
 ---
 
-##### `Key`<sup>Optional</sup> <a name="Key" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.key"></a>
+##### ~~`Key`~~<sup>Optional</sup> <a name="Key" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.key"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Key { get; set; }
@@ -17073,7 +17273,9 @@ public string Key { get; set; }
 
 ---
 
-##### `Password`<sup>Optional</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.password"></a>
+##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.password"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Password { get; set; }
@@ -17083,7 +17285,9 @@ public string Password { get; set; }
 
 ---
 
-##### `ProjectDomainId`<sup>Optional</sup> <a name="ProjectDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainId"></a>
+##### ~~`ProjectDomainId`~~<sup>Optional</sup> <a name="ProjectDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string ProjectDomainId { get; set; }
@@ -17093,7 +17297,9 @@ public string ProjectDomainId { get; set; }
 
 ---
 
-##### `ProjectDomainName`<sup>Optional</sup> <a name="ProjectDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainName"></a>
+##### ~~`ProjectDomainName`~~<sup>Optional</sup> <a name="ProjectDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string ProjectDomainName { get; set; }
@@ -17103,7 +17309,9 @@ public string ProjectDomainName { get; set; }
 
 ---
 
-##### `RegionName`<sup>Optional</sup> <a name="RegionName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.regionName"></a>
+##### ~~`RegionName`~~<sup>Optional</sup> <a name="RegionName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.regionName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string RegionName { get; set; }
@@ -17113,7 +17321,9 @@ public string RegionName { get; set; }
 
 ---
 
-##### `StateName`<sup>Optional</sup> <a name="StateName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.stateName"></a>
+##### ~~`StateName`~~<sup>Optional</sup> <a name="StateName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.stateName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string StateName { get; set; }
@@ -17123,7 +17333,9 @@ public string StateName { get; set; }
 
 ---
 
-##### `TenantId`<sup>Optional</sup> <a name="TenantId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantId"></a>
+##### ~~`TenantId`~~<sup>Optional</sup> <a name="TenantId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string TenantId { get; set; }
@@ -17133,7 +17345,9 @@ public string TenantId { get; set; }
 
 ---
 
-##### `TenantName`<sup>Optional</sup> <a name="TenantName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantName"></a>
+##### ~~`TenantName`~~<sup>Optional</sup> <a name="TenantName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string TenantName { get; set; }
@@ -17143,7 +17357,9 @@ public string TenantName { get; set; }
 
 ---
 
-##### `Token`<sup>Optional</sup> <a name="Token" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.token"></a>
+##### ~~`Token`~~<sup>Optional</sup> <a name="Token" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.token"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Token { get; set; }
@@ -17153,7 +17369,9 @@ public string Token { get; set; }
 
 ---
 
-##### `UserDomainId`<sup>Optional</sup> <a name="UserDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainId"></a>
+##### ~~`UserDomainId`~~<sup>Optional</sup> <a name="UserDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string UserDomainId { get; set; }
@@ -17163,7 +17381,9 @@ public string UserDomainId { get; set; }
 
 ---
 
-##### `UserDomainName`<sup>Optional</sup> <a name="UserDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainName"></a>
+##### ~~`UserDomainName`~~<sup>Optional</sup> <a name="UserDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string UserDomainName { get; set; }
@@ -17173,7 +17393,9 @@ public string UserDomainName { get; set; }
 
 ---
 
-##### `UserId`<sup>Optional</sup> <a name="UserId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userId"></a>
+##### ~~`UserId`~~<sup>Optional</sup> <a name="UserId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string UserId { get; set; }
@@ -17183,7 +17405,9 @@ public string UserId { get; set; }
 
 ---
 
-##### `UserName`<sup>Optional</sup> <a name="UserName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userName"></a>
+##### ~~`UserName`~~<sup>Optional</sup> <a name="UserName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string UserName { get; set; }
@@ -17261,7 +17485,9 @@ new EtcdBackendProps {
 
 ---
 
-##### `Endpoints`<sup>Required</sup> <a name="Endpoints" id="cdktf.EtcdBackendProps.property.endpoints"></a>
+##### ~~`Endpoints`~~<sup>Required</sup> <a name="Endpoints" id="cdktf.EtcdBackendProps.property.endpoints"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Endpoints { get; set; }
@@ -17273,7 +17499,9 @@ public string Endpoints { get; set; }
 
 ---
 
-##### `Path`<sup>Required</sup> <a name="Path" id="cdktf.EtcdBackendProps.property.path"></a>
+##### ~~`Path`~~<sup>Required</sup> <a name="Path" id="cdktf.EtcdBackendProps.property.path"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Path { get; set; }
@@ -17285,7 +17513,9 @@ public string Path { get; set; }
 
 ---
 
-##### `Password`<sup>Optional</sup> <a name="Password" id="cdktf.EtcdBackendProps.property.password"></a>
+##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.EtcdBackendProps.property.password"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Password { get; set; }
@@ -17297,7 +17527,9 @@ public string Password { get; set; }
 
 ---
 
-##### `Username`<sup>Optional</sup> <a name="Username" id="cdktf.EtcdBackendProps.property.username"></a>
+##### ~~`Username`~~<sup>Optional</sup> <a name="Username" id="cdktf.EtcdBackendProps.property.username"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Username { get; set; }
@@ -17350,7 +17582,9 @@ new EtcdV3BackendProps {
 
 ---
 
-##### `Endpoints`<sup>Required</sup> <a name="Endpoints" id="cdktf.EtcdV3BackendProps.property.endpoints"></a>
+##### ~~`Endpoints`~~<sup>Required</sup> <a name="Endpoints" id="cdktf.EtcdV3BackendProps.property.endpoints"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string[] Endpoints { get; set; }
@@ -17362,7 +17596,9 @@ public string[] Endpoints { get; set; }
 
 ---
 
-##### `CacertPath`<sup>Optional</sup> <a name="CacertPath" id="cdktf.EtcdV3BackendProps.property.cacertPath"></a>
+##### ~~`CacertPath`~~<sup>Optional</sup> <a name="CacertPath" id="cdktf.EtcdV3BackendProps.property.cacertPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string CacertPath { get; set; }
@@ -17374,7 +17610,9 @@ public string CacertPath { get; set; }
 
 ---
 
-##### `CertPath`<sup>Optional</sup> <a name="CertPath" id="cdktf.EtcdV3BackendProps.property.certPath"></a>
+##### ~~`CertPath`~~<sup>Optional</sup> <a name="CertPath" id="cdktf.EtcdV3BackendProps.property.certPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string CertPath { get; set; }
@@ -17386,7 +17624,9 @@ public string CertPath { get; set; }
 
 ---
 
-##### `KeyPath`<sup>Optional</sup> <a name="KeyPath" id="cdktf.EtcdV3BackendProps.property.keyPath"></a>
+##### ~~`KeyPath`~~<sup>Optional</sup> <a name="KeyPath" id="cdktf.EtcdV3BackendProps.property.keyPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string KeyPath { get; set; }
@@ -17398,7 +17638,9 @@ public string KeyPath { get; set; }
 
 ---
 
-##### `Lock`<sup>Optional</sup> <a name="Lock" id="cdktf.EtcdV3BackendProps.property.lock"></a>
+##### ~~`Lock`~~<sup>Optional</sup> <a name="Lock" id="cdktf.EtcdV3BackendProps.property.lock"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public bool Lock { get; set; }
@@ -17412,7 +17654,9 @@ Defaults to true.
 
 ---
 
-##### `Password`<sup>Optional</sup> <a name="Password" id="cdktf.EtcdV3BackendProps.property.password"></a>
+##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.EtcdV3BackendProps.property.password"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Password { get; set; }
@@ -17424,7 +17668,9 @@ public string Password { get; set; }
 
 ---
 
-##### `Prefix`<sup>Optional</sup> <a name="Prefix" id="cdktf.EtcdV3BackendProps.property.prefix"></a>
+##### ~~`Prefix`~~<sup>Optional</sup> <a name="Prefix" id="cdktf.EtcdV3BackendProps.property.prefix"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Prefix { get; set; }
@@ -17438,7 +17684,9 @@ Defaults to "".
 
 ---
 
-##### `Username`<sup>Optional</sup> <a name="Username" id="cdktf.EtcdV3BackendProps.property.username"></a>
+##### ~~`Username`~~<sup>Optional</sup> <a name="Username" id="cdktf.EtcdV3BackendProps.property.username"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Username { get; set; }
@@ -18255,7 +18503,9 @@ new MantaBackendProps {
 
 ---
 
-##### `Account`<sup>Required</sup> <a name="Account" id="cdktf.MantaBackendProps.property.account"></a>
+##### ~~`Account`~~<sup>Required</sup> <a name="Account" id="cdktf.MantaBackendProps.property.account"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Account { get; set; }
@@ -18265,7 +18515,9 @@ public string Account { get; set; }
 
 ---
 
-##### `KeyId`<sup>Required</sup> <a name="KeyId" id="cdktf.MantaBackendProps.property.keyId"></a>
+##### ~~`KeyId`~~<sup>Required</sup> <a name="KeyId" id="cdktf.MantaBackendProps.property.keyId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string KeyId { get; set; }
@@ -18275,7 +18527,9 @@ public string KeyId { get; set; }
 
 ---
 
-##### `Path`<sup>Required</sup> <a name="Path" id="cdktf.MantaBackendProps.property.path"></a>
+##### ~~`Path`~~<sup>Required</sup> <a name="Path" id="cdktf.MantaBackendProps.property.path"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Path { get; set; }
@@ -18285,7 +18539,9 @@ public string Path { get; set; }
 
 ---
 
-##### `InsecureSkipTlsVerify`<sup>Optional</sup> <a name="InsecureSkipTlsVerify" id="cdktf.MantaBackendProps.property.insecureSkipTlsVerify"></a>
+##### ~~`InsecureSkipTlsVerify`~~<sup>Optional</sup> <a name="InsecureSkipTlsVerify" id="cdktf.MantaBackendProps.property.insecureSkipTlsVerify"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public bool InsecureSkipTlsVerify { get; set; }
@@ -18295,7 +18551,9 @@ public bool InsecureSkipTlsVerify { get; set; }
 
 ---
 
-##### `KeyMaterial`<sup>Optional</sup> <a name="KeyMaterial" id="cdktf.MantaBackendProps.property.keyMaterial"></a>
+##### ~~`KeyMaterial`~~<sup>Optional</sup> <a name="KeyMaterial" id="cdktf.MantaBackendProps.property.keyMaterial"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string KeyMaterial { get; set; }
@@ -18305,7 +18563,9 @@ public string KeyMaterial { get; set; }
 
 ---
 
-##### `ObjectName`<sup>Optional</sup> <a name="ObjectName" id="cdktf.MantaBackendProps.property.objectName"></a>
+##### ~~`ObjectName`~~<sup>Optional</sup> <a name="ObjectName" id="cdktf.MantaBackendProps.property.objectName"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string ObjectName { get; set; }
@@ -18315,7 +18575,9 @@ public string ObjectName { get; set; }
 
 ---
 
-##### `Url`<sup>Optional</sup> <a name="Url" id="cdktf.MantaBackendProps.property.url"></a>
+##### ~~`Url`~~<sup>Optional</sup> <a name="Url" id="cdktf.MantaBackendProps.property.url"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Url { get; set; }
@@ -18325,7 +18587,9 @@ public string Url { get; set; }
 
 ---
 
-##### `User`<sup>Optional</sup> <a name="User" id="cdktf.MantaBackendProps.property.user"></a>
+##### ~~`User`~~<sup>Optional</sup> <a name="User" id="cdktf.MantaBackendProps.property.user"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string User { get; set; }
@@ -20038,7 +20302,9 @@ new SwiftBackendProps {
 
 ---
 
-##### `Container`<sup>Required</sup> <a name="Container" id="cdktf.SwiftBackendProps.property.container"></a>
+##### ~~`Container`~~<sup>Required</sup> <a name="Container" id="cdktf.SwiftBackendProps.property.container"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Container { get; set; }
@@ -20048,7 +20314,9 @@ public string Container { get; set; }
 
 ---
 
-##### `ApplicationCredentialId`<sup>Optional</sup> <a name="ApplicationCredentialId" id="cdktf.SwiftBackendProps.property.applicationCredentialId"></a>
+##### ~~`ApplicationCredentialId`~~<sup>Optional</sup> <a name="ApplicationCredentialId" id="cdktf.SwiftBackendProps.property.applicationCredentialId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string ApplicationCredentialId { get; set; }
@@ -20058,7 +20326,9 @@ public string ApplicationCredentialId { get; set; }
 
 ---
 
-##### `ApplicationCredentialName`<sup>Optional</sup> <a name="ApplicationCredentialName" id="cdktf.SwiftBackendProps.property.applicationCredentialName"></a>
+##### ~~`ApplicationCredentialName`~~<sup>Optional</sup> <a name="ApplicationCredentialName" id="cdktf.SwiftBackendProps.property.applicationCredentialName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string ApplicationCredentialName { get; set; }
@@ -20068,7 +20338,9 @@ public string ApplicationCredentialName { get; set; }
 
 ---
 
-##### `ApplicationCredentialSecret`<sup>Optional</sup> <a name="ApplicationCredentialSecret" id="cdktf.SwiftBackendProps.property.applicationCredentialSecret"></a>
+##### ~~`ApplicationCredentialSecret`~~<sup>Optional</sup> <a name="ApplicationCredentialSecret" id="cdktf.SwiftBackendProps.property.applicationCredentialSecret"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string ApplicationCredentialSecret { get; set; }
@@ -20078,7 +20350,9 @@ public string ApplicationCredentialSecret { get; set; }
 
 ---
 
-##### `ArchiveContainer`<sup>Optional</sup> <a name="ArchiveContainer" id="cdktf.SwiftBackendProps.property.archiveContainer"></a>
+##### ~~`ArchiveContainer`~~<sup>Optional</sup> <a name="ArchiveContainer" id="cdktf.SwiftBackendProps.property.archiveContainer"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string ArchiveContainer { get; set; }
@@ -20088,7 +20362,9 @@ public string ArchiveContainer { get; set; }
 
 ---
 
-##### `AuthUrl`<sup>Optional</sup> <a name="AuthUrl" id="cdktf.SwiftBackendProps.property.authUrl"></a>
+##### ~~`AuthUrl`~~<sup>Optional</sup> <a name="AuthUrl" id="cdktf.SwiftBackendProps.property.authUrl"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string AuthUrl { get; set; }
@@ -20098,7 +20374,9 @@ public string AuthUrl { get; set; }
 
 ---
 
-##### `CacertFile`<sup>Optional</sup> <a name="CacertFile" id="cdktf.SwiftBackendProps.property.cacertFile"></a>
+##### ~~`CacertFile`~~<sup>Optional</sup> <a name="CacertFile" id="cdktf.SwiftBackendProps.property.cacertFile"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string CacertFile { get; set; }
@@ -20108,7 +20386,9 @@ public string CacertFile { get; set; }
 
 ---
 
-##### `Cert`<sup>Optional</sup> <a name="Cert" id="cdktf.SwiftBackendProps.property.cert"></a>
+##### ~~`Cert`~~<sup>Optional</sup> <a name="Cert" id="cdktf.SwiftBackendProps.property.cert"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Cert { get; set; }
@@ -20118,7 +20398,9 @@ public string Cert { get; set; }
 
 ---
 
-##### `Cloud`<sup>Optional</sup> <a name="Cloud" id="cdktf.SwiftBackendProps.property.cloud"></a>
+##### ~~`Cloud`~~<sup>Optional</sup> <a name="Cloud" id="cdktf.SwiftBackendProps.property.cloud"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Cloud { get; set; }
@@ -20128,7 +20410,9 @@ public string Cloud { get; set; }
 
 ---
 
-##### `DefaultDomain`<sup>Optional</sup> <a name="DefaultDomain" id="cdktf.SwiftBackendProps.property.defaultDomain"></a>
+##### ~~`DefaultDomain`~~<sup>Optional</sup> <a name="DefaultDomain" id="cdktf.SwiftBackendProps.property.defaultDomain"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string DefaultDomain { get; set; }
@@ -20138,7 +20422,9 @@ public string DefaultDomain { get; set; }
 
 ---
 
-##### `DomainId`<sup>Optional</sup> <a name="DomainId" id="cdktf.SwiftBackendProps.property.domainId"></a>
+##### ~~`DomainId`~~<sup>Optional</sup> <a name="DomainId" id="cdktf.SwiftBackendProps.property.domainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string DomainId { get; set; }
@@ -20148,7 +20434,9 @@ public string DomainId { get; set; }
 
 ---
 
-##### `DomainName`<sup>Optional</sup> <a name="DomainName" id="cdktf.SwiftBackendProps.property.domainName"></a>
+##### ~~`DomainName`~~<sup>Optional</sup> <a name="DomainName" id="cdktf.SwiftBackendProps.property.domainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string DomainName { get; set; }
@@ -20158,7 +20446,9 @@ public string DomainName { get; set; }
 
 ---
 
-##### `ExpireAfter`<sup>Optional</sup> <a name="ExpireAfter" id="cdktf.SwiftBackendProps.property.expireAfter"></a>
+##### ~~`ExpireAfter`~~<sup>Optional</sup> <a name="ExpireAfter" id="cdktf.SwiftBackendProps.property.expireAfter"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string ExpireAfter { get; set; }
@@ -20168,7 +20458,9 @@ public string ExpireAfter { get; set; }
 
 ---
 
-##### `Insecure`<sup>Optional</sup> <a name="Insecure" id="cdktf.SwiftBackendProps.property.insecure"></a>
+##### ~~`Insecure`~~<sup>Optional</sup> <a name="Insecure" id="cdktf.SwiftBackendProps.property.insecure"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public bool Insecure { get; set; }
@@ -20178,7 +20470,9 @@ public bool Insecure { get; set; }
 
 ---
 
-##### `Key`<sup>Optional</sup> <a name="Key" id="cdktf.SwiftBackendProps.property.key"></a>
+##### ~~`Key`~~<sup>Optional</sup> <a name="Key" id="cdktf.SwiftBackendProps.property.key"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Key { get; set; }
@@ -20188,7 +20482,9 @@ public string Key { get; set; }
 
 ---
 
-##### `Password`<sup>Optional</sup> <a name="Password" id="cdktf.SwiftBackendProps.property.password"></a>
+##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.SwiftBackendProps.property.password"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Password { get; set; }
@@ -20198,7 +20494,9 @@ public string Password { get; set; }
 
 ---
 
-##### `ProjectDomainId`<sup>Optional</sup> <a name="ProjectDomainId" id="cdktf.SwiftBackendProps.property.projectDomainId"></a>
+##### ~~`ProjectDomainId`~~<sup>Optional</sup> <a name="ProjectDomainId" id="cdktf.SwiftBackendProps.property.projectDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string ProjectDomainId { get; set; }
@@ -20208,7 +20506,9 @@ public string ProjectDomainId { get; set; }
 
 ---
 
-##### `ProjectDomainName`<sup>Optional</sup> <a name="ProjectDomainName" id="cdktf.SwiftBackendProps.property.projectDomainName"></a>
+##### ~~`ProjectDomainName`~~<sup>Optional</sup> <a name="ProjectDomainName" id="cdktf.SwiftBackendProps.property.projectDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string ProjectDomainName { get; set; }
@@ -20218,7 +20518,9 @@ public string ProjectDomainName { get; set; }
 
 ---
 
-##### `RegionName`<sup>Optional</sup> <a name="RegionName" id="cdktf.SwiftBackendProps.property.regionName"></a>
+##### ~~`RegionName`~~<sup>Optional</sup> <a name="RegionName" id="cdktf.SwiftBackendProps.property.regionName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string RegionName { get; set; }
@@ -20228,7 +20530,9 @@ public string RegionName { get; set; }
 
 ---
 
-##### `StateName`<sup>Optional</sup> <a name="StateName" id="cdktf.SwiftBackendProps.property.stateName"></a>
+##### ~~`StateName`~~<sup>Optional</sup> <a name="StateName" id="cdktf.SwiftBackendProps.property.stateName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string StateName { get; set; }
@@ -20238,7 +20542,9 @@ public string StateName { get; set; }
 
 ---
 
-##### `TenantId`<sup>Optional</sup> <a name="TenantId" id="cdktf.SwiftBackendProps.property.tenantId"></a>
+##### ~~`TenantId`~~<sup>Optional</sup> <a name="TenantId" id="cdktf.SwiftBackendProps.property.tenantId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string TenantId { get; set; }
@@ -20248,7 +20554,9 @@ public string TenantId { get; set; }
 
 ---
 
-##### `TenantName`<sup>Optional</sup> <a name="TenantName" id="cdktf.SwiftBackendProps.property.tenantName"></a>
+##### ~~`TenantName`~~<sup>Optional</sup> <a name="TenantName" id="cdktf.SwiftBackendProps.property.tenantName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string TenantName { get; set; }
@@ -20258,7 +20566,9 @@ public string TenantName { get; set; }
 
 ---
 
-##### `Token`<sup>Optional</sup> <a name="Token" id="cdktf.SwiftBackendProps.property.token"></a>
+##### ~~`Token`~~<sup>Optional</sup> <a name="Token" id="cdktf.SwiftBackendProps.property.token"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string Token { get; set; }
@@ -20268,7 +20578,9 @@ public string Token { get; set; }
 
 ---
 
-##### `UserDomainId`<sup>Optional</sup> <a name="UserDomainId" id="cdktf.SwiftBackendProps.property.userDomainId"></a>
+##### ~~`UserDomainId`~~<sup>Optional</sup> <a name="UserDomainId" id="cdktf.SwiftBackendProps.property.userDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string UserDomainId { get; set; }
@@ -20278,7 +20590,9 @@ public string UserDomainId { get; set; }
 
 ---
 
-##### `UserDomainName`<sup>Optional</sup> <a name="UserDomainName" id="cdktf.SwiftBackendProps.property.userDomainName"></a>
+##### ~~`UserDomainName`~~<sup>Optional</sup> <a name="UserDomainName" id="cdktf.SwiftBackendProps.property.userDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string UserDomainName { get; set; }
@@ -20288,7 +20602,9 @@ public string UserDomainName { get; set; }
 
 ---
 
-##### `UserId`<sup>Optional</sup> <a name="UserId" id="cdktf.SwiftBackendProps.property.userId"></a>
+##### ~~`UserId`~~<sup>Optional</sup> <a name="UserId" id="cdktf.SwiftBackendProps.property.userId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string UserId { get; set; }
@@ -20298,7 +20614,9 @@ public string UserId { get; set; }
 
 ---
 
-##### `UserName`<sup>Optional</sup> <a name="UserName" id="cdktf.SwiftBackendProps.property.userName"></a>
+##### ~~`UserName`~~<sup>Optional</sup> <a name="UserName" id="cdktf.SwiftBackendProps.property.userName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```csharp
 public string UserName { get; set; }

--- a/website/docs/cdktf/api-reference/csharp.mdx
+++ b/website/docs/cdktf/api-reference/csharp.mdx
@@ -446,7 +446,7 @@ ArtifactoryBackend.IsBackend(object X);
 
 ##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.ArtifactoryBackend.property.node"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public Node Node { get; }
@@ -460,7 +460,7 @@ The tree node.
 
 ##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.ArtifactoryBackend.property.cdktfStack"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public TerraformStack CdktfStack { get; }
@@ -472,7 +472,7 @@ public TerraformStack CdktfStack { get; }
 
 ##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.ArtifactoryBackend.property.fqn"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Fqn { get; }
@@ -484,7 +484,7 @@ public string Fqn { get; }
 
 ##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.ArtifactoryBackend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string FriendlyUniqueId { get; }
@@ -2070,7 +2070,7 @@ DataTerraformRemoteStateArtifactory.IsTerraformElement(object X);
 
 ##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateArtifactory.property.node"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public Node Node { get; }
@@ -2084,7 +2084,7 @@ The tree node.
 
 ##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateArtifactory.property.cdktfStack"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public TerraformStack CdktfStack { get; }
@@ -2096,7 +2096,7 @@ public TerraformStack CdktfStack { get; }
 
 ##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateArtifactory.property.fqn"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Fqn { get; }
@@ -2108,7 +2108,7 @@ public string Fqn { get; }
 
 ##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateArtifactory.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string FriendlyUniqueId { get; }
@@ -2128,7 +2128,7 @@ public string FriendlyUniqueId { get; }
 
 ##### ~~`TfResourceType`~~<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateArtifactory.property.tfResourceType"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string TfResourceType { get; }
@@ -3296,7 +3296,7 @@ DataTerraformRemoteStateEtcd.IsTerraformElement(object X);
 
 ##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateEtcd.property.node"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public Node Node { get; }
@@ -3310,7 +3310,7 @@ The tree node.
 
 ##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateEtcd.property.cdktfStack"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public TerraformStack CdktfStack { get; }
@@ -3322,7 +3322,7 @@ public TerraformStack CdktfStack { get; }
 
 ##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateEtcd.property.fqn"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Fqn { get; }
@@ -3334,7 +3334,7 @@ public string Fqn { get; }
 
 ##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcd.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string FriendlyUniqueId { get; }
@@ -3354,7 +3354,7 @@ public string FriendlyUniqueId { get; }
 
 ##### ~~`TfResourceType`~~<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateEtcd.property.tfResourceType"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string TfResourceType { get; }
@@ -3610,7 +3610,7 @@ DataTerraformRemoteStateEtcdV3.IsTerraformElement(object X);
 
 ##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateEtcdV3.property.node"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public Node Node { get; }
@@ -3624,7 +3624,7 @@ The tree node.
 
 ##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateEtcdV3.property.cdktfStack"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public TerraformStack CdktfStack { get; }
@@ -3636,7 +3636,7 @@ public TerraformStack CdktfStack { get; }
 
 ##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateEtcdV3.property.fqn"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Fqn { get; }
@@ -3648,7 +3648,7 @@ public string Fqn { get; }
 
 ##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcdV3.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string FriendlyUniqueId { get; }
@@ -3668,7 +3668,7 @@ public string FriendlyUniqueId { get; }
 
 ##### ~~`TfResourceType`~~<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateEtcdV3.property.tfResourceType"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string TfResourceType { get; }
@@ -4836,7 +4836,7 @@ DataTerraformRemoteStateManta.IsTerraformElement(object X);
 
 ##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateManta.property.node"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public Node Node { get; }
@@ -4850,7 +4850,7 @@ The tree node.
 
 ##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateManta.property.cdktfStack"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public TerraformStack CdktfStack { get; }
@@ -4862,7 +4862,7 @@ public TerraformStack CdktfStack { get; }
 
 ##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateManta.property.fqn"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Fqn { get; }
@@ -4874,7 +4874,7 @@ public string Fqn { get; }
 
 ##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateManta.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string FriendlyUniqueId { get; }
@@ -4894,7 +4894,7 @@ public string FriendlyUniqueId { get; }
 
 ##### ~~`TfResourceType`~~<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateManta.property.tfResourceType"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string TfResourceType { get; }
@@ -6062,7 +6062,7 @@ DataTerraformRemoteStateSwift.IsTerraformElement(object X);
 
 ##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateSwift.property.node"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public Node Node { get; }
@@ -6076,7 +6076,7 @@ The tree node.
 
 ##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateSwift.property.cdktfStack"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public TerraformStack CdktfStack { get; }
@@ -6088,7 +6088,7 @@ public TerraformStack CdktfStack { get; }
 
 ##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateSwift.property.fqn"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Fqn { get; }
@@ -6100,7 +6100,7 @@ public string Fqn { get; }
 
 ##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateSwift.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string FriendlyUniqueId { get; }
@@ -6120,7 +6120,7 @@ public string FriendlyUniqueId { get; }
 
 ##### ~~`TfResourceType`~~<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateSwift.property.tfResourceType"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string TfResourceType { get; }
@@ -6346,7 +6346,7 @@ EtcdBackend.IsBackend(object X);
 
 ##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.EtcdBackend.property.node"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public Node Node { get; }
@@ -6360,7 +6360,7 @@ The tree node.
 
 ##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.EtcdBackend.property.cdktfStack"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public TerraformStack CdktfStack { get; }
@@ -6372,7 +6372,7 @@ public TerraformStack CdktfStack { get; }
 
 ##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.EtcdBackend.property.fqn"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Fqn { get; }
@@ -6384,7 +6384,7 @@ public string Fqn { get; }
 
 ##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.EtcdBackend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string FriendlyUniqueId { get; }
@@ -6610,7 +6610,7 @@ EtcdV3Backend.IsBackend(object X);
 
 ##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.EtcdV3Backend.property.node"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public Node Node { get; }
@@ -6624,7 +6624,7 @@ The tree node.
 
 ##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.EtcdV3Backend.property.cdktfStack"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public TerraformStack CdktfStack { get; }
@@ -6636,7 +6636,7 @@ public TerraformStack CdktfStack { get; }
 
 ##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.EtcdV3Backend.property.fqn"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Fqn { get; }
@@ -6648,7 +6648,7 @@ public string Fqn { get; }
 
 ##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.EtcdV3Backend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string FriendlyUniqueId { get; }
@@ -7642,7 +7642,7 @@ MantaBackend.IsBackend(object X);
 
 ##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.MantaBackend.property.node"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public Node Node { get; }
@@ -7656,7 +7656,7 @@ The tree node.
 
 ##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.MantaBackend.property.cdktfStack"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public TerraformStack CdktfStack { get; }
@@ -7668,7 +7668,7 @@ public TerraformStack CdktfStack { get; }
 
 ##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.MantaBackend.property.fqn"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Fqn { get; }
@@ -7680,7 +7680,7 @@ public string Fqn { get; }
 
 ##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.MantaBackend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string FriendlyUniqueId { get; }
@@ -9056,7 +9056,7 @@ SwiftBackend.IsBackend(object X);
 
 ##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.SwiftBackend.property.node"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public Node Node { get; }
@@ -9070,7 +9070,7 @@ The tree node.
 
 ##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.SwiftBackend.property.cdktfStack"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public TerraformStack CdktfStack { get; }
@@ -9082,7 +9082,7 @@ public TerraformStack CdktfStack { get; }
 
 ##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.SwiftBackend.property.fqn"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Fqn { get; }
@@ -9094,7 +9094,7 @@ public string Fqn { get; }
 
 ##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.SwiftBackend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string FriendlyUniqueId { get; }
@@ -13345,7 +13345,7 @@ new ArtifactoryBackendProps {
 
 ##### ~~`Password`~~<sup>Required</sup> <a name="Password" id="cdktf.ArtifactoryBackendProps.property.password"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Password { get; set; }
@@ -13359,7 +13359,7 @@ public string Password { get; set; }
 
 ##### ~~`Repo`~~<sup>Required</sup> <a name="Repo" id="cdktf.ArtifactoryBackendProps.property.repo"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Repo { get; set; }
@@ -13373,7 +13373,7 @@ public string Repo { get; set; }
 
 ##### ~~`Subpath`~~<sup>Required</sup> <a name="Subpath" id="cdktf.ArtifactoryBackendProps.property.subpath"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Subpath { get; set; }
@@ -13387,7 +13387,7 @@ public string Subpath { get; set; }
 
 ##### ~~`Url`~~<sup>Required</sup> <a name="Url" id="cdktf.ArtifactoryBackendProps.property.url"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Url { get; set; }
@@ -13403,7 +13403,7 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ##### ~~`Username`~~<sup>Required</sup> <a name="Username" id="cdktf.ArtifactoryBackendProps.property.username"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Username { get; set; }
@@ -14268,7 +14268,7 @@ new DataTerraformRemoteStateArtifactoryConfig {
 
 ##### ~~`Defaults`~~<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.defaults"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public System.Collections.Generic.IDictionary< string, object > Defaults { get; set; }
@@ -14280,7 +14280,7 @@ public System.Collections.Generic.IDictionary< string, object > Defaults { get; 
 
 ##### ~~`Workspace`~~<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.workspace"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Workspace { get; set; }
@@ -14292,7 +14292,7 @@ public string Workspace { get; set; }
 
 ##### ~~`Password`~~<sup>Required</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.password"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Password { get; set; }
@@ -14306,7 +14306,7 @@ public string Password { get; set; }
 
 ##### ~~`Repo`~~<sup>Required</sup> <a name="Repo" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.repo"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Repo { get; set; }
@@ -14320,7 +14320,7 @@ public string Repo { get; set; }
 
 ##### ~~`Subpath`~~<sup>Required</sup> <a name="Subpath" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.subpath"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Subpath { get; set; }
@@ -14334,7 +14334,7 @@ public string Subpath { get; set; }
 
 ##### ~~`Url`~~<sup>Required</sup> <a name="Url" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.url"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Url { get; set; }
@@ -14350,7 +14350,7 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ##### ~~`Username`~~<sup>Required</sup> <a name="Username" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.username"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Username { get; set; }
@@ -15217,7 +15217,7 @@ new DataTerraformRemoteStateEtcdConfig {
 
 ##### ~~`Defaults`~~<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.defaults"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public System.Collections.Generic.IDictionary< string, object > Defaults { get; set; }
@@ -15229,7 +15229,7 @@ public System.Collections.Generic.IDictionary< string, object > Defaults { get; 
 
 ##### ~~`Workspace`~~<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.workspace"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Workspace { get; set; }
@@ -15241,7 +15241,7 @@ public string Workspace { get; set; }
 
 ##### ~~`Endpoints`~~<sup>Required</sup> <a name="Endpoints" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.endpoints"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Endpoints { get; set; }
@@ -15255,7 +15255,7 @@ public string Endpoints { get; set; }
 
 ##### ~~`Path`~~<sup>Required</sup> <a name="Path" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.path"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Path { get; set; }
@@ -15269,7 +15269,7 @@ public string Path { get; set; }
 
 ##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.password"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Password { get; set; }
@@ -15283,7 +15283,7 @@ public string Password { get; set; }
 
 ##### ~~`Username`~~<sup>Optional</sup> <a name="Username" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.username"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Username { get; set; }
@@ -15335,7 +15335,7 @@ new DataTerraformRemoteStateEtcdV3Config {
 
 ##### ~~`Defaults`~~<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.defaults"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public System.Collections.Generic.IDictionary< string, object > Defaults { get; set; }
@@ -15347,7 +15347,7 @@ public System.Collections.Generic.IDictionary< string, object > Defaults { get; 
 
 ##### ~~`Workspace`~~<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.workspace"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Workspace { get; set; }
@@ -15359,7 +15359,7 @@ public string Workspace { get; set; }
 
 ##### ~~`Endpoints`~~<sup>Required</sup> <a name="Endpoints" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.endpoints"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string[] Endpoints { get; set; }
@@ -15373,7 +15373,7 @@ public string[] Endpoints { get; set; }
 
 ##### ~~`CacertPath`~~<sup>Optional</sup> <a name="CacertPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.cacertPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string CacertPath { get; set; }
@@ -15387,7 +15387,7 @@ public string CacertPath { get; set; }
 
 ##### ~~`CertPath`~~<sup>Optional</sup> <a name="CertPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.certPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string CertPath { get; set; }
@@ -15401,7 +15401,7 @@ public string CertPath { get; set; }
 
 ##### ~~`KeyPath`~~<sup>Optional</sup> <a name="KeyPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.keyPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string KeyPath { get; set; }
@@ -15415,7 +15415,7 @@ public string KeyPath { get; set; }
 
 ##### ~~`Lock`~~<sup>Optional</sup> <a name="Lock" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.lock"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public bool Lock { get; set; }
@@ -15431,7 +15431,7 @@ Defaults to true.
 
 ##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.password"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Password { get; set; }
@@ -15445,7 +15445,7 @@ public string Password { get; set; }
 
 ##### ~~`Prefix`~~<sup>Optional</sup> <a name="Prefix" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.prefix"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Prefix { get; set; }
@@ -15461,7 +15461,7 @@ Defaults to "".
 
 ##### ~~`Username`~~<sup>Optional</sup> <a name="Username" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.username"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Username { get; set; }
@@ -15966,7 +15966,7 @@ new DataTerraformRemoteStateMantaConfig {
 
 ##### ~~`Defaults`~~<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateMantaConfig.property.defaults"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public System.Collections.Generic.IDictionary< string, object > Defaults { get; set; }
@@ -15978,7 +15978,7 @@ public System.Collections.Generic.IDictionary< string, object > Defaults { get; 
 
 ##### ~~`Workspace`~~<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateMantaConfig.property.workspace"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Workspace { get; set; }
@@ -15990,7 +15990,7 @@ public string Workspace { get; set; }
 
 ##### ~~`Account`~~<sup>Required</sup> <a name="Account" id="cdktf.DataTerraformRemoteStateMantaConfig.property.account"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Account { get; set; }
@@ -16002,7 +16002,7 @@ public string Account { get; set; }
 
 ##### ~~`KeyId`~~<sup>Required</sup> <a name="KeyId" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string KeyId { get; set; }
@@ -16014,7 +16014,7 @@ public string KeyId { get; set; }
 
 ##### ~~`Path`~~<sup>Required</sup> <a name="Path" id="cdktf.DataTerraformRemoteStateMantaConfig.property.path"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Path { get; set; }
@@ -16026,7 +16026,7 @@ public string Path { get; set; }
 
 ##### ~~`InsecureSkipTlsVerify`~~<sup>Optional</sup> <a name="InsecureSkipTlsVerify" id="cdktf.DataTerraformRemoteStateMantaConfig.property.insecureSkipTlsVerify"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public bool InsecureSkipTlsVerify { get; set; }
@@ -16038,7 +16038,7 @@ public bool InsecureSkipTlsVerify { get; set; }
 
 ##### ~~`KeyMaterial`~~<sup>Optional</sup> <a name="KeyMaterial" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyMaterial"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string KeyMaterial { get; set; }
@@ -16050,7 +16050,7 @@ public string KeyMaterial { get; set; }
 
 ##### ~~`ObjectName`~~<sup>Optional</sup> <a name="ObjectName" id="cdktf.DataTerraformRemoteStateMantaConfig.property.objectName"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string ObjectName { get; set; }
@@ -16062,7 +16062,7 @@ public string ObjectName { get; set; }
 
 ##### ~~`Url`~~<sup>Optional</sup> <a name="Url" id="cdktf.DataTerraformRemoteStateMantaConfig.property.url"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Url { get; set; }
@@ -16074,7 +16074,7 @@ public string Url { get; set; }
 
 ##### ~~`User`~~<sup>Optional</sup> <a name="User" id="cdktf.DataTerraformRemoteStateMantaConfig.property.user"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string User { get; set; }
@@ -17071,7 +17071,7 @@ new DataTerraformRemoteStateSwiftConfig {
 
 ##### ~~`Defaults`~~<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaults"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public System.Collections.Generic.IDictionary< string, object > Defaults { get; set; }
@@ -17083,7 +17083,7 @@ public System.Collections.Generic.IDictionary< string, object > Defaults { get; 
 
 ##### ~~`Workspace`~~<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.workspace"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Workspace { get; set; }
@@ -17095,7 +17095,7 @@ public string Workspace { get; set; }
 
 ##### ~~`Container`~~<sup>Required</sup> <a name="Container" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.container"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Container { get; set; }
@@ -17107,7 +17107,7 @@ public string Container { get; set; }
 
 ##### ~~`ApplicationCredentialId`~~<sup>Optional</sup> <a name="ApplicationCredentialId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string ApplicationCredentialId { get; set; }
@@ -17119,7 +17119,7 @@ public string ApplicationCredentialId { get; set; }
 
 ##### ~~`ApplicationCredentialName`~~<sup>Optional</sup> <a name="ApplicationCredentialName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string ApplicationCredentialName { get; set; }
@@ -17131,7 +17131,7 @@ public string ApplicationCredentialName { get; set; }
 
 ##### ~~`ApplicationCredentialSecret`~~<sup>Optional</sup> <a name="ApplicationCredentialSecret" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialSecret"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string ApplicationCredentialSecret { get; set; }
@@ -17143,7 +17143,7 @@ public string ApplicationCredentialSecret { get; set; }
 
 ##### ~~`ArchiveContainer`~~<sup>Optional</sup> <a name="ArchiveContainer" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.archiveContainer"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string ArchiveContainer { get; set; }
@@ -17155,7 +17155,7 @@ public string ArchiveContainer { get; set; }
 
 ##### ~~`AuthUrl`~~<sup>Optional</sup> <a name="AuthUrl" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.authUrl"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string AuthUrl { get; set; }
@@ -17167,7 +17167,7 @@ public string AuthUrl { get; set; }
 
 ##### ~~`CacertFile`~~<sup>Optional</sup> <a name="CacertFile" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cacertFile"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string CacertFile { get; set; }
@@ -17179,7 +17179,7 @@ public string CacertFile { get; set; }
 
 ##### ~~`Cert`~~<sup>Optional</sup> <a name="Cert" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cert"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Cert { get; set; }
@@ -17191,7 +17191,7 @@ public string Cert { get; set; }
 
 ##### ~~`Cloud`~~<sup>Optional</sup> <a name="Cloud" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cloud"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Cloud { get; set; }
@@ -17203,7 +17203,7 @@ public string Cloud { get; set; }
 
 ##### ~~`DefaultDomain`~~<sup>Optional</sup> <a name="DefaultDomain" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaultDomain"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string DefaultDomain { get; set; }
@@ -17215,7 +17215,7 @@ public string DefaultDomain { get; set; }
 
 ##### ~~`DomainId`~~<sup>Optional</sup> <a name="DomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string DomainId { get; set; }
@@ -17227,7 +17227,7 @@ public string DomainId { get; set; }
 
 ##### ~~`DomainName`~~<sup>Optional</sup> <a name="DomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string DomainName { get; set; }
@@ -17239,7 +17239,7 @@ public string DomainName { get; set; }
 
 ##### ~~`ExpireAfter`~~<sup>Optional</sup> <a name="ExpireAfter" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.expireAfter"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string ExpireAfter { get; set; }
@@ -17251,7 +17251,7 @@ public string ExpireAfter { get; set; }
 
 ##### ~~`Insecure`~~<sup>Optional</sup> <a name="Insecure" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.insecure"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public bool Insecure { get; set; }
@@ -17263,7 +17263,7 @@ public bool Insecure { get; set; }
 
 ##### ~~`Key`~~<sup>Optional</sup> <a name="Key" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.key"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Key { get; set; }
@@ -17275,7 +17275,7 @@ public string Key { get; set; }
 
 ##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.password"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Password { get; set; }
@@ -17287,7 +17287,7 @@ public string Password { get; set; }
 
 ##### ~~`ProjectDomainId`~~<sup>Optional</sup> <a name="ProjectDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string ProjectDomainId { get; set; }
@@ -17299,7 +17299,7 @@ public string ProjectDomainId { get; set; }
 
 ##### ~~`ProjectDomainName`~~<sup>Optional</sup> <a name="ProjectDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string ProjectDomainName { get; set; }
@@ -17311,7 +17311,7 @@ public string ProjectDomainName { get; set; }
 
 ##### ~~`RegionName`~~<sup>Optional</sup> <a name="RegionName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.regionName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string RegionName { get; set; }
@@ -17323,7 +17323,7 @@ public string RegionName { get; set; }
 
 ##### ~~`StateName`~~<sup>Optional</sup> <a name="StateName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.stateName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string StateName { get; set; }
@@ -17335,7 +17335,7 @@ public string StateName { get; set; }
 
 ##### ~~`TenantId`~~<sup>Optional</sup> <a name="TenantId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string TenantId { get; set; }
@@ -17347,7 +17347,7 @@ public string TenantId { get; set; }
 
 ##### ~~`TenantName`~~<sup>Optional</sup> <a name="TenantName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string TenantName { get; set; }
@@ -17359,7 +17359,7 @@ public string TenantName { get; set; }
 
 ##### ~~`Token`~~<sup>Optional</sup> <a name="Token" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.token"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Token { get; set; }
@@ -17371,7 +17371,7 @@ public string Token { get; set; }
 
 ##### ~~`UserDomainId`~~<sup>Optional</sup> <a name="UserDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string UserDomainId { get; set; }
@@ -17383,7 +17383,7 @@ public string UserDomainId { get; set; }
 
 ##### ~~`UserDomainName`~~<sup>Optional</sup> <a name="UserDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string UserDomainName { get; set; }
@@ -17395,7 +17395,7 @@ public string UserDomainName { get; set; }
 
 ##### ~~`UserId`~~<sup>Optional</sup> <a name="UserId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string UserId { get; set; }
@@ -17407,7 +17407,7 @@ public string UserId { get; set; }
 
 ##### ~~`UserName`~~<sup>Optional</sup> <a name="UserName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string UserName { get; set; }
@@ -17487,7 +17487,7 @@ new EtcdBackendProps {
 
 ##### ~~`Endpoints`~~<sup>Required</sup> <a name="Endpoints" id="cdktf.EtcdBackendProps.property.endpoints"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Endpoints { get; set; }
@@ -17501,7 +17501,7 @@ public string Endpoints { get; set; }
 
 ##### ~~`Path`~~<sup>Required</sup> <a name="Path" id="cdktf.EtcdBackendProps.property.path"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Path { get; set; }
@@ -17515,7 +17515,7 @@ public string Path { get; set; }
 
 ##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.EtcdBackendProps.property.password"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Password { get; set; }
@@ -17529,7 +17529,7 @@ public string Password { get; set; }
 
 ##### ~~`Username`~~<sup>Optional</sup> <a name="Username" id="cdktf.EtcdBackendProps.property.username"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Username { get; set; }
@@ -17584,7 +17584,7 @@ new EtcdV3BackendProps {
 
 ##### ~~`Endpoints`~~<sup>Required</sup> <a name="Endpoints" id="cdktf.EtcdV3BackendProps.property.endpoints"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string[] Endpoints { get; set; }
@@ -17598,7 +17598,7 @@ public string[] Endpoints { get; set; }
 
 ##### ~~`CacertPath`~~<sup>Optional</sup> <a name="CacertPath" id="cdktf.EtcdV3BackendProps.property.cacertPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string CacertPath { get; set; }
@@ -17612,7 +17612,7 @@ public string CacertPath { get; set; }
 
 ##### ~~`CertPath`~~<sup>Optional</sup> <a name="CertPath" id="cdktf.EtcdV3BackendProps.property.certPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string CertPath { get; set; }
@@ -17626,7 +17626,7 @@ public string CertPath { get; set; }
 
 ##### ~~`KeyPath`~~<sup>Optional</sup> <a name="KeyPath" id="cdktf.EtcdV3BackendProps.property.keyPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string KeyPath { get; set; }
@@ -17640,7 +17640,7 @@ public string KeyPath { get; set; }
 
 ##### ~~`Lock`~~<sup>Optional</sup> <a name="Lock" id="cdktf.EtcdV3BackendProps.property.lock"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public bool Lock { get; set; }
@@ -17656,7 +17656,7 @@ Defaults to true.
 
 ##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.EtcdV3BackendProps.property.password"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Password { get; set; }
@@ -17670,7 +17670,7 @@ public string Password { get; set; }
 
 ##### ~~`Prefix`~~<sup>Optional</sup> <a name="Prefix" id="cdktf.EtcdV3BackendProps.property.prefix"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Prefix { get; set; }
@@ -17686,7 +17686,7 @@ Defaults to "".
 
 ##### ~~`Username`~~<sup>Optional</sup> <a name="Username" id="cdktf.EtcdV3BackendProps.property.username"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Username { get; set; }
@@ -18505,7 +18505,7 @@ new MantaBackendProps {
 
 ##### ~~`Account`~~<sup>Required</sup> <a name="Account" id="cdktf.MantaBackendProps.property.account"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Account { get; set; }
@@ -18517,7 +18517,7 @@ public string Account { get; set; }
 
 ##### ~~`KeyId`~~<sup>Required</sup> <a name="KeyId" id="cdktf.MantaBackendProps.property.keyId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string KeyId { get; set; }
@@ -18529,7 +18529,7 @@ public string KeyId { get; set; }
 
 ##### ~~`Path`~~<sup>Required</sup> <a name="Path" id="cdktf.MantaBackendProps.property.path"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Path { get; set; }
@@ -18541,7 +18541,7 @@ public string Path { get; set; }
 
 ##### ~~`InsecureSkipTlsVerify`~~<sup>Optional</sup> <a name="InsecureSkipTlsVerify" id="cdktf.MantaBackendProps.property.insecureSkipTlsVerify"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public bool InsecureSkipTlsVerify { get; set; }
@@ -18553,7 +18553,7 @@ public bool InsecureSkipTlsVerify { get; set; }
 
 ##### ~~`KeyMaterial`~~<sup>Optional</sup> <a name="KeyMaterial" id="cdktf.MantaBackendProps.property.keyMaterial"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string KeyMaterial { get; set; }
@@ -18565,7 +18565,7 @@ public string KeyMaterial { get; set; }
 
 ##### ~~`ObjectName`~~<sup>Optional</sup> <a name="ObjectName" id="cdktf.MantaBackendProps.property.objectName"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string ObjectName { get; set; }
@@ -18577,7 +18577,7 @@ public string ObjectName { get; set; }
 
 ##### ~~`Url`~~<sup>Optional</sup> <a name="Url" id="cdktf.MantaBackendProps.property.url"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Url { get; set; }
@@ -18589,7 +18589,7 @@ public string Url { get; set; }
 
 ##### ~~`User`~~<sup>Optional</sup> <a name="User" id="cdktf.MantaBackendProps.property.user"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string User { get; set; }
@@ -20304,7 +20304,7 @@ new SwiftBackendProps {
 
 ##### ~~`Container`~~<sup>Required</sup> <a name="Container" id="cdktf.SwiftBackendProps.property.container"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Container { get; set; }
@@ -20316,7 +20316,7 @@ public string Container { get; set; }
 
 ##### ~~`ApplicationCredentialId`~~<sup>Optional</sup> <a name="ApplicationCredentialId" id="cdktf.SwiftBackendProps.property.applicationCredentialId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string ApplicationCredentialId { get; set; }
@@ -20328,7 +20328,7 @@ public string ApplicationCredentialId { get; set; }
 
 ##### ~~`ApplicationCredentialName`~~<sup>Optional</sup> <a name="ApplicationCredentialName" id="cdktf.SwiftBackendProps.property.applicationCredentialName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string ApplicationCredentialName { get; set; }
@@ -20340,7 +20340,7 @@ public string ApplicationCredentialName { get; set; }
 
 ##### ~~`ApplicationCredentialSecret`~~<sup>Optional</sup> <a name="ApplicationCredentialSecret" id="cdktf.SwiftBackendProps.property.applicationCredentialSecret"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string ApplicationCredentialSecret { get; set; }
@@ -20352,7 +20352,7 @@ public string ApplicationCredentialSecret { get; set; }
 
 ##### ~~`ArchiveContainer`~~<sup>Optional</sup> <a name="ArchiveContainer" id="cdktf.SwiftBackendProps.property.archiveContainer"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string ArchiveContainer { get; set; }
@@ -20364,7 +20364,7 @@ public string ArchiveContainer { get; set; }
 
 ##### ~~`AuthUrl`~~<sup>Optional</sup> <a name="AuthUrl" id="cdktf.SwiftBackendProps.property.authUrl"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string AuthUrl { get; set; }
@@ -20376,7 +20376,7 @@ public string AuthUrl { get; set; }
 
 ##### ~~`CacertFile`~~<sup>Optional</sup> <a name="CacertFile" id="cdktf.SwiftBackendProps.property.cacertFile"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string CacertFile { get; set; }
@@ -20388,7 +20388,7 @@ public string CacertFile { get; set; }
 
 ##### ~~`Cert`~~<sup>Optional</sup> <a name="Cert" id="cdktf.SwiftBackendProps.property.cert"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Cert { get; set; }
@@ -20400,7 +20400,7 @@ public string Cert { get; set; }
 
 ##### ~~`Cloud`~~<sup>Optional</sup> <a name="Cloud" id="cdktf.SwiftBackendProps.property.cloud"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Cloud { get; set; }
@@ -20412,7 +20412,7 @@ public string Cloud { get; set; }
 
 ##### ~~`DefaultDomain`~~<sup>Optional</sup> <a name="DefaultDomain" id="cdktf.SwiftBackendProps.property.defaultDomain"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string DefaultDomain { get; set; }
@@ -20424,7 +20424,7 @@ public string DefaultDomain { get; set; }
 
 ##### ~~`DomainId`~~<sup>Optional</sup> <a name="DomainId" id="cdktf.SwiftBackendProps.property.domainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string DomainId { get; set; }
@@ -20436,7 +20436,7 @@ public string DomainId { get; set; }
 
 ##### ~~`DomainName`~~<sup>Optional</sup> <a name="DomainName" id="cdktf.SwiftBackendProps.property.domainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string DomainName { get; set; }
@@ -20448,7 +20448,7 @@ public string DomainName { get; set; }
 
 ##### ~~`ExpireAfter`~~<sup>Optional</sup> <a name="ExpireAfter" id="cdktf.SwiftBackendProps.property.expireAfter"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string ExpireAfter { get; set; }
@@ -20460,7 +20460,7 @@ public string ExpireAfter { get; set; }
 
 ##### ~~`Insecure`~~<sup>Optional</sup> <a name="Insecure" id="cdktf.SwiftBackendProps.property.insecure"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public bool Insecure { get; set; }
@@ -20472,7 +20472,7 @@ public bool Insecure { get; set; }
 
 ##### ~~`Key`~~<sup>Optional</sup> <a name="Key" id="cdktf.SwiftBackendProps.property.key"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Key { get; set; }
@@ -20484,7 +20484,7 @@ public string Key { get; set; }
 
 ##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.SwiftBackendProps.property.password"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Password { get; set; }
@@ -20496,7 +20496,7 @@ public string Password { get; set; }
 
 ##### ~~`ProjectDomainId`~~<sup>Optional</sup> <a name="ProjectDomainId" id="cdktf.SwiftBackendProps.property.projectDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string ProjectDomainId { get; set; }
@@ -20508,7 +20508,7 @@ public string ProjectDomainId { get; set; }
 
 ##### ~~`ProjectDomainName`~~<sup>Optional</sup> <a name="ProjectDomainName" id="cdktf.SwiftBackendProps.property.projectDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string ProjectDomainName { get; set; }
@@ -20520,7 +20520,7 @@ public string ProjectDomainName { get; set; }
 
 ##### ~~`RegionName`~~<sup>Optional</sup> <a name="RegionName" id="cdktf.SwiftBackendProps.property.regionName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string RegionName { get; set; }
@@ -20532,7 +20532,7 @@ public string RegionName { get; set; }
 
 ##### ~~`StateName`~~<sup>Optional</sup> <a name="StateName" id="cdktf.SwiftBackendProps.property.stateName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string StateName { get; set; }
@@ -20544,7 +20544,7 @@ public string StateName { get; set; }
 
 ##### ~~`TenantId`~~<sup>Optional</sup> <a name="TenantId" id="cdktf.SwiftBackendProps.property.tenantId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string TenantId { get; set; }
@@ -20556,7 +20556,7 @@ public string TenantId { get; set; }
 
 ##### ~~`TenantName`~~<sup>Optional</sup> <a name="TenantName" id="cdktf.SwiftBackendProps.property.tenantName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string TenantName { get; set; }
@@ -20568,7 +20568,7 @@ public string TenantName { get; set; }
 
 ##### ~~`Token`~~<sup>Optional</sup> <a name="Token" id="cdktf.SwiftBackendProps.property.token"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string Token { get; set; }
@@ -20580,7 +20580,7 @@ public string Token { get; set; }
 
 ##### ~~`UserDomainId`~~<sup>Optional</sup> <a name="UserDomainId" id="cdktf.SwiftBackendProps.property.userDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string UserDomainId { get; set; }
@@ -20592,7 +20592,7 @@ public string UserDomainId { get; set; }
 
 ##### ~~`UserDomainName`~~<sup>Optional</sup> <a name="UserDomainName" id="cdktf.SwiftBackendProps.property.userDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string UserDomainName { get; set; }
@@ -20604,7 +20604,7 @@ public string UserDomainName { get; set; }
 
 ##### ~~`UserId`~~<sup>Optional</sup> <a name="UserId" id="cdktf.SwiftBackendProps.property.userId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string UserId { get; set; }
@@ -20616,7 +20616,7 @@ public string UserId { get; set; }
 
 ##### ~~`UserName`~~<sup>Optional</sup> <a name="UserName" id="cdktf.SwiftBackendProps.property.userName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```csharp
 public string UserName { get; set; }

--- a/website/docs/cdktf/api-reference/go.mdx
+++ b/website/docs/cdktf/api-reference/go.mdx
@@ -273,7 +273,7 @@ cdktf.NewArtifactoryBackend(scope Construct, props ArtifactoryBackendProps) Arti
 
 ---
 
-##### `ToString` <a name="ToString" id="cdktf.ArtifactoryBackend.toString"></a>
+##### ~~`ToString`~~ <a name="ToString" id="cdktf.ArtifactoryBackend.toString"></a>
 
 ```go
 func ToString() *string
@@ -281,7 +281,7 @@ func ToString() *string
 
 Returns a string representation of this construct.
 
-##### `AddOverride` <a name="AddOverride" id="cdktf.ArtifactoryBackend.addOverride"></a>
+##### ~~`AddOverride`~~ <a name="AddOverride" id="cdktf.ArtifactoryBackend.addOverride"></a>
 
 ```go
 func AddOverride(path *string, value interface{})
@@ -299,7 +299,7 @@ func AddOverride(path *string, value interface{})
 
 ---
 
-##### `OverrideLogicalId` <a name="OverrideLogicalId" id="cdktf.ArtifactoryBackend.overrideLogicalId"></a>
+##### ~~`OverrideLogicalId`~~ <a name="OverrideLogicalId" id="cdktf.ArtifactoryBackend.overrideLogicalId"></a>
 
 ```go
 func OverrideLogicalId(newLogicalId *string)
@@ -315,7 +315,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `ResetOverrideLogicalId` <a name="ResetOverrideLogicalId" id="cdktf.ArtifactoryBackend.resetOverrideLogicalId"></a>
+##### ~~`ResetOverrideLogicalId`~~ <a name="ResetOverrideLogicalId" id="cdktf.ArtifactoryBackend.resetOverrideLogicalId"></a>
 
 ```go
 func ResetOverrideLogicalId()
@@ -323,13 +323,13 @@ func ResetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `ToMetadata` <a name="ToMetadata" id="cdktf.ArtifactoryBackend.toMetadata"></a>
+##### ~~`ToMetadata`~~ <a name="ToMetadata" id="cdktf.ArtifactoryBackend.toMetadata"></a>
 
 ```go
 func ToMetadata() interface{}
 ```
 
-##### `ToTerraform` <a name="ToTerraform" id="cdktf.ArtifactoryBackend.toTerraform"></a>
+##### ~~`ToTerraform`~~ <a name="ToTerraform" id="cdktf.ArtifactoryBackend.toTerraform"></a>
 
 ```go
 func ToTerraform() interface{}
@@ -337,7 +337,7 @@ func ToTerraform() interface{}
 
 Adds this resource to the terraform JSON output.
 
-##### `GetRemoteStateDataSource` <a name="GetRemoteStateDataSource" id="cdktf.ArtifactoryBackend.getRemoteStateDataSource"></a>
+##### ~~`GetRemoteStateDataSource`~~ <a name="GetRemoteStateDataSource" id="cdktf.ArtifactoryBackend.getRemoteStateDataSource"></a>
 
 ```go
 func GetRemoteStateDataSource(scope Construct, name *string, _fromStack *string) TerraformRemoteState
@@ -373,7 +373,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `IsConstruct` <a name="IsConstruct" id="cdktf.ArtifactoryBackend.isConstruct"></a>
+##### ~~`IsConstruct`~~ <a name="IsConstruct" id="cdktf.ArtifactoryBackend.isConstruct"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -405,7 +405,7 @@ Any object.
 
 ---
 
-##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.ArtifactoryBackend.isTerraformElement"></a>
+##### ~~`IsTerraformElement`~~ <a name="IsTerraformElement" id="cdktf.ArtifactoryBackend.isTerraformElement"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -419,7 +419,7 @@ cdktf.ArtifactoryBackend_IsTerraformElement(x interface{}) *bool
 
 ---
 
-##### `IsBackend` <a name="IsBackend" id="cdktf.ArtifactoryBackend.isBackend"></a>
+##### ~~`IsBackend`~~ <a name="IsBackend" id="cdktf.ArtifactoryBackend.isBackend"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -444,7 +444,9 @@ cdktf.ArtifactoryBackend_IsBackend(x interface{}) *bool
 
 ---
 
-##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.ArtifactoryBackend.property.node"></a>
+##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.ArtifactoryBackend.property.node"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func Node() Node
@@ -456,7 +458,9 @@ The tree node.
 
 ---
 
-##### `CdktfStack`<sup>Required</sup> <a name="CdktfStack" id="cdktf.ArtifactoryBackend.property.cdktfStack"></a>
+##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.ArtifactoryBackend.property.cdktfStack"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func CdktfStack() TerraformStack
@@ -466,7 +470,9 @@ func CdktfStack() TerraformStack
 
 ---
 
-##### `Fqn`<sup>Required</sup> <a name="Fqn" id="cdktf.ArtifactoryBackend.property.fqn"></a>
+##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.ArtifactoryBackend.property.fqn"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func Fqn() *string
@@ -476,7 +482,9 @@ func Fqn() *string
 
 ---
 
-##### `FriendlyUniqueId`<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.ArtifactoryBackend.property.friendlyUniqueId"></a>
+##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.ArtifactoryBackend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func FriendlyUniqueId() *string
@@ -1870,7 +1878,7 @@ cdktf.NewDataTerraformRemoteStateArtifactory(scope Construct, id *string, config
 
 ---
 
-##### `ToString` <a name="ToString" id="cdktf.DataTerraformRemoteStateArtifactory.toString"></a>
+##### ~~`ToString`~~ <a name="ToString" id="cdktf.DataTerraformRemoteStateArtifactory.toString"></a>
 
 ```go
 func ToString() *string
@@ -1878,7 +1886,7 @@ func ToString() *string
 
 Returns a string representation of this construct.
 
-##### `AddOverride` <a name="AddOverride" id="cdktf.DataTerraformRemoteStateArtifactory.addOverride"></a>
+##### ~~`AddOverride`~~ <a name="AddOverride" id="cdktf.DataTerraformRemoteStateArtifactory.addOverride"></a>
 
 ```go
 func AddOverride(path *string, value interface{})
@@ -1896,7 +1904,7 @@ func AddOverride(path *string, value interface{})
 
 ---
 
-##### `OverrideLogicalId` <a name="OverrideLogicalId" id="cdktf.DataTerraformRemoteStateArtifactory.overrideLogicalId"></a>
+##### ~~`OverrideLogicalId`~~ <a name="OverrideLogicalId" id="cdktf.DataTerraformRemoteStateArtifactory.overrideLogicalId"></a>
 
 ```go
 func OverrideLogicalId(newLogicalId *string)
@@ -1912,7 +1920,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `ResetOverrideLogicalId` <a name="ResetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateArtifactory.resetOverrideLogicalId"></a>
+##### ~~`ResetOverrideLogicalId`~~ <a name="ResetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateArtifactory.resetOverrideLogicalId"></a>
 
 ```go
 func ResetOverrideLogicalId()
@@ -1920,13 +1928,13 @@ func ResetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `ToMetadata` <a name="ToMetadata" id="cdktf.DataTerraformRemoteStateArtifactory.toMetadata"></a>
+##### ~~`ToMetadata`~~ <a name="ToMetadata" id="cdktf.DataTerraformRemoteStateArtifactory.toMetadata"></a>
 
 ```go
 func ToMetadata() interface{}
 ```
 
-##### `ToTerraform` <a name="ToTerraform" id="cdktf.DataTerraformRemoteStateArtifactory.toTerraform"></a>
+##### ~~`ToTerraform`~~ <a name="ToTerraform" id="cdktf.DataTerraformRemoteStateArtifactory.toTerraform"></a>
 
 ```go
 func ToTerraform() interface{}
@@ -1934,7 +1942,7 @@ func ToTerraform() interface{}
 
 Adds this resource to the terraform JSON output.
 
-##### `Get` <a name="Get" id="cdktf.DataTerraformRemoteStateArtifactory.get"></a>
+##### ~~`Get`~~ <a name="Get" id="cdktf.DataTerraformRemoteStateArtifactory.get"></a>
 
 ```go
 func Get(output *string) IResolvable
@@ -1946,7 +1954,7 @@ func Get(output *string) IResolvable
 
 ---
 
-##### `GetBoolean` <a name="GetBoolean" id="cdktf.DataTerraformRemoteStateArtifactory.getBoolean"></a>
+##### ~~`GetBoolean`~~ <a name="GetBoolean" id="cdktf.DataTerraformRemoteStateArtifactory.getBoolean"></a>
 
 ```go
 func GetBoolean(output *string) IResolvable
@@ -1958,7 +1966,7 @@ func GetBoolean(output *string) IResolvable
 
 ---
 
-##### `GetList` <a name="GetList" id="cdktf.DataTerraformRemoteStateArtifactory.getList"></a>
+##### ~~`GetList`~~ <a name="GetList" id="cdktf.DataTerraformRemoteStateArtifactory.getList"></a>
 
 ```go
 func GetList(output *string) *[]*string
@@ -1970,7 +1978,7 @@ func GetList(output *string) *[]*string
 
 ---
 
-##### `GetNumber` <a name="GetNumber" id="cdktf.DataTerraformRemoteStateArtifactory.getNumber"></a>
+##### ~~`GetNumber`~~ <a name="GetNumber" id="cdktf.DataTerraformRemoteStateArtifactory.getNumber"></a>
 
 ```go
 func GetNumber(output *string) *f64
@@ -1982,7 +1990,7 @@ func GetNumber(output *string) *f64
 
 ---
 
-##### `GetString` <a name="GetString" id="cdktf.DataTerraformRemoteStateArtifactory.getString"></a>
+##### ~~`GetString`~~ <a name="GetString" id="cdktf.DataTerraformRemoteStateArtifactory.getString"></a>
 
 ```go
 func GetString(output *string) *string
@@ -2003,7 +2011,7 @@ func GetString(output *string) *string
 
 ---
 
-##### `IsConstruct` <a name="IsConstruct" id="cdktf.DataTerraformRemoteStateArtifactory.isConstruct"></a>
+##### ~~`IsConstruct`~~ <a name="IsConstruct" id="cdktf.DataTerraformRemoteStateArtifactory.isConstruct"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -2035,7 +2043,7 @@ Any object.
 
 ---
 
-##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement"></a>
+##### ~~`IsTerraformElement`~~ <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -2060,7 +2068,9 @@ cdktf.DataTerraformRemoteStateArtifactory_IsTerraformElement(x interface{}) *boo
 
 ---
 
-##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateArtifactory.property.node"></a>
+##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateArtifactory.property.node"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func Node() Node
@@ -2072,7 +2082,9 @@ The tree node.
 
 ---
 
-##### `CdktfStack`<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateArtifactory.property.cdktfStack"></a>
+##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateArtifactory.property.cdktfStack"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func CdktfStack() TerraformStack
@@ -2082,7 +2094,9 @@ func CdktfStack() TerraformStack
 
 ---
 
-##### `Fqn`<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateArtifactory.property.fqn"></a>
+##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateArtifactory.property.fqn"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func Fqn() *string
@@ -2092,7 +2106,9 @@ func Fqn() *string
 
 ---
 
-##### `FriendlyUniqueId`<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateArtifactory.property.friendlyUniqueId"></a>
+##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateArtifactory.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func FriendlyUniqueId() *string
@@ -2110,7 +2126,9 @@ func FriendlyUniqueId() *string
 
 ---
 
-##### `TfResourceType`<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateArtifactory.property.tfResourceType"></a>
+##### ~~`TfResourceType`~~<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateArtifactory.property.tfResourceType"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func TfResourceType() *string
@@ -3086,7 +3104,7 @@ cdktf.NewDataTerraformRemoteStateEtcd(scope Construct, id *string, config DataTe
 
 ---
 
-##### `ToString` <a name="ToString" id="cdktf.DataTerraformRemoteStateEtcd.toString"></a>
+##### ~~`ToString`~~ <a name="ToString" id="cdktf.DataTerraformRemoteStateEtcd.toString"></a>
 
 ```go
 func ToString() *string
@@ -3094,7 +3112,7 @@ func ToString() *string
 
 Returns a string representation of this construct.
 
-##### `AddOverride` <a name="AddOverride" id="cdktf.DataTerraformRemoteStateEtcd.addOverride"></a>
+##### ~~`AddOverride`~~ <a name="AddOverride" id="cdktf.DataTerraformRemoteStateEtcd.addOverride"></a>
 
 ```go
 func AddOverride(path *string, value interface{})
@@ -3112,7 +3130,7 @@ func AddOverride(path *string, value interface{})
 
 ---
 
-##### `OverrideLogicalId` <a name="OverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcd.overrideLogicalId"></a>
+##### ~~`OverrideLogicalId`~~ <a name="OverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcd.overrideLogicalId"></a>
 
 ```go
 func OverrideLogicalId(newLogicalId *string)
@@ -3128,7 +3146,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `ResetOverrideLogicalId` <a name="ResetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcd.resetOverrideLogicalId"></a>
+##### ~~`ResetOverrideLogicalId`~~ <a name="ResetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcd.resetOverrideLogicalId"></a>
 
 ```go
 func ResetOverrideLogicalId()
@@ -3136,13 +3154,13 @@ func ResetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `ToMetadata` <a name="ToMetadata" id="cdktf.DataTerraformRemoteStateEtcd.toMetadata"></a>
+##### ~~`ToMetadata`~~ <a name="ToMetadata" id="cdktf.DataTerraformRemoteStateEtcd.toMetadata"></a>
 
 ```go
 func ToMetadata() interface{}
 ```
 
-##### `ToTerraform` <a name="ToTerraform" id="cdktf.DataTerraformRemoteStateEtcd.toTerraform"></a>
+##### ~~`ToTerraform`~~ <a name="ToTerraform" id="cdktf.DataTerraformRemoteStateEtcd.toTerraform"></a>
 
 ```go
 func ToTerraform() interface{}
@@ -3150,7 +3168,7 @@ func ToTerraform() interface{}
 
 Adds this resource to the terraform JSON output.
 
-##### `Get` <a name="Get" id="cdktf.DataTerraformRemoteStateEtcd.get"></a>
+##### ~~`Get`~~ <a name="Get" id="cdktf.DataTerraformRemoteStateEtcd.get"></a>
 
 ```go
 func Get(output *string) IResolvable
@@ -3162,7 +3180,7 @@ func Get(output *string) IResolvable
 
 ---
 
-##### `GetBoolean` <a name="GetBoolean" id="cdktf.DataTerraformRemoteStateEtcd.getBoolean"></a>
+##### ~~`GetBoolean`~~ <a name="GetBoolean" id="cdktf.DataTerraformRemoteStateEtcd.getBoolean"></a>
 
 ```go
 func GetBoolean(output *string) IResolvable
@@ -3174,7 +3192,7 @@ func GetBoolean(output *string) IResolvable
 
 ---
 
-##### `GetList` <a name="GetList" id="cdktf.DataTerraformRemoteStateEtcd.getList"></a>
+##### ~~`GetList`~~ <a name="GetList" id="cdktf.DataTerraformRemoteStateEtcd.getList"></a>
 
 ```go
 func GetList(output *string) *[]*string
@@ -3186,7 +3204,7 @@ func GetList(output *string) *[]*string
 
 ---
 
-##### `GetNumber` <a name="GetNumber" id="cdktf.DataTerraformRemoteStateEtcd.getNumber"></a>
+##### ~~`GetNumber`~~ <a name="GetNumber" id="cdktf.DataTerraformRemoteStateEtcd.getNumber"></a>
 
 ```go
 func GetNumber(output *string) *f64
@@ -3198,7 +3216,7 @@ func GetNumber(output *string) *f64
 
 ---
 
-##### `GetString` <a name="GetString" id="cdktf.DataTerraformRemoteStateEtcd.getString"></a>
+##### ~~`GetString`~~ <a name="GetString" id="cdktf.DataTerraformRemoteStateEtcd.getString"></a>
 
 ```go
 func GetString(output *string) *string
@@ -3219,7 +3237,7 @@ func GetString(output *string) *string
 
 ---
 
-##### `IsConstruct` <a name="IsConstruct" id="cdktf.DataTerraformRemoteStateEtcd.isConstruct"></a>
+##### ~~`IsConstruct`~~ <a name="IsConstruct" id="cdktf.DataTerraformRemoteStateEtcd.isConstruct"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -3251,7 +3269,7 @@ Any object.
 
 ---
 
-##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateEtcd.isTerraformElement"></a>
+##### ~~`IsTerraformElement`~~ <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateEtcd.isTerraformElement"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -3276,7 +3294,9 @@ cdktf.DataTerraformRemoteStateEtcd_IsTerraformElement(x interface{}) *bool
 
 ---
 
-##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateEtcd.property.node"></a>
+##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateEtcd.property.node"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func Node() Node
@@ -3288,7 +3308,9 @@ The tree node.
 
 ---
 
-##### `CdktfStack`<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateEtcd.property.cdktfStack"></a>
+##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateEtcd.property.cdktfStack"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func CdktfStack() TerraformStack
@@ -3298,7 +3320,9 @@ func CdktfStack() TerraformStack
 
 ---
 
-##### `Fqn`<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateEtcd.property.fqn"></a>
+##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateEtcd.property.fqn"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func Fqn() *string
@@ -3308,7 +3332,9 @@ func Fqn() *string
 
 ---
 
-##### `FriendlyUniqueId`<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcd.property.friendlyUniqueId"></a>
+##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcd.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func FriendlyUniqueId() *string
@@ -3326,7 +3352,9 @@ func FriendlyUniqueId() *string
 
 ---
 
-##### `TfResourceType`<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateEtcd.property.tfResourceType"></a>
+##### ~~`TfResourceType`~~<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateEtcd.property.tfResourceType"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func TfResourceType() *string
@@ -3390,7 +3418,7 @@ cdktf.NewDataTerraformRemoteStateEtcdV3(scope Construct, id *string, config Data
 
 ---
 
-##### `ToString` <a name="ToString" id="cdktf.DataTerraformRemoteStateEtcdV3.toString"></a>
+##### ~~`ToString`~~ <a name="ToString" id="cdktf.DataTerraformRemoteStateEtcdV3.toString"></a>
 
 ```go
 func ToString() *string
@@ -3398,7 +3426,7 @@ func ToString() *string
 
 Returns a string representation of this construct.
 
-##### `AddOverride` <a name="AddOverride" id="cdktf.DataTerraformRemoteStateEtcdV3.addOverride"></a>
+##### ~~`AddOverride`~~ <a name="AddOverride" id="cdktf.DataTerraformRemoteStateEtcdV3.addOverride"></a>
 
 ```go
 func AddOverride(path *string, value interface{})
@@ -3416,7 +3444,7 @@ func AddOverride(path *string, value interface{})
 
 ---
 
-##### `OverrideLogicalId` <a name="OverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcdV3.overrideLogicalId"></a>
+##### ~~`OverrideLogicalId`~~ <a name="OverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcdV3.overrideLogicalId"></a>
 
 ```go
 func OverrideLogicalId(newLogicalId *string)
@@ -3432,7 +3460,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `ResetOverrideLogicalId` <a name="ResetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcdV3.resetOverrideLogicalId"></a>
+##### ~~`ResetOverrideLogicalId`~~ <a name="ResetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcdV3.resetOverrideLogicalId"></a>
 
 ```go
 func ResetOverrideLogicalId()
@@ -3440,13 +3468,13 @@ func ResetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `ToMetadata` <a name="ToMetadata" id="cdktf.DataTerraformRemoteStateEtcdV3.toMetadata"></a>
+##### ~~`ToMetadata`~~ <a name="ToMetadata" id="cdktf.DataTerraformRemoteStateEtcdV3.toMetadata"></a>
 
 ```go
 func ToMetadata() interface{}
 ```
 
-##### `ToTerraform` <a name="ToTerraform" id="cdktf.DataTerraformRemoteStateEtcdV3.toTerraform"></a>
+##### ~~`ToTerraform`~~ <a name="ToTerraform" id="cdktf.DataTerraformRemoteStateEtcdV3.toTerraform"></a>
 
 ```go
 func ToTerraform() interface{}
@@ -3454,7 +3482,7 @@ func ToTerraform() interface{}
 
 Adds this resource to the terraform JSON output.
 
-##### `Get` <a name="Get" id="cdktf.DataTerraformRemoteStateEtcdV3.get"></a>
+##### ~~`Get`~~ <a name="Get" id="cdktf.DataTerraformRemoteStateEtcdV3.get"></a>
 
 ```go
 func Get(output *string) IResolvable
@@ -3466,7 +3494,7 @@ func Get(output *string) IResolvable
 
 ---
 
-##### `GetBoolean` <a name="GetBoolean" id="cdktf.DataTerraformRemoteStateEtcdV3.getBoolean"></a>
+##### ~~`GetBoolean`~~ <a name="GetBoolean" id="cdktf.DataTerraformRemoteStateEtcdV3.getBoolean"></a>
 
 ```go
 func GetBoolean(output *string) IResolvable
@@ -3478,7 +3506,7 @@ func GetBoolean(output *string) IResolvable
 
 ---
 
-##### `GetList` <a name="GetList" id="cdktf.DataTerraformRemoteStateEtcdV3.getList"></a>
+##### ~~`GetList`~~ <a name="GetList" id="cdktf.DataTerraformRemoteStateEtcdV3.getList"></a>
 
 ```go
 func GetList(output *string) *[]*string
@@ -3490,7 +3518,7 @@ func GetList(output *string) *[]*string
 
 ---
 
-##### `GetNumber` <a name="GetNumber" id="cdktf.DataTerraformRemoteStateEtcdV3.getNumber"></a>
+##### ~~`GetNumber`~~ <a name="GetNumber" id="cdktf.DataTerraformRemoteStateEtcdV3.getNumber"></a>
 
 ```go
 func GetNumber(output *string) *f64
@@ -3502,7 +3530,7 @@ func GetNumber(output *string) *f64
 
 ---
 
-##### `GetString` <a name="GetString" id="cdktf.DataTerraformRemoteStateEtcdV3.getString"></a>
+##### ~~`GetString`~~ <a name="GetString" id="cdktf.DataTerraformRemoteStateEtcdV3.getString"></a>
 
 ```go
 func GetString(output *string) *string
@@ -3523,7 +3551,7 @@ func GetString(output *string) *string
 
 ---
 
-##### `IsConstruct` <a name="IsConstruct" id="cdktf.DataTerraformRemoteStateEtcdV3.isConstruct"></a>
+##### ~~`IsConstruct`~~ <a name="IsConstruct" id="cdktf.DataTerraformRemoteStateEtcdV3.isConstruct"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -3555,7 +3583,7 @@ Any object.
 
 ---
 
-##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement"></a>
+##### ~~`IsTerraformElement`~~ <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -3580,7 +3608,9 @@ cdktf.DataTerraformRemoteStateEtcdV3_IsTerraformElement(x interface{}) *bool
 
 ---
 
-##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateEtcdV3.property.node"></a>
+##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateEtcdV3.property.node"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func Node() Node
@@ -3592,7 +3622,9 @@ The tree node.
 
 ---
 
-##### `CdktfStack`<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateEtcdV3.property.cdktfStack"></a>
+##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateEtcdV3.property.cdktfStack"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func CdktfStack() TerraformStack
@@ -3602,7 +3634,9 @@ func CdktfStack() TerraformStack
 
 ---
 
-##### `Fqn`<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateEtcdV3.property.fqn"></a>
+##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateEtcdV3.property.fqn"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func Fqn() *string
@@ -3612,7 +3646,9 @@ func Fqn() *string
 
 ---
 
-##### `FriendlyUniqueId`<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcdV3.property.friendlyUniqueId"></a>
+##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcdV3.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func FriendlyUniqueId() *string
@@ -3630,7 +3666,9 @@ func FriendlyUniqueId() *string
 
 ---
 
-##### `TfResourceType`<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateEtcdV3.property.tfResourceType"></a>
+##### ~~`TfResourceType`~~<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateEtcdV3.property.tfResourceType"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func TfResourceType() *string
@@ -4606,7 +4644,7 @@ cdktf.NewDataTerraformRemoteStateManta(scope Construct, id *string, config DataT
 
 ---
 
-##### `ToString` <a name="ToString" id="cdktf.DataTerraformRemoteStateManta.toString"></a>
+##### ~~`ToString`~~ <a name="ToString" id="cdktf.DataTerraformRemoteStateManta.toString"></a>
 
 ```go
 func ToString() *string
@@ -4614,7 +4652,7 @@ func ToString() *string
 
 Returns a string representation of this construct.
 
-##### `AddOverride` <a name="AddOverride" id="cdktf.DataTerraformRemoteStateManta.addOverride"></a>
+##### ~~`AddOverride`~~ <a name="AddOverride" id="cdktf.DataTerraformRemoteStateManta.addOverride"></a>
 
 ```go
 func AddOverride(path *string, value interface{})
@@ -4632,7 +4670,7 @@ func AddOverride(path *string, value interface{})
 
 ---
 
-##### `OverrideLogicalId` <a name="OverrideLogicalId" id="cdktf.DataTerraformRemoteStateManta.overrideLogicalId"></a>
+##### ~~`OverrideLogicalId`~~ <a name="OverrideLogicalId" id="cdktf.DataTerraformRemoteStateManta.overrideLogicalId"></a>
 
 ```go
 func OverrideLogicalId(newLogicalId *string)
@@ -4648,7 +4686,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `ResetOverrideLogicalId` <a name="ResetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateManta.resetOverrideLogicalId"></a>
+##### ~~`ResetOverrideLogicalId`~~ <a name="ResetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateManta.resetOverrideLogicalId"></a>
 
 ```go
 func ResetOverrideLogicalId()
@@ -4656,13 +4694,13 @@ func ResetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `ToMetadata` <a name="ToMetadata" id="cdktf.DataTerraformRemoteStateManta.toMetadata"></a>
+##### ~~`ToMetadata`~~ <a name="ToMetadata" id="cdktf.DataTerraformRemoteStateManta.toMetadata"></a>
 
 ```go
 func ToMetadata() interface{}
 ```
 
-##### `ToTerraform` <a name="ToTerraform" id="cdktf.DataTerraformRemoteStateManta.toTerraform"></a>
+##### ~~`ToTerraform`~~ <a name="ToTerraform" id="cdktf.DataTerraformRemoteStateManta.toTerraform"></a>
 
 ```go
 func ToTerraform() interface{}
@@ -4670,7 +4708,7 @@ func ToTerraform() interface{}
 
 Adds this resource to the terraform JSON output.
 
-##### `Get` <a name="Get" id="cdktf.DataTerraformRemoteStateManta.get"></a>
+##### ~~`Get`~~ <a name="Get" id="cdktf.DataTerraformRemoteStateManta.get"></a>
 
 ```go
 func Get(output *string) IResolvable
@@ -4682,7 +4720,7 @@ func Get(output *string) IResolvable
 
 ---
 
-##### `GetBoolean` <a name="GetBoolean" id="cdktf.DataTerraformRemoteStateManta.getBoolean"></a>
+##### ~~`GetBoolean`~~ <a name="GetBoolean" id="cdktf.DataTerraformRemoteStateManta.getBoolean"></a>
 
 ```go
 func GetBoolean(output *string) IResolvable
@@ -4694,7 +4732,7 @@ func GetBoolean(output *string) IResolvable
 
 ---
 
-##### `GetList` <a name="GetList" id="cdktf.DataTerraformRemoteStateManta.getList"></a>
+##### ~~`GetList`~~ <a name="GetList" id="cdktf.DataTerraformRemoteStateManta.getList"></a>
 
 ```go
 func GetList(output *string) *[]*string
@@ -4706,7 +4744,7 @@ func GetList(output *string) *[]*string
 
 ---
 
-##### `GetNumber` <a name="GetNumber" id="cdktf.DataTerraformRemoteStateManta.getNumber"></a>
+##### ~~`GetNumber`~~ <a name="GetNumber" id="cdktf.DataTerraformRemoteStateManta.getNumber"></a>
 
 ```go
 func GetNumber(output *string) *f64
@@ -4718,7 +4756,7 @@ func GetNumber(output *string) *f64
 
 ---
 
-##### `GetString` <a name="GetString" id="cdktf.DataTerraformRemoteStateManta.getString"></a>
+##### ~~`GetString`~~ <a name="GetString" id="cdktf.DataTerraformRemoteStateManta.getString"></a>
 
 ```go
 func GetString(output *string) *string
@@ -4739,7 +4777,7 @@ func GetString(output *string) *string
 
 ---
 
-##### `IsConstruct` <a name="IsConstruct" id="cdktf.DataTerraformRemoteStateManta.isConstruct"></a>
+##### ~~`IsConstruct`~~ <a name="IsConstruct" id="cdktf.DataTerraformRemoteStateManta.isConstruct"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -4771,7 +4809,7 @@ Any object.
 
 ---
 
-##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateManta.isTerraformElement"></a>
+##### ~~`IsTerraformElement`~~ <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateManta.isTerraformElement"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -4796,7 +4834,9 @@ cdktf.DataTerraformRemoteStateManta_IsTerraformElement(x interface{}) *bool
 
 ---
 
-##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateManta.property.node"></a>
+##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateManta.property.node"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func Node() Node
@@ -4808,7 +4848,9 @@ The tree node.
 
 ---
 
-##### `CdktfStack`<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateManta.property.cdktfStack"></a>
+##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateManta.property.cdktfStack"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func CdktfStack() TerraformStack
@@ -4818,7 +4860,9 @@ func CdktfStack() TerraformStack
 
 ---
 
-##### `Fqn`<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateManta.property.fqn"></a>
+##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateManta.property.fqn"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func Fqn() *string
@@ -4828,7 +4872,9 @@ func Fqn() *string
 
 ---
 
-##### `FriendlyUniqueId`<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateManta.property.friendlyUniqueId"></a>
+##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateManta.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func FriendlyUniqueId() *string
@@ -4846,7 +4892,9 @@ func FriendlyUniqueId() *string
 
 ---
 
-##### `TfResourceType`<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateManta.property.tfResourceType"></a>
+##### ~~`TfResourceType`~~<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateManta.property.tfResourceType"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func TfResourceType() *string
@@ -5822,7 +5870,7 @@ cdktf.NewDataTerraformRemoteStateSwift(scope Construct, id *string, config DataT
 
 ---
 
-##### `ToString` <a name="ToString" id="cdktf.DataTerraformRemoteStateSwift.toString"></a>
+##### ~~`ToString`~~ <a name="ToString" id="cdktf.DataTerraformRemoteStateSwift.toString"></a>
 
 ```go
 func ToString() *string
@@ -5830,7 +5878,7 @@ func ToString() *string
 
 Returns a string representation of this construct.
 
-##### `AddOverride` <a name="AddOverride" id="cdktf.DataTerraformRemoteStateSwift.addOverride"></a>
+##### ~~`AddOverride`~~ <a name="AddOverride" id="cdktf.DataTerraformRemoteStateSwift.addOverride"></a>
 
 ```go
 func AddOverride(path *string, value interface{})
@@ -5848,7 +5896,7 @@ func AddOverride(path *string, value interface{})
 
 ---
 
-##### `OverrideLogicalId` <a name="OverrideLogicalId" id="cdktf.DataTerraformRemoteStateSwift.overrideLogicalId"></a>
+##### ~~`OverrideLogicalId`~~ <a name="OverrideLogicalId" id="cdktf.DataTerraformRemoteStateSwift.overrideLogicalId"></a>
 
 ```go
 func OverrideLogicalId(newLogicalId *string)
@@ -5864,7 +5912,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `ResetOverrideLogicalId` <a name="ResetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateSwift.resetOverrideLogicalId"></a>
+##### ~~`ResetOverrideLogicalId`~~ <a name="ResetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateSwift.resetOverrideLogicalId"></a>
 
 ```go
 func ResetOverrideLogicalId()
@@ -5872,13 +5920,13 @@ func ResetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `ToMetadata` <a name="ToMetadata" id="cdktf.DataTerraformRemoteStateSwift.toMetadata"></a>
+##### ~~`ToMetadata`~~ <a name="ToMetadata" id="cdktf.DataTerraformRemoteStateSwift.toMetadata"></a>
 
 ```go
 func ToMetadata() interface{}
 ```
 
-##### `ToTerraform` <a name="ToTerraform" id="cdktf.DataTerraformRemoteStateSwift.toTerraform"></a>
+##### ~~`ToTerraform`~~ <a name="ToTerraform" id="cdktf.DataTerraformRemoteStateSwift.toTerraform"></a>
 
 ```go
 func ToTerraform() interface{}
@@ -5886,7 +5934,7 @@ func ToTerraform() interface{}
 
 Adds this resource to the terraform JSON output.
 
-##### `Get` <a name="Get" id="cdktf.DataTerraformRemoteStateSwift.get"></a>
+##### ~~`Get`~~ <a name="Get" id="cdktf.DataTerraformRemoteStateSwift.get"></a>
 
 ```go
 func Get(output *string) IResolvable
@@ -5898,7 +5946,7 @@ func Get(output *string) IResolvable
 
 ---
 
-##### `GetBoolean` <a name="GetBoolean" id="cdktf.DataTerraformRemoteStateSwift.getBoolean"></a>
+##### ~~`GetBoolean`~~ <a name="GetBoolean" id="cdktf.DataTerraformRemoteStateSwift.getBoolean"></a>
 
 ```go
 func GetBoolean(output *string) IResolvable
@@ -5910,7 +5958,7 @@ func GetBoolean(output *string) IResolvable
 
 ---
 
-##### `GetList` <a name="GetList" id="cdktf.DataTerraformRemoteStateSwift.getList"></a>
+##### ~~`GetList`~~ <a name="GetList" id="cdktf.DataTerraformRemoteStateSwift.getList"></a>
 
 ```go
 func GetList(output *string) *[]*string
@@ -5922,7 +5970,7 @@ func GetList(output *string) *[]*string
 
 ---
 
-##### `GetNumber` <a name="GetNumber" id="cdktf.DataTerraformRemoteStateSwift.getNumber"></a>
+##### ~~`GetNumber`~~ <a name="GetNumber" id="cdktf.DataTerraformRemoteStateSwift.getNumber"></a>
 
 ```go
 func GetNumber(output *string) *f64
@@ -5934,7 +5982,7 @@ func GetNumber(output *string) *f64
 
 ---
 
-##### `GetString` <a name="GetString" id="cdktf.DataTerraformRemoteStateSwift.getString"></a>
+##### ~~`GetString`~~ <a name="GetString" id="cdktf.DataTerraformRemoteStateSwift.getString"></a>
 
 ```go
 func GetString(output *string) *string
@@ -5955,7 +6003,7 @@ func GetString(output *string) *string
 
 ---
 
-##### `IsConstruct` <a name="IsConstruct" id="cdktf.DataTerraformRemoteStateSwift.isConstruct"></a>
+##### ~~`IsConstruct`~~ <a name="IsConstruct" id="cdktf.DataTerraformRemoteStateSwift.isConstruct"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -5987,7 +6035,7 @@ Any object.
 
 ---
 
-##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateSwift.isTerraformElement"></a>
+##### ~~`IsTerraformElement`~~ <a name="IsTerraformElement" id="cdktf.DataTerraformRemoteStateSwift.isTerraformElement"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -6012,7 +6060,9 @@ cdktf.DataTerraformRemoteStateSwift_IsTerraformElement(x interface{}) *bool
 
 ---
 
-##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateSwift.property.node"></a>
+##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateSwift.property.node"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func Node() Node
@@ -6024,7 +6074,9 @@ The tree node.
 
 ---
 
-##### `CdktfStack`<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateSwift.property.cdktfStack"></a>
+##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateSwift.property.cdktfStack"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func CdktfStack() TerraformStack
@@ -6034,7 +6086,9 @@ func CdktfStack() TerraformStack
 
 ---
 
-##### `Fqn`<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateSwift.property.fqn"></a>
+##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateSwift.property.fqn"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func Fqn() *string
@@ -6044,7 +6098,9 @@ func Fqn() *string
 
 ---
 
-##### `FriendlyUniqueId`<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateSwift.property.friendlyUniqueId"></a>
+##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateSwift.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func FriendlyUniqueId() *string
@@ -6062,7 +6118,9 @@ func FriendlyUniqueId() *string
 
 ---
 
-##### `TfResourceType`<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateSwift.property.tfResourceType"></a>
+##### ~~`TfResourceType`~~<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateSwift.property.tfResourceType"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func TfResourceType() *string
@@ -6115,7 +6173,7 @@ cdktf.NewEtcdBackend(scope Construct, props EtcdBackendProps) EtcdBackend
 
 ---
 
-##### `ToString` <a name="ToString" id="cdktf.EtcdBackend.toString"></a>
+##### ~~`ToString`~~ <a name="ToString" id="cdktf.EtcdBackend.toString"></a>
 
 ```go
 func ToString() *string
@@ -6123,7 +6181,7 @@ func ToString() *string
 
 Returns a string representation of this construct.
 
-##### `AddOverride` <a name="AddOverride" id="cdktf.EtcdBackend.addOverride"></a>
+##### ~~`AddOverride`~~ <a name="AddOverride" id="cdktf.EtcdBackend.addOverride"></a>
 
 ```go
 func AddOverride(path *string, value interface{})
@@ -6141,7 +6199,7 @@ func AddOverride(path *string, value interface{})
 
 ---
 
-##### `OverrideLogicalId` <a name="OverrideLogicalId" id="cdktf.EtcdBackend.overrideLogicalId"></a>
+##### ~~`OverrideLogicalId`~~ <a name="OverrideLogicalId" id="cdktf.EtcdBackend.overrideLogicalId"></a>
 
 ```go
 func OverrideLogicalId(newLogicalId *string)
@@ -6157,7 +6215,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `ResetOverrideLogicalId` <a name="ResetOverrideLogicalId" id="cdktf.EtcdBackend.resetOverrideLogicalId"></a>
+##### ~~`ResetOverrideLogicalId`~~ <a name="ResetOverrideLogicalId" id="cdktf.EtcdBackend.resetOverrideLogicalId"></a>
 
 ```go
 func ResetOverrideLogicalId()
@@ -6165,13 +6223,13 @@ func ResetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `ToMetadata` <a name="ToMetadata" id="cdktf.EtcdBackend.toMetadata"></a>
+##### ~~`ToMetadata`~~ <a name="ToMetadata" id="cdktf.EtcdBackend.toMetadata"></a>
 
 ```go
 func ToMetadata() interface{}
 ```
 
-##### `ToTerraform` <a name="ToTerraform" id="cdktf.EtcdBackend.toTerraform"></a>
+##### ~~`ToTerraform`~~ <a name="ToTerraform" id="cdktf.EtcdBackend.toTerraform"></a>
 
 ```go
 func ToTerraform() interface{}
@@ -6179,7 +6237,7 @@ func ToTerraform() interface{}
 
 Adds this resource to the terraform JSON output.
 
-##### `GetRemoteStateDataSource` <a name="GetRemoteStateDataSource" id="cdktf.EtcdBackend.getRemoteStateDataSource"></a>
+##### ~~`GetRemoteStateDataSource`~~ <a name="GetRemoteStateDataSource" id="cdktf.EtcdBackend.getRemoteStateDataSource"></a>
 
 ```go
 func GetRemoteStateDataSource(scope Construct, name *string, _fromStack *string) TerraformRemoteState
@@ -6215,7 +6273,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `IsConstruct` <a name="IsConstruct" id="cdktf.EtcdBackend.isConstruct"></a>
+##### ~~`IsConstruct`~~ <a name="IsConstruct" id="cdktf.EtcdBackend.isConstruct"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -6247,7 +6305,7 @@ Any object.
 
 ---
 
-##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.EtcdBackend.isTerraformElement"></a>
+##### ~~`IsTerraformElement`~~ <a name="IsTerraformElement" id="cdktf.EtcdBackend.isTerraformElement"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -6261,7 +6319,7 @@ cdktf.EtcdBackend_IsTerraformElement(x interface{}) *bool
 
 ---
 
-##### `IsBackend` <a name="IsBackend" id="cdktf.EtcdBackend.isBackend"></a>
+##### ~~`IsBackend`~~ <a name="IsBackend" id="cdktf.EtcdBackend.isBackend"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -6286,7 +6344,9 @@ cdktf.EtcdBackend_IsBackend(x interface{}) *bool
 
 ---
 
-##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.EtcdBackend.property.node"></a>
+##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.EtcdBackend.property.node"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func Node() Node
@@ -6298,7 +6358,9 @@ The tree node.
 
 ---
 
-##### `CdktfStack`<sup>Required</sup> <a name="CdktfStack" id="cdktf.EtcdBackend.property.cdktfStack"></a>
+##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.EtcdBackend.property.cdktfStack"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func CdktfStack() TerraformStack
@@ -6308,7 +6370,9 @@ func CdktfStack() TerraformStack
 
 ---
 
-##### `Fqn`<sup>Required</sup> <a name="Fqn" id="cdktf.EtcdBackend.property.fqn"></a>
+##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.EtcdBackend.property.fqn"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func Fqn() *string
@@ -6318,7 +6382,9 @@ func Fqn() *string
 
 ---
 
-##### `FriendlyUniqueId`<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.EtcdBackend.property.friendlyUniqueId"></a>
+##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.EtcdBackend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func FriendlyUniqueId() *string
@@ -6371,7 +6437,7 @@ cdktf.NewEtcdV3Backend(scope Construct, props EtcdV3BackendProps) EtcdV3Backend
 
 ---
 
-##### `ToString` <a name="ToString" id="cdktf.EtcdV3Backend.toString"></a>
+##### ~~`ToString`~~ <a name="ToString" id="cdktf.EtcdV3Backend.toString"></a>
 
 ```go
 func ToString() *string
@@ -6379,7 +6445,7 @@ func ToString() *string
 
 Returns a string representation of this construct.
 
-##### `AddOverride` <a name="AddOverride" id="cdktf.EtcdV3Backend.addOverride"></a>
+##### ~~`AddOverride`~~ <a name="AddOverride" id="cdktf.EtcdV3Backend.addOverride"></a>
 
 ```go
 func AddOverride(path *string, value interface{})
@@ -6397,7 +6463,7 @@ func AddOverride(path *string, value interface{})
 
 ---
 
-##### `OverrideLogicalId` <a name="OverrideLogicalId" id="cdktf.EtcdV3Backend.overrideLogicalId"></a>
+##### ~~`OverrideLogicalId`~~ <a name="OverrideLogicalId" id="cdktf.EtcdV3Backend.overrideLogicalId"></a>
 
 ```go
 func OverrideLogicalId(newLogicalId *string)
@@ -6413,7 +6479,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `ResetOverrideLogicalId` <a name="ResetOverrideLogicalId" id="cdktf.EtcdV3Backend.resetOverrideLogicalId"></a>
+##### ~~`ResetOverrideLogicalId`~~ <a name="ResetOverrideLogicalId" id="cdktf.EtcdV3Backend.resetOverrideLogicalId"></a>
 
 ```go
 func ResetOverrideLogicalId()
@@ -6421,13 +6487,13 @@ func ResetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `ToMetadata` <a name="ToMetadata" id="cdktf.EtcdV3Backend.toMetadata"></a>
+##### ~~`ToMetadata`~~ <a name="ToMetadata" id="cdktf.EtcdV3Backend.toMetadata"></a>
 
 ```go
 func ToMetadata() interface{}
 ```
 
-##### `ToTerraform` <a name="ToTerraform" id="cdktf.EtcdV3Backend.toTerraform"></a>
+##### ~~`ToTerraform`~~ <a name="ToTerraform" id="cdktf.EtcdV3Backend.toTerraform"></a>
 
 ```go
 func ToTerraform() interface{}
@@ -6435,7 +6501,7 @@ func ToTerraform() interface{}
 
 Adds this resource to the terraform JSON output.
 
-##### `GetRemoteStateDataSource` <a name="GetRemoteStateDataSource" id="cdktf.EtcdV3Backend.getRemoteStateDataSource"></a>
+##### ~~`GetRemoteStateDataSource`~~ <a name="GetRemoteStateDataSource" id="cdktf.EtcdV3Backend.getRemoteStateDataSource"></a>
 
 ```go
 func GetRemoteStateDataSource(scope Construct, name *string, _fromStack *string) TerraformRemoteState
@@ -6471,7 +6537,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `IsConstruct` <a name="IsConstruct" id="cdktf.EtcdV3Backend.isConstruct"></a>
+##### ~~`IsConstruct`~~ <a name="IsConstruct" id="cdktf.EtcdV3Backend.isConstruct"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -6503,7 +6569,7 @@ Any object.
 
 ---
 
-##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.EtcdV3Backend.isTerraformElement"></a>
+##### ~~`IsTerraformElement`~~ <a name="IsTerraformElement" id="cdktf.EtcdV3Backend.isTerraformElement"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -6517,7 +6583,7 @@ cdktf.EtcdV3Backend_IsTerraformElement(x interface{}) *bool
 
 ---
 
-##### `IsBackend` <a name="IsBackend" id="cdktf.EtcdV3Backend.isBackend"></a>
+##### ~~`IsBackend`~~ <a name="IsBackend" id="cdktf.EtcdV3Backend.isBackend"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -6542,7 +6608,9 @@ cdktf.EtcdV3Backend_IsBackend(x interface{}) *bool
 
 ---
 
-##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.EtcdV3Backend.property.node"></a>
+##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.EtcdV3Backend.property.node"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func Node() Node
@@ -6554,7 +6622,9 @@ The tree node.
 
 ---
 
-##### `CdktfStack`<sup>Required</sup> <a name="CdktfStack" id="cdktf.EtcdV3Backend.property.cdktfStack"></a>
+##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.EtcdV3Backend.property.cdktfStack"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func CdktfStack() TerraformStack
@@ -6564,7 +6634,9 @@ func CdktfStack() TerraformStack
 
 ---
 
-##### `Fqn`<sup>Required</sup> <a name="Fqn" id="cdktf.EtcdV3Backend.property.fqn"></a>
+##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.EtcdV3Backend.property.fqn"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func Fqn() *string
@@ -6574,7 +6646,9 @@ func Fqn() *string
 
 ---
 
-##### `FriendlyUniqueId`<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.EtcdV3Backend.property.friendlyUniqueId"></a>
+##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.EtcdV3Backend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func FriendlyUniqueId() *string
@@ -7395,7 +7469,7 @@ cdktf.NewMantaBackend(scope Construct, props MantaBackendProps) MantaBackend
 
 ---
 
-##### `ToString` <a name="ToString" id="cdktf.MantaBackend.toString"></a>
+##### ~~`ToString`~~ <a name="ToString" id="cdktf.MantaBackend.toString"></a>
 
 ```go
 func ToString() *string
@@ -7403,7 +7477,7 @@ func ToString() *string
 
 Returns a string representation of this construct.
 
-##### `AddOverride` <a name="AddOverride" id="cdktf.MantaBackend.addOverride"></a>
+##### ~~`AddOverride`~~ <a name="AddOverride" id="cdktf.MantaBackend.addOverride"></a>
 
 ```go
 func AddOverride(path *string, value interface{})
@@ -7421,7 +7495,7 @@ func AddOverride(path *string, value interface{})
 
 ---
 
-##### `OverrideLogicalId` <a name="OverrideLogicalId" id="cdktf.MantaBackend.overrideLogicalId"></a>
+##### ~~`OverrideLogicalId`~~ <a name="OverrideLogicalId" id="cdktf.MantaBackend.overrideLogicalId"></a>
 
 ```go
 func OverrideLogicalId(newLogicalId *string)
@@ -7437,7 +7511,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `ResetOverrideLogicalId` <a name="ResetOverrideLogicalId" id="cdktf.MantaBackend.resetOverrideLogicalId"></a>
+##### ~~`ResetOverrideLogicalId`~~ <a name="ResetOverrideLogicalId" id="cdktf.MantaBackend.resetOverrideLogicalId"></a>
 
 ```go
 func ResetOverrideLogicalId()
@@ -7445,13 +7519,13 @@ func ResetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `ToMetadata` <a name="ToMetadata" id="cdktf.MantaBackend.toMetadata"></a>
+##### ~~`ToMetadata`~~ <a name="ToMetadata" id="cdktf.MantaBackend.toMetadata"></a>
 
 ```go
 func ToMetadata() interface{}
 ```
 
-##### `ToTerraform` <a name="ToTerraform" id="cdktf.MantaBackend.toTerraform"></a>
+##### ~~`ToTerraform`~~ <a name="ToTerraform" id="cdktf.MantaBackend.toTerraform"></a>
 
 ```go
 func ToTerraform() interface{}
@@ -7459,7 +7533,7 @@ func ToTerraform() interface{}
 
 Adds this resource to the terraform JSON output.
 
-##### `GetRemoteStateDataSource` <a name="GetRemoteStateDataSource" id="cdktf.MantaBackend.getRemoteStateDataSource"></a>
+##### ~~`GetRemoteStateDataSource`~~ <a name="GetRemoteStateDataSource" id="cdktf.MantaBackend.getRemoteStateDataSource"></a>
 
 ```go
 func GetRemoteStateDataSource(scope Construct, name *string, _fromStack *string) TerraformRemoteState
@@ -7495,7 +7569,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `IsConstruct` <a name="IsConstruct" id="cdktf.MantaBackend.isConstruct"></a>
+##### ~~`IsConstruct`~~ <a name="IsConstruct" id="cdktf.MantaBackend.isConstruct"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -7527,7 +7601,7 @@ Any object.
 
 ---
 
-##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.MantaBackend.isTerraformElement"></a>
+##### ~~`IsTerraformElement`~~ <a name="IsTerraformElement" id="cdktf.MantaBackend.isTerraformElement"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -7541,7 +7615,7 @@ cdktf.MantaBackend_IsTerraformElement(x interface{}) *bool
 
 ---
 
-##### `IsBackend` <a name="IsBackend" id="cdktf.MantaBackend.isBackend"></a>
+##### ~~`IsBackend`~~ <a name="IsBackend" id="cdktf.MantaBackend.isBackend"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -7566,7 +7640,9 @@ cdktf.MantaBackend_IsBackend(x interface{}) *bool
 
 ---
 
-##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.MantaBackend.property.node"></a>
+##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.MantaBackend.property.node"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func Node() Node
@@ -7578,7 +7654,9 @@ The tree node.
 
 ---
 
-##### `CdktfStack`<sup>Required</sup> <a name="CdktfStack" id="cdktf.MantaBackend.property.cdktfStack"></a>
+##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.MantaBackend.property.cdktfStack"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func CdktfStack() TerraformStack
@@ -7588,7 +7666,9 @@ func CdktfStack() TerraformStack
 
 ---
 
-##### `Fqn`<sup>Required</sup> <a name="Fqn" id="cdktf.MantaBackend.property.fqn"></a>
+##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.MantaBackend.property.fqn"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func Fqn() *string
@@ -7598,7 +7678,9 @@ func Fqn() *string
 
 ---
 
-##### `FriendlyUniqueId`<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.MantaBackend.property.friendlyUniqueId"></a>
+##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.MantaBackend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func FriendlyUniqueId() *string
@@ -8801,7 +8883,7 @@ cdktf.NewSwiftBackend(scope Construct, props SwiftBackendProps) SwiftBackend
 
 ---
 
-##### `ToString` <a name="ToString" id="cdktf.SwiftBackend.toString"></a>
+##### ~~`ToString`~~ <a name="ToString" id="cdktf.SwiftBackend.toString"></a>
 
 ```go
 func ToString() *string
@@ -8809,7 +8891,7 @@ func ToString() *string
 
 Returns a string representation of this construct.
 
-##### `AddOverride` <a name="AddOverride" id="cdktf.SwiftBackend.addOverride"></a>
+##### ~~`AddOverride`~~ <a name="AddOverride" id="cdktf.SwiftBackend.addOverride"></a>
 
 ```go
 func AddOverride(path *string, value interface{})
@@ -8827,7 +8909,7 @@ func AddOverride(path *string, value interface{})
 
 ---
 
-##### `OverrideLogicalId` <a name="OverrideLogicalId" id="cdktf.SwiftBackend.overrideLogicalId"></a>
+##### ~~`OverrideLogicalId`~~ <a name="OverrideLogicalId" id="cdktf.SwiftBackend.overrideLogicalId"></a>
 
 ```go
 func OverrideLogicalId(newLogicalId *string)
@@ -8843,7 +8925,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `ResetOverrideLogicalId` <a name="ResetOverrideLogicalId" id="cdktf.SwiftBackend.resetOverrideLogicalId"></a>
+##### ~~`ResetOverrideLogicalId`~~ <a name="ResetOverrideLogicalId" id="cdktf.SwiftBackend.resetOverrideLogicalId"></a>
 
 ```go
 func ResetOverrideLogicalId()
@@ -8851,13 +8933,13 @@ func ResetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `ToMetadata` <a name="ToMetadata" id="cdktf.SwiftBackend.toMetadata"></a>
+##### ~~`ToMetadata`~~ <a name="ToMetadata" id="cdktf.SwiftBackend.toMetadata"></a>
 
 ```go
 func ToMetadata() interface{}
 ```
 
-##### `ToTerraform` <a name="ToTerraform" id="cdktf.SwiftBackend.toTerraform"></a>
+##### ~~`ToTerraform`~~ <a name="ToTerraform" id="cdktf.SwiftBackend.toTerraform"></a>
 
 ```go
 func ToTerraform() interface{}
@@ -8865,7 +8947,7 @@ func ToTerraform() interface{}
 
 Adds this resource to the terraform JSON output.
 
-##### `GetRemoteStateDataSource` <a name="GetRemoteStateDataSource" id="cdktf.SwiftBackend.getRemoteStateDataSource"></a>
+##### ~~`GetRemoteStateDataSource`~~ <a name="GetRemoteStateDataSource" id="cdktf.SwiftBackend.getRemoteStateDataSource"></a>
 
 ```go
 func GetRemoteStateDataSource(scope Construct, name *string, _fromStack *string) TerraformRemoteState
@@ -8901,7 +8983,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `IsConstruct` <a name="IsConstruct" id="cdktf.SwiftBackend.isConstruct"></a>
+##### ~~`IsConstruct`~~ <a name="IsConstruct" id="cdktf.SwiftBackend.isConstruct"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -8933,7 +9015,7 @@ Any object.
 
 ---
 
-##### `IsTerraformElement` <a name="IsTerraformElement" id="cdktf.SwiftBackend.isTerraformElement"></a>
+##### ~~`IsTerraformElement`~~ <a name="IsTerraformElement" id="cdktf.SwiftBackend.isTerraformElement"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -8947,7 +9029,7 @@ cdktf.SwiftBackend_IsTerraformElement(x interface{}) *bool
 
 ---
 
-##### `IsBackend` <a name="IsBackend" id="cdktf.SwiftBackend.isBackend"></a>
+##### ~~`IsBackend`~~ <a name="IsBackend" id="cdktf.SwiftBackend.isBackend"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
@@ -8972,7 +9054,9 @@ cdktf.SwiftBackend_IsBackend(x interface{}) *bool
 
 ---
 
-##### `Node`<sup>Required</sup> <a name="Node" id="cdktf.SwiftBackend.property.node"></a>
+##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.SwiftBackend.property.node"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func Node() Node
@@ -8984,7 +9068,9 @@ The tree node.
 
 ---
 
-##### `CdktfStack`<sup>Required</sup> <a name="CdktfStack" id="cdktf.SwiftBackend.property.cdktfStack"></a>
+##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.SwiftBackend.property.cdktfStack"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func CdktfStack() TerraformStack
@@ -8994,7 +9080,9 @@ func CdktfStack() TerraformStack
 
 ---
 
-##### `Fqn`<sup>Required</sup> <a name="Fqn" id="cdktf.SwiftBackend.property.fqn"></a>
+##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.SwiftBackend.property.fqn"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func Fqn() *string
@@ -9004,7 +9092,9 @@ func Fqn() *string
 
 ---
 
-##### `FriendlyUniqueId`<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.SwiftBackend.property.friendlyUniqueId"></a>
+##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.SwiftBackend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 func FriendlyUniqueId() *string
@@ -13253,7 +13343,9 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 ---
 
-##### `Password`<sup>Required</sup> <a name="Password" id="cdktf.ArtifactoryBackendProps.property.password"></a>
+##### ~~`Password`~~<sup>Required</sup> <a name="Password" id="cdktf.ArtifactoryBackendProps.property.password"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Password *string
@@ -13265,7 +13357,9 @@ Password *string
 
 ---
 
-##### `Repo`<sup>Required</sup> <a name="Repo" id="cdktf.ArtifactoryBackendProps.property.repo"></a>
+##### ~~`Repo`~~<sup>Required</sup> <a name="Repo" id="cdktf.ArtifactoryBackendProps.property.repo"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Repo *string
@@ -13277,7 +13371,9 @@ Repo *string
 
 ---
 
-##### `Subpath`<sup>Required</sup> <a name="Subpath" id="cdktf.ArtifactoryBackendProps.property.subpath"></a>
+##### ~~`Subpath`~~<sup>Required</sup> <a name="Subpath" id="cdktf.ArtifactoryBackendProps.property.subpath"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Subpath *string
@@ -13289,7 +13385,9 @@ Subpath *string
 
 ---
 
-##### `Url`<sup>Required</sup> <a name="Url" id="cdktf.ArtifactoryBackendProps.property.url"></a>
+##### ~~`Url`~~<sup>Required</sup> <a name="Url" id="cdktf.ArtifactoryBackendProps.property.url"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Url *string
@@ -13303,7 +13401,9 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ---
 
-##### `Username`<sup>Required</sup> <a name="Username" id="cdktf.ArtifactoryBackendProps.property.username"></a>
+##### ~~`Username`~~<sup>Required</sup> <a name="Username" id="cdktf.ArtifactoryBackendProps.property.username"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Username *string
@@ -14166,7 +14266,9 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 ---
 
-##### `Defaults`<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.defaults"></a>
+##### ~~`Defaults`~~<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.defaults"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Defaults *map[string]interface{}
@@ -14176,7 +14278,9 @@ Defaults *map[string]interface{}
 
 ---
 
-##### `Workspace`<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.workspace"></a>
+##### ~~`Workspace`~~<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.workspace"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Workspace *string
@@ -14186,7 +14290,9 @@ Workspace *string
 
 ---
 
-##### `Password`<sup>Required</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.password"></a>
+##### ~~`Password`~~<sup>Required</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.password"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Password *string
@@ -14198,7 +14304,9 @@ Password *string
 
 ---
 
-##### `Repo`<sup>Required</sup> <a name="Repo" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.repo"></a>
+##### ~~`Repo`~~<sup>Required</sup> <a name="Repo" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.repo"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Repo *string
@@ -14210,7 +14318,9 @@ Repo *string
 
 ---
 
-##### `Subpath`<sup>Required</sup> <a name="Subpath" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.subpath"></a>
+##### ~~`Subpath`~~<sup>Required</sup> <a name="Subpath" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.subpath"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Subpath *string
@@ -14222,7 +14332,9 @@ Subpath *string
 
 ---
 
-##### `Url`<sup>Required</sup> <a name="Url" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.url"></a>
+##### ~~`Url`~~<sup>Required</sup> <a name="Url" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.url"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Url *string
@@ -14236,7 +14348,9 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ---
 
-##### `Username`<sup>Required</sup> <a name="Username" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.username"></a>
+##### ~~`Username`~~<sup>Required</sup> <a name="Username" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.username"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Username *string
@@ -15101,7 +15215,9 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 ---
 
-##### `Defaults`<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.defaults"></a>
+##### ~~`Defaults`~~<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.defaults"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Defaults *map[string]interface{}
@@ -15111,7 +15227,9 @@ Defaults *map[string]interface{}
 
 ---
 
-##### `Workspace`<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.workspace"></a>
+##### ~~`Workspace`~~<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.workspace"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Workspace *string
@@ -15121,7 +15239,9 @@ Workspace *string
 
 ---
 
-##### `Endpoints`<sup>Required</sup> <a name="Endpoints" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.endpoints"></a>
+##### ~~`Endpoints`~~<sup>Required</sup> <a name="Endpoints" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.endpoints"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Endpoints *string
@@ -15133,7 +15253,9 @@ Endpoints *string
 
 ---
 
-##### `Path`<sup>Required</sup> <a name="Path" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.path"></a>
+##### ~~`Path`~~<sup>Required</sup> <a name="Path" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.path"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Path *string
@@ -15145,7 +15267,9 @@ Path *string
 
 ---
 
-##### `Password`<sup>Optional</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.password"></a>
+##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.password"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Password *string
@@ -15157,7 +15281,9 @@ Password *string
 
 ---
 
-##### `Username`<sup>Optional</sup> <a name="Username" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.username"></a>
+##### ~~`Username`~~<sup>Optional</sup> <a name="Username" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.username"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Username *string
@@ -15207,7 +15333,9 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 ---
 
-##### `Defaults`<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.defaults"></a>
+##### ~~`Defaults`~~<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.defaults"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Defaults *map[string]interface{}
@@ -15217,7 +15345,9 @@ Defaults *map[string]interface{}
 
 ---
 
-##### `Workspace`<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.workspace"></a>
+##### ~~`Workspace`~~<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.workspace"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Workspace *string
@@ -15227,7 +15357,9 @@ Workspace *string
 
 ---
 
-##### `Endpoints`<sup>Required</sup> <a name="Endpoints" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.endpoints"></a>
+##### ~~`Endpoints`~~<sup>Required</sup> <a name="Endpoints" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.endpoints"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Endpoints *[]*string
@@ -15239,7 +15371,9 @@ Endpoints *[]*string
 
 ---
 
-##### `CacertPath`<sup>Optional</sup> <a name="CacertPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.cacertPath"></a>
+##### ~~`CacertPath`~~<sup>Optional</sup> <a name="CacertPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.cacertPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 CacertPath *string
@@ -15251,7 +15385,9 @@ CacertPath *string
 
 ---
 
-##### `CertPath`<sup>Optional</sup> <a name="CertPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.certPath"></a>
+##### ~~`CertPath`~~<sup>Optional</sup> <a name="CertPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.certPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 CertPath *string
@@ -15263,7 +15399,9 @@ CertPath *string
 
 ---
 
-##### `KeyPath`<sup>Optional</sup> <a name="KeyPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.keyPath"></a>
+##### ~~`KeyPath`~~<sup>Optional</sup> <a name="KeyPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.keyPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 KeyPath *string
@@ -15275,7 +15413,9 @@ KeyPath *string
 
 ---
 
-##### `Lock`<sup>Optional</sup> <a name="Lock" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.lock"></a>
+##### ~~`Lock`~~<sup>Optional</sup> <a name="Lock" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.lock"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Lock *bool
@@ -15289,7 +15429,9 @@ Defaults to true.
 
 ---
 
-##### `Password`<sup>Optional</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.password"></a>
+##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.password"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Password *string
@@ -15301,7 +15443,9 @@ Password *string
 
 ---
 
-##### `Prefix`<sup>Optional</sup> <a name="Prefix" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.prefix"></a>
+##### ~~`Prefix`~~<sup>Optional</sup> <a name="Prefix" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.prefix"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Prefix *string
@@ -15315,7 +15459,9 @@ Defaults to "".
 
 ---
 
-##### `Username`<sup>Optional</sup> <a name="Username" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.username"></a>
+##### ~~`Username`~~<sup>Optional</sup> <a name="Username" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.username"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Username *string
@@ -15818,7 +15964,9 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 ---
 
-##### `Defaults`<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateMantaConfig.property.defaults"></a>
+##### ~~`Defaults`~~<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateMantaConfig.property.defaults"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Defaults *map[string]interface{}
@@ -15828,7 +15976,9 @@ Defaults *map[string]interface{}
 
 ---
 
-##### `Workspace`<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateMantaConfig.property.workspace"></a>
+##### ~~`Workspace`~~<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateMantaConfig.property.workspace"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Workspace *string
@@ -15838,7 +15988,9 @@ Workspace *string
 
 ---
 
-##### `Account`<sup>Required</sup> <a name="Account" id="cdktf.DataTerraformRemoteStateMantaConfig.property.account"></a>
+##### ~~`Account`~~<sup>Required</sup> <a name="Account" id="cdktf.DataTerraformRemoteStateMantaConfig.property.account"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Account *string
@@ -15848,7 +16000,9 @@ Account *string
 
 ---
 
-##### `KeyId`<sup>Required</sup> <a name="KeyId" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyId"></a>
+##### ~~`KeyId`~~<sup>Required</sup> <a name="KeyId" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 KeyId *string
@@ -15858,7 +16012,9 @@ KeyId *string
 
 ---
 
-##### `Path`<sup>Required</sup> <a name="Path" id="cdktf.DataTerraformRemoteStateMantaConfig.property.path"></a>
+##### ~~`Path`~~<sup>Required</sup> <a name="Path" id="cdktf.DataTerraformRemoteStateMantaConfig.property.path"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Path *string
@@ -15868,7 +16024,9 @@ Path *string
 
 ---
 
-##### `InsecureSkipTlsVerify`<sup>Optional</sup> <a name="InsecureSkipTlsVerify" id="cdktf.DataTerraformRemoteStateMantaConfig.property.insecureSkipTlsVerify"></a>
+##### ~~`InsecureSkipTlsVerify`~~<sup>Optional</sup> <a name="InsecureSkipTlsVerify" id="cdktf.DataTerraformRemoteStateMantaConfig.property.insecureSkipTlsVerify"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 InsecureSkipTlsVerify *bool
@@ -15878,7 +16036,9 @@ InsecureSkipTlsVerify *bool
 
 ---
 
-##### `KeyMaterial`<sup>Optional</sup> <a name="KeyMaterial" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyMaterial"></a>
+##### ~~`KeyMaterial`~~<sup>Optional</sup> <a name="KeyMaterial" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyMaterial"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 KeyMaterial *string
@@ -15888,7 +16048,9 @@ KeyMaterial *string
 
 ---
 
-##### `ObjectName`<sup>Optional</sup> <a name="ObjectName" id="cdktf.DataTerraformRemoteStateMantaConfig.property.objectName"></a>
+##### ~~`ObjectName`~~<sup>Optional</sup> <a name="ObjectName" id="cdktf.DataTerraformRemoteStateMantaConfig.property.objectName"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 ObjectName *string
@@ -15898,7 +16060,9 @@ ObjectName *string
 
 ---
 
-##### `Url`<sup>Optional</sup> <a name="Url" id="cdktf.DataTerraformRemoteStateMantaConfig.property.url"></a>
+##### ~~`Url`~~<sup>Optional</sup> <a name="Url" id="cdktf.DataTerraformRemoteStateMantaConfig.property.url"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Url *string
@@ -15908,7 +16072,9 @@ Url *string
 
 ---
 
-##### `User`<sup>Optional</sup> <a name="User" id="cdktf.DataTerraformRemoteStateMantaConfig.property.user"></a>
+##### ~~`User`~~<sup>Optional</sup> <a name="User" id="cdktf.DataTerraformRemoteStateMantaConfig.property.user"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 User *string
@@ -16903,7 +17069,9 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 ---
 
-##### `Defaults`<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaults"></a>
+##### ~~`Defaults`~~<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaults"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Defaults *map[string]interface{}
@@ -16913,7 +17081,9 @@ Defaults *map[string]interface{}
 
 ---
 
-##### `Workspace`<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.workspace"></a>
+##### ~~`Workspace`~~<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.workspace"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Workspace *string
@@ -16923,7 +17093,9 @@ Workspace *string
 
 ---
 
-##### `Container`<sup>Required</sup> <a name="Container" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.container"></a>
+##### ~~`Container`~~<sup>Required</sup> <a name="Container" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.container"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Container *string
@@ -16933,7 +17105,9 @@ Container *string
 
 ---
 
-##### `ApplicationCredentialId`<sup>Optional</sup> <a name="ApplicationCredentialId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialId"></a>
+##### ~~`ApplicationCredentialId`~~<sup>Optional</sup> <a name="ApplicationCredentialId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 ApplicationCredentialId *string
@@ -16943,7 +17117,9 @@ ApplicationCredentialId *string
 
 ---
 
-##### `ApplicationCredentialName`<sup>Optional</sup> <a name="ApplicationCredentialName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialName"></a>
+##### ~~`ApplicationCredentialName`~~<sup>Optional</sup> <a name="ApplicationCredentialName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 ApplicationCredentialName *string
@@ -16953,7 +17129,9 @@ ApplicationCredentialName *string
 
 ---
 
-##### `ApplicationCredentialSecret`<sup>Optional</sup> <a name="ApplicationCredentialSecret" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialSecret"></a>
+##### ~~`ApplicationCredentialSecret`~~<sup>Optional</sup> <a name="ApplicationCredentialSecret" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialSecret"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 ApplicationCredentialSecret *string
@@ -16963,7 +17141,9 @@ ApplicationCredentialSecret *string
 
 ---
 
-##### `ArchiveContainer`<sup>Optional</sup> <a name="ArchiveContainer" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.archiveContainer"></a>
+##### ~~`ArchiveContainer`~~<sup>Optional</sup> <a name="ArchiveContainer" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.archiveContainer"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 ArchiveContainer *string
@@ -16973,7 +17153,9 @@ ArchiveContainer *string
 
 ---
 
-##### `AuthUrl`<sup>Optional</sup> <a name="AuthUrl" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.authUrl"></a>
+##### ~~`AuthUrl`~~<sup>Optional</sup> <a name="AuthUrl" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.authUrl"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 AuthUrl *string
@@ -16983,7 +17165,9 @@ AuthUrl *string
 
 ---
 
-##### `CacertFile`<sup>Optional</sup> <a name="CacertFile" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cacertFile"></a>
+##### ~~`CacertFile`~~<sup>Optional</sup> <a name="CacertFile" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cacertFile"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 CacertFile *string
@@ -16993,7 +17177,9 @@ CacertFile *string
 
 ---
 
-##### `Cert`<sup>Optional</sup> <a name="Cert" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cert"></a>
+##### ~~`Cert`~~<sup>Optional</sup> <a name="Cert" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cert"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Cert *string
@@ -17003,7 +17189,9 @@ Cert *string
 
 ---
 
-##### `Cloud`<sup>Optional</sup> <a name="Cloud" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cloud"></a>
+##### ~~`Cloud`~~<sup>Optional</sup> <a name="Cloud" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cloud"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Cloud *string
@@ -17013,7 +17201,9 @@ Cloud *string
 
 ---
 
-##### `DefaultDomain`<sup>Optional</sup> <a name="DefaultDomain" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaultDomain"></a>
+##### ~~`DefaultDomain`~~<sup>Optional</sup> <a name="DefaultDomain" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaultDomain"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 DefaultDomain *string
@@ -17023,7 +17213,9 @@ DefaultDomain *string
 
 ---
 
-##### `DomainId`<sup>Optional</sup> <a name="DomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainId"></a>
+##### ~~`DomainId`~~<sup>Optional</sup> <a name="DomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 DomainId *string
@@ -17033,7 +17225,9 @@ DomainId *string
 
 ---
 
-##### `DomainName`<sup>Optional</sup> <a name="DomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainName"></a>
+##### ~~`DomainName`~~<sup>Optional</sup> <a name="DomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 DomainName *string
@@ -17043,7 +17237,9 @@ DomainName *string
 
 ---
 
-##### `ExpireAfter`<sup>Optional</sup> <a name="ExpireAfter" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.expireAfter"></a>
+##### ~~`ExpireAfter`~~<sup>Optional</sup> <a name="ExpireAfter" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.expireAfter"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 ExpireAfter *string
@@ -17053,7 +17249,9 @@ ExpireAfter *string
 
 ---
 
-##### `Insecure`<sup>Optional</sup> <a name="Insecure" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.insecure"></a>
+##### ~~`Insecure`~~<sup>Optional</sup> <a name="Insecure" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.insecure"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Insecure *bool
@@ -17063,7 +17261,9 @@ Insecure *bool
 
 ---
 
-##### `Key`<sup>Optional</sup> <a name="Key" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.key"></a>
+##### ~~`Key`~~<sup>Optional</sup> <a name="Key" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.key"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Key *string
@@ -17073,7 +17273,9 @@ Key *string
 
 ---
 
-##### `Password`<sup>Optional</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.password"></a>
+##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.password"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Password *string
@@ -17083,7 +17285,9 @@ Password *string
 
 ---
 
-##### `ProjectDomainId`<sup>Optional</sup> <a name="ProjectDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainId"></a>
+##### ~~`ProjectDomainId`~~<sup>Optional</sup> <a name="ProjectDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 ProjectDomainId *string
@@ -17093,7 +17297,9 @@ ProjectDomainId *string
 
 ---
 
-##### `ProjectDomainName`<sup>Optional</sup> <a name="ProjectDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainName"></a>
+##### ~~`ProjectDomainName`~~<sup>Optional</sup> <a name="ProjectDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 ProjectDomainName *string
@@ -17103,7 +17309,9 @@ ProjectDomainName *string
 
 ---
 
-##### `RegionName`<sup>Optional</sup> <a name="RegionName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.regionName"></a>
+##### ~~`RegionName`~~<sup>Optional</sup> <a name="RegionName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.regionName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 RegionName *string
@@ -17113,7 +17321,9 @@ RegionName *string
 
 ---
 
-##### `StateName`<sup>Optional</sup> <a name="StateName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.stateName"></a>
+##### ~~`StateName`~~<sup>Optional</sup> <a name="StateName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.stateName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 StateName *string
@@ -17123,7 +17333,9 @@ StateName *string
 
 ---
 
-##### `TenantId`<sup>Optional</sup> <a name="TenantId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantId"></a>
+##### ~~`TenantId`~~<sup>Optional</sup> <a name="TenantId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 TenantId *string
@@ -17133,7 +17345,9 @@ TenantId *string
 
 ---
 
-##### `TenantName`<sup>Optional</sup> <a name="TenantName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantName"></a>
+##### ~~`TenantName`~~<sup>Optional</sup> <a name="TenantName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 TenantName *string
@@ -17143,7 +17357,9 @@ TenantName *string
 
 ---
 
-##### `Token`<sup>Optional</sup> <a name="Token" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.token"></a>
+##### ~~`Token`~~<sup>Optional</sup> <a name="Token" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.token"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Token *string
@@ -17153,7 +17369,9 @@ Token *string
 
 ---
 
-##### `UserDomainId`<sup>Optional</sup> <a name="UserDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainId"></a>
+##### ~~`UserDomainId`~~<sup>Optional</sup> <a name="UserDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 UserDomainId *string
@@ -17163,7 +17381,9 @@ UserDomainId *string
 
 ---
 
-##### `UserDomainName`<sup>Optional</sup> <a name="UserDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainName"></a>
+##### ~~`UserDomainName`~~<sup>Optional</sup> <a name="UserDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 UserDomainName *string
@@ -17173,7 +17393,9 @@ UserDomainName *string
 
 ---
 
-##### `UserId`<sup>Optional</sup> <a name="UserId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userId"></a>
+##### ~~`UserId`~~<sup>Optional</sup> <a name="UserId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 UserId *string
@@ -17183,7 +17405,9 @@ UserId *string
 
 ---
 
-##### `UserName`<sup>Optional</sup> <a name="UserName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userName"></a>
+##### ~~`UserName`~~<sup>Optional</sup> <a name="UserName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 UserName *string
@@ -17261,7 +17485,9 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 ---
 
-##### `Endpoints`<sup>Required</sup> <a name="Endpoints" id="cdktf.EtcdBackendProps.property.endpoints"></a>
+##### ~~`Endpoints`~~<sup>Required</sup> <a name="Endpoints" id="cdktf.EtcdBackendProps.property.endpoints"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Endpoints *string
@@ -17273,7 +17499,9 @@ Endpoints *string
 
 ---
 
-##### `Path`<sup>Required</sup> <a name="Path" id="cdktf.EtcdBackendProps.property.path"></a>
+##### ~~`Path`~~<sup>Required</sup> <a name="Path" id="cdktf.EtcdBackendProps.property.path"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Path *string
@@ -17285,7 +17513,9 @@ Path *string
 
 ---
 
-##### `Password`<sup>Optional</sup> <a name="Password" id="cdktf.EtcdBackendProps.property.password"></a>
+##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.EtcdBackendProps.property.password"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Password *string
@@ -17297,7 +17527,9 @@ Password *string
 
 ---
 
-##### `Username`<sup>Optional</sup> <a name="Username" id="cdktf.EtcdBackendProps.property.username"></a>
+##### ~~`Username`~~<sup>Optional</sup> <a name="Username" id="cdktf.EtcdBackendProps.property.username"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Username *string
@@ -17350,7 +17582,9 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 ---
 
-##### `Endpoints`<sup>Required</sup> <a name="Endpoints" id="cdktf.EtcdV3BackendProps.property.endpoints"></a>
+##### ~~`Endpoints`~~<sup>Required</sup> <a name="Endpoints" id="cdktf.EtcdV3BackendProps.property.endpoints"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Endpoints *[]*string
@@ -17362,7 +17596,9 @@ Endpoints *[]*string
 
 ---
 
-##### `CacertPath`<sup>Optional</sup> <a name="CacertPath" id="cdktf.EtcdV3BackendProps.property.cacertPath"></a>
+##### ~~`CacertPath`~~<sup>Optional</sup> <a name="CacertPath" id="cdktf.EtcdV3BackendProps.property.cacertPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 CacertPath *string
@@ -17374,7 +17610,9 @@ CacertPath *string
 
 ---
 
-##### `CertPath`<sup>Optional</sup> <a name="CertPath" id="cdktf.EtcdV3BackendProps.property.certPath"></a>
+##### ~~`CertPath`~~<sup>Optional</sup> <a name="CertPath" id="cdktf.EtcdV3BackendProps.property.certPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 CertPath *string
@@ -17386,7 +17624,9 @@ CertPath *string
 
 ---
 
-##### `KeyPath`<sup>Optional</sup> <a name="KeyPath" id="cdktf.EtcdV3BackendProps.property.keyPath"></a>
+##### ~~`KeyPath`~~<sup>Optional</sup> <a name="KeyPath" id="cdktf.EtcdV3BackendProps.property.keyPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 KeyPath *string
@@ -17398,7 +17638,9 @@ KeyPath *string
 
 ---
 
-##### `Lock`<sup>Optional</sup> <a name="Lock" id="cdktf.EtcdV3BackendProps.property.lock"></a>
+##### ~~`Lock`~~<sup>Optional</sup> <a name="Lock" id="cdktf.EtcdV3BackendProps.property.lock"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Lock *bool
@@ -17412,7 +17654,9 @@ Defaults to true.
 
 ---
 
-##### `Password`<sup>Optional</sup> <a name="Password" id="cdktf.EtcdV3BackendProps.property.password"></a>
+##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.EtcdV3BackendProps.property.password"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Password *string
@@ -17424,7 +17668,9 @@ Password *string
 
 ---
 
-##### `Prefix`<sup>Optional</sup> <a name="Prefix" id="cdktf.EtcdV3BackendProps.property.prefix"></a>
+##### ~~`Prefix`~~<sup>Optional</sup> <a name="Prefix" id="cdktf.EtcdV3BackendProps.property.prefix"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Prefix *string
@@ -17438,7 +17684,9 @@ Defaults to "".
 
 ---
 
-##### `Username`<sup>Optional</sup> <a name="Username" id="cdktf.EtcdV3BackendProps.property.username"></a>
+##### ~~`Username`~~<sup>Optional</sup> <a name="Username" id="cdktf.EtcdV3BackendProps.property.username"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Username *string
@@ -18255,7 +18503,9 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 ---
 
-##### `Account`<sup>Required</sup> <a name="Account" id="cdktf.MantaBackendProps.property.account"></a>
+##### ~~`Account`~~<sup>Required</sup> <a name="Account" id="cdktf.MantaBackendProps.property.account"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Account *string
@@ -18265,7 +18515,9 @@ Account *string
 
 ---
 
-##### `KeyId`<sup>Required</sup> <a name="KeyId" id="cdktf.MantaBackendProps.property.keyId"></a>
+##### ~~`KeyId`~~<sup>Required</sup> <a name="KeyId" id="cdktf.MantaBackendProps.property.keyId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 KeyId *string
@@ -18275,7 +18527,9 @@ KeyId *string
 
 ---
 
-##### `Path`<sup>Required</sup> <a name="Path" id="cdktf.MantaBackendProps.property.path"></a>
+##### ~~`Path`~~<sup>Required</sup> <a name="Path" id="cdktf.MantaBackendProps.property.path"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Path *string
@@ -18285,7 +18539,9 @@ Path *string
 
 ---
 
-##### `InsecureSkipTlsVerify`<sup>Optional</sup> <a name="InsecureSkipTlsVerify" id="cdktf.MantaBackendProps.property.insecureSkipTlsVerify"></a>
+##### ~~`InsecureSkipTlsVerify`~~<sup>Optional</sup> <a name="InsecureSkipTlsVerify" id="cdktf.MantaBackendProps.property.insecureSkipTlsVerify"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 InsecureSkipTlsVerify *bool
@@ -18295,7 +18551,9 @@ InsecureSkipTlsVerify *bool
 
 ---
 
-##### `KeyMaterial`<sup>Optional</sup> <a name="KeyMaterial" id="cdktf.MantaBackendProps.property.keyMaterial"></a>
+##### ~~`KeyMaterial`~~<sup>Optional</sup> <a name="KeyMaterial" id="cdktf.MantaBackendProps.property.keyMaterial"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 KeyMaterial *string
@@ -18305,7 +18563,9 @@ KeyMaterial *string
 
 ---
 
-##### `ObjectName`<sup>Optional</sup> <a name="ObjectName" id="cdktf.MantaBackendProps.property.objectName"></a>
+##### ~~`ObjectName`~~<sup>Optional</sup> <a name="ObjectName" id="cdktf.MantaBackendProps.property.objectName"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 ObjectName *string
@@ -18315,7 +18575,9 @@ ObjectName *string
 
 ---
 
-##### `Url`<sup>Optional</sup> <a name="Url" id="cdktf.MantaBackendProps.property.url"></a>
+##### ~~`Url`~~<sup>Optional</sup> <a name="Url" id="cdktf.MantaBackendProps.property.url"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Url *string
@@ -18325,7 +18587,9 @@ Url *string
 
 ---
 
-##### `User`<sup>Optional</sup> <a name="User" id="cdktf.MantaBackendProps.property.user"></a>
+##### ~~`User`~~<sup>Optional</sup> <a name="User" id="cdktf.MantaBackendProps.property.user"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 User *string
@@ -20038,7 +20302,9 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 ---
 
-##### `Container`<sup>Required</sup> <a name="Container" id="cdktf.SwiftBackendProps.property.container"></a>
+##### ~~`Container`~~<sup>Required</sup> <a name="Container" id="cdktf.SwiftBackendProps.property.container"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Container *string
@@ -20048,7 +20314,9 @@ Container *string
 
 ---
 
-##### `ApplicationCredentialId`<sup>Optional</sup> <a name="ApplicationCredentialId" id="cdktf.SwiftBackendProps.property.applicationCredentialId"></a>
+##### ~~`ApplicationCredentialId`~~<sup>Optional</sup> <a name="ApplicationCredentialId" id="cdktf.SwiftBackendProps.property.applicationCredentialId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 ApplicationCredentialId *string
@@ -20058,7 +20326,9 @@ ApplicationCredentialId *string
 
 ---
 
-##### `ApplicationCredentialName`<sup>Optional</sup> <a name="ApplicationCredentialName" id="cdktf.SwiftBackendProps.property.applicationCredentialName"></a>
+##### ~~`ApplicationCredentialName`~~<sup>Optional</sup> <a name="ApplicationCredentialName" id="cdktf.SwiftBackendProps.property.applicationCredentialName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 ApplicationCredentialName *string
@@ -20068,7 +20338,9 @@ ApplicationCredentialName *string
 
 ---
 
-##### `ApplicationCredentialSecret`<sup>Optional</sup> <a name="ApplicationCredentialSecret" id="cdktf.SwiftBackendProps.property.applicationCredentialSecret"></a>
+##### ~~`ApplicationCredentialSecret`~~<sup>Optional</sup> <a name="ApplicationCredentialSecret" id="cdktf.SwiftBackendProps.property.applicationCredentialSecret"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 ApplicationCredentialSecret *string
@@ -20078,7 +20350,9 @@ ApplicationCredentialSecret *string
 
 ---
 
-##### `ArchiveContainer`<sup>Optional</sup> <a name="ArchiveContainer" id="cdktf.SwiftBackendProps.property.archiveContainer"></a>
+##### ~~`ArchiveContainer`~~<sup>Optional</sup> <a name="ArchiveContainer" id="cdktf.SwiftBackendProps.property.archiveContainer"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 ArchiveContainer *string
@@ -20088,7 +20362,9 @@ ArchiveContainer *string
 
 ---
 
-##### `AuthUrl`<sup>Optional</sup> <a name="AuthUrl" id="cdktf.SwiftBackendProps.property.authUrl"></a>
+##### ~~`AuthUrl`~~<sup>Optional</sup> <a name="AuthUrl" id="cdktf.SwiftBackendProps.property.authUrl"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 AuthUrl *string
@@ -20098,7 +20374,9 @@ AuthUrl *string
 
 ---
 
-##### `CacertFile`<sup>Optional</sup> <a name="CacertFile" id="cdktf.SwiftBackendProps.property.cacertFile"></a>
+##### ~~`CacertFile`~~<sup>Optional</sup> <a name="CacertFile" id="cdktf.SwiftBackendProps.property.cacertFile"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 CacertFile *string
@@ -20108,7 +20386,9 @@ CacertFile *string
 
 ---
 
-##### `Cert`<sup>Optional</sup> <a name="Cert" id="cdktf.SwiftBackendProps.property.cert"></a>
+##### ~~`Cert`~~<sup>Optional</sup> <a name="Cert" id="cdktf.SwiftBackendProps.property.cert"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Cert *string
@@ -20118,7 +20398,9 @@ Cert *string
 
 ---
 
-##### `Cloud`<sup>Optional</sup> <a name="Cloud" id="cdktf.SwiftBackendProps.property.cloud"></a>
+##### ~~`Cloud`~~<sup>Optional</sup> <a name="Cloud" id="cdktf.SwiftBackendProps.property.cloud"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Cloud *string
@@ -20128,7 +20410,9 @@ Cloud *string
 
 ---
 
-##### `DefaultDomain`<sup>Optional</sup> <a name="DefaultDomain" id="cdktf.SwiftBackendProps.property.defaultDomain"></a>
+##### ~~`DefaultDomain`~~<sup>Optional</sup> <a name="DefaultDomain" id="cdktf.SwiftBackendProps.property.defaultDomain"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 DefaultDomain *string
@@ -20138,7 +20422,9 @@ DefaultDomain *string
 
 ---
 
-##### `DomainId`<sup>Optional</sup> <a name="DomainId" id="cdktf.SwiftBackendProps.property.domainId"></a>
+##### ~~`DomainId`~~<sup>Optional</sup> <a name="DomainId" id="cdktf.SwiftBackendProps.property.domainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 DomainId *string
@@ -20148,7 +20434,9 @@ DomainId *string
 
 ---
 
-##### `DomainName`<sup>Optional</sup> <a name="DomainName" id="cdktf.SwiftBackendProps.property.domainName"></a>
+##### ~~`DomainName`~~<sup>Optional</sup> <a name="DomainName" id="cdktf.SwiftBackendProps.property.domainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 DomainName *string
@@ -20158,7 +20446,9 @@ DomainName *string
 
 ---
 
-##### `ExpireAfter`<sup>Optional</sup> <a name="ExpireAfter" id="cdktf.SwiftBackendProps.property.expireAfter"></a>
+##### ~~`ExpireAfter`~~<sup>Optional</sup> <a name="ExpireAfter" id="cdktf.SwiftBackendProps.property.expireAfter"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 ExpireAfter *string
@@ -20168,7 +20458,9 @@ ExpireAfter *string
 
 ---
 
-##### `Insecure`<sup>Optional</sup> <a name="Insecure" id="cdktf.SwiftBackendProps.property.insecure"></a>
+##### ~~`Insecure`~~<sup>Optional</sup> <a name="Insecure" id="cdktf.SwiftBackendProps.property.insecure"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Insecure *bool
@@ -20178,7 +20470,9 @@ Insecure *bool
 
 ---
 
-##### `Key`<sup>Optional</sup> <a name="Key" id="cdktf.SwiftBackendProps.property.key"></a>
+##### ~~`Key`~~<sup>Optional</sup> <a name="Key" id="cdktf.SwiftBackendProps.property.key"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Key *string
@@ -20188,7 +20482,9 @@ Key *string
 
 ---
 
-##### `Password`<sup>Optional</sup> <a name="Password" id="cdktf.SwiftBackendProps.property.password"></a>
+##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.SwiftBackendProps.property.password"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Password *string
@@ -20198,7 +20494,9 @@ Password *string
 
 ---
 
-##### `ProjectDomainId`<sup>Optional</sup> <a name="ProjectDomainId" id="cdktf.SwiftBackendProps.property.projectDomainId"></a>
+##### ~~`ProjectDomainId`~~<sup>Optional</sup> <a name="ProjectDomainId" id="cdktf.SwiftBackendProps.property.projectDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 ProjectDomainId *string
@@ -20208,7 +20506,9 @@ ProjectDomainId *string
 
 ---
 
-##### `ProjectDomainName`<sup>Optional</sup> <a name="ProjectDomainName" id="cdktf.SwiftBackendProps.property.projectDomainName"></a>
+##### ~~`ProjectDomainName`~~<sup>Optional</sup> <a name="ProjectDomainName" id="cdktf.SwiftBackendProps.property.projectDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 ProjectDomainName *string
@@ -20218,7 +20518,9 @@ ProjectDomainName *string
 
 ---
 
-##### `RegionName`<sup>Optional</sup> <a name="RegionName" id="cdktf.SwiftBackendProps.property.regionName"></a>
+##### ~~`RegionName`~~<sup>Optional</sup> <a name="RegionName" id="cdktf.SwiftBackendProps.property.regionName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 RegionName *string
@@ -20228,7 +20530,9 @@ RegionName *string
 
 ---
 
-##### `StateName`<sup>Optional</sup> <a name="StateName" id="cdktf.SwiftBackendProps.property.stateName"></a>
+##### ~~`StateName`~~<sup>Optional</sup> <a name="StateName" id="cdktf.SwiftBackendProps.property.stateName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 StateName *string
@@ -20238,7 +20542,9 @@ StateName *string
 
 ---
 
-##### `TenantId`<sup>Optional</sup> <a name="TenantId" id="cdktf.SwiftBackendProps.property.tenantId"></a>
+##### ~~`TenantId`~~<sup>Optional</sup> <a name="TenantId" id="cdktf.SwiftBackendProps.property.tenantId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 TenantId *string
@@ -20248,7 +20554,9 @@ TenantId *string
 
 ---
 
-##### `TenantName`<sup>Optional</sup> <a name="TenantName" id="cdktf.SwiftBackendProps.property.tenantName"></a>
+##### ~~`TenantName`~~<sup>Optional</sup> <a name="TenantName" id="cdktf.SwiftBackendProps.property.tenantName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 TenantName *string
@@ -20258,7 +20566,9 @@ TenantName *string
 
 ---
 
-##### `Token`<sup>Optional</sup> <a name="Token" id="cdktf.SwiftBackendProps.property.token"></a>
+##### ~~`Token`~~<sup>Optional</sup> <a name="Token" id="cdktf.SwiftBackendProps.property.token"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 Token *string
@@ -20268,7 +20578,9 @@ Token *string
 
 ---
 
-##### `UserDomainId`<sup>Optional</sup> <a name="UserDomainId" id="cdktf.SwiftBackendProps.property.userDomainId"></a>
+##### ~~`UserDomainId`~~<sup>Optional</sup> <a name="UserDomainId" id="cdktf.SwiftBackendProps.property.userDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 UserDomainId *string
@@ -20278,7 +20590,9 @@ UserDomainId *string
 
 ---
 
-##### `UserDomainName`<sup>Optional</sup> <a name="UserDomainName" id="cdktf.SwiftBackendProps.property.userDomainName"></a>
+##### ~~`UserDomainName`~~<sup>Optional</sup> <a name="UserDomainName" id="cdktf.SwiftBackendProps.property.userDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 UserDomainName *string
@@ -20288,7 +20602,9 @@ UserDomainName *string
 
 ---
 
-##### `UserId`<sup>Optional</sup> <a name="UserId" id="cdktf.SwiftBackendProps.property.userId"></a>
+##### ~~`UserId`~~<sup>Optional</sup> <a name="UserId" id="cdktf.SwiftBackendProps.property.userId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 UserId *string
@@ -20298,7 +20614,9 @@ UserId *string
 
 ---
 
-##### `UserName`<sup>Optional</sup> <a name="UserName" id="cdktf.SwiftBackendProps.property.userName"></a>
+##### ~~`UserName`~~<sup>Optional</sup> <a name="UserName" id="cdktf.SwiftBackendProps.property.userName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```go
 UserName *string

--- a/website/docs/cdktf/api-reference/go.mdx
+++ b/website/docs/cdktf/api-reference/go.mdx
@@ -446,7 +446,7 @@ cdktf.ArtifactoryBackend_IsBackend(x interface{}) *bool
 
 ##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.ArtifactoryBackend.property.node"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```go
 func Node() Node
@@ -460,7 +460,7 @@ The tree node.
 
 ##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.ArtifactoryBackend.property.cdktfStack"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```go
 func CdktfStack() TerraformStack
@@ -472,7 +472,7 @@ func CdktfStack() TerraformStack
 
 ##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.ArtifactoryBackend.property.fqn"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```go
 func Fqn() *string
@@ -484,7 +484,7 @@ func Fqn() *string
 
 ##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.ArtifactoryBackend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```go
 func FriendlyUniqueId() *string
@@ -2070,7 +2070,7 @@ cdktf.DataTerraformRemoteStateArtifactory_IsTerraformElement(x interface{}) *boo
 
 ##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateArtifactory.property.node"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```go
 func Node() Node
@@ -2084,7 +2084,7 @@ The tree node.
 
 ##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateArtifactory.property.cdktfStack"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```go
 func CdktfStack() TerraformStack
@@ -2096,7 +2096,7 @@ func CdktfStack() TerraformStack
 
 ##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateArtifactory.property.fqn"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```go
 func Fqn() *string
@@ -2108,7 +2108,7 @@ func Fqn() *string
 
 ##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateArtifactory.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```go
 func FriendlyUniqueId() *string
@@ -2128,7 +2128,7 @@ func FriendlyUniqueId() *string
 
 ##### ~~`TfResourceType`~~<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateArtifactory.property.tfResourceType"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```go
 func TfResourceType() *string
@@ -3296,7 +3296,7 @@ cdktf.DataTerraformRemoteStateEtcd_IsTerraformElement(x interface{}) *bool
 
 ##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateEtcd.property.node"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```go
 func Node() Node
@@ -3310,7 +3310,7 @@ The tree node.
 
 ##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateEtcd.property.cdktfStack"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```go
 func CdktfStack() TerraformStack
@@ -3322,7 +3322,7 @@ func CdktfStack() TerraformStack
 
 ##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateEtcd.property.fqn"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```go
 func Fqn() *string
@@ -3334,7 +3334,7 @@ func Fqn() *string
 
 ##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcd.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```go
 func FriendlyUniqueId() *string
@@ -3354,7 +3354,7 @@ func FriendlyUniqueId() *string
 
 ##### ~~`TfResourceType`~~<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateEtcd.property.tfResourceType"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```go
 func TfResourceType() *string
@@ -3610,7 +3610,7 @@ cdktf.DataTerraformRemoteStateEtcdV3_IsTerraformElement(x interface{}) *bool
 
 ##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateEtcdV3.property.node"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 func Node() Node
@@ -3624,7 +3624,7 @@ The tree node.
 
 ##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateEtcdV3.property.cdktfStack"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 func CdktfStack() TerraformStack
@@ -3636,7 +3636,7 @@ func CdktfStack() TerraformStack
 
 ##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateEtcdV3.property.fqn"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 func Fqn() *string
@@ -3648,7 +3648,7 @@ func Fqn() *string
 
 ##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcdV3.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 func FriendlyUniqueId() *string
@@ -3668,7 +3668,7 @@ func FriendlyUniqueId() *string
 
 ##### ~~`TfResourceType`~~<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateEtcdV3.property.tfResourceType"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 func TfResourceType() *string
@@ -4836,7 +4836,7 @@ cdktf.DataTerraformRemoteStateManta_IsTerraformElement(x interface{}) *bool
 
 ##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateManta.property.node"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 func Node() Node
@@ -4850,7 +4850,7 @@ The tree node.
 
 ##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateManta.property.cdktfStack"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 func CdktfStack() TerraformStack
@@ -4862,7 +4862,7 @@ func CdktfStack() TerraformStack
 
 ##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateManta.property.fqn"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 func Fqn() *string
@@ -4874,7 +4874,7 @@ func Fqn() *string
 
 ##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateManta.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 func FriendlyUniqueId() *string
@@ -4894,7 +4894,7 @@ func FriendlyUniqueId() *string
 
 ##### ~~`TfResourceType`~~<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateManta.property.tfResourceType"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 func TfResourceType() *string
@@ -6062,7 +6062,7 @@ cdktf.DataTerraformRemoteStateSwift_IsTerraformElement(x interface{}) *bool
 
 ##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.DataTerraformRemoteStateSwift.property.node"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 func Node() Node
@@ -6076,7 +6076,7 @@ The tree node.
 
 ##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.DataTerraformRemoteStateSwift.property.cdktfStack"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 func CdktfStack() TerraformStack
@@ -6088,7 +6088,7 @@ func CdktfStack() TerraformStack
 
 ##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.DataTerraformRemoteStateSwift.property.fqn"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 func Fqn() *string
@@ -6100,7 +6100,7 @@ func Fqn() *string
 
 ##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.DataTerraformRemoteStateSwift.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 func FriendlyUniqueId() *string
@@ -6120,7 +6120,7 @@ func FriendlyUniqueId() *string
 
 ##### ~~`TfResourceType`~~<sup>Required</sup> <a name="TfResourceType" id="cdktf.DataTerraformRemoteStateSwift.property.tfResourceType"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 func TfResourceType() *string
@@ -6346,7 +6346,7 @@ cdktf.EtcdBackend_IsBackend(x interface{}) *bool
 
 ##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.EtcdBackend.property.node"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```go
 func Node() Node
@@ -6360,7 +6360,7 @@ The tree node.
 
 ##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.EtcdBackend.property.cdktfStack"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```go
 func CdktfStack() TerraformStack
@@ -6372,7 +6372,7 @@ func CdktfStack() TerraformStack
 
 ##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.EtcdBackend.property.fqn"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```go
 func Fqn() *string
@@ -6384,7 +6384,7 @@ func Fqn() *string
 
 ##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.EtcdBackend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```go
 func FriendlyUniqueId() *string
@@ -6610,7 +6610,7 @@ cdktf.EtcdV3Backend_IsBackend(x interface{}) *bool
 
 ##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.EtcdV3Backend.property.node"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 func Node() Node
@@ -6624,7 +6624,7 @@ The tree node.
 
 ##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.EtcdV3Backend.property.cdktfStack"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 func CdktfStack() TerraformStack
@@ -6636,7 +6636,7 @@ func CdktfStack() TerraformStack
 
 ##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.EtcdV3Backend.property.fqn"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 func Fqn() *string
@@ -6648,7 +6648,7 @@ func Fqn() *string
 
 ##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.EtcdV3Backend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 func FriendlyUniqueId() *string
@@ -7642,7 +7642,7 @@ cdktf.MantaBackend_IsBackend(x interface{}) *bool
 
 ##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.MantaBackend.property.node"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 func Node() Node
@@ -7656,7 +7656,7 @@ The tree node.
 
 ##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.MantaBackend.property.cdktfStack"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 func CdktfStack() TerraformStack
@@ -7668,7 +7668,7 @@ func CdktfStack() TerraformStack
 
 ##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.MantaBackend.property.fqn"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 func Fqn() *string
@@ -7680,7 +7680,7 @@ func Fqn() *string
 
 ##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.MantaBackend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 func FriendlyUniqueId() *string
@@ -9056,7 +9056,7 @@ cdktf.SwiftBackend_IsBackend(x interface{}) *bool
 
 ##### ~~`Node`~~<sup>Required</sup> <a name="Node" id="cdktf.SwiftBackend.property.node"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 func Node() Node
@@ -9070,7 +9070,7 @@ The tree node.
 
 ##### ~~`CdktfStack`~~<sup>Required</sup> <a name="CdktfStack" id="cdktf.SwiftBackend.property.cdktfStack"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 func CdktfStack() TerraformStack
@@ -9082,7 +9082,7 @@ func CdktfStack() TerraformStack
 
 ##### ~~`Fqn`~~<sup>Required</sup> <a name="Fqn" id="cdktf.SwiftBackend.property.fqn"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 func Fqn() *string
@@ -9094,7 +9094,7 @@ func Fqn() *string
 
 ##### ~~`FriendlyUniqueId`~~<sup>Required</sup> <a name="FriendlyUniqueId" id="cdktf.SwiftBackend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 func FriendlyUniqueId() *string
@@ -13345,7 +13345,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 ##### ~~`Password`~~<sup>Required</sup> <a name="Password" id="cdktf.ArtifactoryBackendProps.property.password"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```go
 Password *string
@@ -13359,7 +13359,7 @@ Password *string
 
 ##### ~~`Repo`~~<sup>Required</sup> <a name="Repo" id="cdktf.ArtifactoryBackendProps.property.repo"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```go
 Repo *string
@@ -13373,7 +13373,7 @@ Repo *string
 
 ##### ~~`Subpath`~~<sup>Required</sup> <a name="Subpath" id="cdktf.ArtifactoryBackendProps.property.subpath"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```go
 Subpath *string
@@ -13387,7 +13387,7 @@ Subpath *string
 
 ##### ~~`Url`~~<sup>Required</sup> <a name="Url" id="cdktf.ArtifactoryBackendProps.property.url"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```go
 Url *string
@@ -13403,7 +13403,7 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ##### ~~`Username`~~<sup>Required</sup> <a name="Username" id="cdktf.ArtifactoryBackendProps.property.username"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```go
 Username *string
@@ -14268,7 +14268,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 ##### ~~`Defaults`~~<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.defaults"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```go
 Defaults *map[string]interface{}
@@ -14280,7 +14280,7 @@ Defaults *map[string]interface{}
 
 ##### ~~`Workspace`~~<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.workspace"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```go
 Workspace *string
@@ -14292,7 +14292,7 @@ Workspace *string
 
 ##### ~~`Password`~~<sup>Required</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.password"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```go
 Password *string
@@ -14306,7 +14306,7 @@ Password *string
 
 ##### ~~`Repo`~~<sup>Required</sup> <a name="Repo" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.repo"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```go
 Repo *string
@@ -14320,7 +14320,7 @@ Repo *string
 
 ##### ~~`Subpath`~~<sup>Required</sup> <a name="Subpath" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.subpath"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```go
 Subpath *string
@@ -14334,7 +14334,7 @@ Subpath *string
 
 ##### ~~`Url`~~<sup>Required</sup> <a name="Url" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.url"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```go
 Url *string
@@ -14350,7 +14350,7 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ##### ~~`Username`~~<sup>Required</sup> <a name="Username" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.username"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```go
 Username *string
@@ -15217,7 +15217,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 ##### ~~`Defaults`~~<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.defaults"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```go
 Defaults *map[string]interface{}
@@ -15229,7 +15229,7 @@ Defaults *map[string]interface{}
 
 ##### ~~`Workspace`~~<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.workspace"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```go
 Workspace *string
@@ -15241,7 +15241,7 @@ Workspace *string
 
 ##### ~~`Endpoints`~~<sup>Required</sup> <a name="Endpoints" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.endpoints"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```go
 Endpoints *string
@@ -15255,7 +15255,7 @@ Endpoints *string
 
 ##### ~~`Path`~~<sup>Required</sup> <a name="Path" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.path"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```go
 Path *string
@@ -15269,7 +15269,7 @@ Path *string
 
 ##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.password"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```go
 Password *string
@@ -15283,7 +15283,7 @@ Password *string
 
 ##### ~~`Username`~~<sup>Optional</sup> <a name="Username" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.username"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```go
 Username *string
@@ -15335,7 +15335,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 ##### ~~`Defaults`~~<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.defaults"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 Defaults *map[string]interface{}
@@ -15347,7 +15347,7 @@ Defaults *map[string]interface{}
 
 ##### ~~`Workspace`~~<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.workspace"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 Workspace *string
@@ -15359,7 +15359,7 @@ Workspace *string
 
 ##### ~~`Endpoints`~~<sup>Required</sup> <a name="Endpoints" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.endpoints"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 Endpoints *[]*string
@@ -15373,7 +15373,7 @@ Endpoints *[]*string
 
 ##### ~~`CacertPath`~~<sup>Optional</sup> <a name="CacertPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.cacertPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 CacertPath *string
@@ -15387,7 +15387,7 @@ CacertPath *string
 
 ##### ~~`CertPath`~~<sup>Optional</sup> <a name="CertPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.certPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 CertPath *string
@@ -15401,7 +15401,7 @@ CertPath *string
 
 ##### ~~`KeyPath`~~<sup>Optional</sup> <a name="KeyPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.keyPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 KeyPath *string
@@ -15415,7 +15415,7 @@ KeyPath *string
 
 ##### ~~`Lock`~~<sup>Optional</sup> <a name="Lock" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.lock"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 Lock *bool
@@ -15431,7 +15431,7 @@ Defaults to true.
 
 ##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.password"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 Password *string
@@ -15445,7 +15445,7 @@ Password *string
 
 ##### ~~`Prefix`~~<sup>Optional</sup> <a name="Prefix" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.prefix"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 Prefix *string
@@ -15461,7 +15461,7 @@ Defaults to "".
 
 ##### ~~`Username`~~<sup>Optional</sup> <a name="Username" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.username"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 Username *string
@@ -15966,7 +15966,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 ##### ~~`Defaults`~~<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateMantaConfig.property.defaults"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 Defaults *map[string]interface{}
@@ -15978,7 +15978,7 @@ Defaults *map[string]interface{}
 
 ##### ~~`Workspace`~~<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateMantaConfig.property.workspace"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 Workspace *string
@@ -15990,7 +15990,7 @@ Workspace *string
 
 ##### ~~`Account`~~<sup>Required</sup> <a name="Account" id="cdktf.DataTerraformRemoteStateMantaConfig.property.account"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 Account *string
@@ -16002,7 +16002,7 @@ Account *string
 
 ##### ~~`KeyId`~~<sup>Required</sup> <a name="KeyId" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 KeyId *string
@@ -16014,7 +16014,7 @@ KeyId *string
 
 ##### ~~`Path`~~<sup>Required</sup> <a name="Path" id="cdktf.DataTerraformRemoteStateMantaConfig.property.path"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 Path *string
@@ -16026,7 +16026,7 @@ Path *string
 
 ##### ~~`InsecureSkipTlsVerify`~~<sup>Optional</sup> <a name="InsecureSkipTlsVerify" id="cdktf.DataTerraformRemoteStateMantaConfig.property.insecureSkipTlsVerify"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 InsecureSkipTlsVerify *bool
@@ -16038,7 +16038,7 @@ InsecureSkipTlsVerify *bool
 
 ##### ~~`KeyMaterial`~~<sup>Optional</sup> <a name="KeyMaterial" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyMaterial"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 KeyMaterial *string
@@ -16050,7 +16050,7 @@ KeyMaterial *string
 
 ##### ~~`ObjectName`~~<sup>Optional</sup> <a name="ObjectName" id="cdktf.DataTerraformRemoteStateMantaConfig.property.objectName"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 ObjectName *string
@@ -16062,7 +16062,7 @@ ObjectName *string
 
 ##### ~~`Url`~~<sup>Optional</sup> <a name="Url" id="cdktf.DataTerraformRemoteStateMantaConfig.property.url"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 Url *string
@@ -16074,7 +16074,7 @@ Url *string
 
 ##### ~~`User`~~<sup>Optional</sup> <a name="User" id="cdktf.DataTerraformRemoteStateMantaConfig.property.user"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 User *string
@@ -17071,7 +17071,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 ##### ~~`Defaults`~~<sup>Optional</sup> <a name="Defaults" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaults"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 Defaults *map[string]interface{}
@@ -17083,7 +17083,7 @@ Defaults *map[string]interface{}
 
 ##### ~~`Workspace`~~<sup>Optional</sup> <a name="Workspace" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.workspace"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 Workspace *string
@@ -17095,7 +17095,7 @@ Workspace *string
 
 ##### ~~`Container`~~<sup>Required</sup> <a name="Container" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.container"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 Container *string
@@ -17107,7 +17107,7 @@ Container *string
 
 ##### ~~`ApplicationCredentialId`~~<sup>Optional</sup> <a name="ApplicationCredentialId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 ApplicationCredentialId *string
@@ -17119,7 +17119,7 @@ ApplicationCredentialId *string
 
 ##### ~~`ApplicationCredentialName`~~<sup>Optional</sup> <a name="ApplicationCredentialName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 ApplicationCredentialName *string
@@ -17131,7 +17131,7 @@ ApplicationCredentialName *string
 
 ##### ~~`ApplicationCredentialSecret`~~<sup>Optional</sup> <a name="ApplicationCredentialSecret" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialSecret"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 ApplicationCredentialSecret *string
@@ -17143,7 +17143,7 @@ ApplicationCredentialSecret *string
 
 ##### ~~`ArchiveContainer`~~<sup>Optional</sup> <a name="ArchiveContainer" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.archiveContainer"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 ArchiveContainer *string
@@ -17155,7 +17155,7 @@ ArchiveContainer *string
 
 ##### ~~`AuthUrl`~~<sup>Optional</sup> <a name="AuthUrl" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.authUrl"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 AuthUrl *string
@@ -17167,7 +17167,7 @@ AuthUrl *string
 
 ##### ~~`CacertFile`~~<sup>Optional</sup> <a name="CacertFile" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cacertFile"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 CacertFile *string
@@ -17179,7 +17179,7 @@ CacertFile *string
 
 ##### ~~`Cert`~~<sup>Optional</sup> <a name="Cert" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cert"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 Cert *string
@@ -17191,7 +17191,7 @@ Cert *string
 
 ##### ~~`Cloud`~~<sup>Optional</sup> <a name="Cloud" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cloud"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 Cloud *string
@@ -17203,7 +17203,7 @@ Cloud *string
 
 ##### ~~`DefaultDomain`~~<sup>Optional</sup> <a name="DefaultDomain" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaultDomain"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 DefaultDomain *string
@@ -17215,7 +17215,7 @@ DefaultDomain *string
 
 ##### ~~`DomainId`~~<sup>Optional</sup> <a name="DomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 DomainId *string
@@ -17227,7 +17227,7 @@ DomainId *string
 
 ##### ~~`DomainName`~~<sup>Optional</sup> <a name="DomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 DomainName *string
@@ -17239,7 +17239,7 @@ DomainName *string
 
 ##### ~~`ExpireAfter`~~<sup>Optional</sup> <a name="ExpireAfter" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.expireAfter"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 ExpireAfter *string
@@ -17251,7 +17251,7 @@ ExpireAfter *string
 
 ##### ~~`Insecure`~~<sup>Optional</sup> <a name="Insecure" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.insecure"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 Insecure *bool
@@ -17263,7 +17263,7 @@ Insecure *bool
 
 ##### ~~`Key`~~<sup>Optional</sup> <a name="Key" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.key"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 Key *string
@@ -17275,7 +17275,7 @@ Key *string
 
 ##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.password"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 Password *string
@@ -17287,7 +17287,7 @@ Password *string
 
 ##### ~~`ProjectDomainId`~~<sup>Optional</sup> <a name="ProjectDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 ProjectDomainId *string
@@ -17299,7 +17299,7 @@ ProjectDomainId *string
 
 ##### ~~`ProjectDomainName`~~<sup>Optional</sup> <a name="ProjectDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 ProjectDomainName *string
@@ -17311,7 +17311,7 @@ ProjectDomainName *string
 
 ##### ~~`RegionName`~~<sup>Optional</sup> <a name="RegionName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.regionName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 RegionName *string
@@ -17323,7 +17323,7 @@ RegionName *string
 
 ##### ~~`StateName`~~<sup>Optional</sup> <a name="StateName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.stateName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 StateName *string
@@ -17335,7 +17335,7 @@ StateName *string
 
 ##### ~~`TenantId`~~<sup>Optional</sup> <a name="TenantId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 TenantId *string
@@ -17347,7 +17347,7 @@ TenantId *string
 
 ##### ~~`TenantName`~~<sup>Optional</sup> <a name="TenantName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 TenantName *string
@@ -17359,7 +17359,7 @@ TenantName *string
 
 ##### ~~`Token`~~<sup>Optional</sup> <a name="Token" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.token"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 Token *string
@@ -17371,7 +17371,7 @@ Token *string
 
 ##### ~~`UserDomainId`~~<sup>Optional</sup> <a name="UserDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 UserDomainId *string
@@ -17383,7 +17383,7 @@ UserDomainId *string
 
 ##### ~~`UserDomainName`~~<sup>Optional</sup> <a name="UserDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 UserDomainName *string
@@ -17395,7 +17395,7 @@ UserDomainName *string
 
 ##### ~~`UserId`~~<sup>Optional</sup> <a name="UserId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 UserId *string
@@ -17407,7 +17407,7 @@ UserId *string
 
 ##### ~~`UserName`~~<sup>Optional</sup> <a name="UserName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 UserName *string
@@ -17487,7 +17487,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 ##### ~~`Endpoints`~~<sup>Required</sup> <a name="Endpoints" id="cdktf.EtcdBackendProps.property.endpoints"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```go
 Endpoints *string
@@ -17501,7 +17501,7 @@ Endpoints *string
 
 ##### ~~`Path`~~<sup>Required</sup> <a name="Path" id="cdktf.EtcdBackendProps.property.path"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```go
 Path *string
@@ -17515,7 +17515,7 @@ Path *string
 
 ##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.EtcdBackendProps.property.password"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```go
 Password *string
@@ -17529,7 +17529,7 @@ Password *string
 
 ##### ~~`Username`~~<sup>Optional</sup> <a name="Username" id="cdktf.EtcdBackendProps.property.username"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```go
 Username *string
@@ -17584,7 +17584,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 ##### ~~`Endpoints`~~<sup>Required</sup> <a name="Endpoints" id="cdktf.EtcdV3BackendProps.property.endpoints"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 Endpoints *[]*string
@@ -17598,7 +17598,7 @@ Endpoints *[]*string
 
 ##### ~~`CacertPath`~~<sup>Optional</sup> <a name="CacertPath" id="cdktf.EtcdV3BackendProps.property.cacertPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 CacertPath *string
@@ -17612,7 +17612,7 @@ CacertPath *string
 
 ##### ~~`CertPath`~~<sup>Optional</sup> <a name="CertPath" id="cdktf.EtcdV3BackendProps.property.certPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 CertPath *string
@@ -17626,7 +17626,7 @@ CertPath *string
 
 ##### ~~`KeyPath`~~<sup>Optional</sup> <a name="KeyPath" id="cdktf.EtcdV3BackendProps.property.keyPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 KeyPath *string
@@ -17640,7 +17640,7 @@ KeyPath *string
 
 ##### ~~`Lock`~~<sup>Optional</sup> <a name="Lock" id="cdktf.EtcdV3BackendProps.property.lock"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 Lock *bool
@@ -17656,7 +17656,7 @@ Defaults to true.
 
 ##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.EtcdV3BackendProps.property.password"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 Password *string
@@ -17670,7 +17670,7 @@ Password *string
 
 ##### ~~`Prefix`~~<sup>Optional</sup> <a name="Prefix" id="cdktf.EtcdV3BackendProps.property.prefix"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 Prefix *string
@@ -17686,7 +17686,7 @@ Defaults to "".
 
 ##### ~~`Username`~~<sup>Optional</sup> <a name="Username" id="cdktf.EtcdV3BackendProps.property.username"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```go
 Username *string
@@ -18505,7 +18505,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 ##### ~~`Account`~~<sup>Required</sup> <a name="Account" id="cdktf.MantaBackendProps.property.account"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 Account *string
@@ -18517,7 +18517,7 @@ Account *string
 
 ##### ~~`KeyId`~~<sup>Required</sup> <a name="KeyId" id="cdktf.MantaBackendProps.property.keyId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 KeyId *string
@@ -18529,7 +18529,7 @@ KeyId *string
 
 ##### ~~`Path`~~<sup>Required</sup> <a name="Path" id="cdktf.MantaBackendProps.property.path"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 Path *string
@@ -18541,7 +18541,7 @@ Path *string
 
 ##### ~~`InsecureSkipTlsVerify`~~<sup>Optional</sup> <a name="InsecureSkipTlsVerify" id="cdktf.MantaBackendProps.property.insecureSkipTlsVerify"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 InsecureSkipTlsVerify *bool
@@ -18553,7 +18553,7 @@ InsecureSkipTlsVerify *bool
 
 ##### ~~`KeyMaterial`~~<sup>Optional</sup> <a name="KeyMaterial" id="cdktf.MantaBackendProps.property.keyMaterial"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 KeyMaterial *string
@@ -18565,7 +18565,7 @@ KeyMaterial *string
 
 ##### ~~`ObjectName`~~<sup>Optional</sup> <a name="ObjectName" id="cdktf.MantaBackendProps.property.objectName"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 ObjectName *string
@@ -18577,7 +18577,7 @@ ObjectName *string
 
 ##### ~~`Url`~~<sup>Optional</sup> <a name="Url" id="cdktf.MantaBackendProps.property.url"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 Url *string
@@ -18589,7 +18589,7 @@ Url *string
 
 ##### ~~`User`~~<sup>Optional</sup> <a name="User" id="cdktf.MantaBackendProps.property.user"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```go
 User *string
@@ -20304,7 +20304,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 ##### ~~`Container`~~<sup>Required</sup> <a name="Container" id="cdktf.SwiftBackendProps.property.container"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 Container *string
@@ -20316,7 +20316,7 @@ Container *string
 
 ##### ~~`ApplicationCredentialId`~~<sup>Optional</sup> <a name="ApplicationCredentialId" id="cdktf.SwiftBackendProps.property.applicationCredentialId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 ApplicationCredentialId *string
@@ -20328,7 +20328,7 @@ ApplicationCredentialId *string
 
 ##### ~~`ApplicationCredentialName`~~<sup>Optional</sup> <a name="ApplicationCredentialName" id="cdktf.SwiftBackendProps.property.applicationCredentialName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 ApplicationCredentialName *string
@@ -20340,7 +20340,7 @@ ApplicationCredentialName *string
 
 ##### ~~`ApplicationCredentialSecret`~~<sup>Optional</sup> <a name="ApplicationCredentialSecret" id="cdktf.SwiftBackendProps.property.applicationCredentialSecret"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 ApplicationCredentialSecret *string
@@ -20352,7 +20352,7 @@ ApplicationCredentialSecret *string
 
 ##### ~~`ArchiveContainer`~~<sup>Optional</sup> <a name="ArchiveContainer" id="cdktf.SwiftBackendProps.property.archiveContainer"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 ArchiveContainer *string
@@ -20364,7 +20364,7 @@ ArchiveContainer *string
 
 ##### ~~`AuthUrl`~~<sup>Optional</sup> <a name="AuthUrl" id="cdktf.SwiftBackendProps.property.authUrl"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 AuthUrl *string
@@ -20376,7 +20376,7 @@ AuthUrl *string
 
 ##### ~~`CacertFile`~~<sup>Optional</sup> <a name="CacertFile" id="cdktf.SwiftBackendProps.property.cacertFile"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 CacertFile *string
@@ -20388,7 +20388,7 @@ CacertFile *string
 
 ##### ~~`Cert`~~<sup>Optional</sup> <a name="Cert" id="cdktf.SwiftBackendProps.property.cert"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 Cert *string
@@ -20400,7 +20400,7 @@ Cert *string
 
 ##### ~~`Cloud`~~<sup>Optional</sup> <a name="Cloud" id="cdktf.SwiftBackendProps.property.cloud"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 Cloud *string
@@ -20412,7 +20412,7 @@ Cloud *string
 
 ##### ~~`DefaultDomain`~~<sup>Optional</sup> <a name="DefaultDomain" id="cdktf.SwiftBackendProps.property.defaultDomain"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 DefaultDomain *string
@@ -20424,7 +20424,7 @@ DefaultDomain *string
 
 ##### ~~`DomainId`~~<sup>Optional</sup> <a name="DomainId" id="cdktf.SwiftBackendProps.property.domainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 DomainId *string
@@ -20436,7 +20436,7 @@ DomainId *string
 
 ##### ~~`DomainName`~~<sup>Optional</sup> <a name="DomainName" id="cdktf.SwiftBackendProps.property.domainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 DomainName *string
@@ -20448,7 +20448,7 @@ DomainName *string
 
 ##### ~~`ExpireAfter`~~<sup>Optional</sup> <a name="ExpireAfter" id="cdktf.SwiftBackendProps.property.expireAfter"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 ExpireAfter *string
@@ -20460,7 +20460,7 @@ ExpireAfter *string
 
 ##### ~~`Insecure`~~<sup>Optional</sup> <a name="Insecure" id="cdktf.SwiftBackendProps.property.insecure"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 Insecure *bool
@@ -20472,7 +20472,7 @@ Insecure *bool
 
 ##### ~~`Key`~~<sup>Optional</sup> <a name="Key" id="cdktf.SwiftBackendProps.property.key"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 Key *string
@@ -20484,7 +20484,7 @@ Key *string
 
 ##### ~~`Password`~~<sup>Optional</sup> <a name="Password" id="cdktf.SwiftBackendProps.property.password"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 Password *string
@@ -20496,7 +20496,7 @@ Password *string
 
 ##### ~~`ProjectDomainId`~~<sup>Optional</sup> <a name="ProjectDomainId" id="cdktf.SwiftBackendProps.property.projectDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 ProjectDomainId *string
@@ -20508,7 +20508,7 @@ ProjectDomainId *string
 
 ##### ~~`ProjectDomainName`~~<sup>Optional</sup> <a name="ProjectDomainName" id="cdktf.SwiftBackendProps.property.projectDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 ProjectDomainName *string
@@ -20520,7 +20520,7 @@ ProjectDomainName *string
 
 ##### ~~`RegionName`~~<sup>Optional</sup> <a name="RegionName" id="cdktf.SwiftBackendProps.property.regionName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 RegionName *string
@@ -20532,7 +20532,7 @@ RegionName *string
 
 ##### ~~`StateName`~~<sup>Optional</sup> <a name="StateName" id="cdktf.SwiftBackendProps.property.stateName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 StateName *string
@@ -20544,7 +20544,7 @@ StateName *string
 
 ##### ~~`TenantId`~~<sup>Optional</sup> <a name="TenantId" id="cdktf.SwiftBackendProps.property.tenantId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 TenantId *string
@@ -20556,7 +20556,7 @@ TenantId *string
 
 ##### ~~`TenantName`~~<sup>Optional</sup> <a name="TenantName" id="cdktf.SwiftBackendProps.property.tenantName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 TenantName *string
@@ -20568,7 +20568,7 @@ TenantName *string
 
 ##### ~~`Token`~~<sup>Optional</sup> <a name="Token" id="cdktf.SwiftBackendProps.property.token"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 Token *string
@@ -20580,7 +20580,7 @@ Token *string
 
 ##### ~~`UserDomainId`~~<sup>Optional</sup> <a name="UserDomainId" id="cdktf.SwiftBackendProps.property.userDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 UserDomainId *string
@@ -20592,7 +20592,7 @@ UserDomainId *string
 
 ##### ~~`UserDomainName`~~<sup>Optional</sup> <a name="UserDomainName" id="cdktf.SwiftBackendProps.property.userDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 UserDomainName *string
@@ -20604,7 +20604,7 @@ UserDomainName *string
 
 ##### ~~`UserId`~~<sup>Optional</sup> <a name="UserId" id="cdktf.SwiftBackendProps.property.userId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 UserId *string
@@ -20616,7 +20616,7 @@ UserId *string
 
 ##### ~~`UserName`~~<sup>Optional</sup> <a name="UserName" id="cdktf.SwiftBackendProps.property.userName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```go
 UserName *string

--- a/website/docs/cdktf/api-reference/java.mdx
+++ b/website/docs/cdktf/api-reference/java.mdx
@@ -300,7 +300,9 @@ ArtifactoryBackend.Builder.create(Construct scope)
 
 ---
 
-##### `password`<sup>Required</sup> <a name="password" id="cdktf.ArtifactoryBackend.Initializer.parameter.password"></a>
+##### ~~`password`~~<sup>Required</sup> <a name="password" id="cdktf.ArtifactoryBackend.Initializer.parameter.password"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -308,7 +310,9 @@ ArtifactoryBackend.Builder.create(Construct scope)
 
 ---
 
-##### `repo`<sup>Required</sup> <a name="repo" id="cdktf.ArtifactoryBackend.Initializer.parameter.repo"></a>
+##### ~~`repo`~~<sup>Required</sup> <a name="repo" id="cdktf.ArtifactoryBackend.Initializer.parameter.repo"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -316,7 +320,9 @@ ArtifactoryBackend.Builder.create(Construct scope)
 
 ---
 
-##### `subpath`<sup>Required</sup> <a name="subpath" id="cdktf.ArtifactoryBackend.Initializer.parameter.subpath"></a>
+##### ~~`subpath`~~<sup>Required</sup> <a name="subpath" id="cdktf.ArtifactoryBackend.Initializer.parameter.subpath"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -324,7 +330,9 @@ ArtifactoryBackend.Builder.create(Construct scope)
 
 ---
 
-##### `url`<sup>Required</sup> <a name="url" id="cdktf.ArtifactoryBackend.Initializer.parameter.url"></a>
+##### ~~`url`~~<sup>Required</sup> <a name="url" id="cdktf.ArtifactoryBackend.Initializer.parameter.url"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -334,7 +342,9 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ---
 
-##### `username`<sup>Required</sup> <a name="username" id="cdktf.ArtifactoryBackend.Initializer.parameter.username"></a>
+##### ~~`username`~~<sup>Required</sup> <a name="username" id="cdktf.ArtifactoryBackend.Initializer.parameter.username"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -356,7 +366,7 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ---
 
-##### `toString` <a name="toString" id="cdktf.ArtifactoryBackend.toString"></a>
+##### ~~`toString`~~ <a name="toString" id="cdktf.ArtifactoryBackend.toString"></a>
 
 ```java
 public java.lang.String toString()
@@ -364,7 +374,7 @@ public java.lang.String toString()
 
 Returns a string representation of this construct.
 
-##### `addOverride` <a name="addOverride" id="cdktf.ArtifactoryBackend.addOverride"></a>
+##### ~~`addOverride`~~ <a name="addOverride" id="cdktf.ArtifactoryBackend.addOverride"></a>
 
 ```java
 public void addOverride(java.lang.String path, java.lang.Object value)
@@ -382,7 +392,7 @@ public void addOverride(java.lang.String path, java.lang.Object value)
 
 ---
 
-##### `overrideLogicalId` <a name="overrideLogicalId" id="cdktf.ArtifactoryBackend.overrideLogicalId"></a>
+##### ~~`overrideLogicalId`~~ <a name="overrideLogicalId" id="cdktf.ArtifactoryBackend.overrideLogicalId"></a>
 
 ```java
 public void overrideLogicalId(java.lang.String newLogicalId)
@@ -398,7 +408,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `resetOverrideLogicalId` <a name="resetOverrideLogicalId" id="cdktf.ArtifactoryBackend.resetOverrideLogicalId"></a>
+##### ~~`resetOverrideLogicalId`~~ <a name="resetOverrideLogicalId" id="cdktf.ArtifactoryBackend.resetOverrideLogicalId"></a>
 
 ```java
 public void resetOverrideLogicalId()
@@ -406,13 +416,13 @@ public void resetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `toMetadata` <a name="toMetadata" id="cdktf.ArtifactoryBackend.toMetadata"></a>
+##### ~~`toMetadata`~~ <a name="toMetadata" id="cdktf.ArtifactoryBackend.toMetadata"></a>
 
 ```java
 public java.lang.Object toMetadata()
 ```
 
-##### `toTerraform` <a name="toTerraform" id="cdktf.ArtifactoryBackend.toTerraform"></a>
+##### ~~`toTerraform`~~ <a name="toTerraform" id="cdktf.ArtifactoryBackend.toTerraform"></a>
 
 ```java
 public java.lang.Object toTerraform()
@@ -420,7 +430,7 @@ public java.lang.Object toTerraform()
 
 Adds this resource to the terraform JSON output.
 
-##### `getRemoteStateDataSource` <a name="getRemoteStateDataSource" id="cdktf.ArtifactoryBackend.getRemoteStateDataSource"></a>
+##### ~~`getRemoteStateDataSource`~~ <a name="getRemoteStateDataSource" id="cdktf.ArtifactoryBackend.getRemoteStateDataSource"></a>
 
 ```java
 public TerraformRemoteState getRemoteStateDataSource(Construct scope, java.lang.String name, java.lang.String _fromStack)
@@ -456,7 +466,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdktf.ArtifactoryBackend.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdktf.ArtifactoryBackend.isConstruct"></a>
 
 ```java
 import com.hashicorp.cdktf.ArtifactoryBackend;
@@ -488,7 +498,7 @@ Any object.
 
 ---
 
-##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.ArtifactoryBackend.isTerraformElement"></a>
+##### ~~`isTerraformElement`~~ <a name="isTerraformElement" id="cdktf.ArtifactoryBackend.isTerraformElement"></a>
 
 ```java
 import com.hashicorp.cdktf.ArtifactoryBackend;
@@ -502,7 +512,7 @@ ArtifactoryBackend.isTerraformElement(java.lang.Object x)
 
 ---
 
-##### `isBackend` <a name="isBackend" id="cdktf.ArtifactoryBackend.isBackend"></a>
+##### ~~`isBackend`~~ <a name="isBackend" id="cdktf.ArtifactoryBackend.isBackend"></a>
 
 ```java
 import com.hashicorp.cdktf.ArtifactoryBackend;
@@ -527,7 +537,9 @@ ArtifactoryBackend.isBackend(java.lang.Object x)
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.ArtifactoryBackend.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.ArtifactoryBackend.property.node"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public Node getNode();
@@ -539,7 +551,9 @@ The tree node.
 
 ---
 
-##### `cdktfStack`<sup>Required</sup> <a name="cdktfStack" id="cdktf.ArtifactoryBackend.property.cdktfStack"></a>
+##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.ArtifactoryBackend.property.cdktfStack"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public TerraformStack getCdktfStack();
@@ -549,7 +563,9 @@ public TerraformStack getCdktfStack();
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.ArtifactoryBackend.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.ArtifactoryBackend.property.fqn"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getFqn();
@@ -559,7 +575,9 @@ public java.lang.String getFqn();
 
 ---
 
-##### `friendlyUniqueId`<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.ArtifactoryBackend.property.friendlyUniqueId"></a>
+##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.ArtifactoryBackend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getFriendlyUniqueId();
@@ -2498,19 +2516,25 @@ DataTerraformRemoteStateArtifactory.Builder.create(Construct scope, java.lang.St
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.defaults"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.util.Map< java.lang.String, java.lang.Object >
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.workspace"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `password`<sup>Required</sup> <a name="password" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.password"></a>
+##### ~~`password`~~<sup>Required</sup> <a name="password" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.password"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -2518,7 +2542,9 @@ DataTerraformRemoteStateArtifactory.Builder.create(Construct scope, java.lang.St
 
 ---
 
-##### `repo`<sup>Required</sup> <a name="repo" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.repo"></a>
+##### ~~`repo`~~<sup>Required</sup> <a name="repo" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.repo"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -2526,7 +2552,9 @@ DataTerraformRemoteStateArtifactory.Builder.create(Construct scope, java.lang.St
 
 ---
 
-##### `subpath`<sup>Required</sup> <a name="subpath" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.subpath"></a>
+##### ~~`subpath`~~<sup>Required</sup> <a name="subpath" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.subpath"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -2534,7 +2562,9 @@ DataTerraformRemoteStateArtifactory.Builder.create(Construct scope, java.lang.St
 
 ---
 
-##### `url`<sup>Required</sup> <a name="url" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.url"></a>
+##### ~~`url`~~<sup>Required</sup> <a name="url" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.url"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -2544,7 +2574,9 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ---
 
-##### `username`<sup>Required</sup> <a name="username" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.username"></a>
+##### ~~`username`~~<sup>Required</sup> <a name="username" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.username"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -2570,7 +2602,7 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ---
 
-##### `toString` <a name="toString" id="cdktf.DataTerraformRemoteStateArtifactory.toString"></a>
+##### ~~`toString`~~ <a name="toString" id="cdktf.DataTerraformRemoteStateArtifactory.toString"></a>
 
 ```java
 public java.lang.String toString()
@@ -2578,7 +2610,7 @@ public java.lang.String toString()
 
 Returns a string representation of this construct.
 
-##### `addOverride` <a name="addOverride" id="cdktf.DataTerraformRemoteStateArtifactory.addOverride"></a>
+##### ~~`addOverride`~~ <a name="addOverride" id="cdktf.DataTerraformRemoteStateArtifactory.addOverride"></a>
 
 ```java
 public void addOverride(java.lang.String path, java.lang.Object value)
@@ -2596,7 +2628,7 @@ public void addOverride(java.lang.String path, java.lang.Object value)
 
 ---
 
-##### `overrideLogicalId` <a name="overrideLogicalId" id="cdktf.DataTerraformRemoteStateArtifactory.overrideLogicalId"></a>
+##### ~~`overrideLogicalId`~~ <a name="overrideLogicalId" id="cdktf.DataTerraformRemoteStateArtifactory.overrideLogicalId"></a>
 
 ```java
 public void overrideLogicalId(java.lang.String newLogicalId)
@@ -2612,7 +2644,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `resetOverrideLogicalId` <a name="resetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateArtifactory.resetOverrideLogicalId"></a>
+##### ~~`resetOverrideLogicalId`~~ <a name="resetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateArtifactory.resetOverrideLogicalId"></a>
 
 ```java
 public void resetOverrideLogicalId()
@@ -2620,13 +2652,13 @@ public void resetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `toMetadata` <a name="toMetadata" id="cdktf.DataTerraformRemoteStateArtifactory.toMetadata"></a>
+##### ~~`toMetadata`~~ <a name="toMetadata" id="cdktf.DataTerraformRemoteStateArtifactory.toMetadata"></a>
 
 ```java
 public java.lang.Object toMetadata()
 ```
 
-##### `toTerraform` <a name="toTerraform" id="cdktf.DataTerraformRemoteStateArtifactory.toTerraform"></a>
+##### ~~`toTerraform`~~ <a name="toTerraform" id="cdktf.DataTerraformRemoteStateArtifactory.toTerraform"></a>
 
 ```java
 public java.lang.Object toTerraform()
@@ -2634,7 +2666,7 @@ public java.lang.Object toTerraform()
 
 Adds this resource to the terraform JSON output.
 
-##### `get` <a name="get" id="cdktf.DataTerraformRemoteStateArtifactory.get"></a>
+##### ~~`get`~~ <a name="get" id="cdktf.DataTerraformRemoteStateArtifactory.get"></a>
 
 ```java
 public IResolvable get(java.lang.String output)
@@ -2646,7 +2678,7 @@ public IResolvable get(java.lang.String output)
 
 ---
 
-##### `getBoolean` <a name="getBoolean" id="cdktf.DataTerraformRemoteStateArtifactory.getBoolean"></a>
+##### ~~`getBoolean`~~ <a name="getBoolean" id="cdktf.DataTerraformRemoteStateArtifactory.getBoolean"></a>
 
 ```java
 public IResolvable getBoolean(java.lang.String output)
@@ -2658,7 +2690,7 @@ public IResolvable getBoolean(java.lang.String output)
 
 ---
 
-##### `getList` <a name="getList" id="cdktf.DataTerraformRemoteStateArtifactory.getList"></a>
+##### ~~`getList`~~ <a name="getList" id="cdktf.DataTerraformRemoteStateArtifactory.getList"></a>
 
 ```java
 public java.util.List< java.lang.String > getList(java.lang.String output)
@@ -2670,7 +2702,7 @@ public java.util.List< java.lang.String > getList(java.lang.String output)
 
 ---
 
-##### `getNumber` <a name="getNumber" id="cdktf.DataTerraformRemoteStateArtifactory.getNumber"></a>
+##### ~~`getNumber`~~ <a name="getNumber" id="cdktf.DataTerraformRemoteStateArtifactory.getNumber"></a>
 
 ```java
 public java.lang.Number getNumber(java.lang.String output)
@@ -2682,7 +2714,7 @@ public java.lang.Number getNumber(java.lang.String output)
 
 ---
 
-##### `getString` <a name="getString" id="cdktf.DataTerraformRemoteStateArtifactory.getString"></a>
+##### ~~`getString`~~ <a name="getString" id="cdktf.DataTerraformRemoteStateArtifactory.getString"></a>
 
 ```java
 public java.lang.String getString(java.lang.String output)
@@ -2703,7 +2735,7 @@ public java.lang.String getString(java.lang.String output)
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdktf.DataTerraformRemoteStateArtifactory.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdktf.DataTerraformRemoteStateArtifactory.isConstruct"></a>
 
 ```java
 import com.hashicorp.cdktf.DataTerraformRemoteStateArtifactory;
@@ -2735,7 +2767,7 @@ Any object.
 
 ---
 
-##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement"></a>
+##### ~~`isTerraformElement`~~ <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement"></a>
 
 ```java
 import com.hashicorp.cdktf.DataTerraformRemoteStateArtifactory;
@@ -2760,7 +2792,9 @@ DataTerraformRemoteStateArtifactory.isTerraformElement(java.lang.Object x)
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateArtifactory.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateArtifactory.property.node"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public Node getNode();
@@ -2772,7 +2806,9 @@ The tree node.
 
 ---
 
-##### `cdktfStack`<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateArtifactory.property.cdktfStack"></a>
+##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateArtifactory.property.cdktfStack"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public TerraformStack getCdktfStack();
@@ -2782,7 +2818,9 @@ public TerraformStack getCdktfStack();
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateArtifactory.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateArtifactory.property.fqn"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getFqn();
@@ -2792,7 +2830,9 @@ public java.lang.String getFqn();
 
 ---
 
-##### `friendlyUniqueId`<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateArtifactory.property.friendlyUniqueId"></a>
+##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateArtifactory.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getFriendlyUniqueId();
@@ -2810,7 +2850,9 @@ public java.lang.String getFriendlyUniqueId();
 
 ---
 
-##### `tfResourceType`<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateArtifactory.property.tfResourceType"></a>
+##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateArtifactory.property.tfResourceType"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getTfResourceType();
@@ -4295,19 +4337,25 @@ DataTerraformRemoteStateEtcd.Builder.create(Construct scope, java.lang.String id
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.defaults"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.util.Map< java.lang.String, java.lang.Object >
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.workspace"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `endpoints`<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.endpoints"></a>
+##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.endpoints"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -4315,7 +4363,9 @@ DataTerraformRemoteStateEtcd.Builder.create(Construct scope, java.lang.String id
 
 ---
 
-##### `path`<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.path"></a>
+##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.path"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -4323,7 +4373,9 @@ DataTerraformRemoteStateEtcd.Builder.create(Construct scope, java.lang.String id
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.password"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -4331,7 +4383,9 @@ DataTerraformRemoteStateEtcd.Builder.create(Construct scope, java.lang.String id
 
 ---
 
-##### `username`<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.username"></a>
+##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.username"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -4357,7 +4411,7 @@ DataTerraformRemoteStateEtcd.Builder.create(Construct scope, java.lang.String id
 
 ---
 
-##### `toString` <a name="toString" id="cdktf.DataTerraformRemoteStateEtcd.toString"></a>
+##### ~~`toString`~~ <a name="toString" id="cdktf.DataTerraformRemoteStateEtcd.toString"></a>
 
 ```java
 public java.lang.String toString()
@@ -4365,7 +4419,7 @@ public java.lang.String toString()
 
 Returns a string representation of this construct.
 
-##### `addOverride` <a name="addOverride" id="cdktf.DataTerraformRemoteStateEtcd.addOverride"></a>
+##### ~~`addOverride`~~ <a name="addOverride" id="cdktf.DataTerraformRemoteStateEtcd.addOverride"></a>
 
 ```java
 public void addOverride(java.lang.String path, java.lang.Object value)
@@ -4383,7 +4437,7 @@ public void addOverride(java.lang.String path, java.lang.Object value)
 
 ---
 
-##### `overrideLogicalId` <a name="overrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcd.overrideLogicalId"></a>
+##### ~~`overrideLogicalId`~~ <a name="overrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcd.overrideLogicalId"></a>
 
 ```java
 public void overrideLogicalId(java.lang.String newLogicalId)
@@ -4399,7 +4453,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `resetOverrideLogicalId` <a name="resetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcd.resetOverrideLogicalId"></a>
+##### ~~`resetOverrideLogicalId`~~ <a name="resetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcd.resetOverrideLogicalId"></a>
 
 ```java
 public void resetOverrideLogicalId()
@@ -4407,13 +4461,13 @@ public void resetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `toMetadata` <a name="toMetadata" id="cdktf.DataTerraformRemoteStateEtcd.toMetadata"></a>
+##### ~~`toMetadata`~~ <a name="toMetadata" id="cdktf.DataTerraformRemoteStateEtcd.toMetadata"></a>
 
 ```java
 public java.lang.Object toMetadata()
 ```
 
-##### `toTerraform` <a name="toTerraform" id="cdktf.DataTerraformRemoteStateEtcd.toTerraform"></a>
+##### ~~`toTerraform`~~ <a name="toTerraform" id="cdktf.DataTerraformRemoteStateEtcd.toTerraform"></a>
 
 ```java
 public java.lang.Object toTerraform()
@@ -4421,7 +4475,7 @@ public java.lang.Object toTerraform()
 
 Adds this resource to the terraform JSON output.
 
-##### `get` <a name="get" id="cdktf.DataTerraformRemoteStateEtcd.get"></a>
+##### ~~`get`~~ <a name="get" id="cdktf.DataTerraformRemoteStateEtcd.get"></a>
 
 ```java
 public IResolvable get(java.lang.String output)
@@ -4433,7 +4487,7 @@ public IResolvable get(java.lang.String output)
 
 ---
 
-##### `getBoolean` <a name="getBoolean" id="cdktf.DataTerraformRemoteStateEtcd.getBoolean"></a>
+##### ~~`getBoolean`~~ <a name="getBoolean" id="cdktf.DataTerraformRemoteStateEtcd.getBoolean"></a>
 
 ```java
 public IResolvable getBoolean(java.lang.String output)
@@ -4445,7 +4499,7 @@ public IResolvable getBoolean(java.lang.String output)
 
 ---
 
-##### `getList` <a name="getList" id="cdktf.DataTerraformRemoteStateEtcd.getList"></a>
+##### ~~`getList`~~ <a name="getList" id="cdktf.DataTerraformRemoteStateEtcd.getList"></a>
 
 ```java
 public java.util.List< java.lang.String > getList(java.lang.String output)
@@ -4457,7 +4511,7 @@ public java.util.List< java.lang.String > getList(java.lang.String output)
 
 ---
 
-##### `getNumber` <a name="getNumber" id="cdktf.DataTerraformRemoteStateEtcd.getNumber"></a>
+##### ~~`getNumber`~~ <a name="getNumber" id="cdktf.DataTerraformRemoteStateEtcd.getNumber"></a>
 
 ```java
 public java.lang.Number getNumber(java.lang.String output)
@@ -4469,7 +4523,7 @@ public java.lang.Number getNumber(java.lang.String output)
 
 ---
 
-##### `getString` <a name="getString" id="cdktf.DataTerraformRemoteStateEtcd.getString"></a>
+##### ~~`getString`~~ <a name="getString" id="cdktf.DataTerraformRemoteStateEtcd.getString"></a>
 
 ```java
 public java.lang.String getString(java.lang.String output)
@@ -4490,7 +4544,7 @@ public java.lang.String getString(java.lang.String output)
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdktf.DataTerraformRemoteStateEtcd.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdktf.DataTerraformRemoteStateEtcd.isConstruct"></a>
 
 ```java
 import com.hashicorp.cdktf.DataTerraformRemoteStateEtcd;
@@ -4522,7 +4576,7 @@ Any object.
 
 ---
 
-##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateEtcd.isTerraformElement"></a>
+##### ~~`isTerraformElement`~~ <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateEtcd.isTerraformElement"></a>
 
 ```java
 import com.hashicorp.cdktf.DataTerraformRemoteStateEtcd;
@@ -4547,7 +4601,9 @@ DataTerraformRemoteStateEtcd.isTerraformElement(java.lang.Object x)
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateEtcd.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateEtcd.property.node"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public Node getNode();
@@ -4559,7 +4615,9 @@ The tree node.
 
 ---
 
-##### `cdktfStack`<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateEtcd.property.cdktfStack"></a>
+##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateEtcd.property.cdktfStack"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public TerraformStack getCdktfStack();
@@ -4569,7 +4627,9 @@ public TerraformStack getCdktfStack();
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateEtcd.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateEtcd.property.fqn"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getFqn();
@@ -4579,7 +4639,9 @@ public java.lang.String getFqn();
 
 ---
 
-##### `friendlyUniqueId`<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcd.property.friendlyUniqueId"></a>
+##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcd.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getFriendlyUniqueId();
@@ -4597,7 +4659,9 @@ public java.lang.String getFriendlyUniqueId();
 
 ---
 
-##### `tfResourceType`<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateEtcd.property.tfResourceType"></a>
+##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateEtcd.property.tfResourceType"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getTfResourceType();
@@ -4657,19 +4721,25 @@ DataTerraformRemoteStateEtcdV3.Builder.create(Construct scope, java.lang.String 
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.defaults"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.util.Map< java.lang.String, java.lang.Object >
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.workspace"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `endpoints`<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.endpoints"></a>
+##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.endpoints"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.util.List< java.lang.String >
 
@@ -4677,7 +4747,9 @@ DataTerraformRemoteStateEtcdV3.Builder.create(Construct scope, java.lang.String 
 
 ---
 
-##### `cacertPath`<sup>Optional</sup> <a name="cacertPath" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.cacertPath"></a>
+##### ~~`cacertPath`~~<sup>Optional</sup> <a name="cacertPath" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.cacertPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -4685,7 +4757,9 @@ DataTerraformRemoteStateEtcdV3.Builder.create(Construct scope, java.lang.String 
 
 ---
 
-##### `certPath`<sup>Optional</sup> <a name="certPath" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.certPath"></a>
+##### ~~`certPath`~~<sup>Optional</sup> <a name="certPath" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.certPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -4693,7 +4767,9 @@ DataTerraformRemoteStateEtcdV3.Builder.create(Construct scope, java.lang.String 
 
 ---
 
-##### `keyPath`<sup>Optional</sup> <a name="keyPath" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.keyPath"></a>
+##### ~~`keyPath`~~<sup>Optional</sup> <a name="keyPath" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.keyPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -4701,7 +4777,9 @@ DataTerraformRemoteStateEtcdV3.Builder.create(Construct scope, java.lang.String 
 
 ---
 
-##### `lock`<sup>Optional</sup> <a name="lock" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.lock"></a>
+##### ~~`lock`~~<sup>Optional</sup> <a name="lock" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.lock"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.Boolean
 
@@ -4711,7 +4789,9 @@ Defaults to true.
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.password"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -4719,7 +4799,9 @@ Defaults to true.
 
 ---
 
-##### `prefix`<sup>Optional</sup> <a name="prefix" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.prefix"></a>
+##### ~~`prefix`~~<sup>Optional</sup> <a name="prefix" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.prefix"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -4729,7 +4811,9 @@ Defaults to "".
 
 ---
 
-##### `username`<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.username"></a>
+##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.username"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -4755,7 +4839,7 @@ Defaults to "".
 
 ---
 
-##### `toString` <a name="toString" id="cdktf.DataTerraformRemoteStateEtcdV3.toString"></a>
+##### ~~`toString`~~ <a name="toString" id="cdktf.DataTerraformRemoteStateEtcdV3.toString"></a>
 
 ```java
 public java.lang.String toString()
@@ -4763,7 +4847,7 @@ public java.lang.String toString()
 
 Returns a string representation of this construct.
 
-##### `addOverride` <a name="addOverride" id="cdktf.DataTerraformRemoteStateEtcdV3.addOverride"></a>
+##### ~~`addOverride`~~ <a name="addOverride" id="cdktf.DataTerraformRemoteStateEtcdV3.addOverride"></a>
 
 ```java
 public void addOverride(java.lang.String path, java.lang.Object value)
@@ -4781,7 +4865,7 @@ public void addOverride(java.lang.String path, java.lang.Object value)
 
 ---
 
-##### `overrideLogicalId` <a name="overrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcdV3.overrideLogicalId"></a>
+##### ~~`overrideLogicalId`~~ <a name="overrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcdV3.overrideLogicalId"></a>
 
 ```java
 public void overrideLogicalId(java.lang.String newLogicalId)
@@ -4797,7 +4881,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `resetOverrideLogicalId` <a name="resetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcdV3.resetOverrideLogicalId"></a>
+##### ~~`resetOverrideLogicalId`~~ <a name="resetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcdV3.resetOverrideLogicalId"></a>
 
 ```java
 public void resetOverrideLogicalId()
@@ -4805,13 +4889,13 @@ public void resetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `toMetadata` <a name="toMetadata" id="cdktf.DataTerraformRemoteStateEtcdV3.toMetadata"></a>
+##### ~~`toMetadata`~~ <a name="toMetadata" id="cdktf.DataTerraformRemoteStateEtcdV3.toMetadata"></a>
 
 ```java
 public java.lang.Object toMetadata()
 ```
 
-##### `toTerraform` <a name="toTerraform" id="cdktf.DataTerraformRemoteStateEtcdV3.toTerraform"></a>
+##### ~~`toTerraform`~~ <a name="toTerraform" id="cdktf.DataTerraformRemoteStateEtcdV3.toTerraform"></a>
 
 ```java
 public java.lang.Object toTerraform()
@@ -4819,7 +4903,7 @@ public java.lang.Object toTerraform()
 
 Adds this resource to the terraform JSON output.
 
-##### `get` <a name="get" id="cdktf.DataTerraformRemoteStateEtcdV3.get"></a>
+##### ~~`get`~~ <a name="get" id="cdktf.DataTerraformRemoteStateEtcdV3.get"></a>
 
 ```java
 public IResolvable get(java.lang.String output)
@@ -4831,7 +4915,7 @@ public IResolvable get(java.lang.String output)
 
 ---
 
-##### `getBoolean` <a name="getBoolean" id="cdktf.DataTerraformRemoteStateEtcdV3.getBoolean"></a>
+##### ~~`getBoolean`~~ <a name="getBoolean" id="cdktf.DataTerraformRemoteStateEtcdV3.getBoolean"></a>
 
 ```java
 public IResolvable getBoolean(java.lang.String output)
@@ -4843,7 +4927,7 @@ public IResolvable getBoolean(java.lang.String output)
 
 ---
 
-##### `getList` <a name="getList" id="cdktf.DataTerraformRemoteStateEtcdV3.getList"></a>
+##### ~~`getList`~~ <a name="getList" id="cdktf.DataTerraformRemoteStateEtcdV3.getList"></a>
 
 ```java
 public java.util.List< java.lang.String > getList(java.lang.String output)
@@ -4855,7 +4939,7 @@ public java.util.List< java.lang.String > getList(java.lang.String output)
 
 ---
 
-##### `getNumber` <a name="getNumber" id="cdktf.DataTerraformRemoteStateEtcdV3.getNumber"></a>
+##### ~~`getNumber`~~ <a name="getNumber" id="cdktf.DataTerraformRemoteStateEtcdV3.getNumber"></a>
 
 ```java
 public java.lang.Number getNumber(java.lang.String output)
@@ -4867,7 +4951,7 @@ public java.lang.Number getNumber(java.lang.String output)
 
 ---
 
-##### `getString` <a name="getString" id="cdktf.DataTerraformRemoteStateEtcdV3.getString"></a>
+##### ~~`getString`~~ <a name="getString" id="cdktf.DataTerraformRemoteStateEtcdV3.getString"></a>
 
 ```java
 public java.lang.String getString(java.lang.String output)
@@ -4888,7 +4972,7 @@ public java.lang.String getString(java.lang.String output)
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdktf.DataTerraformRemoteStateEtcdV3.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdktf.DataTerraformRemoteStateEtcdV3.isConstruct"></a>
 
 ```java
 import com.hashicorp.cdktf.DataTerraformRemoteStateEtcdV3;
@@ -4920,7 +5004,7 @@ Any object.
 
 ---
 
-##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement"></a>
+##### ~~`isTerraformElement`~~ <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement"></a>
 
 ```java
 import com.hashicorp.cdktf.DataTerraformRemoteStateEtcdV3;
@@ -4945,7 +5029,9 @@ DataTerraformRemoteStateEtcdV3.isTerraformElement(java.lang.Object x)
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateEtcdV3.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateEtcdV3.property.node"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public Node getNode();
@@ -4957,7 +5043,9 @@ The tree node.
 
 ---
 
-##### `cdktfStack`<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateEtcdV3.property.cdktfStack"></a>
+##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateEtcdV3.property.cdktfStack"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public TerraformStack getCdktfStack();
@@ -4967,7 +5055,9 @@ public TerraformStack getCdktfStack();
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateEtcdV3.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateEtcdV3.property.fqn"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getFqn();
@@ -4977,7 +5067,9 @@ public java.lang.String getFqn();
 
 ---
 
-##### `friendlyUniqueId`<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcdV3.property.friendlyUniqueId"></a>
+##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcdV3.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getFriendlyUniqueId();
@@ -4995,7 +5087,9 @@ public java.lang.String getFriendlyUniqueId();
 
 ---
 
-##### `tfResourceType`<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateEtcdV3.property.tfResourceType"></a>
+##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateEtcdV3.property.tfResourceType"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getTfResourceType();
@@ -6240,61 +6334,81 @@ DataTerraformRemoteStateManta.Builder.create(Construct scope, java.lang.String i
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.defaults"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.util.Map< java.lang.String, java.lang.Object >
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.workspace"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `account`<sup>Required</sup> <a name="account" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.account"></a>
+##### ~~`account`~~<sup>Required</sup> <a name="account" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.account"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `keyId`<sup>Required</sup> <a name="keyId" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.keyId"></a>
+##### ~~`keyId`~~<sup>Required</sup> <a name="keyId" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.keyId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `path`<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.path"></a>
+##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.path"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `insecureSkipTlsVerify`<sup>Optional</sup> <a name="insecureSkipTlsVerify" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.insecureSkipTlsVerify"></a>
+##### ~~`insecureSkipTlsVerify`~~<sup>Optional</sup> <a name="insecureSkipTlsVerify" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.insecureSkipTlsVerify"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.Boolean
 
 ---
 
-##### `keyMaterial`<sup>Optional</sup> <a name="keyMaterial" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.keyMaterial"></a>
+##### ~~`keyMaterial`~~<sup>Optional</sup> <a name="keyMaterial" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.keyMaterial"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `objectName`<sup>Optional</sup> <a name="objectName" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.objectName"></a>
+##### ~~`objectName`~~<sup>Optional</sup> <a name="objectName" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.objectName"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `url`<sup>Optional</sup> <a name="url" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.url"></a>
+##### ~~`url`~~<sup>Optional</sup> <a name="url" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.url"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `user`<sup>Optional</sup> <a name="user" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.user"></a>
+##### ~~`user`~~<sup>Optional</sup> <a name="user" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.user"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -6318,7 +6432,7 @@ DataTerraformRemoteStateManta.Builder.create(Construct scope, java.lang.String i
 
 ---
 
-##### `toString` <a name="toString" id="cdktf.DataTerraformRemoteStateManta.toString"></a>
+##### ~~`toString`~~ <a name="toString" id="cdktf.DataTerraformRemoteStateManta.toString"></a>
 
 ```java
 public java.lang.String toString()
@@ -6326,7 +6440,7 @@ public java.lang.String toString()
 
 Returns a string representation of this construct.
 
-##### `addOverride` <a name="addOverride" id="cdktf.DataTerraformRemoteStateManta.addOverride"></a>
+##### ~~`addOverride`~~ <a name="addOverride" id="cdktf.DataTerraformRemoteStateManta.addOverride"></a>
 
 ```java
 public void addOverride(java.lang.String path, java.lang.Object value)
@@ -6344,7 +6458,7 @@ public void addOverride(java.lang.String path, java.lang.Object value)
 
 ---
 
-##### `overrideLogicalId` <a name="overrideLogicalId" id="cdktf.DataTerraformRemoteStateManta.overrideLogicalId"></a>
+##### ~~`overrideLogicalId`~~ <a name="overrideLogicalId" id="cdktf.DataTerraformRemoteStateManta.overrideLogicalId"></a>
 
 ```java
 public void overrideLogicalId(java.lang.String newLogicalId)
@@ -6360,7 +6474,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `resetOverrideLogicalId` <a name="resetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateManta.resetOverrideLogicalId"></a>
+##### ~~`resetOverrideLogicalId`~~ <a name="resetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateManta.resetOverrideLogicalId"></a>
 
 ```java
 public void resetOverrideLogicalId()
@@ -6368,13 +6482,13 @@ public void resetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `toMetadata` <a name="toMetadata" id="cdktf.DataTerraformRemoteStateManta.toMetadata"></a>
+##### ~~`toMetadata`~~ <a name="toMetadata" id="cdktf.DataTerraformRemoteStateManta.toMetadata"></a>
 
 ```java
 public java.lang.Object toMetadata()
 ```
 
-##### `toTerraform` <a name="toTerraform" id="cdktf.DataTerraformRemoteStateManta.toTerraform"></a>
+##### ~~`toTerraform`~~ <a name="toTerraform" id="cdktf.DataTerraformRemoteStateManta.toTerraform"></a>
 
 ```java
 public java.lang.Object toTerraform()
@@ -6382,7 +6496,7 @@ public java.lang.Object toTerraform()
 
 Adds this resource to the terraform JSON output.
 
-##### `get` <a name="get" id="cdktf.DataTerraformRemoteStateManta.get"></a>
+##### ~~`get`~~ <a name="get" id="cdktf.DataTerraformRemoteStateManta.get"></a>
 
 ```java
 public IResolvable get(java.lang.String output)
@@ -6394,7 +6508,7 @@ public IResolvable get(java.lang.String output)
 
 ---
 
-##### `getBoolean` <a name="getBoolean" id="cdktf.DataTerraformRemoteStateManta.getBoolean"></a>
+##### ~~`getBoolean`~~ <a name="getBoolean" id="cdktf.DataTerraformRemoteStateManta.getBoolean"></a>
 
 ```java
 public IResolvable getBoolean(java.lang.String output)
@@ -6406,7 +6520,7 @@ public IResolvable getBoolean(java.lang.String output)
 
 ---
 
-##### `getList` <a name="getList" id="cdktf.DataTerraformRemoteStateManta.getList"></a>
+##### ~~`getList`~~ <a name="getList" id="cdktf.DataTerraformRemoteStateManta.getList"></a>
 
 ```java
 public java.util.List< java.lang.String > getList(java.lang.String output)
@@ -6418,7 +6532,7 @@ public java.util.List< java.lang.String > getList(java.lang.String output)
 
 ---
 
-##### `getNumber` <a name="getNumber" id="cdktf.DataTerraformRemoteStateManta.getNumber"></a>
+##### ~~`getNumber`~~ <a name="getNumber" id="cdktf.DataTerraformRemoteStateManta.getNumber"></a>
 
 ```java
 public java.lang.Number getNumber(java.lang.String output)
@@ -6430,7 +6544,7 @@ public java.lang.Number getNumber(java.lang.String output)
 
 ---
 
-##### `getString` <a name="getString" id="cdktf.DataTerraformRemoteStateManta.getString"></a>
+##### ~~`getString`~~ <a name="getString" id="cdktf.DataTerraformRemoteStateManta.getString"></a>
 
 ```java
 public java.lang.String getString(java.lang.String output)
@@ -6451,7 +6565,7 @@ public java.lang.String getString(java.lang.String output)
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdktf.DataTerraformRemoteStateManta.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdktf.DataTerraformRemoteStateManta.isConstruct"></a>
 
 ```java
 import com.hashicorp.cdktf.DataTerraformRemoteStateManta;
@@ -6483,7 +6597,7 @@ Any object.
 
 ---
 
-##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateManta.isTerraformElement"></a>
+##### ~~`isTerraformElement`~~ <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateManta.isTerraformElement"></a>
 
 ```java
 import com.hashicorp.cdktf.DataTerraformRemoteStateManta;
@@ -6508,7 +6622,9 @@ DataTerraformRemoteStateManta.isTerraformElement(java.lang.Object x)
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateManta.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateManta.property.node"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public Node getNode();
@@ -6520,7 +6636,9 @@ The tree node.
 
 ---
 
-##### `cdktfStack`<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateManta.property.cdktfStack"></a>
+##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateManta.property.cdktfStack"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public TerraformStack getCdktfStack();
@@ -6530,7 +6648,9 @@ public TerraformStack getCdktfStack();
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateManta.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateManta.property.fqn"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getFqn();
@@ -6540,7 +6660,9 @@ public java.lang.String getFqn();
 
 ---
 
-##### `friendlyUniqueId`<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateManta.property.friendlyUniqueId"></a>
+##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateManta.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getFriendlyUniqueId();
@@ -6558,7 +6680,9 @@ public java.lang.String getFriendlyUniqueId();
 
 ---
 
-##### `tfResourceType`<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateManta.property.tfResourceType"></a>
+##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateManta.property.tfResourceType"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getTfResourceType();
@@ -8095,175 +8219,233 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.defaults"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.util.Map< java.lang.String, java.lang.Object >
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.workspace"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `container`<sup>Required</sup> <a name="container" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.container"></a>
+##### ~~`container`~~<sup>Required</sup> <a name="container" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.container"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `applicationCredentialId`<sup>Optional</sup> <a name="applicationCredentialId" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.applicationCredentialId"></a>
+##### ~~`applicationCredentialId`~~<sup>Optional</sup> <a name="applicationCredentialId" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.applicationCredentialId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `applicationCredentialName`<sup>Optional</sup> <a name="applicationCredentialName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.applicationCredentialName"></a>
+##### ~~`applicationCredentialName`~~<sup>Optional</sup> <a name="applicationCredentialName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.applicationCredentialName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `applicationCredentialSecret`<sup>Optional</sup> <a name="applicationCredentialSecret" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.applicationCredentialSecret"></a>
+##### ~~`applicationCredentialSecret`~~<sup>Optional</sup> <a name="applicationCredentialSecret" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.applicationCredentialSecret"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `archiveContainer`<sup>Optional</sup> <a name="archiveContainer" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.archiveContainer"></a>
+##### ~~`archiveContainer`~~<sup>Optional</sup> <a name="archiveContainer" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.archiveContainer"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `authUrl`<sup>Optional</sup> <a name="authUrl" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.authUrl"></a>
+##### ~~`authUrl`~~<sup>Optional</sup> <a name="authUrl" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.authUrl"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `cacertFile`<sup>Optional</sup> <a name="cacertFile" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.cacertFile"></a>
+##### ~~`cacertFile`~~<sup>Optional</sup> <a name="cacertFile" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.cacertFile"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `cert`<sup>Optional</sup> <a name="cert" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.cert"></a>
+##### ~~`cert`~~<sup>Optional</sup> <a name="cert" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.cert"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `cloud`<sup>Optional</sup> <a name="cloud" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.cloud"></a>
+##### ~~`cloud`~~<sup>Optional</sup> <a name="cloud" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.cloud"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `defaultDomain`<sup>Optional</sup> <a name="defaultDomain" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.defaultDomain"></a>
+##### ~~`defaultDomain`~~<sup>Optional</sup> <a name="defaultDomain" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.defaultDomain"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `domainId`<sup>Optional</sup> <a name="domainId" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.domainId"></a>
+##### ~~`domainId`~~<sup>Optional</sup> <a name="domainId" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.domainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `domainName`<sup>Optional</sup> <a name="domainName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.domainName"></a>
+##### ~~`domainName`~~<sup>Optional</sup> <a name="domainName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.domainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `expireAfter`<sup>Optional</sup> <a name="expireAfter" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.expireAfter"></a>
+##### ~~`expireAfter`~~<sup>Optional</sup> <a name="expireAfter" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.expireAfter"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `insecure`<sup>Optional</sup> <a name="insecure" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.insecure"></a>
+##### ~~`insecure`~~<sup>Optional</sup> <a name="insecure" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.insecure"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.Boolean
 
 ---
 
-##### `key`<sup>Optional</sup> <a name="key" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.key"></a>
+##### ~~`key`~~<sup>Optional</sup> <a name="key" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.key"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.password"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `projectDomainId`<sup>Optional</sup> <a name="projectDomainId" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.projectDomainId"></a>
+##### ~~`projectDomainId`~~<sup>Optional</sup> <a name="projectDomainId" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.projectDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `projectDomainName`<sup>Optional</sup> <a name="projectDomainName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.projectDomainName"></a>
+##### ~~`projectDomainName`~~<sup>Optional</sup> <a name="projectDomainName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.projectDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `regionName`<sup>Optional</sup> <a name="regionName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.regionName"></a>
+##### ~~`regionName`~~<sup>Optional</sup> <a name="regionName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.regionName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `stateName`<sup>Optional</sup> <a name="stateName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.stateName"></a>
+##### ~~`stateName`~~<sup>Optional</sup> <a name="stateName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.stateName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `tenantId`<sup>Optional</sup> <a name="tenantId" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.tenantId"></a>
+##### ~~`tenantId`~~<sup>Optional</sup> <a name="tenantId" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.tenantId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `tenantName`<sup>Optional</sup> <a name="tenantName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.tenantName"></a>
+##### ~~`tenantName`~~<sup>Optional</sup> <a name="tenantName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.tenantName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `token`<sup>Optional</sup> <a name="token" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.token"></a>
+##### ~~`token`~~<sup>Optional</sup> <a name="token" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.token"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `userDomainId`<sup>Optional</sup> <a name="userDomainId" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userDomainId"></a>
+##### ~~`userDomainId`~~<sup>Optional</sup> <a name="userDomainId" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `userDomainName`<sup>Optional</sup> <a name="userDomainName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userDomainName"></a>
+##### ~~`userDomainName`~~<sup>Optional</sup> <a name="userDomainName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `userId`<sup>Optional</sup> <a name="userId" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userId"></a>
+##### ~~`userId`~~<sup>Optional</sup> <a name="userId" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `userName`<sup>Optional</sup> <a name="userName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userName"></a>
+##### ~~`userName`~~<sup>Optional</sup> <a name="userName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -8287,7 +8469,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ---
 
-##### `toString` <a name="toString" id="cdktf.DataTerraformRemoteStateSwift.toString"></a>
+##### ~~`toString`~~ <a name="toString" id="cdktf.DataTerraformRemoteStateSwift.toString"></a>
 
 ```java
 public java.lang.String toString()
@@ -8295,7 +8477,7 @@ public java.lang.String toString()
 
 Returns a string representation of this construct.
 
-##### `addOverride` <a name="addOverride" id="cdktf.DataTerraformRemoteStateSwift.addOverride"></a>
+##### ~~`addOverride`~~ <a name="addOverride" id="cdktf.DataTerraformRemoteStateSwift.addOverride"></a>
 
 ```java
 public void addOverride(java.lang.String path, java.lang.Object value)
@@ -8313,7 +8495,7 @@ public void addOverride(java.lang.String path, java.lang.Object value)
 
 ---
 
-##### `overrideLogicalId` <a name="overrideLogicalId" id="cdktf.DataTerraformRemoteStateSwift.overrideLogicalId"></a>
+##### ~~`overrideLogicalId`~~ <a name="overrideLogicalId" id="cdktf.DataTerraformRemoteStateSwift.overrideLogicalId"></a>
 
 ```java
 public void overrideLogicalId(java.lang.String newLogicalId)
@@ -8329,7 +8511,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `resetOverrideLogicalId` <a name="resetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateSwift.resetOverrideLogicalId"></a>
+##### ~~`resetOverrideLogicalId`~~ <a name="resetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateSwift.resetOverrideLogicalId"></a>
 
 ```java
 public void resetOverrideLogicalId()
@@ -8337,13 +8519,13 @@ public void resetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `toMetadata` <a name="toMetadata" id="cdktf.DataTerraformRemoteStateSwift.toMetadata"></a>
+##### ~~`toMetadata`~~ <a name="toMetadata" id="cdktf.DataTerraformRemoteStateSwift.toMetadata"></a>
 
 ```java
 public java.lang.Object toMetadata()
 ```
 
-##### `toTerraform` <a name="toTerraform" id="cdktf.DataTerraformRemoteStateSwift.toTerraform"></a>
+##### ~~`toTerraform`~~ <a name="toTerraform" id="cdktf.DataTerraformRemoteStateSwift.toTerraform"></a>
 
 ```java
 public java.lang.Object toTerraform()
@@ -8351,7 +8533,7 @@ public java.lang.Object toTerraform()
 
 Adds this resource to the terraform JSON output.
 
-##### `get` <a name="get" id="cdktf.DataTerraformRemoteStateSwift.get"></a>
+##### ~~`get`~~ <a name="get" id="cdktf.DataTerraformRemoteStateSwift.get"></a>
 
 ```java
 public IResolvable get(java.lang.String output)
@@ -8363,7 +8545,7 @@ public IResolvable get(java.lang.String output)
 
 ---
 
-##### `getBoolean` <a name="getBoolean" id="cdktf.DataTerraformRemoteStateSwift.getBoolean"></a>
+##### ~~`getBoolean`~~ <a name="getBoolean" id="cdktf.DataTerraformRemoteStateSwift.getBoolean"></a>
 
 ```java
 public IResolvable getBoolean(java.lang.String output)
@@ -8375,7 +8557,7 @@ public IResolvable getBoolean(java.lang.String output)
 
 ---
 
-##### `getList` <a name="getList" id="cdktf.DataTerraformRemoteStateSwift.getList"></a>
+##### ~~`getList`~~ <a name="getList" id="cdktf.DataTerraformRemoteStateSwift.getList"></a>
 
 ```java
 public java.util.List< java.lang.String > getList(java.lang.String output)
@@ -8387,7 +8569,7 @@ public java.util.List< java.lang.String > getList(java.lang.String output)
 
 ---
 
-##### `getNumber` <a name="getNumber" id="cdktf.DataTerraformRemoteStateSwift.getNumber"></a>
+##### ~~`getNumber`~~ <a name="getNumber" id="cdktf.DataTerraformRemoteStateSwift.getNumber"></a>
 
 ```java
 public java.lang.Number getNumber(java.lang.String output)
@@ -8399,7 +8581,7 @@ public java.lang.Number getNumber(java.lang.String output)
 
 ---
 
-##### `getString` <a name="getString" id="cdktf.DataTerraformRemoteStateSwift.getString"></a>
+##### ~~`getString`~~ <a name="getString" id="cdktf.DataTerraformRemoteStateSwift.getString"></a>
 
 ```java
 public java.lang.String getString(java.lang.String output)
@@ -8420,7 +8602,7 @@ public java.lang.String getString(java.lang.String output)
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdktf.DataTerraformRemoteStateSwift.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdktf.DataTerraformRemoteStateSwift.isConstruct"></a>
 
 ```java
 import com.hashicorp.cdktf.DataTerraformRemoteStateSwift;
@@ -8452,7 +8634,7 @@ Any object.
 
 ---
 
-##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateSwift.isTerraformElement"></a>
+##### ~~`isTerraformElement`~~ <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateSwift.isTerraformElement"></a>
 
 ```java
 import com.hashicorp.cdktf.DataTerraformRemoteStateSwift;
@@ -8477,7 +8659,9 @@ DataTerraformRemoteStateSwift.isTerraformElement(java.lang.Object x)
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateSwift.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateSwift.property.node"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public Node getNode();
@@ -8489,7 +8673,9 @@ The tree node.
 
 ---
 
-##### `cdktfStack`<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateSwift.property.cdktfStack"></a>
+##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateSwift.property.cdktfStack"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public TerraformStack getCdktfStack();
@@ -8499,7 +8685,9 @@ public TerraformStack getCdktfStack();
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateSwift.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateSwift.property.fqn"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getFqn();
@@ -8509,7 +8697,9 @@ public java.lang.String getFqn();
 
 ---
 
-##### `friendlyUniqueId`<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateSwift.property.friendlyUniqueId"></a>
+##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateSwift.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getFriendlyUniqueId();
@@ -8527,7 +8717,9 @@ public java.lang.String getFriendlyUniqueId();
 
 ---
 
-##### `tfResourceType`<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateSwift.property.tfResourceType"></a>
+##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateSwift.property.tfResourceType"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getTfResourceType();
@@ -8568,7 +8760,9 @@ EtcdBackend.Builder.create(Construct scope)
 
 ---
 
-##### `endpoints`<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdBackend.Initializer.parameter.endpoints"></a>
+##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdBackend.Initializer.parameter.endpoints"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -8576,7 +8770,9 @@ EtcdBackend.Builder.create(Construct scope)
 
 ---
 
-##### `path`<sup>Required</sup> <a name="path" id="cdktf.EtcdBackend.Initializer.parameter.path"></a>
+##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.EtcdBackend.Initializer.parameter.path"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -8584,7 +8780,9 @@ EtcdBackend.Builder.create(Construct scope)
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.EtcdBackend.Initializer.parameter.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.EtcdBackend.Initializer.parameter.password"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -8592,7 +8790,9 @@ EtcdBackend.Builder.create(Construct scope)
 
 ---
 
-##### `username`<sup>Optional</sup> <a name="username" id="cdktf.EtcdBackend.Initializer.parameter.username"></a>
+##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.EtcdBackend.Initializer.parameter.username"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -8614,7 +8814,7 @@ EtcdBackend.Builder.create(Construct scope)
 
 ---
 
-##### `toString` <a name="toString" id="cdktf.EtcdBackend.toString"></a>
+##### ~~`toString`~~ <a name="toString" id="cdktf.EtcdBackend.toString"></a>
 
 ```java
 public java.lang.String toString()
@@ -8622,7 +8822,7 @@ public java.lang.String toString()
 
 Returns a string representation of this construct.
 
-##### `addOverride` <a name="addOverride" id="cdktf.EtcdBackend.addOverride"></a>
+##### ~~`addOverride`~~ <a name="addOverride" id="cdktf.EtcdBackend.addOverride"></a>
 
 ```java
 public void addOverride(java.lang.String path, java.lang.Object value)
@@ -8640,7 +8840,7 @@ public void addOverride(java.lang.String path, java.lang.Object value)
 
 ---
 
-##### `overrideLogicalId` <a name="overrideLogicalId" id="cdktf.EtcdBackend.overrideLogicalId"></a>
+##### ~~`overrideLogicalId`~~ <a name="overrideLogicalId" id="cdktf.EtcdBackend.overrideLogicalId"></a>
 
 ```java
 public void overrideLogicalId(java.lang.String newLogicalId)
@@ -8656,7 +8856,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `resetOverrideLogicalId` <a name="resetOverrideLogicalId" id="cdktf.EtcdBackend.resetOverrideLogicalId"></a>
+##### ~~`resetOverrideLogicalId`~~ <a name="resetOverrideLogicalId" id="cdktf.EtcdBackend.resetOverrideLogicalId"></a>
 
 ```java
 public void resetOverrideLogicalId()
@@ -8664,13 +8864,13 @@ public void resetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `toMetadata` <a name="toMetadata" id="cdktf.EtcdBackend.toMetadata"></a>
+##### ~~`toMetadata`~~ <a name="toMetadata" id="cdktf.EtcdBackend.toMetadata"></a>
 
 ```java
 public java.lang.Object toMetadata()
 ```
 
-##### `toTerraform` <a name="toTerraform" id="cdktf.EtcdBackend.toTerraform"></a>
+##### ~~`toTerraform`~~ <a name="toTerraform" id="cdktf.EtcdBackend.toTerraform"></a>
 
 ```java
 public java.lang.Object toTerraform()
@@ -8678,7 +8878,7 @@ public java.lang.Object toTerraform()
 
 Adds this resource to the terraform JSON output.
 
-##### `getRemoteStateDataSource` <a name="getRemoteStateDataSource" id="cdktf.EtcdBackend.getRemoteStateDataSource"></a>
+##### ~~`getRemoteStateDataSource`~~ <a name="getRemoteStateDataSource" id="cdktf.EtcdBackend.getRemoteStateDataSource"></a>
 
 ```java
 public TerraformRemoteState getRemoteStateDataSource(Construct scope, java.lang.String name, java.lang.String _fromStack)
@@ -8714,7 +8914,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdktf.EtcdBackend.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdktf.EtcdBackend.isConstruct"></a>
 
 ```java
 import com.hashicorp.cdktf.EtcdBackend;
@@ -8746,7 +8946,7 @@ Any object.
 
 ---
 
-##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.EtcdBackend.isTerraformElement"></a>
+##### ~~`isTerraformElement`~~ <a name="isTerraformElement" id="cdktf.EtcdBackend.isTerraformElement"></a>
 
 ```java
 import com.hashicorp.cdktf.EtcdBackend;
@@ -8760,7 +8960,7 @@ EtcdBackend.isTerraformElement(java.lang.Object x)
 
 ---
 
-##### `isBackend` <a name="isBackend" id="cdktf.EtcdBackend.isBackend"></a>
+##### ~~`isBackend`~~ <a name="isBackend" id="cdktf.EtcdBackend.isBackend"></a>
 
 ```java
 import com.hashicorp.cdktf.EtcdBackend;
@@ -8785,7 +8985,9 @@ EtcdBackend.isBackend(java.lang.Object x)
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.EtcdBackend.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.EtcdBackend.property.node"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public Node getNode();
@@ -8797,7 +8999,9 @@ The tree node.
 
 ---
 
-##### `cdktfStack`<sup>Required</sup> <a name="cdktfStack" id="cdktf.EtcdBackend.property.cdktfStack"></a>
+##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.EtcdBackend.property.cdktfStack"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public TerraformStack getCdktfStack();
@@ -8807,7 +9011,9 @@ public TerraformStack getCdktfStack();
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.EtcdBackend.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.EtcdBackend.property.fqn"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getFqn();
@@ -8817,7 +9023,9 @@ public java.lang.String getFqn();
 
 ---
 
-##### `friendlyUniqueId`<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.EtcdBackend.property.friendlyUniqueId"></a>
+##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.EtcdBackend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getFriendlyUniqueId();
@@ -8866,7 +9074,9 @@ EtcdV3Backend.Builder.create(Construct scope)
 
 ---
 
-##### `endpoints`<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdV3Backend.Initializer.parameter.endpoints"></a>
+##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdV3Backend.Initializer.parameter.endpoints"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.util.List< java.lang.String >
 
@@ -8874,7 +9084,9 @@ EtcdV3Backend.Builder.create(Construct scope)
 
 ---
 
-##### `cacertPath`<sup>Optional</sup> <a name="cacertPath" id="cdktf.EtcdV3Backend.Initializer.parameter.cacertPath"></a>
+##### ~~`cacertPath`~~<sup>Optional</sup> <a name="cacertPath" id="cdktf.EtcdV3Backend.Initializer.parameter.cacertPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -8882,7 +9094,9 @@ EtcdV3Backend.Builder.create(Construct scope)
 
 ---
 
-##### `certPath`<sup>Optional</sup> <a name="certPath" id="cdktf.EtcdV3Backend.Initializer.parameter.certPath"></a>
+##### ~~`certPath`~~<sup>Optional</sup> <a name="certPath" id="cdktf.EtcdV3Backend.Initializer.parameter.certPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -8890,7 +9104,9 @@ EtcdV3Backend.Builder.create(Construct scope)
 
 ---
 
-##### `keyPath`<sup>Optional</sup> <a name="keyPath" id="cdktf.EtcdV3Backend.Initializer.parameter.keyPath"></a>
+##### ~~`keyPath`~~<sup>Optional</sup> <a name="keyPath" id="cdktf.EtcdV3Backend.Initializer.parameter.keyPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -8898,7 +9114,9 @@ EtcdV3Backend.Builder.create(Construct scope)
 
 ---
 
-##### `lock`<sup>Optional</sup> <a name="lock" id="cdktf.EtcdV3Backend.Initializer.parameter.lock"></a>
+##### ~~`lock`~~<sup>Optional</sup> <a name="lock" id="cdktf.EtcdV3Backend.Initializer.parameter.lock"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.Boolean
 
@@ -8908,7 +9126,9 @@ Defaults to true.
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.EtcdV3Backend.Initializer.parameter.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.EtcdV3Backend.Initializer.parameter.password"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -8916,7 +9136,9 @@ Defaults to true.
 
 ---
 
-##### `prefix`<sup>Optional</sup> <a name="prefix" id="cdktf.EtcdV3Backend.Initializer.parameter.prefix"></a>
+##### ~~`prefix`~~<sup>Optional</sup> <a name="prefix" id="cdktf.EtcdV3Backend.Initializer.parameter.prefix"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -8926,7 +9148,9 @@ Defaults to "".
 
 ---
 
-##### `username`<sup>Optional</sup> <a name="username" id="cdktf.EtcdV3Backend.Initializer.parameter.username"></a>
+##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.EtcdV3Backend.Initializer.parameter.username"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -8948,7 +9172,7 @@ Defaults to "".
 
 ---
 
-##### `toString` <a name="toString" id="cdktf.EtcdV3Backend.toString"></a>
+##### ~~`toString`~~ <a name="toString" id="cdktf.EtcdV3Backend.toString"></a>
 
 ```java
 public java.lang.String toString()
@@ -8956,7 +9180,7 @@ public java.lang.String toString()
 
 Returns a string representation of this construct.
 
-##### `addOverride` <a name="addOverride" id="cdktf.EtcdV3Backend.addOverride"></a>
+##### ~~`addOverride`~~ <a name="addOverride" id="cdktf.EtcdV3Backend.addOverride"></a>
 
 ```java
 public void addOverride(java.lang.String path, java.lang.Object value)
@@ -8974,7 +9198,7 @@ public void addOverride(java.lang.String path, java.lang.Object value)
 
 ---
 
-##### `overrideLogicalId` <a name="overrideLogicalId" id="cdktf.EtcdV3Backend.overrideLogicalId"></a>
+##### ~~`overrideLogicalId`~~ <a name="overrideLogicalId" id="cdktf.EtcdV3Backend.overrideLogicalId"></a>
 
 ```java
 public void overrideLogicalId(java.lang.String newLogicalId)
@@ -8990,7 +9214,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `resetOverrideLogicalId` <a name="resetOverrideLogicalId" id="cdktf.EtcdV3Backend.resetOverrideLogicalId"></a>
+##### ~~`resetOverrideLogicalId`~~ <a name="resetOverrideLogicalId" id="cdktf.EtcdV3Backend.resetOverrideLogicalId"></a>
 
 ```java
 public void resetOverrideLogicalId()
@@ -8998,13 +9222,13 @@ public void resetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `toMetadata` <a name="toMetadata" id="cdktf.EtcdV3Backend.toMetadata"></a>
+##### ~~`toMetadata`~~ <a name="toMetadata" id="cdktf.EtcdV3Backend.toMetadata"></a>
 
 ```java
 public java.lang.Object toMetadata()
 ```
 
-##### `toTerraform` <a name="toTerraform" id="cdktf.EtcdV3Backend.toTerraform"></a>
+##### ~~`toTerraform`~~ <a name="toTerraform" id="cdktf.EtcdV3Backend.toTerraform"></a>
 
 ```java
 public java.lang.Object toTerraform()
@@ -9012,7 +9236,7 @@ public java.lang.Object toTerraform()
 
 Adds this resource to the terraform JSON output.
 
-##### `getRemoteStateDataSource` <a name="getRemoteStateDataSource" id="cdktf.EtcdV3Backend.getRemoteStateDataSource"></a>
+##### ~~`getRemoteStateDataSource`~~ <a name="getRemoteStateDataSource" id="cdktf.EtcdV3Backend.getRemoteStateDataSource"></a>
 
 ```java
 public TerraformRemoteState getRemoteStateDataSource(Construct scope, java.lang.String name, java.lang.String _fromStack)
@@ -9048,7 +9272,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdktf.EtcdV3Backend.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdktf.EtcdV3Backend.isConstruct"></a>
 
 ```java
 import com.hashicorp.cdktf.EtcdV3Backend;
@@ -9080,7 +9304,7 @@ Any object.
 
 ---
 
-##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.EtcdV3Backend.isTerraformElement"></a>
+##### ~~`isTerraformElement`~~ <a name="isTerraformElement" id="cdktf.EtcdV3Backend.isTerraformElement"></a>
 
 ```java
 import com.hashicorp.cdktf.EtcdV3Backend;
@@ -9094,7 +9318,7 @@ EtcdV3Backend.isTerraformElement(java.lang.Object x)
 
 ---
 
-##### `isBackend` <a name="isBackend" id="cdktf.EtcdV3Backend.isBackend"></a>
+##### ~~`isBackend`~~ <a name="isBackend" id="cdktf.EtcdV3Backend.isBackend"></a>
 
 ```java
 import com.hashicorp.cdktf.EtcdV3Backend;
@@ -9119,7 +9343,9 @@ EtcdV3Backend.isBackend(java.lang.Object x)
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.EtcdV3Backend.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.EtcdV3Backend.property.node"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public Node getNode();
@@ -9131,7 +9357,9 @@ The tree node.
 
 ---
 
-##### `cdktfStack`<sup>Required</sup> <a name="cdktfStack" id="cdktf.EtcdV3Backend.property.cdktfStack"></a>
+##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.EtcdV3Backend.property.cdktfStack"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public TerraformStack getCdktfStack();
@@ -9141,7 +9369,9 @@ public TerraformStack getCdktfStack();
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.EtcdV3Backend.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.EtcdV3Backend.property.fqn"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getFqn();
@@ -9151,7 +9381,9 @@ public java.lang.String getFqn();
 
 ---
 
-##### `friendlyUniqueId`<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.EtcdV3Backend.property.friendlyUniqueId"></a>
+##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.EtcdV3Backend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getFriendlyUniqueId();
@@ -10193,49 +10425,65 @@ MantaBackend.Builder.create(Construct scope)
 
 ---
 
-##### `account`<sup>Required</sup> <a name="account" id="cdktf.MantaBackend.Initializer.parameter.account"></a>
+##### ~~`account`~~<sup>Required</sup> <a name="account" id="cdktf.MantaBackend.Initializer.parameter.account"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `keyId`<sup>Required</sup> <a name="keyId" id="cdktf.MantaBackend.Initializer.parameter.keyId"></a>
+##### ~~`keyId`~~<sup>Required</sup> <a name="keyId" id="cdktf.MantaBackend.Initializer.parameter.keyId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `path`<sup>Required</sup> <a name="path" id="cdktf.MantaBackend.Initializer.parameter.path"></a>
+##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.MantaBackend.Initializer.parameter.path"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `insecureSkipTlsVerify`<sup>Optional</sup> <a name="insecureSkipTlsVerify" id="cdktf.MantaBackend.Initializer.parameter.insecureSkipTlsVerify"></a>
+##### ~~`insecureSkipTlsVerify`~~<sup>Optional</sup> <a name="insecureSkipTlsVerify" id="cdktf.MantaBackend.Initializer.parameter.insecureSkipTlsVerify"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.Boolean
 
 ---
 
-##### `keyMaterial`<sup>Optional</sup> <a name="keyMaterial" id="cdktf.MantaBackend.Initializer.parameter.keyMaterial"></a>
+##### ~~`keyMaterial`~~<sup>Optional</sup> <a name="keyMaterial" id="cdktf.MantaBackend.Initializer.parameter.keyMaterial"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `objectName`<sup>Optional</sup> <a name="objectName" id="cdktf.MantaBackend.Initializer.parameter.objectName"></a>
+##### ~~`objectName`~~<sup>Optional</sup> <a name="objectName" id="cdktf.MantaBackend.Initializer.parameter.objectName"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `url`<sup>Optional</sup> <a name="url" id="cdktf.MantaBackend.Initializer.parameter.url"></a>
+##### ~~`url`~~<sup>Optional</sup> <a name="url" id="cdktf.MantaBackend.Initializer.parameter.url"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `user`<sup>Optional</sup> <a name="user" id="cdktf.MantaBackend.Initializer.parameter.user"></a>
+##### ~~`user`~~<sup>Optional</sup> <a name="user" id="cdktf.MantaBackend.Initializer.parameter.user"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -10255,7 +10503,7 @@ MantaBackend.Builder.create(Construct scope)
 
 ---
 
-##### `toString` <a name="toString" id="cdktf.MantaBackend.toString"></a>
+##### ~~`toString`~~ <a name="toString" id="cdktf.MantaBackend.toString"></a>
 
 ```java
 public java.lang.String toString()
@@ -10263,7 +10511,7 @@ public java.lang.String toString()
 
 Returns a string representation of this construct.
 
-##### `addOverride` <a name="addOverride" id="cdktf.MantaBackend.addOverride"></a>
+##### ~~`addOverride`~~ <a name="addOverride" id="cdktf.MantaBackend.addOverride"></a>
 
 ```java
 public void addOverride(java.lang.String path, java.lang.Object value)
@@ -10281,7 +10529,7 @@ public void addOverride(java.lang.String path, java.lang.Object value)
 
 ---
 
-##### `overrideLogicalId` <a name="overrideLogicalId" id="cdktf.MantaBackend.overrideLogicalId"></a>
+##### ~~`overrideLogicalId`~~ <a name="overrideLogicalId" id="cdktf.MantaBackend.overrideLogicalId"></a>
 
 ```java
 public void overrideLogicalId(java.lang.String newLogicalId)
@@ -10297,7 +10545,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `resetOverrideLogicalId` <a name="resetOverrideLogicalId" id="cdktf.MantaBackend.resetOverrideLogicalId"></a>
+##### ~~`resetOverrideLogicalId`~~ <a name="resetOverrideLogicalId" id="cdktf.MantaBackend.resetOverrideLogicalId"></a>
 
 ```java
 public void resetOverrideLogicalId()
@@ -10305,13 +10553,13 @@ public void resetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `toMetadata` <a name="toMetadata" id="cdktf.MantaBackend.toMetadata"></a>
+##### ~~`toMetadata`~~ <a name="toMetadata" id="cdktf.MantaBackend.toMetadata"></a>
 
 ```java
 public java.lang.Object toMetadata()
 ```
 
-##### `toTerraform` <a name="toTerraform" id="cdktf.MantaBackend.toTerraform"></a>
+##### ~~`toTerraform`~~ <a name="toTerraform" id="cdktf.MantaBackend.toTerraform"></a>
 
 ```java
 public java.lang.Object toTerraform()
@@ -10319,7 +10567,7 @@ public java.lang.Object toTerraform()
 
 Adds this resource to the terraform JSON output.
 
-##### `getRemoteStateDataSource` <a name="getRemoteStateDataSource" id="cdktf.MantaBackend.getRemoteStateDataSource"></a>
+##### ~~`getRemoteStateDataSource`~~ <a name="getRemoteStateDataSource" id="cdktf.MantaBackend.getRemoteStateDataSource"></a>
 
 ```java
 public TerraformRemoteState getRemoteStateDataSource(Construct scope, java.lang.String name, java.lang.String _fromStack)
@@ -10355,7 +10603,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdktf.MantaBackend.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdktf.MantaBackend.isConstruct"></a>
 
 ```java
 import com.hashicorp.cdktf.MantaBackend;
@@ -10387,7 +10635,7 @@ Any object.
 
 ---
 
-##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.MantaBackend.isTerraformElement"></a>
+##### ~~`isTerraformElement`~~ <a name="isTerraformElement" id="cdktf.MantaBackend.isTerraformElement"></a>
 
 ```java
 import com.hashicorp.cdktf.MantaBackend;
@@ -10401,7 +10649,7 @@ MantaBackend.isTerraformElement(java.lang.Object x)
 
 ---
 
-##### `isBackend` <a name="isBackend" id="cdktf.MantaBackend.isBackend"></a>
+##### ~~`isBackend`~~ <a name="isBackend" id="cdktf.MantaBackend.isBackend"></a>
 
 ```java
 import com.hashicorp.cdktf.MantaBackend;
@@ -10426,7 +10674,9 @@ MantaBackend.isBackend(java.lang.Object x)
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.MantaBackend.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.MantaBackend.property.node"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public Node getNode();
@@ -10438,7 +10688,9 @@ The tree node.
 
 ---
 
-##### `cdktfStack`<sup>Required</sup> <a name="cdktfStack" id="cdktf.MantaBackend.property.cdktfStack"></a>
+##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.MantaBackend.property.cdktfStack"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public TerraformStack getCdktfStack();
@@ -10448,7 +10700,9 @@ public TerraformStack getCdktfStack();
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.MantaBackend.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.MantaBackend.property.fqn"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getFqn();
@@ -10458,7 +10712,9 @@ public java.lang.String getFqn();
 
 ---
 
-##### `friendlyUniqueId`<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.MantaBackend.property.friendlyUniqueId"></a>
+##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.MantaBackend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getFriendlyUniqueId();
@@ -12200,163 +12456,217 @@ SwiftBackend.Builder.create(Construct scope)
 
 ---
 
-##### `container`<sup>Required</sup> <a name="container" id="cdktf.SwiftBackend.Initializer.parameter.container"></a>
+##### ~~`container`~~<sup>Required</sup> <a name="container" id="cdktf.SwiftBackend.Initializer.parameter.container"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `applicationCredentialId`<sup>Optional</sup> <a name="applicationCredentialId" id="cdktf.SwiftBackend.Initializer.parameter.applicationCredentialId"></a>
+##### ~~`applicationCredentialId`~~<sup>Optional</sup> <a name="applicationCredentialId" id="cdktf.SwiftBackend.Initializer.parameter.applicationCredentialId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `applicationCredentialName`<sup>Optional</sup> <a name="applicationCredentialName" id="cdktf.SwiftBackend.Initializer.parameter.applicationCredentialName"></a>
+##### ~~`applicationCredentialName`~~<sup>Optional</sup> <a name="applicationCredentialName" id="cdktf.SwiftBackend.Initializer.parameter.applicationCredentialName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `applicationCredentialSecret`<sup>Optional</sup> <a name="applicationCredentialSecret" id="cdktf.SwiftBackend.Initializer.parameter.applicationCredentialSecret"></a>
+##### ~~`applicationCredentialSecret`~~<sup>Optional</sup> <a name="applicationCredentialSecret" id="cdktf.SwiftBackend.Initializer.parameter.applicationCredentialSecret"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `archiveContainer`<sup>Optional</sup> <a name="archiveContainer" id="cdktf.SwiftBackend.Initializer.parameter.archiveContainer"></a>
+##### ~~`archiveContainer`~~<sup>Optional</sup> <a name="archiveContainer" id="cdktf.SwiftBackend.Initializer.parameter.archiveContainer"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `authUrl`<sup>Optional</sup> <a name="authUrl" id="cdktf.SwiftBackend.Initializer.parameter.authUrl"></a>
+##### ~~`authUrl`~~<sup>Optional</sup> <a name="authUrl" id="cdktf.SwiftBackend.Initializer.parameter.authUrl"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `cacertFile`<sup>Optional</sup> <a name="cacertFile" id="cdktf.SwiftBackend.Initializer.parameter.cacertFile"></a>
+##### ~~`cacertFile`~~<sup>Optional</sup> <a name="cacertFile" id="cdktf.SwiftBackend.Initializer.parameter.cacertFile"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `cert`<sup>Optional</sup> <a name="cert" id="cdktf.SwiftBackend.Initializer.parameter.cert"></a>
+##### ~~`cert`~~<sup>Optional</sup> <a name="cert" id="cdktf.SwiftBackend.Initializer.parameter.cert"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `cloud`<sup>Optional</sup> <a name="cloud" id="cdktf.SwiftBackend.Initializer.parameter.cloud"></a>
+##### ~~`cloud`~~<sup>Optional</sup> <a name="cloud" id="cdktf.SwiftBackend.Initializer.parameter.cloud"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `defaultDomain`<sup>Optional</sup> <a name="defaultDomain" id="cdktf.SwiftBackend.Initializer.parameter.defaultDomain"></a>
+##### ~~`defaultDomain`~~<sup>Optional</sup> <a name="defaultDomain" id="cdktf.SwiftBackend.Initializer.parameter.defaultDomain"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `domainId`<sup>Optional</sup> <a name="domainId" id="cdktf.SwiftBackend.Initializer.parameter.domainId"></a>
+##### ~~`domainId`~~<sup>Optional</sup> <a name="domainId" id="cdktf.SwiftBackend.Initializer.parameter.domainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `domainName`<sup>Optional</sup> <a name="domainName" id="cdktf.SwiftBackend.Initializer.parameter.domainName"></a>
+##### ~~`domainName`~~<sup>Optional</sup> <a name="domainName" id="cdktf.SwiftBackend.Initializer.parameter.domainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `expireAfter`<sup>Optional</sup> <a name="expireAfter" id="cdktf.SwiftBackend.Initializer.parameter.expireAfter"></a>
+##### ~~`expireAfter`~~<sup>Optional</sup> <a name="expireAfter" id="cdktf.SwiftBackend.Initializer.parameter.expireAfter"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `insecure`<sup>Optional</sup> <a name="insecure" id="cdktf.SwiftBackend.Initializer.parameter.insecure"></a>
+##### ~~`insecure`~~<sup>Optional</sup> <a name="insecure" id="cdktf.SwiftBackend.Initializer.parameter.insecure"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.Boolean
 
 ---
 
-##### `key`<sup>Optional</sup> <a name="key" id="cdktf.SwiftBackend.Initializer.parameter.key"></a>
+##### ~~`key`~~<sup>Optional</sup> <a name="key" id="cdktf.SwiftBackend.Initializer.parameter.key"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.SwiftBackend.Initializer.parameter.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.SwiftBackend.Initializer.parameter.password"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `projectDomainId`<sup>Optional</sup> <a name="projectDomainId" id="cdktf.SwiftBackend.Initializer.parameter.projectDomainId"></a>
+##### ~~`projectDomainId`~~<sup>Optional</sup> <a name="projectDomainId" id="cdktf.SwiftBackend.Initializer.parameter.projectDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `projectDomainName`<sup>Optional</sup> <a name="projectDomainName" id="cdktf.SwiftBackend.Initializer.parameter.projectDomainName"></a>
+##### ~~`projectDomainName`~~<sup>Optional</sup> <a name="projectDomainName" id="cdktf.SwiftBackend.Initializer.parameter.projectDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `regionName`<sup>Optional</sup> <a name="regionName" id="cdktf.SwiftBackend.Initializer.parameter.regionName"></a>
+##### ~~`regionName`~~<sup>Optional</sup> <a name="regionName" id="cdktf.SwiftBackend.Initializer.parameter.regionName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `stateName`<sup>Optional</sup> <a name="stateName" id="cdktf.SwiftBackend.Initializer.parameter.stateName"></a>
+##### ~~`stateName`~~<sup>Optional</sup> <a name="stateName" id="cdktf.SwiftBackend.Initializer.parameter.stateName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `tenantId`<sup>Optional</sup> <a name="tenantId" id="cdktf.SwiftBackend.Initializer.parameter.tenantId"></a>
+##### ~~`tenantId`~~<sup>Optional</sup> <a name="tenantId" id="cdktf.SwiftBackend.Initializer.parameter.tenantId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `tenantName`<sup>Optional</sup> <a name="tenantName" id="cdktf.SwiftBackend.Initializer.parameter.tenantName"></a>
+##### ~~`tenantName`~~<sup>Optional</sup> <a name="tenantName" id="cdktf.SwiftBackend.Initializer.parameter.tenantName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `token`<sup>Optional</sup> <a name="token" id="cdktf.SwiftBackend.Initializer.parameter.token"></a>
+##### ~~`token`~~<sup>Optional</sup> <a name="token" id="cdktf.SwiftBackend.Initializer.parameter.token"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `userDomainId`<sup>Optional</sup> <a name="userDomainId" id="cdktf.SwiftBackend.Initializer.parameter.userDomainId"></a>
+##### ~~`userDomainId`~~<sup>Optional</sup> <a name="userDomainId" id="cdktf.SwiftBackend.Initializer.parameter.userDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `userDomainName`<sup>Optional</sup> <a name="userDomainName" id="cdktf.SwiftBackend.Initializer.parameter.userDomainName"></a>
+##### ~~`userDomainName`~~<sup>Optional</sup> <a name="userDomainName" id="cdktf.SwiftBackend.Initializer.parameter.userDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `userId`<sup>Optional</sup> <a name="userId" id="cdktf.SwiftBackend.Initializer.parameter.userId"></a>
+##### ~~`userId`~~<sup>Optional</sup> <a name="userId" id="cdktf.SwiftBackend.Initializer.parameter.userId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
 ---
 
-##### `userName`<sup>Optional</sup> <a name="userName" id="cdktf.SwiftBackend.Initializer.parameter.userName"></a>
+##### ~~`userName`~~<sup>Optional</sup> <a name="userName" id="cdktf.SwiftBackend.Initializer.parameter.userName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ java.lang.String
 
@@ -12376,7 +12686,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ---
 
-##### `toString` <a name="toString" id="cdktf.SwiftBackend.toString"></a>
+##### ~~`toString`~~ <a name="toString" id="cdktf.SwiftBackend.toString"></a>
 
 ```java
 public java.lang.String toString()
@@ -12384,7 +12694,7 @@ public java.lang.String toString()
 
 Returns a string representation of this construct.
 
-##### `addOverride` <a name="addOverride" id="cdktf.SwiftBackend.addOverride"></a>
+##### ~~`addOverride`~~ <a name="addOverride" id="cdktf.SwiftBackend.addOverride"></a>
 
 ```java
 public void addOverride(java.lang.String path, java.lang.Object value)
@@ -12402,7 +12712,7 @@ public void addOverride(java.lang.String path, java.lang.Object value)
 
 ---
 
-##### `overrideLogicalId` <a name="overrideLogicalId" id="cdktf.SwiftBackend.overrideLogicalId"></a>
+##### ~~`overrideLogicalId`~~ <a name="overrideLogicalId" id="cdktf.SwiftBackend.overrideLogicalId"></a>
 
 ```java
 public void overrideLogicalId(java.lang.String newLogicalId)
@@ -12418,7 +12728,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `resetOverrideLogicalId` <a name="resetOverrideLogicalId" id="cdktf.SwiftBackend.resetOverrideLogicalId"></a>
+##### ~~`resetOverrideLogicalId`~~ <a name="resetOverrideLogicalId" id="cdktf.SwiftBackend.resetOverrideLogicalId"></a>
 
 ```java
 public void resetOverrideLogicalId()
@@ -12426,13 +12736,13 @@ public void resetOverrideLogicalId()
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `toMetadata` <a name="toMetadata" id="cdktf.SwiftBackend.toMetadata"></a>
+##### ~~`toMetadata`~~ <a name="toMetadata" id="cdktf.SwiftBackend.toMetadata"></a>
 
 ```java
 public java.lang.Object toMetadata()
 ```
 
-##### `toTerraform` <a name="toTerraform" id="cdktf.SwiftBackend.toTerraform"></a>
+##### ~~`toTerraform`~~ <a name="toTerraform" id="cdktf.SwiftBackend.toTerraform"></a>
 
 ```java
 public java.lang.Object toTerraform()
@@ -12440,7 +12750,7 @@ public java.lang.Object toTerraform()
 
 Adds this resource to the terraform JSON output.
 
-##### `getRemoteStateDataSource` <a name="getRemoteStateDataSource" id="cdktf.SwiftBackend.getRemoteStateDataSource"></a>
+##### ~~`getRemoteStateDataSource`~~ <a name="getRemoteStateDataSource" id="cdktf.SwiftBackend.getRemoteStateDataSource"></a>
 
 ```java
 public TerraformRemoteState getRemoteStateDataSource(Construct scope, java.lang.String name, java.lang.String _fromStack)
@@ -12476,7 +12786,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdktf.SwiftBackend.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdktf.SwiftBackend.isConstruct"></a>
 
 ```java
 import com.hashicorp.cdktf.SwiftBackend;
@@ -12508,7 +12818,7 @@ Any object.
 
 ---
 
-##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.SwiftBackend.isTerraformElement"></a>
+##### ~~`isTerraformElement`~~ <a name="isTerraformElement" id="cdktf.SwiftBackend.isTerraformElement"></a>
 
 ```java
 import com.hashicorp.cdktf.SwiftBackend;
@@ -12522,7 +12832,7 @@ SwiftBackend.isTerraformElement(java.lang.Object x)
 
 ---
 
-##### `isBackend` <a name="isBackend" id="cdktf.SwiftBackend.isBackend"></a>
+##### ~~`isBackend`~~ <a name="isBackend" id="cdktf.SwiftBackend.isBackend"></a>
 
 ```java
 import com.hashicorp.cdktf.SwiftBackend;
@@ -12547,7 +12857,9 @@ SwiftBackend.isBackend(java.lang.Object x)
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.SwiftBackend.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.SwiftBackend.property.node"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public Node getNode();
@@ -12559,7 +12871,9 @@ The tree node.
 
 ---
 
-##### `cdktfStack`<sup>Required</sup> <a name="cdktfStack" id="cdktf.SwiftBackend.property.cdktfStack"></a>
+##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.SwiftBackend.property.cdktfStack"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public TerraformStack getCdktfStack();
@@ -12569,7 +12883,9 @@ public TerraformStack getCdktfStack();
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.SwiftBackend.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.SwiftBackend.property.fqn"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getFqn();
@@ -12579,7 +12895,9 @@ public java.lang.String getFqn();
 
 ---
 
-##### `friendlyUniqueId`<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.SwiftBackend.property.friendlyUniqueId"></a>
+##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.SwiftBackend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getFriendlyUniqueId();
@@ -17211,7 +17529,9 @@ ArtifactoryBackendProps.builder()
 
 ---
 
-##### `password`<sup>Required</sup> <a name="password" id="cdktf.ArtifactoryBackendProps.property.password"></a>
+##### ~~`password`~~<sup>Required</sup> <a name="password" id="cdktf.ArtifactoryBackendProps.property.password"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getPassword();
@@ -17223,7 +17543,9 @@ public java.lang.String getPassword();
 
 ---
 
-##### `repo`<sup>Required</sup> <a name="repo" id="cdktf.ArtifactoryBackendProps.property.repo"></a>
+##### ~~`repo`~~<sup>Required</sup> <a name="repo" id="cdktf.ArtifactoryBackendProps.property.repo"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getRepo();
@@ -17235,7 +17557,9 @@ public java.lang.String getRepo();
 
 ---
 
-##### `subpath`<sup>Required</sup> <a name="subpath" id="cdktf.ArtifactoryBackendProps.property.subpath"></a>
+##### ~~`subpath`~~<sup>Required</sup> <a name="subpath" id="cdktf.ArtifactoryBackendProps.property.subpath"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getSubpath();
@@ -17247,7 +17571,9 @@ public java.lang.String getSubpath();
 
 ---
 
-##### `url`<sup>Required</sup> <a name="url" id="cdktf.ArtifactoryBackendProps.property.url"></a>
+##### ~~`url`~~<sup>Required</sup> <a name="url" id="cdktf.ArtifactoryBackendProps.property.url"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getUrl();
@@ -17261,7 +17587,9 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ---
 
-##### `username`<sup>Required</sup> <a name="username" id="cdktf.ArtifactoryBackendProps.property.username"></a>
+##### ~~`username`~~<sup>Required</sup> <a name="username" id="cdktf.ArtifactoryBackendProps.property.username"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getUsername();
@@ -18125,7 +18453,9 @@ DataTerraformRemoteStateArtifactoryConfig.builder()
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.defaults"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.util.Map< java.lang.String, java.lang.Object > getDefaults();
@@ -18135,7 +18465,9 @@ public java.util.Map< java.lang.String, java.lang.Object > getDefaults();
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.workspace"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getWorkspace();
@@ -18145,7 +18477,9 @@ public java.lang.String getWorkspace();
 
 ---
 
-##### `password`<sup>Required</sup> <a name="password" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.password"></a>
+##### ~~`password`~~<sup>Required</sup> <a name="password" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.password"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getPassword();
@@ -18157,7 +18491,9 @@ public java.lang.String getPassword();
 
 ---
 
-##### `repo`<sup>Required</sup> <a name="repo" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.repo"></a>
+##### ~~`repo`~~<sup>Required</sup> <a name="repo" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.repo"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getRepo();
@@ -18169,7 +18505,9 @@ public java.lang.String getRepo();
 
 ---
 
-##### `subpath`<sup>Required</sup> <a name="subpath" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.subpath"></a>
+##### ~~`subpath`~~<sup>Required</sup> <a name="subpath" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.subpath"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getSubpath();
@@ -18181,7 +18519,9 @@ public java.lang.String getSubpath();
 
 ---
 
-##### `url`<sup>Required</sup> <a name="url" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.url"></a>
+##### ~~`url`~~<sup>Required</sup> <a name="url" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.url"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getUrl();
@@ -18195,7 +18535,9 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ---
 
-##### `username`<sup>Required</sup> <a name="username" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.username"></a>
+##### ~~`username`~~<sup>Required</sup> <a name="username" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.username"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getUsername();
@@ -19060,7 +19402,9 @@ DataTerraformRemoteStateEtcdConfig.builder()
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.defaults"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.util.Map< java.lang.String, java.lang.Object > getDefaults();
@@ -19070,7 +19414,9 @@ public java.util.Map< java.lang.String, java.lang.Object > getDefaults();
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.workspace"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getWorkspace();
@@ -19080,7 +19426,9 @@ public java.lang.String getWorkspace();
 
 ---
 
-##### `endpoints`<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.endpoints"></a>
+##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.endpoints"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getEndpoints();
@@ -19092,7 +19440,9 @@ public java.lang.String getEndpoints();
 
 ---
 
-##### `path`<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.path"></a>
+##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.path"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getPath();
@@ -19104,7 +19454,9 @@ public java.lang.String getPath();
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.password"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getPassword();
@@ -19116,7 +19468,9 @@ public java.lang.String getPassword();
 
 ---
 
-##### `username`<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.username"></a>
+##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.username"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getUsername();
@@ -19166,7 +19520,9 @@ DataTerraformRemoteStateEtcdV3Config.builder()
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.defaults"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.util.Map< java.lang.String, java.lang.Object > getDefaults();
@@ -19176,7 +19532,9 @@ public java.util.Map< java.lang.String, java.lang.Object > getDefaults();
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.workspace"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getWorkspace();
@@ -19186,7 +19544,9 @@ public java.lang.String getWorkspace();
 
 ---
 
-##### `endpoints`<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.endpoints"></a>
+##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.endpoints"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.util.List< java.lang.String > getEndpoints();
@@ -19198,7 +19558,9 @@ public java.util.List< java.lang.String > getEndpoints();
 
 ---
 
-##### `cacertPath`<sup>Optional</sup> <a name="cacertPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.cacertPath"></a>
+##### ~~`cacertPath`~~<sup>Optional</sup> <a name="cacertPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.cacertPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getCacertPath();
@@ -19210,7 +19572,9 @@ public java.lang.String getCacertPath();
 
 ---
 
-##### `certPath`<sup>Optional</sup> <a name="certPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.certPath"></a>
+##### ~~`certPath`~~<sup>Optional</sup> <a name="certPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.certPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getCertPath();
@@ -19222,7 +19586,9 @@ public java.lang.String getCertPath();
 
 ---
 
-##### `keyPath`<sup>Optional</sup> <a name="keyPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.keyPath"></a>
+##### ~~`keyPath`~~<sup>Optional</sup> <a name="keyPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.keyPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getKeyPath();
@@ -19234,7 +19600,9 @@ public java.lang.String getKeyPath();
 
 ---
 
-##### `lock`<sup>Optional</sup> <a name="lock" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.lock"></a>
+##### ~~`lock`~~<sup>Optional</sup> <a name="lock" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.lock"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.Boolean getLock();
@@ -19248,7 +19616,9 @@ Defaults to true.
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.password"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getPassword();
@@ -19260,7 +19630,9 @@ public java.lang.String getPassword();
 
 ---
 
-##### `prefix`<sup>Optional</sup> <a name="prefix" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.prefix"></a>
+##### ~~`prefix`~~<sup>Optional</sup> <a name="prefix" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.prefix"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getPrefix();
@@ -19274,7 +19646,9 @@ Defaults to "".
 
 ---
 
-##### `username`<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.username"></a>
+##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.username"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getUsername();
@@ -19777,7 +20151,9 @@ DataTerraformRemoteStateMantaConfig.builder()
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateMantaConfig.property.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateMantaConfig.property.defaults"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.util.Map< java.lang.String, java.lang.Object > getDefaults();
@@ -19787,7 +20163,9 @@ public java.util.Map< java.lang.String, java.lang.Object > getDefaults();
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateMantaConfig.property.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateMantaConfig.property.workspace"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getWorkspace();
@@ -19797,7 +20175,9 @@ public java.lang.String getWorkspace();
 
 ---
 
-##### `account`<sup>Required</sup> <a name="account" id="cdktf.DataTerraformRemoteStateMantaConfig.property.account"></a>
+##### ~~`account`~~<sup>Required</sup> <a name="account" id="cdktf.DataTerraformRemoteStateMantaConfig.property.account"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getAccount();
@@ -19807,7 +20187,9 @@ public java.lang.String getAccount();
 
 ---
 
-##### `keyId`<sup>Required</sup> <a name="keyId" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyId"></a>
+##### ~~`keyId`~~<sup>Required</sup> <a name="keyId" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getKeyId();
@@ -19817,7 +20199,9 @@ public java.lang.String getKeyId();
 
 ---
 
-##### `path`<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateMantaConfig.property.path"></a>
+##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateMantaConfig.property.path"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getPath();
@@ -19827,7 +20211,9 @@ public java.lang.String getPath();
 
 ---
 
-##### `insecureSkipTlsVerify`<sup>Optional</sup> <a name="insecureSkipTlsVerify" id="cdktf.DataTerraformRemoteStateMantaConfig.property.insecureSkipTlsVerify"></a>
+##### ~~`insecureSkipTlsVerify`~~<sup>Optional</sup> <a name="insecureSkipTlsVerify" id="cdktf.DataTerraformRemoteStateMantaConfig.property.insecureSkipTlsVerify"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.Boolean getInsecureSkipTlsVerify();
@@ -19837,7 +20223,9 @@ public java.lang.Boolean getInsecureSkipTlsVerify();
 
 ---
 
-##### `keyMaterial`<sup>Optional</sup> <a name="keyMaterial" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyMaterial"></a>
+##### ~~`keyMaterial`~~<sup>Optional</sup> <a name="keyMaterial" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyMaterial"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getKeyMaterial();
@@ -19847,7 +20235,9 @@ public java.lang.String getKeyMaterial();
 
 ---
 
-##### `objectName`<sup>Optional</sup> <a name="objectName" id="cdktf.DataTerraformRemoteStateMantaConfig.property.objectName"></a>
+##### ~~`objectName`~~<sup>Optional</sup> <a name="objectName" id="cdktf.DataTerraformRemoteStateMantaConfig.property.objectName"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getObjectName();
@@ -19857,7 +20247,9 @@ public java.lang.String getObjectName();
 
 ---
 
-##### `url`<sup>Optional</sup> <a name="url" id="cdktf.DataTerraformRemoteStateMantaConfig.property.url"></a>
+##### ~~`url`~~<sup>Optional</sup> <a name="url" id="cdktf.DataTerraformRemoteStateMantaConfig.property.url"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getUrl();
@@ -19867,7 +20259,9 @@ public java.lang.String getUrl();
 
 ---
 
-##### `user`<sup>Optional</sup> <a name="user" id="cdktf.DataTerraformRemoteStateMantaConfig.property.user"></a>
+##### ~~`user`~~<sup>Optional</sup> <a name="user" id="cdktf.DataTerraformRemoteStateMantaConfig.property.user"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getUser();
@@ -20862,7 +21256,9 @@ DataTerraformRemoteStateSwiftConfig.builder()
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaults"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.util.Map< java.lang.String, java.lang.Object > getDefaults();
@@ -20872,7 +21268,9 @@ public java.util.Map< java.lang.String, java.lang.Object > getDefaults();
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.workspace"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getWorkspace();
@@ -20882,7 +21280,9 @@ public java.lang.String getWorkspace();
 
 ---
 
-##### `container`<sup>Required</sup> <a name="container" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.container"></a>
+##### ~~`container`~~<sup>Required</sup> <a name="container" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.container"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getContainer();
@@ -20892,7 +21292,9 @@ public java.lang.String getContainer();
 
 ---
 
-##### `applicationCredentialId`<sup>Optional</sup> <a name="applicationCredentialId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialId"></a>
+##### ~~`applicationCredentialId`~~<sup>Optional</sup> <a name="applicationCredentialId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getApplicationCredentialId();
@@ -20902,7 +21304,9 @@ public java.lang.String getApplicationCredentialId();
 
 ---
 
-##### `applicationCredentialName`<sup>Optional</sup> <a name="applicationCredentialName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialName"></a>
+##### ~~`applicationCredentialName`~~<sup>Optional</sup> <a name="applicationCredentialName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getApplicationCredentialName();
@@ -20912,7 +21316,9 @@ public java.lang.String getApplicationCredentialName();
 
 ---
 
-##### `applicationCredentialSecret`<sup>Optional</sup> <a name="applicationCredentialSecret" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialSecret"></a>
+##### ~~`applicationCredentialSecret`~~<sup>Optional</sup> <a name="applicationCredentialSecret" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialSecret"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getApplicationCredentialSecret();
@@ -20922,7 +21328,9 @@ public java.lang.String getApplicationCredentialSecret();
 
 ---
 
-##### `archiveContainer`<sup>Optional</sup> <a name="archiveContainer" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.archiveContainer"></a>
+##### ~~`archiveContainer`~~<sup>Optional</sup> <a name="archiveContainer" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.archiveContainer"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getArchiveContainer();
@@ -20932,7 +21340,9 @@ public java.lang.String getArchiveContainer();
 
 ---
 
-##### `authUrl`<sup>Optional</sup> <a name="authUrl" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.authUrl"></a>
+##### ~~`authUrl`~~<sup>Optional</sup> <a name="authUrl" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.authUrl"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getAuthUrl();
@@ -20942,7 +21352,9 @@ public java.lang.String getAuthUrl();
 
 ---
 
-##### `cacertFile`<sup>Optional</sup> <a name="cacertFile" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cacertFile"></a>
+##### ~~`cacertFile`~~<sup>Optional</sup> <a name="cacertFile" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cacertFile"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getCacertFile();
@@ -20952,7 +21364,9 @@ public java.lang.String getCacertFile();
 
 ---
 
-##### `cert`<sup>Optional</sup> <a name="cert" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cert"></a>
+##### ~~`cert`~~<sup>Optional</sup> <a name="cert" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cert"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getCert();
@@ -20962,7 +21376,9 @@ public java.lang.String getCert();
 
 ---
 
-##### `cloud`<sup>Optional</sup> <a name="cloud" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cloud"></a>
+##### ~~`cloud`~~<sup>Optional</sup> <a name="cloud" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cloud"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getCloud();
@@ -20972,7 +21388,9 @@ public java.lang.String getCloud();
 
 ---
 
-##### `defaultDomain`<sup>Optional</sup> <a name="defaultDomain" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaultDomain"></a>
+##### ~~`defaultDomain`~~<sup>Optional</sup> <a name="defaultDomain" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaultDomain"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getDefaultDomain();
@@ -20982,7 +21400,9 @@ public java.lang.String getDefaultDomain();
 
 ---
 
-##### `domainId`<sup>Optional</sup> <a name="domainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainId"></a>
+##### ~~`domainId`~~<sup>Optional</sup> <a name="domainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getDomainId();
@@ -20992,7 +21412,9 @@ public java.lang.String getDomainId();
 
 ---
 
-##### `domainName`<sup>Optional</sup> <a name="domainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainName"></a>
+##### ~~`domainName`~~<sup>Optional</sup> <a name="domainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getDomainName();
@@ -21002,7 +21424,9 @@ public java.lang.String getDomainName();
 
 ---
 
-##### `expireAfter`<sup>Optional</sup> <a name="expireAfter" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.expireAfter"></a>
+##### ~~`expireAfter`~~<sup>Optional</sup> <a name="expireAfter" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.expireAfter"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getExpireAfter();
@@ -21012,7 +21436,9 @@ public java.lang.String getExpireAfter();
 
 ---
 
-##### `insecure`<sup>Optional</sup> <a name="insecure" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.insecure"></a>
+##### ~~`insecure`~~<sup>Optional</sup> <a name="insecure" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.insecure"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.Boolean getInsecure();
@@ -21022,7 +21448,9 @@ public java.lang.Boolean getInsecure();
 
 ---
 
-##### `key`<sup>Optional</sup> <a name="key" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.key"></a>
+##### ~~`key`~~<sup>Optional</sup> <a name="key" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.key"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getKey();
@@ -21032,7 +21460,9 @@ public java.lang.String getKey();
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.password"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getPassword();
@@ -21042,7 +21472,9 @@ public java.lang.String getPassword();
 
 ---
 
-##### `projectDomainId`<sup>Optional</sup> <a name="projectDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainId"></a>
+##### ~~`projectDomainId`~~<sup>Optional</sup> <a name="projectDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getProjectDomainId();
@@ -21052,7 +21484,9 @@ public java.lang.String getProjectDomainId();
 
 ---
 
-##### `projectDomainName`<sup>Optional</sup> <a name="projectDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainName"></a>
+##### ~~`projectDomainName`~~<sup>Optional</sup> <a name="projectDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getProjectDomainName();
@@ -21062,7 +21496,9 @@ public java.lang.String getProjectDomainName();
 
 ---
 
-##### `regionName`<sup>Optional</sup> <a name="regionName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.regionName"></a>
+##### ~~`regionName`~~<sup>Optional</sup> <a name="regionName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.regionName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getRegionName();
@@ -21072,7 +21508,9 @@ public java.lang.String getRegionName();
 
 ---
 
-##### `stateName`<sup>Optional</sup> <a name="stateName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.stateName"></a>
+##### ~~`stateName`~~<sup>Optional</sup> <a name="stateName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.stateName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getStateName();
@@ -21082,7 +21520,9 @@ public java.lang.String getStateName();
 
 ---
 
-##### `tenantId`<sup>Optional</sup> <a name="tenantId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantId"></a>
+##### ~~`tenantId`~~<sup>Optional</sup> <a name="tenantId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getTenantId();
@@ -21092,7 +21532,9 @@ public java.lang.String getTenantId();
 
 ---
 
-##### `tenantName`<sup>Optional</sup> <a name="tenantName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantName"></a>
+##### ~~`tenantName`~~<sup>Optional</sup> <a name="tenantName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getTenantName();
@@ -21102,7 +21544,9 @@ public java.lang.String getTenantName();
 
 ---
 
-##### `token`<sup>Optional</sup> <a name="token" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.token"></a>
+##### ~~`token`~~<sup>Optional</sup> <a name="token" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.token"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getToken();
@@ -21112,7 +21556,9 @@ public java.lang.String getToken();
 
 ---
 
-##### `userDomainId`<sup>Optional</sup> <a name="userDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainId"></a>
+##### ~~`userDomainId`~~<sup>Optional</sup> <a name="userDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getUserDomainId();
@@ -21122,7 +21568,9 @@ public java.lang.String getUserDomainId();
 
 ---
 
-##### `userDomainName`<sup>Optional</sup> <a name="userDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainName"></a>
+##### ~~`userDomainName`~~<sup>Optional</sup> <a name="userDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getUserDomainName();
@@ -21132,7 +21580,9 @@ public java.lang.String getUserDomainName();
 
 ---
 
-##### `userId`<sup>Optional</sup> <a name="userId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userId"></a>
+##### ~~`userId`~~<sup>Optional</sup> <a name="userId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getUserId();
@@ -21142,7 +21592,9 @@ public java.lang.String getUserId();
 
 ---
 
-##### `userName`<sup>Optional</sup> <a name="userName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userName"></a>
+##### ~~`userName`~~<sup>Optional</sup> <a name="userName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getUserName();
@@ -21220,7 +21672,9 @@ EtcdBackendProps.builder()
 
 ---
 
-##### `endpoints`<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdBackendProps.property.endpoints"></a>
+##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdBackendProps.property.endpoints"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getEndpoints();
@@ -21232,7 +21686,9 @@ public java.lang.String getEndpoints();
 
 ---
 
-##### `path`<sup>Required</sup> <a name="path" id="cdktf.EtcdBackendProps.property.path"></a>
+##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.EtcdBackendProps.property.path"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getPath();
@@ -21244,7 +21700,9 @@ public java.lang.String getPath();
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.EtcdBackendProps.property.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.EtcdBackendProps.property.password"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getPassword();
@@ -21256,7 +21714,9 @@ public java.lang.String getPassword();
 
 ---
 
-##### `username`<sup>Optional</sup> <a name="username" id="cdktf.EtcdBackendProps.property.username"></a>
+##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.EtcdBackendProps.property.username"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getUsername();
@@ -21309,7 +21769,9 @@ EtcdV3BackendProps.builder()
 
 ---
 
-##### `endpoints`<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdV3BackendProps.property.endpoints"></a>
+##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdV3BackendProps.property.endpoints"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.util.List< java.lang.String > getEndpoints();
@@ -21321,7 +21783,9 @@ public java.util.List< java.lang.String > getEndpoints();
 
 ---
 
-##### `cacertPath`<sup>Optional</sup> <a name="cacertPath" id="cdktf.EtcdV3BackendProps.property.cacertPath"></a>
+##### ~~`cacertPath`~~<sup>Optional</sup> <a name="cacertPath" id="cdktf.EtcdV3BackendProps.property.cacertPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getCacertPath();
@@ -21333,7 +21797,9 @@ public java.lang.String getCacertPath();
 
 ---
 
-##### `certPath`<sup>Optional</sup> <a name="certPath" id="cdktf.EtcdV3BackendProps.property.certPath"></a>
+##### ~~`certPath`~~<sup>Optional</sup> <a name="certPath" id="cdktf.EtcdV3BackendProps.property.certPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getCertPath();
@@ -21345,7 +21811,9 @@ public java.lang.String getCertPath();
 
 ---
 
-##### `keyPath`<sup>Optional</sup> <a name="keyPath" id="cdktf.EtcdV3BackendProps.property.keyPath"></a>
+##### ~~`keyPath`~~<sup>Optional</sup> <a name="keyPath" id="cdktf.EtcdV3BackendProps.property.keyPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getKeyPath();
@@ -21357,7 +21825,9 @@ public java.lang.String getKeyPath();
 
 ---
 
-##### `lock`<sup>Optional</sup> <a name="lock" id="cdktf.EtcdV3BackendProps.property.lock"></a>
+##### ~~`lock`~~<sup>Optional</sup> <a name="lock" id="cdktf.EtcdV3BackendProps.property.lock"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.Boolean getLock();
@@ -21371,7 +21841,9 @@ Defaults to true.
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.EtcdV3BackendProps.property.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.EtcdV3BackendProps.property.password"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getPassword();
@@ -21383,7 +21855,9 @@ public java.lang.String getPassword();
 
 ---
 
-##### `prefix`<sup>Optional</sup> <a name="prefix" id="cdktf.EtcdV3BackendProps.property.prefix"></a>
+##### ~~`prefix`~~<sup>Optional</sup> <a name="prefix" id="cdktf.EtcdV3BackendProps.property.prefix"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getPrefix();
@@ -21397,7 +21871,9 @@ Defaults to "".
 
 ---
 
-##### `username`<sup>Optional</sup> <a name="username" id="cdktf.EtcdV3BackendProps.property.username"></a>
+##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.EtcdV3BackendProps.property.username"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getUsername();
@@ -22215,7 +22691,9 @@ MantaBackendProps.builder()
 
 ---
 
-##### `account`<sup>Required</sup> <a name="account" id="cdktf.MantaBackendProps.property.account"></a>
+##### ~~`account`~~<sup>Required</sup> <a name="account" id="cdktf.MantaBackendProps.property.account"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getAccount();
@@ -22225,7 +22703,9 @@ public java.lang.String getAccount();
 
 ---
 
-##### `keyId`<sup>Required</sup> <a name="keyId" id="cdktf.MantaBackendProps.property.keyId"></a>
+##### ~~`keyId`~~<sup>Required</sup> <a name="keyId" id="cdktf.MantaBackendProps.property.keyId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getKeyId();
@@ -22235,7 +22715,9 @@ public java.lang.String getKeyId();
 
 ---
 
-##### `path`<sup>Required</sup> <a name="path" id="cdktf.MantaBackendProps.property.path"></a>
+##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.MantaBackendProps.property.path"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getPath();
@@ -22245,7 +22727,9 @@ public java.lang.String getPath();
 
 ---
 
-##### `insecureSkipTlsVerify`<sup>Optional</sup> <a name="insecureSkipTlsVerify" id="cdktf.MantaBackendProps.property.insecureSkipTlsVerify"></a>
+##### ~~`insecureSkipTlsVerify`~~<sup>Optional</sup> <a name="insecureSkipTlsVerify" id="cdktf.MantaBackendProps.property.insecureSkipTlsVerify"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.Boolean getInsecureSkipTlsVerify();
@@ -22255,7 +22739,9 @@ public java.lang.Boolean getInsecureSkipTlsVerify();
 
 ---
 
-##### `keyMaterial`<sup>Optional</sup> <a name="keyMaterial" id="cdktf.MantaBackendProps.property.keyMaterial"></a>
+##### ~~`keyMaterial`~~<sup>Optional</sup> <a name="keyMaterial" id="cdktf.MantaBackendProps.property.keyMaterial"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getKeyMaterial();
@@ -22265,7 +22751,9 @@ public java.lang.String getKeyMaterial();
 
 ---
 
-##### `objectName`<sup>Optional</sup> <a name="objectName" id="cdktf.MantaBackendProps.property.objectName"></a>
+##### ~~`objectName`~~<sup>Optional</sup> <a name="objectName" id="cdktf.MantaBackendProps.property.objectName"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getObjectName();
@@ -22275,7 +22763,9 @@ public java.lang.String getObjectName();
 
 ---
 
-##### `url`<sup>Optional</sup> <a name="url" id="cdktf.MantaBackendProps.property.url"></a>
+##### ~~`url`~~<sup>Optional</sup> <a name="url" id="cdktf.MantaBackendProps.property.url"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getUrl();
@@ -22285,7 +22775,9 @@ public java.lang.String getUrl();
 
 ---
 
-##### `user`<sup>Optional</sup> <a name="user" id="cdktf.MantaBackendProps.property.user"></a>
+##### ~~`user`~~<sup>Optional</sup> <a name="user" id="cdktf.MantaBackendProps.property.user"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getUser();
@@ -23999,7 +24491,9 @@ SwiftBackendProps.builder()
 
 ---
 
-##### `container`<sup>Required</sup> <a name="container" id="cdktf.SwiftBackendProps.property.container"></a>
+##### ~~`container`~~<sup>Required</sup> <a name="container" id="cdktf.SwiftBackendProps.property.container"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getContainer();
@@ -24009,7 +24503,9 @@ public java.lang.String getContainer();
 
 ---
 
-##### `applicationCredentialId`<sup>Optional</sup> <a name="applicationCredentialId" id="cdktf.SwiftBackendProps.property.applicationCredentialId"></a>
+##### ~~`applicationCredentialId`~~<sup>Optional</sup> <a name="applicationCredentialId" id="cdktf.SwiftBackendProps.property.applicationCredentialId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getApplicationCredentialId();
@@ -24019,7 +24515,9 @@ public java.lang.String getApplicationCredentialId();
 
 ---
 
-##### `applicationCredentialName`<sup>Optional</sup> <a name="applicationCredentialName" id="cdktf.SwiftBackendProps.property.applicationCredentialName"></a>
+##### ~~`applicationCredentialName`~~<sup>Optional</sup> <a name="applicationCredentialName" id="cdktf.SwiftBackendProps.property.applicationCredentialName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getApplicationCredentialName();
@@ -24029,7 +24527,9 @@ public java.lang.String getApplicationCredentialName();
 
 ---
 
-##### `applicationCredentialSecret`<sup>Optional</sup> <a name="applicationCredentialSecret" id="cdktf.SwiftBackendProps.property.applicationCredentialSecret"></a>
+##### ~~`applicationCredentialSecret`~~<sup>Optional</sup> <a name="applicationCredentialSecret" id="cdktf.SwiftBackendProps.property.applicationCredentialSecret"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getApplicationCredentialSecret();
@@ -24039,7 +24539,9 @@ public java.lang.String getApplicationCredentialSecret();
 
 ---
 
-##### `archiveContainer`<sup>Optional</sup> <a name="archiveContainer" id="cdktf.SwiftBackendProps.property.archiveContainer"></a>
+##### ~~`archiveContainer`~~<sup>Optional</sup> <a name="archiveContainer" id="cdktf.SwiftBackendProps.property.archiveContainer"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getArchiveContainer();
@@ -24049,7 +24551,9 @@ public java.lang.String getArchiveContainer();
 
 ---
 
-##### `authUrl`<sup>Optional</sup> <a name="authUrl" id="cdktf.SwiftBackendProps.property.authUrl"></a>
+##### ~~`authUrl`~~<sup>Optional</sup> <a name="authUrl" id="cdktf.SwiftBackendProps.property.authUrl"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getAuthUrl();
@@ -24059,7 +24563,9 @@ public java.lang.String getAuthUrl();
 
 ---
 
-##### `cacertFile`<sup>Optional</sup> <a name="cacertFile" id="cdktf.SwiftBackendProps.property.cacertFile"></a>
+##### ~~`cacertFile`~~<sup>Optional</sup> <a name="cacertFile" id="cdktf.SwiftBackendProps.property.cacertFile"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getCacertFile();
@@ -24069,7 +24575,9 @@ public java.lang.String getCacertFile();
 
 ---
 
-##### `cert`<sup>Optional</sup> <a name="cert" id="cdktf.SwiftBackendProps.property.cert"></a>
+##### ~~`cert`~~<sup>Optional</sup> <a name="cert" id="cdktf.SwiftBackendProps.property.cert"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getCert();
@@ -24079,7 +24587,9 @@ public java.lang.String getCert();
 
 ---
 
-##### `cloud`<sup>Optional</sup> <a name="cloud" id="cdktf.SwiftBackendProps.property.cloud"></a>
+##### ~~`cloud`~~<sup>Optional</sup> <a name="cloud" id="cdktf.SwiftBackendProps.property.cloud"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getCloud();
@@ -24089,7 +24599,9 @@ public java.lang.String getCloud();
 
 ---
 
-##### `defaultDomain`<sup>Optional</sup> <a name="defaultDomain" id="cdktf.SwiftBackendProps.property.defaultDomain"></a>
+##### ~~`defaultDomain`~~<sup>Optional</sup> <a name="defaultDomain" id="cdktf.SwiftBackendProps.property.defaultDomain"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getDefaultDomain();
@@ -24099,7 +24611,9 @@ public java.lang.String getDefaultDomain();
 
 ---
 
-##### `domainId`<sup>Optional</sup> <a name="domainId" id="cdktf.SwiftBackendProps.property.domainId"></a>
+##### ~~`domainId`~~<sup>Optional</sup> <a name="domainId" id="cdktf.SwiftBackendProps.property.domainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getDomainId();
@@ -24109,7 +24623,9 @@ public java.lang.String getDomainId();
 
 ---
 
-##### `domainName`<sup>Optional</sup> <a name="domainName" id="cdktf.SwiftBackendProps.property.domainName"></a>
+##### ~~`domainName`~~<sup>Optional</sup> <a name="domainName" id="cdktf.SwiftBackendProps.property.domainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getDomainName();
@@ -24119,7 +24635,9 @@ public java.lang.String getDomainName();
 
 ---
 
-##### `expireAfter`<sup>Optional</sup> <a name="expireAfter" id="cdktf.SwiftBackendProps.property.expireAfter"></a>
+##### ~~`expireAfter`~~<sup>Optional</sup> <a name="expireAfter" id="cdktf.SwiftBackendProps.property.expireAfter"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getExpireAfter();
@@ -24129,7 +24647,9 @@ public java.lang.String getExpireAfter();
 
 ---
 
-##### `insecure`<sup>Optional</sup> <a name="insecure" id="cdktf.SwiftBackendProps.property.insecure"></a>
+##### ~~`insecure`~~<sup>Optional</sup> <a name="insecure" id="cdktf.SwiftBackendProps.property.insecure"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.Boolean getInsecure();
@@ -24139,7 +24659,9 @@ public java.lang.Boolean getInsecure();
 
 ---
 
-##### `key`<sup>Optional</sup> <a name="key" id="cdktf.SwiftBackendProps.property.key"></a>
+##### ~~`key`~~<sup>Optional</sup> <a name="key" id="cdktf.SwiftBackendProps.property.key"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getKey();
@@ -24149,7 +24671,9 @@ public java.lang.String getKey();
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.SwiftBackendProps.property.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.SwiftBackendProps.property.password"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getPassword();
@@ -24159,7 +24683,9 @@ public java.lang.String getPassword();
 
 ---
 
-##### `projectDomainId`<sup>Optional</sup> <a name="projectDomainId" id="cdktf.SwiftBackendProps.property.projectDomainId"></a>
+##### ~~`projectDomainId`~~<sup>Optional</sup> <a name="projectDomainId" id="cdktf.SwiftBackendProps.property.projectDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getProjectDomainId();
@@ -24169,7 +24695,9 @@ public java.lang.String getProjectDomainId();
 
 ---
 
-##### `projectDomainName`<sup>Optional</sup> <a name="projectDomainName" id="cdktf.SwiftBackendProps.property.projectDomainName"></a>
+##### ~~`projectDomainName`~~<sup>Optional</sup> <a name="projectDomainName" id="cdktf.SwiftBackendProps.property.projectDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getProjectDomainName();
@@ -24179,7 +24707,9 @@ public java.lang.String getProjectDomainName();
 
 ---
 
-##### `regionName`<sup>Optional</sup> <a name="regionName" id="cdktf.SwiftBackendProps.property.regionName"></a>
+##### ~~`regionName`~~<sup>Optional</sup> <a name="regionName" id="cdktf.SwiftBackendProps.property.regionName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getRegionName();
@@ -24189,7 +24719,9 @@ public java.lang.String getRegionName();
 
 ---
 
-##### `stateName`<sup>Optional</sup> <a name="stateName" id="cdktf.SwiftBackendProps.property.stateName"></a>
+##### ~~`stateName`~~<sup>Optional</sup> <a name="stateName" id="cdktf.SwiftBackendProps.property.stateName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getStateName();
@@ -24199,7 +24731,9 @@ public java.lang.String getStateName();
 
 ---
 
-##### `tenantId`<sup>Optional</sup> <a name="tenantId" id="cdktf.SwiftBackendProps.property.tenantId"></a>
+##### ~~`tenantId`~~<sup>Optional</sup> <a name="tenantId" id="cdktf.SwiftBackendProps.property.tenantId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getTenantId();
@@ -24209,7 +24743,9 @@ public java.lang.String getTenantId();
 
 ---
 
-##### `tenantName`<sup>Optional</sup> <a name="tenantName" id="cdktf.SwiftBackendProps.property.tenantName"></a>
+##### ~~`tenantName`~~<sup>Optional</sup> <a name="tenantName" id="cdktf.SwiftBackendProps.property.tenantName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getTenantName();
@@ -24219,7 +24755,9 @@ public java.lang.String getTenantName();
 
 ---
 
-##### `token`<sup>Optional</sup> <a name="token" id="cdktf.SwiftBackendProps.property.token"></a>
+##### ~~`token`~~<sup>Optional</sup> <a name="token" id="cdktf.SwiftBackendProps.property.token"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getToken();
@@ -24229,7 +24767,9 @@ public java.lang.String getToken();
 
 ---
 
-##### `userDomainId`<sup>Optional</sup> <a name="userDomainId" id="cdktf.SwiftBackendProps.property.userDomainId"></a>
+##### ~~`userDomainId`~~<sup>Optional</sup> <a name="userDomainId" id="cdktf.SwiftBackendProps.property.userDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getUserDomainId();
@@ -24239,7 +24779,9 @@ public java.lang.String getUserDomainId();
 
 ---
 
-##### `userDomainName`<sup>Optional</sup> <a name="userDomainName" id="cdktf.SwiftBackendProps.property.userDomainName"></a>
+##### ~~`userDomainName`~~<sup>Optional</sup> <a name="userDomainName" id="cdktf.SwiftBackendProps.property.userDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getUserDomainName();
@@ -24249,7 +24791,9 @@ public java.lang.String getUserDomainName();
 
 ---
 
-##### `userId`<sup>Optional</sup> <a name="userId" id="cdktf.SwiftBackendProps.property.userId"></a>
+##### ~~`userId`~~<sup>Optional</sup> <a name="userId" id="cdktf.SwiftBackendProps.property.userId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getUserId();
@@ -24259,7 +24803,9 @@ public java.lang.String getUserId();
 
 ---
 
-##### `userName`<sup>Optional</sup> <a name="userName" id="cdktf.SwiftBackendProps.property.userName"></a>
+##### ~~`userName`~~<sup>Optional</sup> <a name="userName" id="cdktf.SwiftBackendProps.property.userName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```java
 public java.lang.String getUserName();

--- a/website/docs/cdktf/api-reference/java.mdx
+++ b/website/docs/cdktf/api-reference/java.mdx
@@ -302,7 +302,7 @@ ArtifactoryBackend.Builder.create(Construct scope)
 
 ##### ~~`password`~~<sup>Required</sup> <a name="password" id="cdktf.ArtifactoryBackend.Initializer.parameter.password"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -312,7 +312,7 @@ ArtifactoryBackend.Builder.create(Construct scope)
 
 ##### ~~`repo`~~<sup>Required</sup> <a name="repo" id="cdktf.ArtifactoryBackend.Initializer.parameter.repo"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -322,7 +322,7 @@ ArtifactoryBackend.Builder.create(Construct scope)
 
 ##### ~~`subpath`~~<sup>Required</sup> <a name="subpath" id="cdktf.ArtifactoryBackend.Initializer.parameter.subpath"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -332,7 +332,7 @@ ArtifactoryBackend.Builder.create(Construct scope)
 
 ##### ~~`url`~~<sup>Required</sup> <a name="url" id="cdktf.ArtifactoryBackend.Initializer.parameter.url"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -344,7 +344,7 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ##### ~~`username`~~<sup>Required</sup> <a name="username" id="cdktf.ArtifactoryBackend.Initializer.parameter.username"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -539,7 +539,7 @@ ArtifactoryBackend.isBackend(java.lang.Object x)
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.ArtifactoryBackend.property.node"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```java
 public Node getNode();
@@ -553,7 +553,7 @@ The tree node.
 
 ##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.ArtifactoryBackend.property.cdktfStack"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```java
 public TerraformStack getCdktfStack();
@@ -565,7 +565,7 @@ public TerraformStack getCdktfStack();
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.ArtifactoryBackend.property.fqn"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getFqn();
@@ -577,7 +577,7 @@ public java.lang.String getFqn();
 
 ##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.ArtifactoryBackend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getFriendlyUniqueId();
@@ -2518,7 +2518,7 @@ DataTerraformRemoteStateArtifactory.Builder.create(Construct scope, java.lang.St
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.defaults"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.util.Map< java.lang.String, java.lang.Object >
 
@@ -2526,7 +2526,7 @@ DataTerraformRemoteStateArtifactory.Builder.create(Construct scope, java.lang.St
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.workspace"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -2534,7 +2534,7 @@ DataTerraformRemoteStateArtifactory.Builder.create(Construct scope, java.lang.St
 
 ##### ~~`password`~~<sup>Required</sup> <a name="password" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.password"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -2544,7 +2544,7 @@ DataTerraformRemoteStateArtifactory.Builder.create(Construct scope, java.lang.St
 
 ##### ~~`repo`~~<sup>Required</sup> <a name="repo" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.repo"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -2554,7 +2554,7 @@ DataTerraformRemoteStateArtifactory.Builder.create(Construct scope, java.lang.St
 
 ##### ~~`subpath`~~<sup>Required</sup> <a name="subpath" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.subpath"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -2564,7 +2564,7 @@ DataTerraformRemoteStateArtifactory.Builder.create(Construct scope, java.lang.St
 
 ##### ~~`url`~~<sup>Required</sup> <a name="url" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.url"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -2576,7 +2576,7 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ##### ~~`username`~~<sup>Required</sup> <a name="username" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.username"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -2794,7 +2794,7 @@ DataTerraformRemoteStateArtifactory.isTerraformElement(java.lang.Object x)
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateArtifactory.property.node"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```java
 public Node getNode();
@@ -2808,7 +2808,7 @@ The tree node.
 
 ##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateArtifactory.property.cdktfStack"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```java
 public TerraformStack getCdktfStack();
@@ -2820,7 +2820,7 @@ public TerraformStack getCdktfStack();
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateArtifactory.property.fqn"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getFqn();
@@ -2832,7 +2832,7 @@ public java.lang.String getFqn();
 
 ##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateArtifactory.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getFriendlyUniqueId();
@@ -2852,7 +2852,7 @@ public java.lang.String getFriendlyUniqueId();
 
 ##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateArtifactory.property.tfResourceType"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getTfResourceType();
@@ -4339,7 +4339,7 @@ DataTerraformRemoteStateEtcd.Builder.create(Construct scope, java.lang.String id
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.defaults"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.util.Map< java.lang.String, java.lang.Object >
 
@@ -4347,7 +4347,7 @@ DataTerraformRemoteStateEtcd.Builder.create(Construct scope, java.lang.String id
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.workspace"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -4355,7 +4355,7 @@ DataTerraformRemoteStateEtcd.Builder.create(Construct scope, java.lang.String id
 
 ##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.endpoints"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -4365,7 +4365,7 @@ DataTerraformRemoteStateEtcd.Builder.create(Construct scope, java.lang.String id
 
 ##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.path"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -4375,7 +4375,7 @@ DataTerraformRemoteStateEtcd.Builder.create(Construct scope, java.lang.String id
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.password"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -4385,7 +4385,7 @@ DataTerraformRemoteStateEtcd.Builder.create(Construct scope, java.lang.String id
 
 ##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.username"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -4603,7 +4603,7 @@ DataTerraformRemoteStateEtcd.isTerraformElement(java.lang.Object x)
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateEtcd.property.node"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```java
 public Node getNode();
@@ -4617,7 +4617,7 @@ The tree node.
 
 ##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateEtcd.property.cdktfStack"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```java
 public TerraformStack getCdktfStack();
@@ -4629,7 +4629,7 @@ public TerraformStack getCdktfStack();
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateEtcd.property.fqn"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getFqn();
@@ -4641,7 +4641,7 @@ public java.lang.String getFqn();
 
 ##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcd.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getFriendlyUniqueId();
@@ -4661,7 +4661,7 @@ public java.lang.String getFriendlyUniqueId();
 
 ##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateEtcd.property.tfResourceType"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getTfResourceType();
@@ -4723,7 +4723,7 @@ DataTerraformRemoteStateEtcdV3.Builder.create(Construct scope, java.lang.String 
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.defaults"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.util.Map< java.lang.String, java.lang.Object >
 
@@ -4731,7 +4731,7 @@ DataTerraformRemoteStateEtcdV3.Builder.create(Construct scope, java.lang.String 
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.workspace"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -4739,7 +4739,7 @@ DataTerraformRemoteStateEtcdV3.Builder.create(Construct scope, java.lang.String 
 
 ##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.endpoints"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.util.List< java.lang.String >
 
@@ -4749,7 +4749,7 @@ DataTerraformRemoteStateEtcdV3.Builder.create(Construct scope, java.lang.String 
 
 ##### ~~`cacertPath`~~<sup>Optional</sup> <a name="cacertPath" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.cacertPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -4759,7 +4759,7 @@ DataTerraformRemoteStateEtcdV3.Builder.create(Construct scope, java.lang.String 
 
 ##### ~~`certPath`~~<sup>Optional</sup> <a name="certPath" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.certPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -4769,7 +4769,7 @@ DataTerraformRemoteStateEtcdV3.Builder.create(Construct scope, java.lang.String 
 
 ##### ~~`keyPath`~~<sup>Optional</sup> <a name="keyPath" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.keyPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -4779,7 +4779,7 @@ DataTerraformRemoteStateEtcdV3.Builder.create(Construct scope, java.lang.String 
 
 ##### ~~`lock`~~<sup>Optional</sup> <a name="lock" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.lock"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.Boolean
 
@@ -4791,7 +4791,7 @@ Defaults to true.
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.password"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -4801,7 +4801,7 @@ Defaults to true.
 
 ##### ~~`prefix`~~<sup>Optional</sup> <a name="prefix" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.prefix"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -4813,7 +4813,7 @@ Defaults to "".
 
 ##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.username"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -5031,7 +5031,7 @@ DataTerraformRemoteStateEtcdV3.isTerraformElement(java.lang.Object x)
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateEtcdV3.property.node"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public Node getNode();
@@ -5045,7 +5045,7 @@ The tree node.
 
 ##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateEtcdV3.property.cdktfStack"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public TerraformStack getCdktfStack();
@@ -5057,7 +5057,7 @@ public TerraformStack getCdktfStack();
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateEtcdV3.property.fqn"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getFqn();
@@ -5069,7 +5069,7 @@ public java.lang.String getFqn();
 
 ##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcdV3.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getFriendlyUniqueId();
@@ -5089,7 +5089,7 @@ public java.lang.String getFriendlyUniqueId();
 
 ##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateEtcdV3.property.tfResourceType"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getTfResourceType();
@@ -6336,7 +6336,7 @@ DataTerraformRemoteStateManta.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.defaults"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.util.Map< java.lang.String, java.lang.Object >
 
@@ -6344,7 +6344,7 @@ DataTerraformRemoteStateManta.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.workspace"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -6352,7 +6352,7 @@ DataTerraformRemoteStateManta.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`account`~~<sup>Required</sup> <a name="account" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.account"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -6360,7 +6360,7 @@ DataTerraformRemoteStateManta.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`keyId`~~<sup>Required</sup> <a name="keyId" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.keyId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -6368,7 +6368,7 @@ DataTerraformRemoteStateManta.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.path"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -6376,7 +6376,7 @@ DataTerraformRemoteStateManta.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`insecureSkipTlsVerify`~~<sup>Optional</sup> <a name="insecureSkipTlsVerify" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.insecureSkipTlsVerify"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.Boolean
 
@@ -6384,7 +6384,7 @@ DataTerraformRemoteStateManta.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`keyMaterial`~~<sup>Optional</sup> <a name="keyMaterial" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.keyMaterial"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -6392,7 +6392,7 @@ DataTerraformRemoteStateManta.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`objectName`~~<sup>Optional</sup> <a name="objectName" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.objectName"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -6400,7 +6400,7 @@ DataTerraformRemoteStateManta.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`url`~~<sup>Optional</sup> <a name="url" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.url"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -6408,7 +6408,7 @@ DataTerraformRemoteStateManta.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`user`~~<sup>Optional</sup> <a name="user" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.user"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -6624,7 +6624,7 @@ DataTerraformRemoteStateManta.isTerraformElement(java.lang.Object x)
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateManta.property.node"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public Node getNode();
@@ -6638,7 +6638,7 @@ The tree node.
 
 ##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateManta.property.cdktfStack"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public TerraformStack getCdktfStack();
@@ -6650,7 +6650,7 @@ public TerraformStack getCdktfStack();
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateManta.property.fqn"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getFqn();
@@ -6662,7 +6662,7 @@ public java.lang.String getFqn();
 
 ##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateManta.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getFriendlyUniqueId();
@@ -6682,7 +6682,7 @@ public java.lang.String getFriendlyUniqueId();
 
 ##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateManta.property.tfResourceType"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getTfResourceType();
@@ -8221,7 +8221,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.defaults"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.util.Map< java.lang.String, java.lang.Object >
 
@@ -8229,7 +8229,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.workspace"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8237,7 +8237,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`container`~~<sup>Required</sup> <a name="container" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.container"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8245,7 +8245,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`applicationCredentialId`~~<sup>Optional</sup> <a name="applicationCredentialId" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.applicationCredentialId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8253,7 +8253,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`applicationCredentialName`~~<sup>Optional</sup> <a name="applicationCredentialName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.applicationCredentialName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8261,7 +8261,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`applicationCredentialSecret`~~<sup>Optional</sup> <a name="applicationCredentialSecret" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.applicationCredentialSecret"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8269,7 +8269,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`archiveContainer`~~<sup>Optional</sup> <a name="archiveContainer" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.archiveContainer"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8277,7 +8277,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`authUrl`~~<sup>Optional</sup> <a name="authUrl" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.authUrl"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8285,7 +8285,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`cacertFile`~~<sup>Optional</sup> <a name="cacertFile" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.cacertFile"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8293,7 +8293,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`cert`~~<sup>Optional</sup> <a name="cert" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.cert"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8301,7 +8301,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`cloud`~~<sup>Optional</sup> <a name="cloud" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.cloud"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8309,7 +8309,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`defaultDomain`~~<sup>Optional</sup> <a name="defaultDomain" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.defaultDomain"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8317,7 +8317,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`domainId`~~<sup>Optional</sup> <a name="domainId" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.domainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8325,7 +8325,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`domainName`~~<sup>Optional</sup> <a name="domainName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.domainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8333,7 +8333,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`expireAfter`~~<sup>Optional</sup> <a name="expireAfter" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.expireAfter"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8341,7 +8341,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`insecure`~~<sup>Optional</sup> <a name="insecure" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.insecure"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.Boolean
 
@@ -8349,7 +8349,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`key`~~<sup>Optional</sup> <a name="key" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.key"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8357,7 +8357,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.password"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8365,7 +8365,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`projectDomainId`~~<sup>Optional</sup> <a name="projectDomainId" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.projectDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8373,7 +8373,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`projectDomainName`~~<sup>Optional</sup> <a name="projectDomainName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.projectDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8381,7 +8381,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`regionName`~~<sup>Optional</sup> <a name="regionName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.regionName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8389,7 +8389,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`stateName`~~<sup>Optional</sup> <a name="stateName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.stateName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8397,7 +8397,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`tenantId`~~<sup>Optional</sup> <a name="tenantId" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.tenantId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8405,7 +8405,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`tenantName`~~<sup>Optional</sup> <a name="tenantName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.tenantName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8413,7 +8413,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`token`~~<sup>Optional</sup> <a name="token" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.token"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8421,7 +8421,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`userDomainId`~~<sup>Optional</sup> <a name="userDomainId" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8429,7 +8429,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`userDomainName`~~<sup>Optional</sup> <a name="userDomainName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8437,7 +8437,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`userId`~~<sup>Optional</sup> <a name="userId" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8445,7 +8445,7 @@ DataTerraformRemoteStateSwift.Builder.create(Construct scope, java.lang.String i
 
 ##### ~~`userName`~~<sup>Optional</sup> <a name="userName" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8661,7 +8661,7 @@ DataTerraformRemoteStateSwift.isTerraformElement(java.lang.Object x)
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateSwift.property.node"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public Node getNode();
@@ -8675,7 +8675,7 @@ The tree node.
 
 ##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateSwift.property.cdktfStack"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public TerraformStack getCdktfStack();
@@ -8687,7 +8687,7 @@ public TerraformStack getCdktfStack();
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateSwift.property.fqn"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getFqn();
@@ -8699,7 +8699,7 @@ public java.lang.String getFqn();
 
 ##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateSwift.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getFriendlyUniqueId();
@@ -8719,7 +8719,7 @@ public java.lang.String getFriendlyUniqueId();
 
 ##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateSwift.property.tfResourceType"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getTfResourceType();
@@ -8762,7 +8762,7 @@ EtcdBackend.Builder.create(Construct scope)
 
 ##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdBackend.Initializer.parameter.endpoints"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8772,7 +8772,7 @@ EtcdBackend.Builder.create(Construct scope)
 
 ##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.EtcdBackend.Initializer.parameter.path"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8782,7 +8782,7 @@ EtcdBackend.Builder.create(Construct scope)
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.EtcdBackend.Initializer.parameter.password"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8792,7 +8792,7 @@ EtcdBackend.Builder.create(Construct scope)
 
 ##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.EtcdBackend.Initializer.parameter.username"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -8987,7 +8987,7 @@ EtcdBackend.isBackend(java.lang.Object x)
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.EtcdBackend.property.node"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```java
 public Node getNode();
@@ -9001,7 +9001,7 @@ The tree node.
 
 ##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.EtcdBackend.property.cdktfStack"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```java
 public TerraformStack getCdktfStack();
@@ -9013,7 +9013,7 @@ public TerraformStack getCdktfStack();
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.EtcdBackend.property.fqn"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getFqn();
@@ -9025,7 +9025,7 @@ public java.lang.String getFqn();
 
 ##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.EtcdBackend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getFriendlyUniqueId();
@@ -9076,7 +9076,7 @@ EtcdV3Backend.Builder.create(Construct scope)
 
 ##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdV3Backend.Initializer.parameter.endpoints"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.util.List< java.lang.String >
 
@@ -9086,7 +9086,7 @@ EtcdV3Backend.Builder.create(Construct scope)
 
 ##### ~~`cacertPath`~~<sup>Optional</sup> <a name="cacertPath" id="cdktf.EtcdV3Backend.Initializer.parameter.cacertPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -9096,7 +9096,7 @@ EtcdV3Backend.Builder.create(Construct scope)
 
 ##### ~~`certPath`~~<sup>Optional</sup> <a name="certPath" id="cdktf.EtcdV3Backend.Initializer.parameter.certPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -9106,7 +9106,7 @@ EtcdV3Backend.Builder.create(Construct scope)
 
 ##### ~~`keyPath`~~<sup>Optional</sup> <a name="keyPath" id="cdktf.EtcdV3Backend.Initializer.parameter.keyPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -9116,7 +9116,7 @@ EtcdV3Backend.Builder.create(Construct scope)
 
 ##### ~~`lock`~~<sup>Optional</sup> <a name="lock" id="cdktf.EtcdV3Backend.Initializer.parameter.lock"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.Boolean
 
@@ -9128,7 +9128,7 @@ Defaults to true.
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.EtcdV3Backend.Initializer.parameter.password"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -9138,7 +9138,7 @@ Defaults to true.
 
 ##### ~~`prefix`~~<sup>Optional</sup> <a name="prefix" id="cdktf.EtcdV3Backend.Initializer.parameter.prefix"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -9150,7 +9150,7 @@ Defaults to "".
 
 ##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.EtcdV3Backend.Initializer.parameter.username"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -9345,7 +9345,7 @@ EtcdV3Backend.isBackend(java.lang.Object x)
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.EtcdV3Backend.property.node"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public Node getNode();
@@ -9359,7 +9359,7 @@ The tree node.
 
 ##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.EtcdV3Backend.property.cdktfStack"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public TerraformStack getCdktfStack();
@@ -9371,7 +9371,7 @@ public TerraformStack getCdktfStack();
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.EtcdV3Backend.property.fqn"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getFqn();
@@ -9383,7 +9383,7 @@ public java.lang.String getFqn();
 
 ##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.EtcdV3Backend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getFriendlyUniqueId();
@@ -10427,7 +10427,7 @@ MantaBackend.Builder.create(Construct scope)
 
 ##### ~~`account`~~<sup>Required</sup> <a name="account" id="cdktf.MantaBackend.Initializer.parameter.account"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -10435,7 +10435,7 @@ MantaBackend.Builder.create(Construct scope)
 
 ##### ~~`keyId`~~<sup>Required</sup> <a name="keyId" id="cdktf.MantaBackend.Initializer.parameter.keyId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -10443,7 +10443,7 @@ MantaBackend.Builder.create(Construct scope)
 
 ##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.MantaBackend.Initializer.parameter.path"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -10451,7 +10451,7 @@ MantaBackend.Builder.create(Construct scope)
 
 ##### ~~`insecureSkipTlsVerify`~~<sup>Optional</sup> <a name="insecureSkipTlsVerify" id="cdktf.MantaBackend.Initializer.parameter.insecureSkipTlsVerify"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.Boolean
 
@@ -10459,7 +10459,7 @@ MantaBackend.Builder.create(Construct scope)
 
 ##### ~~`keyMaterial`~~<sup>Optional</sup> <a name="keyMaterial" id="cdktf.MantaBackend.Initializer.parameter.keyMaterial"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -10467,7 +10467,7 @@ MantaBackend.Builder.create(Construct scope)
 
 ##### ~~`objectName`~~<sup>Optional</sup> <a name="objectName" id="cdktf.MantaBackend.Initializer.parameter.objectName"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -10475,7 +10475,7 @@ MantaBackend.Builder.create(Construct scope)
 
 ##### ~~`url`~~<sup>Optional</sup> <a name="url" id="cdktf.MantaBackend.Initializer.parameter.url"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -10483,7 +10483,7 @@ MantaBackend.Builder.create(Construct scope)
 
 ##### ~~`user`~~<sup>Optional</sup> <a name="user" id="cdktf.MantaBackend.Initializer.parameter.user"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -10676,7 +10676,7 @@ MantaBackend.isBackend(java.lang.Object x)
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.MantaBackend.property.node"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public Node getNode();
@@ -10690,7 +10690,7 @@ The tree node.
 
 ##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.MantaBackend.property.cdktfStack"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public TerraformStack getCdktfStack();
@@ -10702,7 +10702,7 @@ public TerraformStack getCdktfStack();
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.MantaBackend.property.fqn"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getFqn();
@@ -10714,7 +10714,7 @@ public java.lang.String getFqn();
 
 ##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.MantaBackend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getFriendlyUniqueId();
@@ -12458,7 +12458,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`container`~~<sup>Required</sup> <a name="container" id="cdktf.SwiftBackend.Initializer.parameter.container"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12466,7 +12466,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`applicationCredentialId`~~<sup>Optional</sup> <a name="applicationCredentialId" id="cdktf.SwiftBackend.Initializer.parameter.applicationCredentialId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12474,7 +12474,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`applicationCredentialName`~~<sup>Optional</sup> <a name="applicationCredentialName" id="cdktf.SwiftBackend.Initializer.parameter.applicationCredentialName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12482,7 +12482,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`applicationCredentialSecret`~~<sup>Optional</sup> <a name="applicationCredentialSecret" id="cdktf.SwiftBackend.Initializer.parameter.applicationCredentialSecret"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12490,7 +12490,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`archiveContainer`~~<sup>Optional</sup> <a name="archiveContainer" id="cdktf.SwiftBackend.Initializer.parameter.archiveContainer"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12498,7 +12498,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`authUrl`~~<sup>Optional</sup> <a name="authUrl" id="cdktf.SwiftBackend.Initializer.parameter.authUrl"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12506,7 +12506,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`cacertFile`~~<sup>Optional</sup> <a name="cacertFile" id="cdktf.SwiftBackend.Initializer.parameter.cacertFile"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12514,7 +12514,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`cert`~~<sup>Optional</sup> <a name="cert" id="cdktf.SwiftBackend.Initializer.parameter.cert"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12522,7 +12522,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`cloud`~~<sup>Optional</sup> <a name="cloud" id="cdktf.SwiftBackend.Initializer.parameter.cloud"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12530,7 +12530,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`defaultDomain`~~<sup>Optional</sup> <a name="defaultDomain" id="cdktf.SwiftBackend.Initializer.parameter.defaultDomain"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12538,7 +12538,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`domainId`~~<sup>Optional</sup> <a name="domainId" id="cdktf.SwiftBackend.Initializer.parameter.domainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12546,7 +12546,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`domainName`~~<sup>Optional</sup> <a name="domainName" id="cdktf.SwiftBackend.Initializer.parameter.domainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12554,7 +12554,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`expireAfter`~~<sup>Optional</sup> <a name="expireAfter" id="cdktf.SwiftBackend.Initializer.parameter.expireAfter"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12562,7 +12562,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`insecure`~~<sup>Optional</sup> <a name="insecure" id="cdktf.SwiftBackend.Initializer.parameter.insecure"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.Boolean
 
@@ -12570,7 +12570,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`key`~~<sup>Optional</sup> <a name="key" id="cdktf.SwiftBackend.Initializer.parameter.key"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12578,7 +12578,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.SwiftBackend.Initializer.parameter.password"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12586,7 +12586,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`projectDomainId`~~<sup>Optional</sup> <a name="projectDomainId" id="cdktf.SwiftBackend.Initializer.parameter.projectDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12594,7 +12594,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`projectDomainName`~~<sup>Optional</sup> <a name="projectDomainName" id="cdktf.SwiftBackend.Initializer.parameter.projectDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12602,7 +12602,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`regionName`~~<sup>Optional</sup> <a name="regionName" id="cdktf.SwiftBackend.Initializer.parameter.regionName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12610,7 +12610,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`stateName`~~<sup>Optional</sup> <a name="stateName" id="cdktf.SwiftBackend.Initializer.parameter.stateName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12618,7 +12618,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`tenantId`~~<sup>Optional</sup> <a name="tenantId" id="cdktf.SwiftBackend.Initializer.parameter.tenantId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12626,7 +12626,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`tenantName`~~<sup>Optional</sup> <a name="tenantName" id="cdktf.SwiftBackend.Initializer.parameter.tenantName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12634,7 +12634,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`token`~~<sup>Optional</sup> <a name="token" id="cdktf.SwiftBackend.Initializer.parameter.token"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12642,7 +12642,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`userDomainId`~~<sup>Optional</sup> <a name="userDomainId" id="cdktf.SwiftBackend.Initializer.parameter.userDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12650,7 +12650,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`userDomainName`~~<sup>Optional</sup> <a name="userDomainName" id="cdktf.SwiftBackend.Initializer.parameter.userDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12658,7 +12658,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`userId`~~<sup>Optional</sup> <a name="userId" id="cdktf.SwiftBackend.Initializer.parameter.userId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12666,7 +12666,7 @@ SwiftBackend.Builder.create(Construct scope)
 
 ##### ~~`userName`~~<sup>Optional</sup> <a name="userName" id="cdktf.SwiftBackend.Initializer.parameter.userName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ java.lang.String
 
@@ -12859,7 +12859,7 @@ SwiftBackend.isBackend(java.lang.Object x)
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.SwiftBackend.property.node"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public Node getNode();
@@ -12873,7 +12873,7 @@ The tree node.
 
 ##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.SwiftBackend.property.cdktfStack"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public TerraformStack getCdktfStack();
@@ -12885,7 +12885,7 @@ public TerraformStack getCdktfStack();
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.SwiftBackend.property.fqn"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getFqn();
@@ -12897,7 +12897,7 @@ public java.lang.String getFqn();
 
 ##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.SwiftBackend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getFriendlyUniqueId();
@@ -17531,7 +17531,7 @@ ArtifactoryBackendProps.builder()
 
 ##### ~~`password`~~<sup>Required</sup> <a name="password" id="cdktf.ArtifactoryBackendProps.property.password"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getPassword();
@@ -17545,7 +17545,7 @@ public java.lang.String getPassword();
 
 ##### ~~`repo`~~<sup>Required</sup> <a name="repo" id="cdktf.ArtifactoryBackendProps.property.repo"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getRepo();
@@ -17559,7 +17559,7 @@ public java.lang.String getRepo();
 
 ##### ~~`subpath`~~<sup>Required</sup> <a name="subpath" id="cdktf.ArtifactoryBackendProps.property.subpath"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getSubpath();
@@ -17573,7 +17573,7 @@ public java.lang.String getSubpath();
 
 ##### ~~`url`~~<sup>Required</sup> <a name="url" id="cdktf.ArtifactoryBackendProps.property.url"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getUrl();
@@ -17589,7 +17589,7 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ##### ~~`username`~~<sup>Required</sup> <a name="username" id="cdktf.ArtifactoryBackendProps.property.username"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getUsername();
@@ -18455,7 +18455,7 @@ DataTerraformRemoteStateArtifactoryConfig.builder()
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.defaults"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.util.Map< java.lang.String, java.lang.Object > getDefaults();
@@ -18467,7 +18467,7 @@ public java.util.Map< java.lang.String, java.lang.Object > getDefaults();
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.workspace"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getWorkspace();
@@ -18479,7 +18479,7 @@ public java.lang.String getWorkspace();
 
 ##### ~~`password`~~<sup>Required</sup> <a name="password" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.password"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getPassword();
@@ -18493,7 +18493,7 @@ public java.lang.String getPassword();
 
 ##### ~~`repo`~~<sup>Required</sup> <a name="repo" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.repo"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getRepo();
@@ -18507,7 +18507,7 @@ public java.lang.String getRepo();
 
 ##### ~~`subpath`~~<sup>Required</sup> <a name="subpath" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.subpath"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getSubpath();
@@ -18521,7 +18521,7 @@ public java.lang.String getSubpath();
 
 ##### ~~`url`~~<sup>Required</sup> <a name="url" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.url"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getUrl();
@@ -18537,7 +18537,7 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ##### ~~`username`~~<sup>Required</sup> <a name="username" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.username"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getUsername();
@@ -19404,7 +19404,7 @@ DataTerraformRemoteStateEtcdConfig.builder()
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.defaults"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.util.Map< java.lang.String, java.lang.Object > getDefaults();
@@ -19416,7 +19416,7 @@ public java.util.Map< java.lang.String, java.lang.Object > getDefaults();
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.workspace"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getWorkspace();
@@ -19428,7 +19428,7 @@ public java.lang.String getWorkspace();
 
 ##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.endpoints"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getEndpoints();
@@ -19442,7 +19442,7 @@ public java.lang.String getEndpoints();
 
 ##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.path"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getPath();
@@ -19456,7 +19456,7 @@ public java.lang.String getPath();
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.password"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getPassword();
@@ -19470,7 +19470,7 @@ public java.lang.String getPassword();
 
 ##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.username"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getUsername();
@@ -19522,7 +19522,7 @@ DataTerraformRemoteStateEtcdV3Config.builder()
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.defaults"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.util.Map< java.lang.String, java.lang.Object > getDefaults();
@@ -19534,7 +19534,7 @@ public java.util.Map< java.lang.String, java.lang.Object > getDefaults();
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.workspace"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getWorkspace();
@@ -19546,7 +19546,7 @@ public java.lang.String getWorkspace();
 
 ##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.endpoints"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.util.List< java.lang.String > getEndpoints();
@@ -19560,7 +19560,7 @@ public java.util.List< java.lang.String > getEndpoints();
 
 ##### ~~`cacertPath`~~<sup>Optional</sup> <a name="cacertPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.cacertPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getCacertPath();
@@ -19574,7 +19574,7 @@ public java.lang.String getCacertPath();
 
 ##### ~~`certPath`~~<sup>Optional</sup> <a name="certPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.certPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getCertPath();
@@ -19588,7 +19588,7 @@ public java.lang.String getCertPath();
 
 ##### ~~`keyPath`~~<sup>Optional</sup> <a name="keyPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.keyPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getKeyPath();
@@ -19602,7 +19602,7 @@ public java.lang.String getKeyPath();
 
 ##### ~~`lock`~~<sup>Optional</sup> <a name="lock" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.lock"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.Boolean getLock();
@@ -19618,7 +19618,7 @@ Defaults to true.
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.password"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getPassword();
@@ -19632,7 +19632,7 @@ public java.lang.String getPassword();
 
 ##### ~~`prefix`~~<sup>Optional</sup> <a name="prefix" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.prefix"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getPrefix();
@@ -19648,7 +19648,7 @@ Defaults to "".
 
 ##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.username"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getUsername();
@@ -20153,7 +20153,7 @@ DataTerraformRemoteStateMantaConfig.builder()
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateMantaConfig.property.defaults"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.util.Map< java.lang.String, java.lang.Object > getDefaults();
@@ -20165,7 +20165,7 @@ public java.util.Map< java.lang.String, java.lang.Object > getDefaults();
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateMantaConfig.property.workspace"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getWorkspace();
@@ -20177,7 +20177,7 @@ public java.lang.String getWorkspace();
 
 ##### ~~`account`~~<sup>Required</sup> <a name="account" id="cdktf.DataTerraformRemoteStateMantaConfig.property.account"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getAccount();
@@ -20189,7 +20189,7 @@ public java.lang.String getAccount();
 
 ##### ~~`keyId`~~<sup>Required</sup> <a name="keyId" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getKeyId();
@@ -20201,7 +20201,7 @@ public java.lang.String getKeyId();
 
 ##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateMantaConfig.property.path"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getPath();
@@ -20213,7 +20213,7 @@ public java.lang.String getPath();
 
 ##### ~~`insecureSkipTlsVerify`~~<sup>Optional</sup> <a name="insecureSkipTlsVerify" id="cdktf.DataTerraformRemoteStateMantaConfig.property.insecureSkipTlsVerify"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.Boolean getInsecureSkipTlsVerify();
@@ -20225,7 +20225,7 @@ public java.lang.Boolean getInsecureSkipTlsVerify();
 
 ##### ~~`keyMaterial`~~<sup>Optional</sup> <a name="keyMaterial" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyMaterial"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getKeyMaterial();
@@ -20237,7 +20237,7 @@ public java.lang.String getKeyMaterial();
 
 ##### ~~`objectName`~~<sup>Optional</sup> <a name="objectName" id="cdktf.DataTerraformRemoteStateMantaConfig.property.objectName"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getObjectName();
@@ -20249,7 +20249,7 @@ public java.lang.String getObjectName();
 
 ##### ~~`url`~~<sup>Optional</sup> <a name="url" id="cdktf.DataTerraformRemoteStateMantaConfig.property.url"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getUrl();
@@ -20261,7 +20261,7 @@ public java.lang.String getUrl();
 
 ##### ~~`user`~~<sup>Optional</sup> <a name="user" id="cdktf.DataTerraformRemoteStateMantaConfig.property.user"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getUser();
@@ -21258,7 +21258,7 @@ DataTerraformRemoteStateSwiftConfig.builder()
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaults"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.util.Map< java.lang.String, java.lang.Object > getDefaults();
@@ -21270,7 +21270,7 @@ public java.util.Map< java.lang.String, java.lang.Object > getDefaults();
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.workspace"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getWorkspace();
@@ -21282,7 +21282,7 @@ public java.lang.String getWorkspace();
 
 ##### ~~`container`~~<sup>Required</sup> <a name="container" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.container"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getContainer();
@@ -21294,7 +21294,7 @@ public java.lang.String getContainer();
 
 ##### ~~`applicationCredentialId`~~<sup>Optional</sup> <a name="applicationCredentialId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getApplicationCredentialId();
@@ -21306,7 +21306,7 @@ public java.lang.String getApplicationCredentialId();
 
 ##### ~~`applicationCredentialName`~~<sup>Optional</sup> <a name="applicationCredentialName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getApplicationCredentialName();
@@ -21318,7 +21318,7 @@ public java.lang.String getApplicationCredentialName();
 
 ##### ~~`applicationCredentialSecret`~~<sup>Optional</sup> <a name="applicationCredentialSecret" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialSecret"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getApplicationCredentialSecret();
@@ -21330,7 +21330,7 @@ public java.lang.String getApplicationCredentialSecret();
 
 ##### ~~`archiveContainer`~~<sup>Optional</sup> <a name="archiveContainer" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.archiveContainer"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getArchiveContainer();
@@ -21342,7 +21342,7 @@ public java.lang.String getArchiveContainer();
 
 ##### ~~`authUrl`~~<sup>Optional</sup> <a name="authUrl" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.authUrl"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getAuthUrl();
@@ -21354,7 +21354,7 @@ public java.lang.String getAuthUrl();
 
 ##### ~~`cacertFile`~~<sup>Optional</sup> <a name="cacertFile" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cacertFile"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getCacertFile();
@@ -21366,7 +21366,7 @@ public java.lang.String getCacertFile();
 
 ##### ~~`cert`~~<sup>Optional</sup> <a name="cert" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cert"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getCert();
@@ -21378,7 +21378,7 @@ public java.lang.String getCert();
 
 ##### ~~`cloud`~~<sup>Optional</sup> <a name="cloud" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cloud"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getCloud();
@@ -21390,7 +21390,7 @@ public java.lang.String getCloud();
 
 ##### ~~`defaultDomain`~~<sup>Optional</sup> <a name="defaultDomain" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaultDomain"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getDefaultDomain();
@@ -21402,7 +21402,7 @@ public java.lang.String getDefaultDomain();
 
 ##### ~~`domainId`~~<sup>Optional</sup> <a name="domainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getDomainId();
@@ -21414,7 +21414,7 @@ public java.lang.String getDomainId();
 
 ##### ~~`domainName`~~<sup>Optional</sup> <a name="domainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getDomainName();
@@ -21426,7 +21426,7 @@ public java.lang.String getDomainName();
 
 ##### ~~`expireAfter`~~<sup>Optional</sup> <a name="expireAfter" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.expireAfter"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getExpireAfter();
@@ -21438,7 +21438,7 @@ public java.lang.String getExpireAfter();
 
 ##### ~~`insecure`~~<sup>Optional</sup> <a name="insecure" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.insecure"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.Boolean getInsecure();
@@ -21450,7 +21450,7 @@ public java.lang.Boolean getInsecure();
 
 ##### ~~`key`~~<sup>Optional</sup> <a name="key" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.key"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getKey();
@@ -21462,7 +21462,7 @@ public java.lang.String getKey();
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.password"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getPassword();
@@ -21474,7 +21474,7 @@ public java.lang.String getPassword();
 
 ##### ~~`projectDomainId`~~<sup>Optional</sup> <a name="projectDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getProjectDomainId();
@@ -21486,7 +21486,7 @@ public java.lang.String getProjectDomainId();
 
 ##### ~~`projectDomainName`~~<sup>Optional</sup> <a name="projectDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getProjectDomainName();
@@ -21498,7 +21498,7 @@ public java.lang.String getProjectDomainName();
 
 ##### ~~`regionName`~~<sup>Optional</sup> <a name="regionName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.regionName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getRegionName();
@@ -21510,7 +21510,7 @@ public java.lang.String getRegionName();
 
 ##### ~~`stateName`~~<sup>Optional</sup> <a name="stateName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.stateName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getStateName();
@@ -21522,7 +21522,7 @@ public java.lang.String getStateName();
 
 ##### ~~`tenantId`~~<sup>Optional</sup> <a name="tenantId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getTenantId();
@@ -21534,7 +21534,7 @@ public java.lang.String getTenantId();
 
 ##### ~~`tenantName`~~<sup>Optional</sup> <a name="tenantName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getTenantName();
@@ -21546,7 +21546,7 @@ public java.lang.String getTenantName();
 
 ##### ~~`token`~~<sup>Optional</sup> <a name="token" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.token"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getToken();
@@ -21558,7 +21558,7 @@ public java.lang.String getToken();
 
 ##### ~~`userDomainId`~~<sup>Optional</sup> <a name="userDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getUserDomainId();
@@ -21570,7 +21570,7 @@ public java.lang.String getUserDomainId();
 
 ##### ~~`userDomainName`~~<sup>Optional</sup> <a name="userDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getUserDomainName();
@@ -21582,7 +21582,7 @@ public java.lang.String getUserDomainName();
 
 ##### ~~`userId`~~<sup>Optional</sup> <a name="userId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getUserId();
@@ -21594,7 +21594,7 @@ public java.lang.String getUserId();
 
 ##### ~~`userName`~~<sup>Optional</sup> <a name="userName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getUserName();
@@ -21674,7 +21674,7 @@ EtcdBackendProps.builder()
 
 ##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdBackendProps.property.endpoints"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getEndpoints();
@@ -21688,7 +21688,7 @@ public java.lang.String getEndpoints();
 
 ##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.EtcdBackendProps.property.path"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getPath();
@@ -21702,7 +21702,7 @@ public java.lang.String getPath();
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.EtcdBackendProps.property.password"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getPassword();
@@ -21716,7 +21716,7 @@ public java.lang.String getPassword();
 
 ##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.EtcdBackendProps.property.username"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getUsername();
@@ -21771,7 +21771,7 @@ EtcdV3BackendProps.builder()
 
 ##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdV3BackendProps.property.endpoints"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.util.List< java.lang.String > getEndpoints();
@@ -21785,7 +21785,7 @@ public java.util.List< java.lang.String > getEndpoints();
 
 ##### ~~`cacertPath`~~<sup>Optional</sup> <a name="cacertPath" id="cdktf.EtcdV3BackendProps.property.cacertPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getCacertPath();
@@ -21799,7 +21799,7 @@ public java.lang.String getCacertPath();
 
 ##### ~~`certPath`~~<sup>Optional</sup> <a name="certPath" id="cdktf.EtcdV3BackendProps.property.certPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getCertPath();
@@ -21813,7 +21813,7 @@ public java.lang.String getCertPath();
 
 ##### ~~`keyPath`~~<sup>Optional</sup> <a name="keyPath" id="cdktf.EtcdV3BackendProps.property.keyPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getKeyPath();
@@ -21827,7 +21827,7 @@ public java.lang.String getKeyPath();
 
 ##### ~~`lock`~~<sup>Optional</sup> <a name="lock" id="cdktf.EtcdV3BackendProps.property.lock"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.Boolean getLock();
@@ -21843,7 +21843,7 @@ Defaults to true.
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.EtcdV3BackendProps.property.password"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getPassword();
@@ -21857,7 +21857,7 @@ public java.lang.String getPassword();
 
 ##### ~~`prefix`~~<sup>Optional</sup> <a name="prefix" id="cdktf.EtcdV3BackendProps.property.prefix"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getPrefix();
@@ -21873,7 +21873,7 @@ Defaults to "".
 
 ##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.EtcdV3BackendProps.property.username"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getUsername();
@@ -22693,7 +22693,7 @@ MantaBackendProps.builder()
 
 ##### ~~`account`~~<sup>Required</sup> <a name="account" id="cdktf.MantaBackendProps.property.account"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getAccount();
@@ -22705,7 +22705,7 @@ public java.lang.String getAccount();
 
 ##### ~~`keyId`~~<sup>Required</sup> <a name="keyId" id="cdktf.MantaBackendProps.property.keyId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getKeyId();
@@ -22717,7 +22717,7 @@ public java.lang.String getKeyId();
 
 ##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.MantaBackendProps.property.path"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getPath();
@@ -22729,7 +22729,7 @@ public java.lang.String getPath();
 
 ##### ~~`insecureSkipTlsVerify`~~<sup>Optional</sup> <a name="insecureSkipTlsVerify" id="cdktf.MantaBackendProps.property.insecureSkipTlsVerify"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.Boolean getInsecureSkipTlsVerify();
@@ -22741,7 +22741,7 @@ public java.lang.Boolean getInsecureSkipTlsVerify();
 
 ##### ~~`keyMaterial`~~<sup>Optional</sup> <a name="keyMaterial" id="cdktf.MantaBackendProps.property.keyMaterial"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getKeyMaterial();
@@ -22753,7 +22753,7 @@ public java.lang.String getKeyMaterial();
 
 ##### ~~`objectName`~~<sup>Optional</sup> <a name="objectName" id="cdktf.MantaBackendProps.property.objectName"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getObjectName();
@@ -22765,7 +22765,7 @@ public java.lang.String getObjectName();
 
 ##### ~~`url`~~<sup>Optional</sup> <a name="url" id="cdktf.MantaBackendProps.property.url"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getUrl();
@@ -22777,7 +22777,7 @@ public java.lang.String getUrl();
 
 ##### ~~`user`~~<sup>Optional</sup> <a name="user" id="cdktf.MantaBackendProps.property.user"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getUser();
@@ -24493,7 +24493,7 @@ SwiftBackendProps.builder()
 
 ##### ~~`container`~~<sup>Required</sup> <a name="container" id="cdktf.SwiftBackendProps.property.container"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getContainer();
@@ -24505,7 +24505,7 @@ public java.lang.String getContainer();
 
 ##### ~~`applicationCredentialId`~~<sup>Optional</sup> <a name="applicationCredentialId" id="cdktf.SwiftBackendProps.property.applicationCredentialId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getApplicationCredentialId();
@@ -24517,7 +24517,7 @@ public java.lang.String getApplicationCredentialId();
 
 ##### ~~`applicationCredentialName`~~<sup>Optional</sup> <a name="applicationCredentialName" id="cdktf.SwiftBackendProps.property.applicationCredentialName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getApplicationCredentialName();
@@ -24529,7 +24529,7 @@ public java.lang.String getApplicationCredentialName();
 
 ##### ~~`applicationCredentialSecret`~~<sup>Optional</sup> <a name="applicationCredentialSecret" id="cdktf.SwiftBackendProps.property.applicationCredentialSecret"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getApplicationCredentialSecret();
@@ -24541,7 +24541,7 @@ public java.lang.String getApplicationCredentialSecret();
 
 ##### ~~`archiveContainer`~~<sup>Optional</sup> <a name="archiveContainer" id="cdktf.SwiftBackendProps.property.archiveContainer"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getArchiveContainer();
@@ -24553,7 +24553,7 @@ public java.lang.String getArchiveContainer();
 
 ##### ~~`authUrl`~~<sup>Optional</sup> <a name="authUrl" id="cdktf.SwiftBackendProps.property.authUrl"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getAuthUrl();
@@ -24565,7 +24565,7 @@ public java.lang.String getAuthUrl();
 
 ##### ~~`cacertFile`~~<sup>Optional</sup> <a name="cacertFile" id="cdktf.SwiftBackendProps.property.cacertFile"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getCacertFile();
@@ -24577,7 +24577,7 @@ public java.lang.String getCacertFile();
 
 ##### ~~`cert`~~<sup>Optional</sup> <a name="cert" id="cdktf.SwiftBackendProps.property.cert"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getCert();
@@ -24589,7 +24589,7 @@ public java.lang.String getCert();
 
 ##### ~~`cloud`~~<sup>Optional</sup> <a name="cloud" id="cdktf.SwiftBackendProps.property.cloud"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getCloud();
@@ -24601,7 +24601,7 @@ public java.lang.String getCloud();
 
 ##### ~~`defaultDomain`~~<sup>Optional</sup> <a name="defaultDomain" id="cdktf.SwiftBackendProps.property.defaultDomain"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getDefaultDomain();
@@ -24613,7 +24613,7 @@ public java.lang.String getDefaultDomain();
 
 ##### ~~`domainId`~~<sup>Optional</sup> <a name="domainId" id="cdktf.SwiftBackendProps.property.domainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getDomainId();
@@ -24625,7 +24625,7 @@ public java.lang.String getDomainId();
 
 ##### ~~`domainName`~~<sup>Optional</sup> <a name="domainName" id="cdktf.SwiftBackendProps.property.domainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getDomainName();
@@ -24637,7 +24637,7 @@ public java.lang.String getDomainName();
 
 ##### ~~`expireAfter`~~<sup>Optional</sup> <a name="expireAfter" id="cdktf.SwiftBackendProps.property.expireAfter"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getExpireAfter();
@@ -24649,7 +24649,7 @@ public java.lang.String getExpireAfter();
 
 ##### ~~`insecure`~~<sup>Optional</sup> <a name="insecure" id="cdktf.SwiftBackendProps.property.insecure"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.Boolean getInsecure();
@@ -24661,7 +24661,7 @@ public java.lang.Boolean getInsecure();
 
 ##### ~~`key`~~<sup>Optional</sup> <a name="key" id="cdktf.SwiftBackendProps.property.key"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getKey();
@@ -24673,7 +24673,7 @@ public java.lang.String getKey();
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.SwiftBackendProps.property.password"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getPassword();
@@ -24685,7 +24685,7 @@ public java.lang.String getPassword();
 
 ##### ~~`projectDomainId`~~<sup>Optional</sup> <a name="projectDomainId" id="cdktf.SwiftBackendProps.property.projectDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getProjectDomainId();
@@ -24697,7 +24697,7 @@ public java.lang.String getProjectDomainId();
 
 ##### ~~`projectDomainName`~~<sup>Optional</sup> <a name="projectDomainName" id="cdktf.SwiftBackendProps.property.projectDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getProjectDomainName();
@@ -24709,7 +24709,7 @@ public java.lang.String getProjectDomainName();
 
 ##### ~~`regionName`~~<sup>Optional</sup> <a name="regionName" id="cdktf.SwiftBackendProps.property.regionName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getRegionName();
@@ -24721,7 +24721,7 @@ public java.lang.String getRegionName();
 
 ##### ~~`stateName`~~<sup>Optional</sup> <a name="stateName" id="cdktf.SwiftBackendProps.property.stateName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getStateName();
@@ -24733,7 +24733,7 @@ public java.lang.String getStateName();
 
 ##### ~~`tenantId`~~<sup>Optional</sup> <a name="tenantId" id="cdktf.SwiftBackendProps.property.tenantId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getTenantId();
@@ -24745,7 +24745,7 @@ public java.lang.String getTenantId();
 
 ##### ~~`tenantName`~~<sup>Optional</sup> <a name="tenantName" id="cdktf.SwiftBackendProps.property.tenantName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getTenantName();
@@ -24757,7 +24757,7 @@ public java.lang.String getTenantName();
 
 ##### ~~`token`~~<sup>Optional</sup> <a name="token" id="cdktf.SwiftBackendProps.property.token"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getToken();
@@ -24769,7 +24769,7 @@ public java.lang.String getToken();
 
 ##### ~~`userDomainId`~~<sup>Optional</sup> <a name="userDomainId" id="cdktf.SwiftBackendProps.property.userDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getUserDomainId();
@@ -24781,7 +24781,7 @@ public java.lang.String getUserDomainId();
 
 ##### ~~`userDomainName`~~<sup>Optional</sup> <a name="userDomainName" id="cdktf.SwiftBackendProps.property.userDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getUserDomainName();
@@ -24793,7 +24793,7 @@ public java.lang.String getUserDomainName();
 
 ##### ~~`userId`~~<sup>Optional</sup> <a name="userId" id="cdktf.SwiftBackendProps.property.userId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getUserId();
@@ -24805,7 +24805,7 @@ public java.lang.String getUserId();
 
 ##### ~~`userName`~~<sup>Optional</sup> <a name="userName" id="cdktf.SwiftBackendProps.property.userName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```java
 public java.lang.String getUserName();

--- a/website/docs/cdktf/api-reference/python.mdx
+++ b/website/docs/cdktf/api-reference/python.mdx
@@ -313,7 +313,7 @@ cdktf.ArtifactoryBackend(
 
 ##### ~~`password`~~<sup>Required</sup> <a name="password" id="cdktf.ArtifactoryBackend.Initializer.parameter.password"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -323,7 +323,7 @@ cdktf.ArtifactoryBackend(
 
 ##### ~~`repo`~~<sup>Required</sup> <a name="repo" id="cdktf.ArtifactoryBackend.Initializer.parameter.repo"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -333,7 +333,7 @@ cdktf.ArtifactoryBackend(
 
 ##### ~~`subpath`~~<sup>Required</sup> <a name="subpath" id="cdktf.ArtifactoryBackend.Initializer.parameter.subpath"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -343,7 +343,7 @@ cdktf.ArtifactoryBackend(
 
 ##### ~~`url`~~<sup>Required</sup> <a name="url" id="cdktf.ArtifactoryBackend.Initializer.parameter.url"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -355,7 +355,7 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ##### ~~`username`~~<sup>Required</sup> <a name="username" id="cdktf.ArtifactoryBackend.Initializer.parameter.username"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -565,7 +565,7 @@ cdktf.ArtifactoryBackend.is_backend(
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.ArtifactoryBackend.property.node"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```python
 node: Node
@@ -579,7 +579,7 @@ The tree node.
 
 ##### ~~`cdktf_stack`~~<sup>Required</sup> <a name="cdktf_stack" id="cdktf.ArtifactoryBackend.property.cdktfStack"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```python
 cdktf_stack: TerraformStack
@@ -591,7 +591,7 @@ cdktf_stack: TerraformStack
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.ArtifactoryBackend.property.fqn"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```python
 fqn: str
@@ -603,7 +603,7 @@ fqn: str
 
 ##### ~~`friendly_unique_id`~~<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.ArtifactoryBackend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```python
 friendly_unique_id: str
@@ -2630,7 +2630,7 @@ cdktf.DataTerraformRemoteStateArtifactory(
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.defaults"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ typing.Mapping[typing.Any]
 
@@ -2638,7 +2638,7 @@ cdktf.DataTerraformRemoteStateArtifactory(
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.workspace"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -2646,7 +2646,7 @@ cdktf.DataTerraformRemoteStateArtifactory(
 
 ##### ~~`password`~~<sup>Required</sup> <a name="password" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.password"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -2656,7 +2656,7 @@ cdktf.DataTerraformRemoteStateArtifactory(
 
 ##### ~~`repo`~~<sup>Required</sup> <a name="repo" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.repo"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -2666,7 +2666,7 @@ cdktf.DataTerraformRemoteStateArtifactory(
 
 ##### ~~`subpath`~~<sup>Required</sup> <a name="subpath" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.subpath"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -2676,7 +2676,7 @@ cdktf.DataTerraformRemoteStateArtifactory(
 
 ##### ~~`url`~~<sup>Required</sup> <a name="url" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.url"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -2688,7 +2688,7 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ##### ~~`username`~~<sup>Required</sup> <a name="username" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.username"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -2925,7 +2925,7 @@ cdktf.DataTerraformRemoteStateArtifactory.is_terraform_element(
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateArtifactory.property.node"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```python
 node: Node
@@ -2939,7 +2939,7 @@ The tree node.
 
 ##### ~~`cdktf_stack`~~<sup>Required</sup> <a name="cdktf_stack" id="cdktf.DataTerraformRemoteStateArtifactory.property.cdktfStack"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```python
 cdktf_stack: TerraformStack
@@ -2951,7 +2951,7 @@ cdktf_stack: TerraformStack
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateArtifactory.property.fqn"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```python
 fqn: str
@@ -2963,7 +2963,7 @@ fqn: str
 
 ##### ~~`friendly_unique_id`~~<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.DataTerraformRemoteStateArtifactory.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```python
 friendly_unique_id: str
@@ -2983,7 +2983,7 @@ friendly_unique_id: str
 
 ##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateArtifactory.property.tfResourceType"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```python
 tfResourceType: str
@@ -4535,7 +4535,7 @@ cdktf.DataTerraformRemoteStateEtcd(
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.defaults"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 - _Type:_ typing.Mapping[typing.Any]
 
@@ -4543,7 +4543,7 @@ cdktf.DataTerraformRemoteStateEtcd(
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.workspace"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -4551,7 +4551,7 @@ cdktf.DataTerraformRemoteStateEtcd(
 
 ##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.endpoints"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -4561,7 +4561,7 @@ cdktf.DataTerraformRemoteStateEtcd(
 
 ##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.path"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -4571,7 +4571,7 @@ cdktf.DataTerraformRemoteStateEtcd(
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.password"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -4581,7 +4581,7 @@ cdktf.DataTerraformRemoteStateEtcd(
 
 ##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.username"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -4818,7 +4818,7 @@ cdktf.DataTerraformRemoteStateEtcd.is_terraform_element(
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateEtcd.property.node"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```python
 node: Node
@@ -4832,7 +4832,7 @@ The tree node.
 
 ##### ~~`cdktf_stack`~~<sup>Required</sup> <a name="cdktf_stack" id="cdktf.DataTerraformRemoteStateEtcd.property.cdktfStack"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```python
 cdktf_stack: TerraformStack
@@ -4844,7 +4844,7 @@ cdktf_stack: TerraformStack
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateEtcd.property.fqn"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```python
 fqn: str
@@ -4856,7 +4856,7 @@ fqn: str
 
 ##### ~~`friendly_unique_id`~~<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.DataTerraformRemoteStateEtcd.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```python
 friendly_unique_id: str
@@ -4876,7 +4876,7 @@ friendly_unique_id: str
 
 ##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateEtcd.property.tfResourceType"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```python
 tfResourceType: str
@@ -4940,7 +4940,7 @@ cdktf.DataTerraformRemoteStateEtcdV3(
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.defaults"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ typing.Mapping[typing.Any]
 
@@ -4948,7 +4948,7 @@ cdktf.DataTerraformRemoteStateEtcdV3(
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.workspace"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -4956,7 +4956,7 @@ cdktf.DataTerraformRemoteStateEtcdV3(
 
 ##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.endpoints"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ typing.List[str]
 
@@ -4966,7 +4966,7 @@ cdktf.DataTerraformRemoteStateEtcdV3(
 
 ##### ~~`cacert_path`~~<sup>Optional</sup> <a name="cacert_path" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.cacertPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -4976,7 +4976,7 @@ cdktf.DataTerraformRemoteStateEtcdV3(
 
 ##### ~~`cert_path`~~<sup>Optional</sup> <a name="cert_path" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.certPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -4986,7 +4986,7 @@ cdktf.DataTerraformRemoteStateEtcdV3(
 
 ##### ~~`key_path`~~<sup>Optional</sup> <a name="key_path" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.keyPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -4996,7 +4996,7 @@ cdktf.DataTerraformRemoteStateEtcdV3(
 
 ##### ~~`lock`~~<sup>Optional</sup> <a name="lock" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.lock"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ bool
 
@@ -5008,7 +5008,7 @@ Defaults to true.
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.password"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -5018,7 +5018,7 @@ Defaults to true.
 
 ##### ~~`prefix`~~<sup>Optional</sup> <a name="prefix" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.prefix"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -5030,7 +5030,7 @@ Defaults to "".
 
 ##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.username"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -5267,7 +5267,7 @@ cdktf.DataTerraformRemoteStateEtcdV3.is_terraform_element(
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateEtcdV3.property.node"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 node: Node
@@ -5281,7 +5281,7 @@ The tree node.
 
 ##### ~~`cdktf_stack`~~<sup>Required</sup> <a name="cdktf_stack" id="cdktf.DataTerraformRemoteStateEtcdV3.property.cdktfStack"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 cdktf_stack: TerraformStack
@@ -5293,7 +5293,7 @@ cdktf_stack: TerraformStack
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateEtcdV3.property.fqn"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 fqn: str
@@ -5305,7 +5305,7 @@ fqn: str
 
 ##### ~~`friendly_unique_id`~~<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.DataTerraformRemoteStateEtcdV3.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 friendly_unique_id: str
@@ -5325,7 +5325,7 @@ friendly_unique_id: str
 
 ##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateEtcdV3.property.tfResourceType"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 tfResourceType: str
@@ -6637,7 +6637,7 @@ cdktf.DataTerraformRemoteStateManta(
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.defaults"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ typing.Mapping[typing.Any]
 
@@ -6645,7 +6645,7 @@ cdktf.DataTerraformRemoteStateManta(
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.workspace"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -6653,7 +6653,7 @@ cdktf.DataTerraformRemoteStateManta(
 
 ##### ~~`account`~~<sup>Required</sup> <a name="account" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.account"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -6661,7 +6661,7 @@ cdktf.DataTerraformRemoteStateManta(
 
 ##### ~~`key_id`~~<sup>Required</sup> <a name="key_id" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.keyId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -6669,7 +6669,7 @@ cdktf.DataTerraformRemoteStateManta(
 
 ##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.path"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -6677,7 +6677,7 @@ cdktf.DataTerraformRemoteStateManta(
 
 ##### ~~`insecure_skip_tls_verify`~~<sup>Optional</sup> <a name="insecure_skip_tls_verify" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.insecureSkipTlsVerify"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ bool
 
@@ -6685,7 +6685,7 @@ cdktf.DataTerraformRemoteStateManta(
 
 ##### ~~`key_material`~~<sup>Optional</sup> <a name="key_material" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.keyMaterial"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -6693,7 +6693,7 @@ cdktf.DataTerraformRemoteStateManta(
 
 ##### ~~`object_name`~~<sup>Optional</sup> <a name="object_name" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.objectName"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -6701,7 +6701,7 @@ cdktf.DataTerraformRemoteStateManta(
 
 ##### ~~`url`~~<sup>Optional</sup> <a name="url" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.url"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -6709,7 +6709,7 @@ cdktf.DataTerraformRemoteStateManta(
 
 ##### ~~`user`~~<sup>Optional</sup> <a name="user" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.user"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -6944,7 +6944,7 @@ cdktf.DataTerraformRemoteStateManta.is_terraform_element(
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateManta.property.node"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 node: Node
@@ -6958,7 +6958,7 @@ The tree node.
 
 ##### ~~`cdktf_stack`~~<sup>Required</sup> <a name="cdktf_stack" id="cdktf.DataTerraformRemoteStateManta.property.cdktfStack"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 cdktf_stack: TerraformStack
@@ -6970,7 +6970,7 @@ cdktf_stack: TerraformStack
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateManta.property.fqn"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 fqn: str
@@ -6982,7 +6982,7 @@ fqn: str
 
 ##### ~~`friendly_unique_id`~~<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.DataTerraformRemoteStateManta.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 friendly_unique_id: str
@@ -7002,7 +7002,7 @@ friendly_unique_id: str
 
 ##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateManta.property.tfResourceType"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 tfResourceType: str
@@ -8606,7 +8606,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.defaults"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ typing.Mapping[typing.Any]
 
@@ -8614,7 +8614,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.workspace"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8622,7 +8622,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`container`~~<sup>Required</sup> <a name="container" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.container"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8630,7 +8630,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`application_credential_id`~~<sup>Optional</sup> <a name="application_credential_id" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.applicationCredentialId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8638,7 +8638,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`application_credential_name`~~<sup>Optional</sup> <a name="application_credential_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.applicationCredentialName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8646,7 +8646,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`application_credential_secret`~~<sup>Optional</sup> <a name="application_credential_secret" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.applicationCredentialSecret"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8654,7 +8654,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`archive_container`~~<sup>Optional</sup> <a name="archive_container" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.archiveContainer"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8662,7 +8662,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`auth_url`~~<sup>Optional</sup> <a name="auth_url" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.authUrl"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8670,7 +8670,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`cacert_file`~~<sup>Optional</sup> <a name="cacert_file" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.cacertFile"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8678,7 +8678,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`cert`~~<sup>Optional</sup> <a name="cert" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.cert"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8686,7 +8686,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`cloud`~~<sup>Optional</sup> <a name="cloud" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.cloud"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8694,7 +8694,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`default_domain`~~<sup>Optional</sup> <a name="default_domain" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.defaultDomain"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8702,7 +8702,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`domain_id`~~<sup>Optional</sup> <a name="domain_id" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.domainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8710,7 +8710,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`domain_name`~~<sup>Optional</sup> <a name="domain_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.domainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8718,7 +8718,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`expire_after`~~<sup>Optional</sup> <a name="expire_after" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.expireAfter"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8726,7 +8726,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`insecure`~~<sup>Optional</sup> <a name="insecure" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.insecure"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ bool
 
@@ -8734,7 +8734,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`key`~~<sup>Optional</sup> <a name="key" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.key"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8742,7 +8742,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.password"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8750,7 +8750,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`project_domain_id`~~<sup>Optional</sup> <a name="project_domain_id" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.projectDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8758,7 +8758,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`project_domain_name`~~<sup>Optional</sup> <a name="project_domain_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.projectDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8766,7 +8766,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`region_name`~~<sup>Optional</sup> <a name="region_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.regionName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8774,7 +8774,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`state_name`~~<sup>Optional</sup> <a name="state_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.stateName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8782,7 +8782,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`tenant_id`~~<sup>Optional</sup> <a name="tenant_id" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.tenantId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8790,7 +8790,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`tenant_name`~~<sup>Optional</sup> <a name="tenant_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.tenantName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8798,7 +8798,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`token`~~<sup>Optional</sup> <a name="token" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.token"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8806,7 +8806,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`user_domain_id`~~<sup>Optional</sup> <a name="user_domain_id" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8814,7 +8814,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`user_domain_name`~~<sup>Optional</sup> <a name="user_domain_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8822,7 +8822,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`user_id`~~<sup>Optional</sup> <a name="user_id" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -8830,7 +8830,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ##### ~~`user_name`~~<sup>Optional</sup> <a name="user_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -9065,7 +9065,7 @@ cdktf.DataTerraformRemoteStateSwift.is_terraform_element(
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateSwift.property.node"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 node: Node
@@ -9079,7 +9079,7 @@ The tree node.
 
 ##### ~~`cdktf_stack`~~<sup>Required</sup> <a name="cdktf_stack" id="cdktf.DataTerraformRemoteStateSwift.property.cdktfStack"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 cdktf_stack: TerraformStack
@@ -9091,7 +9091,7 @@ cdktf_stack: TerraformStack
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateSwift.property.fqn"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 fqn: str
@@ -9103,7 +9103,7 @@ fqn: str
 
 ##### ~~`friendly_unique_id`~~<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.DataTerraformRemoteStateSwift.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 friendly_unique_id: str
@@ -9123,7 +9123,7 @@ friendly_unique_id: str
 
 ##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateSwift.property.tfResourceType"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 tfResourceType: str
@@ -9167,7 +9167,7 @@ cdktf.EtcdBackend(
 
 ##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdBackend.Initializer.parameter.endpoints"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -9177,7 +9177,7 @@ cdktf.EtcdBackend(
 
 ##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.EtcdBackend.Initializer.parameter.path"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -9187,7 +9187,7 @@ cdktf.EtcdBackend(
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.EtcdBackend.Initializer.parameter.password"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -9197,7 +9197,7 @@ cdktf.EtcdBackend(
 
 ##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.EtcdBackend.Initializer.parameter.username"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -9407,7 +9407,7 @@ cdktf.EtcdBackend.is_backend(
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.EtcdBackend.property.node"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```python
 node: Node
@@ -9421,7 +9421,7 @@ The tree node.
 
 ##### ~~`cdktf_stack`~~<sup>Required</sup> <a name="cdktf_stack" id="cdktf.EtcdBackend.property.cdktfStack"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```python
 cdktf_stack: TerraformStack
@@ -9433,7 +9433,7 @@ cdktf_stack: TerraformStack
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.EtcdBackend.property.fqn"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```python
 fqn: str
@@ -9445,7 +9445,7 @@ fqn: str
 
 ##### ~~`friendly_unique_id`~~<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.EtcdBackend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```python
 friendly_unique_id: str
@@ -9497,7 +9497,7 @@ cdktf.EtcdV3Backend(
 
 ##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdV3Backend.Initializer.parameter.endpoints"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ typing.List[str]
 
@@ -9507,7 +9507,7 @@ cdktf.EtcdV3Backend(
 
 ##### ~~`cacert_path`~~<sup>Optional</sup> <a name="cacert_path" id="cdktf.EtcdV3Backend.Initializer.parameter.cacertPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -9517,7 +9517,7 @@ cdktf.EtcdV3Backend(
 
 ##### ~~`cert_path`~~<sup>Optional</sup> <a name="cert_path" id="cdktf.EtcdV3Backend.Initializer.parameter.certPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -9527,7 +9527,7 @@ cdktf.EtcdV3Backend(
 
 ##### ~~`key_path`~~<sup>Optional</sup> <a name="key_path" id="cdktf.EtcdV3Backend.Initializer.parameter.keyPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -9537,7 +9537,7 @@ cdktf.EtcdV3Backend(
 
 ##### ~~`lock`~~<sup>Optional</sup> <a name="lock" id="cdktf.EtcdV3Backend.Initializer.parameter.lock"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ bool
 
@@ -9549,7 +9549,7 @@ Defaults to true.
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.EtcdV3Backend.Initializer.parameter.password"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -9559,7 +9559,7 @@ Defaults to true.
 
 ##### ~~`prefix`~~<sup>Optional</sup> <a name="prefix" id="cdktf.EtcdV3Backend.Initializer.parameter.prefix"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -9571,7 +9571,7 @@ Defaults to "".
 
 ##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.EtcdV3Backend.Initializer.parameter.username"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -9781,7 +9781,7 @@ cdktf.EtcdV3Backend.is_backend(
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.EtcdV3Backend.property.node"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 node: Node
@@ -9795,7 +9795,7 @@ The tree node.
 
 ##### ~~`cdktf_stack`~~<sup>Required</sup> <a name="cdktf_stack" id="cdktf.EtcdV3Backend.property.cdktfStack"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 cdktf_stack: TerraformStack
@@ -9807,7 +9807,7 @@ cdktf_stack: TerraformStack
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.EtcdV3Backend.property.fqn"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 fqn: str
@@ -9819,7 +9819,7 @@ fqn: str
 
 ##### ~~`friendly_unique_id`~~<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.EtcdV3Backend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 friendly_unique_id: str
@@ -10912,7 +10912,7 @@ cdktf.MantaBackend(
 
 ##### ~~`account`~~<sup>Required</sup> <a name="account" id="cdktf.MantaBackend.Initializer.parameter.account"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -10920,7 +10920,7 @@ cdktf.MantaBackend(
 
 ##### ~~`key_id`~~<sup>Required</sup> <a name="key_id" id="cdktf.MantaBackend.Initializer.parameter.keyId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -10928,7 +10928,7 @@ cdktf.MantaBackend(
 
 ##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.MantaBackend.Initializer.parameter.path"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -10936,7 +10936,7 @@ cdktf.MantaBackend(
 
 ##### ~~`insecure_skip_tls_verify`~~<sup>Optional</sup> <a name="insecure_skip_tls_verify" id="cdktf.MantaBackend.Initializer.parameter.insecureSkipTlsVerify"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ bool
 
@@ -10944,7 +10944,7 @@ cdktf.MantaBackend(
 
 ##### ~~`key_material`~~<sup>Optional</sup> <a name="key_material" id="cdktf.MantaBackend.Initializer.parameter.keyMaterial"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -10952,7 +10952,7 @@ cdktf.MantaBackend(
 
 ##### ~~`object_name`~~<sup>Optional</sup> <a name="object_name" id="cdktf.MantaBackend.Initializer.parameter.objectName"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -10960,7 +10960,7 @@ cdktf.MantaBackend(
 
 ##### ~~`url`~~<sup>Optional</sup> <a name="url" id="cdktf.MantaBackend.Initializer.parameter.url"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -10968,7 +10968,7 @@ cdktf.MantaBackend(
 
 ##### ~~`user`~~<sup>Optional</sup> <a name="user" id="cdktf.MantaBackend.Initializer.parameter.user"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -11176,7 +11176,7 @@ cdktf.MantaBackend.is_backend(
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.MantaBackend.property.node"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 node: Node
@@ -11190,7 +11190,7 @@ The tree node.
 
 ##### ~~`cdktf_stack`~~<sup>Required</sup> <a name="cdktf_stack" id="cdktf.MantaBackend.property.cdktfStack"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 cdktf_stack: TerraformStack
@@ -11202,7 +11202,7 @@ cdktf_stack: TerraformStack
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.MantaBackend.property.fqn"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 fqn: str
@@ -11214,7 +11214,7 @@ fqn: str
 
 ##### ~~`friendly_unique_id`~~<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.MantaBackend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 friendly_unique_id: str
@@ -13028,7 +13028,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`container`~~<sup>Required</sup> <a name="container" id="cdktf.SwiftBackend.Initializer.parameter.container"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13036,7 +13036,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`application_credential_id`~~<sup>Optional</sup> <a name="application_credential_id" id="cdktf.SwiftBackend.Initializer.parameter.applicationCredentialId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13044,7 +13044,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`application_credential_name`~~<sup>Optional</sup> <a name="application_credential_name" id="cdktf.SwiftBackend.Initializer.parameter.applicationCredentialName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13052,7 +13052,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`application_credential_secret`~~<sup>Optional</sup> <a name="application_credential_secret" id="cdktf.SwiftBackend.Initializer.parameter.applicationCredentialSecret"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13060,7 +13060,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`archive_container`~~<sup>Optional</sup> <a name="archive_container" id="cdktf.SwiftBackend.Initializer.parameter.archiveContainer"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13068,7 +13068,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`auth_url`~~<sup>Optional</sup> <a name="auth_url" id="cdktf.SwiftBackend.Initializer.parameter.authUrl"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13076,7 +13076,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`cacert_file`~~<sup>Optional</sup> <a name="cacert_file" id="cdktf.SwiftBackend.Initializer.parameter.cacertFile"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13084,7 +13084,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`cert`~~<sup>Optional</sup> <a name="cert" id="cdktf.SwiftBackend.Initializer.parameter.cert"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13092,7 +13092,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`cloud`~~<sup>Optional</sup> <a name="cloud" id="cdktf.SwiftBackend.Initializer.parameter.cloud"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13100,7 +13100,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`default_domain`~~<sup>Optional</sup> <a name="default_domain" id="cdktf.SwiftBackend.Initializer.parameter.defaultDomain"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13108,7 +13108,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`domain_id`~~<sup>Optional</sup> <a name="domain_id" id="cdktf.SwiftBackend.Initializer.parameter.domainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13116,7 +13116,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`domain_name`~~<sup>Optional</sup> <a name="domain_name" id="cdktf.SwiftBackend.Initializer.parameter.domainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13124,7 +13124,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`expire_after`~~<sup>Optional</sup> <a name="expire_after" id="cdktf.SwiftBackend.Initializer.parameter.expireAfter"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13132,7 +13132,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`insecure`~~<sup>Optional</sup> <a name="insecure" id="cdktf.SwiftBackend.Initializer.parameter.insecure"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ bool
 
@@ -13140,7 +13140,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`key`~~<sup>Optional</sup> <a name="key" id="cdktf.SwiftBackend.Initializer.parameter.key"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13148,7 +13148,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.SwiftBackend.Initializer.parameter.password"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13156,7 +13156,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`project_domain_id`~~<sup>Optional</sup> <a name="project_domain_id" id="cdktf.SwiftBackend.Initializer.parameter.projectDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13164,7 +13164,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`project_domain_name`~~<sup>Optional</sup> <a name="project_domain_name" id="cdktf.SwiftBackend.Initializer.parameter.projectDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13172,7 +13172,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`region_name`~~<sup>Optional</sup> <a name="region_name" id="cdktf.SwiftBackend.Initializer.parameter.regionName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13180,7 +13180,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`state_name`~~<sup>Optional</sup> <a name="state_name" id="cdktf.SwiftBackend.Initializer.parameter.stateName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13188,7 +13188,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`tenant_id`~~<sup>Optional</sup> <a name="tenant_id" id="cdktf.SwiftBackend.Initializer.parameter.tenantId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13196,7 +13196,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`tenant_name`~~<sup>Optional</sup> <a name="tenant_name" id="cdktf.SwiftBackend.Initializer.parameter.tenantName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13204,7 +13204,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`token`~~<sup>Optional</sup> <a name="token" id="cdktf.SwiftBackend.Initializer.parameter.token"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13212,7 +13212,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`user_domain_id`~~<sup>Optional</sup> <a name="user_domain_id" id="cdktf.SwiftBackend.Initializer.parameter.userDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13220,7 +13220,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`user_domain_name`~~<sup>Optional</sup> <a name="user_domain_name" id="cdktf.SwiftBackend.Initializer.parameter.userDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13228,7 +13228,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`user_id`~~<sup>Optional</sup> <a name="user_id" id="cdktf.SwiftBackend.Initializer.parameter.userId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13236,7 +13236,7 @@ cdktf.SwiftBackend(
 
 ##### ~~`user_name`~~<sup>Optional</sup> <a name="user_name" id="cdktf.SwiftBackend.Initializer.parameter.userName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 - _Type:_ str
 
@@ -13444,7 +13444,7 @@ cdktf.SwiftBackend.is_backend(
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.SwiftBackend.property.node"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 node: Node
@@ -13458,7 +13458,7 @@ The tree node.
 
 ##### ~~`cdktf_stack`~~<sup>Required</sup> <a name="cdktf_stack" id="cdktf.SwiftBackend.property.cdktfStack"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 cdktf_stack: TerraformStack
@@ -13470,7 +13470,7 @@ cdktf_stack: TerraformStack
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.SwiftBackend.property.fqn"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 fqn: str
@@ -13482,7 +13482,7 @@ fqn: str
 
 ##### ~~`friendly_unique_id`~~<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.SwiftBackend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 friendly_unique_id: str
@@ -18358,7 +18358,7 @@ cdktf.ArtifactoryBackendProps(
 
 ##### ~~`password`~~<sup>Required</sup> <a name="password" id="cdktf.ArtifactoryBackendProps.property.password"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```python
 password: str
@@ -18372,7 +18372,7 @@ password: str
 
 ##### ~~`repo`~~<sup>Required</sup> <a name="repo" id="cdktf.ArtifactoryBackendProps.property.repo"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```python
 repo: str
@@ -18386,7 +18386,7 @@ repo: str
 
 ##### ~~`subpath`~~<sup>Required</sup> <a name="subpath" id="cdktf.ArtifactoryBackendProps.property.subpath"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```python
 subpath: str
@@ -18400,7 +18400,7 @@ subpath: str
 
 ##### ~~`url`~~<sup>Required</sup> <a name="url" id="cdktf.ArtifactoryBackendProps.property.url"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```python
 url: str
@@ -18416,7 +18416,7 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ##### ~~`username`~~<sup>Required</sup> <a name="username" id="cdktf.ArtifactoryBackendProps.property.username"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```python
 username: str
@@ -19281,7 +19281,7 @@ cdktf.DataTerraformRemoteStateArtifactoryConfig(
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.defaults"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```python
 defaults: typing.Mapping[typing.Any]
@@ -19293,7 +19293,7 @@ defaults: typing.Mapping[typing.Any]
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.workspace"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```python
 workspace: str
@@ -19305,7 +19305,7 @@ workspace: str
 
 ##### ~~`password`~~<sup>Required</sup> <a name="password" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.password"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```python
 password: str
@@ -19319,7 +19319,7 @@ password: str
 
 ##### ~~`repo`~~<sup>Required</sup> <a name="repo" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.repo"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```python
 repo: str
@@ -19333,7 +19333,7 @@ repo: str
 
 ##### ~~`subpath`~~<sup>Required</sup> <a name="subpath" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.subpath"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```python
 subpath: str
@@ -19347,7 +19347,7 @@ subpath: str
 
 ##### ~~`url`~~<sup>Required</sup> <a name="url" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.url"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```python
 url: str
@@ -19363,7 +19363,7 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ##### ~~`username`~~<sup>Required</sup> <a name="username" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.username"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```python
 username: str
@@ -20230,7 +20230,7 @@ cdktf.DataTerraformRemoteStateEtcdConfig(
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.defaults"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```python
 defaults: typing.Mapping[typing.Any]
@@ -20242,7 +20242,7 @@ defaults: typing.Mapping[typing.Any]
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.workspace"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```python
 workspace: str
@@ -20254,7 +20254,7 @@ workspace: str
 
 ##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.endpoints"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```python
 endpoints: str
@@ -20268,7 +20268,7 @@ endpoints: str
 
 ##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.path"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```python
 path: str
@@ -20282,7 +20282,7 @@ path: str
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.password"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```python
 password: str
@@ -20296,7 +20296,7 @@ password: str
 
 ##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.username"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```python
 username: str
@@ -20348,7 +20348,7 @@ cdktf.DataTerraformRemoteStateEtcdV3Config(
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.defaults"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 defaults: typing.Mapping[typing.Any]
@@ -20360,7 +20360,7 @@ defaults: typing.Mapping[typing.Any]
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.workspace"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 workspace: str
@@ -20372,7 +20372,7 @@ workspace: str
 
 ##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.endpoints"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 endpoints: typing.List[str]
@@ -20386,7 +20386,7 @@ endpoints: typing.List[str]
 
 ##### ~~`cacert_path`~~<sup>Optional</sup> <a name="cacert_path" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.cacertPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 cacert_path: str
@@ -20400,7 +20400,7 @@ cacert_path: str
 
 ##### ~~`cert_path`~~<sup>Optional</sup> <a name="cert_path" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.certPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 cert_path: str
@@ -20414,7 +20414,7 @@ cert_path: str
 
 ##### ~~`key_path`~~<sup>Optional</sup> <a name="key_path" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.keyPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 key_path: str
@@ -20428,7 +20428,7 @@ key_path: str
 
 ##### ~~`lock`~~<sup>Optional</sup> <a name="lock" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.lock"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 lock: bool
@@ -20444,7 +20444,7 @@ Defaults to true.
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.password"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 password: str
@@ -20458,7 +20458,7 @@ password: str
 
 ##### ~~`prefix`~~<sup>Optional</sup> <a name="prefix" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.prefix"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 prefix: str
@@ -20474,7 +20474,7 @@ Defaults to "".
 
 ##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.username"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 username: str
@@ -20979,7 +20979,7 @@ cdktf.DataTerraformRemoteStateMantaConfig(
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateMantaConfig.property.defaults"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 defaults: typing.Mapping[typing.Any]
@@ -20991,7 +20991,7 @@ defaults: typing.Mapping[typing.Any]
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateMantaConfig.property.workspace"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 workspace: str
@@ -21003,7 +21003,7 @@ workspace: str
 
 ##### ~~`account`~~<sup>Required</sup> <a name="account" id="cdktf.DataTerraformRemoteStateMantaConfig.property.account"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 account: str
@@ -21015,7 +21015,7 @@ account: str
 
 ##### ~~`key_id`~~<sup>Required</sup> <a name="key_id" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 key_id: str
@@ -21027,7 +21027,7 @@ key_id: str
 
 ##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateMantaConfig.property.path"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 path: str
@@ -21039,7 +21039,7 @@ path: str
 
 ##### ~~`insecure_skip_tls_verify`~~<sup>Optional</sup> <a name="insecure_skip_tls_verify" id="cdktf.DataTerraformRemoteStateMantaConfig.property.insecureSkipTlsVerify"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 insecure_skip_tls_verify: bool
@@ -21051,7 +21051,7 @@ insecure_skip_tls_verify: bool
 
 ##### ~~`key_material`~~<sup>Optional</sup> <a name="key_material" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyMaterial"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 key_material: str
@@ -21063,7 +21063,7 @@ key_material: str
 
 ##### ~~`object_name`~~<sup>Optional</sup> <a name="object_name" id="cdktf.DataTerraformRemoteStateMantaConfig.property.objectName"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 object_name: str
@@ -21075,7 +21075,7 @@ object_name: str
 
 ##### ~~`url`~~<sup>Optional</sup> <a name="url" id="cdktf.DataTerraformRemoteStateMantaConfig.property.url"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 url: str
@@ -21087,7 +21087,7 @@ url: str
 
 ##### ~~`user`~~<sup>Optional</sup> <a name="user" id="cdktf.DataTerraformRemoteStateMantaConfig.property.user"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 user: str
@@ -22084,7 +22084,7 @@ cdktf.DataTerraformRemoteStateSwiftConfig(
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaults"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 defaults: typing.Mapping[typing.Any]
@@ -22096,7 +22096,7 @@ defaults: typing.Mapping[typing.Any]
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.workspace"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 workspace: str
@@ -22108,7 +22108,7 @@ workspace: str
 
 ##### ~~`container`~~<sup>Required</sup> <a name="container" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.container"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 container: str
@@ -22120,7 +22120,7 @@ container: str
 
 ##### ~~`application_credential_id`~~<sup>Optional</sup> <a name="application_credential_id" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 application_credential_id: str
@@ -22132,7 +22132,7 @@ application_credential_id: str
 
 ##### ~~`application_credential_name`~~<sup>Optional</sup> <a name="application_credential_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 application_credential_name: str
@@ -22144,7 +22144,7 @@ application_credential_name: str
 
 ##### ~~`application_credential_secret`~~<sup>Optional</sup> <a name="application_credential_secret" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialSecret"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 application_credential_secret: str
@@ -22156,7 +22156,7 @@ application_credential_secret: str
 
 ##### ~~`archive_container`~~<sup>Optional</sup> <a name="archive_container" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.archiveContainer"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 archive_container: str
@@ -22168,7 +22168,7 @@ archive_container: str
 
 ##### ~~`auth_url`~~<sup>Optional</sup> <a name="auth_url" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.authUrl"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 auth_url: str
@@ -22180,7 +22180,7 @@ auth_url: str
 
 ##### ~~`cacert_file`~~<sup>Optional</sup> <a name="cacert_file" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cacertFile"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 cacert_file: str
@@ -22192,7 +22192,7 @@ cacert_file: str
 
 ##### ~~`cert`~~<sup>Optional</sup> <a name="cert" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cert"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 cert: str
@@ -22204,7 +22204,7 @@ cert: str
 
 ##### ~~`cloud`~~<sup>Optional</sup> <a name="cloud" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cloud"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 cloud: str
@@ -22216,7 +22216,7 @@ cloud: str
 
 ##### ~~`default_domain`~~<sup>Optional</sup> <a name="default_domain" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaultDomain"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 default_domain: str
@@ -22228,7 +22228,7 @@ default_domain: str
 
 ##### ~~`domain_id`~~<sup>Optional</sup> <a name="domain_id" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 domain_id: str
@@ -22240,7 +22240,7 @@ domain_id: str
 
 ##### ~~`domain_name`~~<sup>Optional</sup> <a name="domain_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 domain_name: str
@@ -22252,7 +22252,7 @@ domain_name: str
 
 ##### ~~`expire_after`~~<sup>Optional</sup> <a name="expire_after" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.expireAfter"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 expire_after: str
@@ -22264,7 +22264,7 @@ expire_after: str
 
 ##### ~~`insecure`~~<sup>Optional</sup> <a name="insecure" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.insecure"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 insecure: bool
@@ -22276,7 +22276,7 @@ insecure: bool
 
 ##### ~~`key`~~<sup>Optional</sup> <a name="key" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.key"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 key: str
@@ -22288,7 +22288,7 @@ key: str
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.password"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 password: str
@@ -22300,7 +22300,7 @@ password: str
 
 ##### ~~`project_domain_id`~~<sup>Optional</sup> <a name="project_domain_id" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 project_domain_id: str
@@ -22312,7 +22312,7 @@ project_domain_id: str
 
 ##### ~~`project_domain_name`~~<sup>Optional</sup> <a name="project_domain_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 project_domain_name: str
@@ -22324,7 +22324,7 @@ project_domain_name: str
 
 ##### ~~`region_name`~~<sup>Optional</sup> <a name="region_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.regionName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 region_name: str
@@ -22336,7 +22336,7 @@ region_name: str
 
 ##### ~~`state_name`~~<sup>Optional</sup> <a name="state_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.stateName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 state_name: str
@@ -22348,7 +22348,7 @@ state_name: str
 
 ##### ~~`tenant_id`~~<sup>Optional</sup> <a name="tenant_id" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 tenant_id: str
@@ -22360,7 +22360,7 @@ tenant_id: str
 
 ##### ~~`tenant_name`~~<sup>Optional</sup> <a name="tenant_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 tenant_name: str
@@ -22372,7 +22372,7 @@ tenant_name: str
 
 ##### ~~`token`~~<sup>Optional</sup> <a name="token" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.token"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 token: str
@@ -22384,7 +22384,7 @@ token: str
 
 ##### ~~`user_domain_id`~~<sup>Optional</sup> <a name="user_domain_id" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 user_domain_id: str
@@ -22396,7 +22396,7 @@ user_domain_id: str
 
 ##### ~~`user_domain_name`~~<sup>Optional</sup> <a name="user_domain_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 user_domain_name: str
@@ -22408,7 +22408,7 @@ user_domain_name: str
 
 ##### ~~`user_id`~~<sup>Optional</sup> <a name="user_id" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 user_id: str
@@ -22420,7 +22420,7 @@ user_id: str
 
 ##### ~~`user_name`~~<sup>Optional</sup> <a name="user_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 user_name: str
@@ -22500,7 +22500,7 @@ cdktf.EtcdBackendProps(
 
 ##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdBackendProps.property.endpoints"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```python
 endpoints: str
@@ -22514,7 +22514,7 @@ endpoints: str
 
 ##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.EtcdBackendProps.property.path"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```python
 path: str
@@ -22528,7 +22528,7 @@ path: str
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.EtcdBackendProps.property.password"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```python
 password: str
@@ -22542,7 +22542,7 @@ password: str
 
 ##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.EtcdBackendProps.property.username"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```python
 username: str
@@ -22597,7 +22597,7 @@ cdktf.EtcdV3BackendProps(
 
 ##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdV3BackendProps.property.endpoints"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 endpoints: typing.List[str]
@@ -22611,7 +22611,7 @@ endpoints: typing.List[str]
 
 ##### ~~`cacert_path`~~<sup>Optional</sup> <a name="cacert_path" id="cdktf.EtcdV3BackendProps.property.cacertPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 cacert_path: str
@@ -22625,7 +22625,7 @@ cacert_path: str
 
 ##### ~~`cert_path`~~<sup>Optional</sup> <a name="cert_path" id="cdktf.EtcdV3BackendProps.property.certPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 cert_path: str
@@ -22639,7 +22639,7 @@ cert_path: str
 
 ##### ~~`key_path`~~<sup>Optional</sup> <a name="key_path" id="cdktf.EtcdV3BackendProps.property.keyPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 key_path: str
@@ -22653,7 +22653,7 @@ key_path: str
 
 ##### ~~`lock`~~<sup>Optional</sup> <a name="lock" id="cdktf.EtcdV3BackendProps.property.lock"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 lock: bool
@@ -22669,7 +22669,7 @@ Defaults to true.
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.EtcdV3BackendProps.property.password"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 password: str
@@ -22683,7 +22683,7 @@ password: str
 
 ##### ~~`prefix`~~<sup>Optional</sup> <a name="prefix" id="cdktf.EtcdV3BackendProps.property.prefix"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 prefix: str
@@ -22699,7 +22699,7 @@ Defaults to "".
 
 ##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.EtcdV3BackendProps.property.username"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```python
 username: str
@@ -23518,7 +23518,7 @@ cdktf.MantaBackendProps(
 
 ##### ~~`account`~~<sup>Required</sup> <a name="account" id="cdktf.MantaBackendProps.property.account"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 account: str
@@ -23530,7 +23530,7 @@ account: str
 
 ##### ~~`key_id`~~<sup>Required</sup> <a name="key_id" id="cdktf.MantaBackendProps.property.keyId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 key_id: str
@@ -23542,7 +23542,7 @@ key_id: str
 
 ##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.MantaBackendProps.property.path"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 path: str
@@ -23554,7 +23554,7 @@ path: str
 
 ##### ~~`insecure_skip_tls_verify`~~<sup>Optional</sup> <a name="insecure_skip_tls_verify" id="cdktf.MantaBackendProps.property.insecureSkipTlsVerify"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 insecure_skip_tls_verify: bool
@@ -23566,7 +23566,7 @@ insecure_skip_tls_verify: bool
 
 ##### ~~`key_material`~~<sup>Optional</sup> <a name="key_material" id="cdktf.MantaBackendProps.property.keyMaterial"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 key_material: str
@@ -23578,7 +23578,7 @@ key_material: str
 
 ##### ~~`object_name`~~<sup>Optional</sup> <a name="object_name" id="cdktf.MantaBackendProps.property.objectName"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 object_name: str
@@ -23590,7 +23590,7 @@ object_name: str
 
 ##### ~~`url`~~<sup>Optional</sup> <a name="url" id="cdktf.MantaBackendProps.property.url"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 url: str
@@ -23602,7 +23602,7 @@ url: str
 
 ##### ~~`user`~~<sup>Optional</sup> <a name="user" id="cdktf.MantaBackendProps.property.user"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```python
 user: str
@@ -25317,7 +25317,7 @@ cdktf.SwiftBackendProps(
 
 ##### ~~`container`~~<sup>Required</sup> <a name="container" id="cdktf.SwiftBackendProps.property.container"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 container: str
@@ -25329,7 +25329,7 @@ container: str
 
 ##### ~~`application_credential_id`~~<sup>Optional</sup> <a name="application_credential_id" id="cdktf.SwiftBackendProps.property.applicationCredentialId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 application_credential_id: str
@@ -25341,7 +25341,7 @@ application_credential_id: str
 
 ##### ~~`application_credential_name`~~<sup>Optional</sup> <a name="application_credential_name" id="cdktf.SwiftBackendProps.property.applicationCredentialName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 application_credential_name: str
@@ -25353,7 +25353,7 @@ application_credential_name: str
 
 ##### ~~`application_credential_secret`~~<sup>Optional</sup> <a name="application_credential_secret" id="cdktf.SwiftBackendProps.property.applicationCredentialSecret"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 application_credential_secret: str
@@ -25365,7 +25365,7 @@ application_credential_secret: str
 
 ##### ~~`archive_container`~~<sup>Optional</sup> <a name="archive_container" id="cdktf.SwiftBackendProps.property.archiveContainer"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 archive_container: str
@@ -25377,7 +25377,7 @@ archive_container: str
 
 ##### ~~`auth_url`~~<sup>Optional</sup> <a name="auth_url" id="cdktf.SwiftBackendProps.property.authUrl"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 auth_url: str
@@ -25389,7 +25389,7 @@ auth_url: str
 
 ##### ~~`cacert_file`~~<sup>Optional</sup> <a name="cacert_file" id="cdktf.SwiftBackendProps.property.cacertFile"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 cacert_file: str
@@ -25401,7 +25401,7 @@ cacert_file: str
 
 ##### ~~`cert`~~<sup>Optional</sup> <a name="cert" id="cdktf.SwiftBackendProps.property.cert"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 cert: str
@@ -25413,7 +25413,7 @@ cert: str
 
 ##### ~~`cloud`~~<sup>Optional</sup> <a name="cloud" id="cdktf.SwiftBackendProps.property.cloud"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 cloud: str
@@ -25425,7 +25425,7 @@ cloud: str
 
 ##### ~~`default_domain`~~<sup>Optional</sup> <a name="default_domain" id="cdktf.SwiftBackendProps.property.defaultDomain"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 default_domain: str
@@ -25437,7 +25437,7 @@ default_domain: str
 
 ##### ~~`domain_id`~~<sup>Optional</sup> <a name="domain_id" id="cdktf.SwiftBackendProps.property.domainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 domain_id: str
@@ -25449,7 +25449,7 @@ domain_id: str
 
 ##### ~~`domain_name`~~<sup>Optional</sup> <a name="domain_name" id="cdktf.SwiftBackendProps.property.domainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 domain_name: str
@@ -25461,7 +25461,7 @@ domain_name: str
 
 ##### ~~`expire_after`~~<sup>Optional</sup> <a name="expire_after" id="cdktf.SwiftBackendProps.property.expireAfter"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 expire_after: str
@@ -25473,7 +25473,7 @@ expire_after: str
 
 ##### ~~`insecure`~~<sup>Optional</sup> <a name="insecure" id="cdktf.SwiftBackendProps.property.insecure"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 insecure: bool
@@ -25485,7 +25485,7 @@ insecure: bool
 
 ##### ~~`key`~~<sup>Optional</sup> <a name="key" id="cdktf.SwiftBackendProps.property.key"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 key: str
@@ -25497,7 +25497,7 @@ key: str
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.SwiftBackendProps.property.password"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 password: str
@@ -25509,7 +25509,7 @@ password: str
 
 ##### ~~`project_domain_id`~~<sup>Optional</sup> <a name="project_domain_id" id="cdktf.SwiftBackendProps.property.projectDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 project_domain_id: str
@@ -25521,7 +25521,7 @@ project_domain_id: str
 
 ##### ~~`project_domain_name`~~<sup>Optional</sup> <a name="project_domain_name" id="cdktf.SwiftBackendProps.property.projectDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 project_domain_name: str
@@ -25533,7 +25533,7 @@ project_domain_name: str
 
 ##### ~~`region_name`~~<sup>Optional</sup> <a name="region_name" id="cdktf.SwiftBackendProps.property.regionName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 region_name: str
@@ -25545,7 +25545,7 @@ region_name: str
 
 ##### ~~`state_name`~~<sup>Optional</sup> <a name="state_name" id="cdktf.SwiftBackendProps.property.stateName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 state_name: str
@@ -25557,7 +25557,7 @@ state_name: str
 
 ##### ~~`tenant_id`~~<sup>Optional</sup> <a name="tenant_id" id="cdktf.SwiftBackendProps.property.tenantId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 tenant_id: str
@@ -25569,7 +25569,7 @@ tenant_id: str
 
 ##### ~~`tenant_name`~~<sup>Optional</sup> <a name="tenant_name" id="cdktf.SwiftBackendProps.property.tenantName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 tenant_name: str
@@ -25581,7 +25581,7 @@ tenant_name: str
 
 ##### ~~`token`~~<sup>Optional</sup> <a name="token" id="cdktf.SwiftBackendProps.property.token"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 token: str
@@ -25593,7 +25593,7 @@ token: str
 
 ##### ~~`user_domain_id`~~<sup>Optional</sup> <a name="user_domain_id" id="cdktf.SwiftBackendProps.property.userDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 user_domain_id: str
@@ -25605,7 +25605,7 @@ user_domain_id: str
 
 ##### ~~`user_domain_name`~~<sup>Optional</sup> <a name="user_domain_name" id="cdktf.SwiftBackendProps.property.userDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 user_domain_name: str
@@ -25617,7 +25617,7 @@ user_domain_name: str
 
 ##### ~~`user_id`~~<sup>Optional</sup> <a name="user_id" id="cdktf.SwiftBackendProps.property.userId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 user_id: str
@@ -25629,7 +25629,7 @@ user_id: str
 
 ##### ~~`user_name`~~<sup>Optional</sup> <a name="user_name" id="cdktf.SwiftBackendProps.property.userName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```python
 user_name: str

--- a/website/docs/cdktf/api-reference/python.mdx
+++ b/website/docs/cdktf/api-reference/python.mdx
@@ -311,7 +311,9 @@ cdktf.ArtifactoryBackend(
 
 ---
 
-##### `password`<sup>Required</sup> <a name="password" id="cdktf.ArtifactoryBackend.Initializer.parameter.password"></a>
+##### ~~`password`~~<sup>Required</sup> <a name="password" id="cdktf.ArtifactoryBackend.Initializer.parameter.password"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -319,7 +321,9 @@ cdktf.ArtifactoryBackend(
 
 ---
 
-##### `repo`<sup>Required</sup> <a name="repo" id="cdktf.ArtifactoryBackend.Initializer.parameter.repo"></a>
+##### ~~`repo`~~<sup>Required</sup> <a name="repo" id="cdktf.ArtifactoryBackend.Initializer.parameter.repo"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -327,7 +331,9 @@ cdktf.ArtifactoryBackend(
 
 ---
 
-##### `subpath`<sup>Required</sup> <a name="subpath" id="cdktf.ArtifactoryBackend.Initializer.parameter.subpath"></a>
+##### ~~`subpath`~~<sup>Required</sup> <a name="subpath" id="cdktf.ArtifactoryBackend.Initializer.parameter.subpath"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -335,7 +341,9 @@ cdktf.ArtifactoryBackend(
 
 ---
 
-##### `url`<sup>Required</sup> <a name="url" id="cdktf.ArtifactoryBackend.Initializer.parameter.url"></a>
+##### ~~`url`~~<sup>Required</sup> <a name="url" id="cdktf.ArtifactoryBackend.Initializer.parameter.url"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -345,7 +353,9 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ---
 
-##### `username`<sup>Required</sup> <a name="username" id="cdktf.ArtifactoryBackend.Initializer.parameter.username"></a>
+##### ~~`username`~~<sup>Required</sup> <a name="username" id="cdktf.ArtifactoryBackend.Initializer.parameter.username"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -367,7 +377,7 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ---
 
-##### `to_string` <a name="to_string" id="cdktf.ArtifactoryBackend.toString"></a>
+##### ~~`to_string`~~ <a name="to_string" id="cdktf.ArtifactoryBackend.toString"></a>
 
 ```python
 def to_string() - > str
@@ -375,7 +385,7 @@ def to_string() - > str
 
 Returns a string representation of this construct.
 
-##### `add_override` <a name="add_override" id="cdktf.ArtifactoryBackend.addOverride"></a>
+##### ~~`add_override`~~ <a name="add_override" id="cdktf.ArtifactoryBackend.addOverride"></a>
 
 ```python
 def add_override(
@@ -396,7 +406,7 @@ def add_override(
 
 ---
 
-##### `override_logical_id` <a name="override_logical_id" id="cdktf.ArtifactoryBackend.overrideLogicalId"></a>
+##### ~~`override_logical_id`~~ <a name="override_logical_id" id="cdktf.ArtifactoryBackend.overrideLogicalId"></a>
 
 ```python
 def override_logical_id(
@@ -414,7 +424,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `reset_override_logical_id` <a name="reset_override_logical_id" id="cdktf.ArtifactoryBackend.resetOverrideLogicalId"></a>
+##### ~~`reset_override_logical_id`~~ <a name="reset_override_logical_id" id="cdktf.ArtifactoryBackend.resetOverrideLogicalId"></a>
 
 ```python
 def reset_override_logical_id() - > None
@@ -422,13 +432,13 @@ def reset_override_logical_id() - > None
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `to_metadata` <a name="to_metadata" id="cdktf.ArtifactoryBackend.toMetadata"></a>
+##### ~~`to_metadata`~~ <a name="to_metadata" id="cdktf.ArtifactoryBackend.toMetadata"></a>
 
 ```python
 def to_metadata() - > typing.Any
 ```
 
-##### `to_terraform` <a name="to_terraform" id="cdktf.ArtifactoryBackend.toTerraform"></a>
+##### ~~`to_terraform`~~ <a name="to_terraform" id="cdktf.ArtifactoryBackend.toTerraform"></a>
 
 ```python
 def to_terraform() - > typing.Any
@@ -436,7 +446,7 @@ def to_terraform() - > typing.Any
 
 Adds this resource to the terraform JSON output.
 
-##### `get_remote_state_data_source` <a name="get_remote_state_data_source" id="cdktf.ArtifactoryBackend.getRemoteStateDataSource"></a>
+##### ~~`get_remote_state_data_source`~~ <a name="get_remote_state_data_source" id="cdktf.ArtifactoryBackend.getRemoteStateDataSource"></a>
 
 ```python
 def get_remote_state_data_source(
@@ -476,7 +486,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `is_construct` <a name="is_construct" id="cdktf.ArtifactoryBackend.isConstruct"></a>
+##### ~~`is_construct`~~ <a name="is_construct" id="cdktf.ArtifactoryBackend.isConstruct"></a>
 
 ```python
 import cdktf
@@ -510,7 +520,7 @@ Any object.
 
 ---
 
-##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.ArtifactoryBackend.isTerraformElement"></a>
+##### ~~`is_terraform_element`~~ <a name="is_terraform_element" id="cdktf.ArtifactoryBackend.isTerraformElement"></a>
 
 ```python
 import cdktf
@@ -526,7 +536,7 @@ cdktf.ArtifactoryBackend.is_terraform_element(
 
 ---
 
-##### `is_backend` <a name="is_backend" id="cdktf.ArtifactoryBackend.isBackend"></a>
+##### ~~`is_backend`~~ <a name="is_backend" id="cdktf.ArtifactoryBackend.isBackend"></a>
 
 ```python
 import cdktf
@@ -553,7 +563,9 @@ cdktf.ArtifactoryBackend.is_backend(
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.ArtifactoryBackend.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.ArtifactoryBackend.property.node"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 node: Node
@@ -565,7 +577,9 @@ The tree node.
 
 ---
 
-##### `cdktf_stack`<sup>Required</sup> <a name="cdktf_stack" id="cdktf.ArtifactoryBackend.property.cdktfStack"></a>
+##### ~~`cdktf_stack`~~<sup>Required</sup> <a name="cdktf_stack" id="cdktf.ArtifactoryBackend.property.cdktfStack"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 cdktf_stack: TerraformStack
@@ -575,7 +589,9 @@ cdktf_stack: TerraformStack
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.ArtifactoryBackend.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.ArtifactoryBackend.property.fqn"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 fqn: str
@@ -585,7 +601,9 @@ fqn: str
 
 ---
 
-##### `friendly_unique_id`<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.ArtifactoryBackend.property.friendlyUniqueId"></a>
+##### ~~`friendly_unique_id`~~<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.ArtifactoryBackend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 friendly_unique_id: str
@@ -2610,19 +2628,25 @@ cdktf.DataTerraformRemoteStateArtifactory(
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.defaults"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ typing.Mapping[typing.Any]
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.workspace"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `password`<sup>Required</sup> <a name="password" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.password"></a>
+##### ~~`password`~~<sup>Required</sup> <a name="password" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.password"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -2630,7 +2654,9 @@ cdktf.DataTerraformRemoteStateArtifactory(
 
 ---
 
-##### `repo`<sup>Required</sup> <a name="repo" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.repo"></a>
+##### ~~`repo`~~<sup>Required</sup> <a name="repo" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.repo"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -2638,7 +2664,9 @@ cdktf.DataTerraformRemoteStateArtifactory(
 
 ---
 
-##### `subpath`<sup>Required</sup> <a name="subpath" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.subpath"></a>
+##### ~~`subpath`~~<sup>Required</sup> <a name="subpath" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.subpath"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -2646,7 +2674,9 @@ cdktf.DataTerraformRemoteStateArtifactory(
 
 ---
 
-##### `url`<sup>Required</sup> <a name="url" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.url"></a>
+##### ~~`url`~~<sup>Required</sup> <a name="url" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.url"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -2656,7 +2686,9 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ---
 
-##### `username`<sup>Required</sup> <a name="username" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.username"></a>
+##### ~~`username`~~<sup>Required</sup> <a name="username" id="cdktf.DataTerraformRemoteStateArtifactory.Initializer.parameter.username"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -2682,7 +2714,7 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ---
 
-##### `to_string` <a name="to_string" id="cdktf.DataTerraformRemoteStateArtifactory.toString"></a>
+##### ~~`to_string`~~ <a name="to_string" id="cdktf.DataTerraformRemoteStateArtifactory.toString"></a>
 
 ```python
 def to_string() - > str
@@ -2690,7 +2722,7 @@ def to_string() - > str
 
 Returns a string representation of this construct.
 
-##### `add_override` <a name="add_override" id="cdktf.DataTerraformRemoteStateArtifactory.addOverride"></a>
+##### ~~`add_override`~~ <a name="add_override" id="cdktf.DataTerraformRemoteStateArtifactory.addOverride"></a>
 
 ```python
 def add_override(
@@ -2711,7 +2743,7 @@ def add_override(
 
 ---
 
-##### `override_logical_id` <a name="override_logical_id" id="cdktf.DataTerraformRemoteStateArtifactory.overrideLogicalId"></a>
+##### ~~`override_logical_id`~~ <a name="override_logical_id" id="cdktf.DataTerraformRemoteStateArtifactory.overrideLogicalId"></a>
 
 ```python
 def override_logical_id(
@@ -2729,7 +2761,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `reset_override_logical_id` <a name="reset_override_logical_id" id="cdktf.DataTerraformRemoteStateArtifactory.resetOverrideLogicalId"></a>
+##### ~~`reset_override_logical_id`~~ <a name="reset_override_logical_id" id="cdktf.DataTerraformRemoteStateArtifactory.resetOverrideLogicalId"></a>
 
 ```python
 def reset_override_logical_id() - > None
@@ -2737,13 +2769,13 @@ def reset_override_logical_id() - > None
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `to_metadata` <a name="to_metadata" id="cdktf.DataTerraformRemoteStateArtifactory.toMetadata"></a>
+##### ~~`to_metadata`~~ <a name="to_metadata" id="cdktf.DataTerraformRemoteStateArtifactory.toMetadata"></a>
 
 ```python
 def to_metadata() - > typing.Any
 ```
 
-##### `to_terraform` <a name="to_terraform" id="cdktf.DataTerraformRemoteStateArtifactory.toTerraform"></a>
+##### ~~`to_terraform`~~ <a name="to_terraform" id="cdktf.DataTerraformRemoteStateArtifactory.toTerraform"></a>
 
 ```python
 def to_terraform() - > typing.Any
@@ -2751,7 +2783,7 @@ def to_terraform() - > typing.Any
 
 Adds this resource to the terraform JSON output.
 
-##### `get` <a name="get" id="cdktf.DataTerraformRemoteStateArtifactory.get"></a>
+##### ~~`get`~~ <a name="get" id="cdktf.DataTerraformRemoteStateArtifactory.get"></a>
 
 ```python
 def get(
@@ -2765,7 +2797,7 @@ def get(
 
 ---
 
-##### `get_boolean` <a name="get_boolean" id="cdktf.DataTerraformRemoteStateArtifactory.getBoolean"></a>
+##### ~~`get_boolean`~~ <a name="get_boolean" id="cdktf.DataTerraformRemoteStateArtifactory.getBoolean"></a>
 
 ```python
 def get_boolean(
@@ -2779,7 +2811,7 @@ def get_boolean(
 
 ---
 
-##### `get_list` <a name="get_list" id="cdktf.DataTerraformRemoteStateArtifactory.getList"></a>
+##### ~~`get_list`~~ <a name="get_list" id="cdktf.DataTerraformRemoteStateArtifactory.getList"></a>
 
 ```python
 def get_list(
@@ -2793,7 +2825,7 @@ def get_list(
 
 ---
 
-##### `get_number` <a name="get_number" id="cdktf.DataTerraformRemoteStateArtifactory.getNumber"></a>
+##### ~~`get_number`~~ <a name="get_number" id="cdktf.DataTerraformRemoteStateArtifactory.getNumber"></a>
 
 ```python
 def get_number(
@@ -2807,7 +2839,7 @@ def get_number(
 
 ---
 
-##### `get_string` <a name="get_string" id="cdktf.DataTerraformRemoteStateArtifactory.getString"></a>
+##### ~~`get_string`~~ <a name="get_string" id="cdktf.DataTerraformRemoteStateArtifactory.getString"></a>
 
 ```python
 def get_string(
@@ -2830,7 +2862,7 @@ def get_string(
 
 ---
 
-##### `is_construct` <a name="is_construct" id="cdktf.DataTerraformRemoteStateArtifactory.isConstruct"></a>
+##### ~~`is_construct`~~ <a name="is_construct" id="cdktf.DataTerraformRemoteStateArtifactory.isConstruct"></a>
 
 ```python
 import cdktf
@@ -2864,7 +2896,7 @@ Any object.
 
 ---
 
-##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement"></a>
+##### ~~`is_terraform_element`~~ <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement"></a>
 
 ```python
 import cdktf
@@ -2891,7 +2923,9 @@ cdktf.DataTerraformRemoteStateArtifactory.is_terraform_element(
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateArtifactory.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateArtifactory.property.node"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 node: Node
@@ -2903,7 +2937,9 @@ The tree node.
 
 ---
 
-##### `cdktf_stack`<sup>Required</sup> <a name="cdktf_stack" id="cdktf.DataTerraformRemoteStateArtifactory.property.cdktfStack"></a>
+##### ~~`cdktf_stack`~~<sup>Required</sup> <a name="cdktf_stack" id="cdktf.DataTerraformRemoteStateArtifactory.property.cdktfStack"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 cdktf_stack: TerraformStack
@@ -2913,7 +2949,9 @@ cdktf_stack: TerraformStack
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateArtifactory.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateArtifactory.property.fqn"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 fqn: str
@@ -2923,7 +2961,9 @@ fqn: str
 
 ---
 
-##### `friendly_unique_id`<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.DataTerraformRemoteStateArtifactory.property.friendlyUniqueId"></a>
+##### ~~`friendly_unique_id`~~<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.DataTerraformRemoteStateArtifactory.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 friendly_unique_id: str
@@ -2941,7 +2981,9 @@ friendly_unique_id: str
 
 ---
 
-##### `tfResourceType`<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateArtifactory.property.tfResourceType"></a>
+##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateArtifactory.property.tfResourceType"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 tfResourceType: str
@@ -4491,19 +4533,25 @@ cdktf.DataTerraformRemoteStateEtcd(
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.defaults"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ typing.Mapping[typing.Any]
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.workspace"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `endpoints`<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.endpoints"></a>
+##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.endpoints"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -4511,7 +4559,9 @@ cdktf.DataTerraformRemoteStateEtcd(
 
 ---
 
-##### `path`<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.path"></a>
+##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.path"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -4519,7 +4569,9 @@ cdktf.DataTerraformRemoteStateEtcd(
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.password"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -4527,7 +4579,9 @@ cdktf.DataTerraformRemoteStateEtcd(
 
 ---
 
-##### `username`<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.username"></a>
+##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcd.Initializer.parameter.username"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -4553,7 +4607,7 @@ cdktf.DataTerraformRemoteStateEtcd(
 
 ---
 
-##### `to_string` <a name="to_string" id="cdktf.DataTerraformRemoteStateEtcd.toString"></a>
+##### ~~`to_string`~~ <a name="to_string" id="cdktf.DataTerraformRemoteStateEtcd.toString"></a>
 
 ```python
 def to_string() - > str
@@ -4561,7 +4615,7 @@ def to_string() - > str
 
 Returns a string representation of this construct.
 
-##### `add_override` <a name="add_override" id="cdktf.DataTerraformRemoteStateEtcd.addOverride"></a>
+##### ~~`add_override`~~ <a name="add_override" id="cdktf.DataTerraformRemoteStateEtcd.addOverride"></a>
 
 ```python
 def add_override(
@@ -4582,7 +4636,7 @@ def add_override(
 
 ---
 
-##### `override_logical_id` <a name="override_logical_id" id="cdktf.DataTerraformRemoteStateEtcd.overrideLogicalId"></a>
+##### ~~`override_logical_id`~~ <a name="override_logical_id" id="cdktf.DataTerraformRemoteStateEtcd.overrideLogicalId"></a>
 
 ```python
 def override_logical_id(
@@ -4600,7 +4654,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `reset_override_logical_id` <a name="reset_override_logical_id" id="cdktf.DataTerraformRemoteStateEtcd.resetOverrideLogicalId"></a>
+##### ~~`reset_override_logical_id`~~ <a name="reset_override_logical_id" id="cdktf.DataTerraformRemoteStateEtcd.resetOverrideLogicalId"></a>
 
 ```python
 def reset_override_logical_id() - > None
@@ -4608,13 +4662,13 @@ def reset_override_logical_id() - > None
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `to_metadata` <a name="to_metadata" id="cdktf.DataTerraformRemoteStateEtcd.toMetadata"></a>
+##### ~~`to_metadata`~~ <a name="to_metadata" id="cdktf.DataTerraformRemoteStateEtcd.toMetadata"></a>
 
 ```python
 def to_metadata() - > typing.Any
 ```
 
-##### `to_terraform` <a name="to_terraform" id="cdktf.DataTerraformRemoteStateEtcd.toTerraform"></a>
+##### ~~`to_terraform`~~ <a name="to_terraform" id="cdktf.DataTerraformRemoteStateEtcd.toTerraform"></a>
 
 ```python
 def to_terraform() - > typing.Any
@@ -4622,7 +4676,7 @@ def to_terraform() - > typing.Any
 
 Adds this resource to the terraform JSON output.
 
-##### `get` <a name="get" id="cdktf.DataTerraformRemoteStateEtcd.get"></a>
+##### ~~`get`~~ <a name="get" id="cdktf.DataTerraformRemoteStateEtcd.get"></a>
 
 ```python
 def get(
@@ -4636,7 +4690,7 @@ def get(
 
 ---
 
-##### `get_boolean` <a name="get_boolean" id="cdktf.DataTerraformRemoteStateEtcd.getBoolean"></a>
+##### ~~`get_boolean`~~ <a name="get_boolean" id="cdktf.DataTerraformRemoteStateEtcd.getBoolean"></a>
 
 ```python
 def get_boolean(
@@ -4650,7 +4704,7 @@ def get_boolean(
 
 ---
 
-##### `get_list` <a name="get_list" id="cdktf.DataTerraformRemoteStateEtcd.getList"></a>
+##### ~~`get_list`~~ <a name="get_list" id="cdktf.DataTerraformRemoteStateEtcd.getList"></a>
 
 ```python
 def get_list(
@@ -4664,7 +4718,7 @@ def get_list(
 
 ---
 
-##### `get_number` <a name="get_number" id="cdktf.DataTerraformRemoteStateEtcd.getNumber"></a>
+##### ~~`get_number`~~ <a name="get_number" id="cdktf.DataTerraformRemoteStateEtcd.getNumber"></a>
 
 ```python
 def get_number(
@@ -4678,7 +4732,7 @@ def get_number(
 
 ---
 
-##### `get_string` <a name="get_string" id="cdktf.DataTerraformRemoteStateEtcd.getString"></a>
+##### ~~`get_string`~~ <a name="get_string" id="cdktf.DataTerraformRemoteStateEtcd.getString"></a>
 
 ```python
 def get_string(
@@ -4701,7 +4755,7 @@ def get_string(
 
 ---
 
-##### `is_construct` <a name="is_construct" id="cdktf.DataTerraformRemoteStateEtcd.isConstruct"></a>
+##### ~~`is_construct`~~ <a name="is_construct" id="cdktf.DataTerraformRemoteStateEtcd.isConstruct"></a>
 
 ```python
 import cdktf
@@ -4735,7 +4789,7 @@ Any object.
 
 ---
 
-##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStateEtcd.isTerraformElement"></a>
+##### ~~`is_terraform_element`~~ <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStateEtcd.isTerraformElement"></a>
 
 ```python
 import cdktf
@@ -4762,7 +4816,9 @@ cdktf.DataTerraformRemoteStateEtcd.is_terraform_element(
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateEtcd.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateEtcd.property.node"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 node: Node
@@ -4774,7 +4830,9 @@ The tree node.
 
 ---
 
-##### `cdktf_stack`<sup>Required</sup> <a name="cdktf_stack" id="cdktf.DataTerraformRemoteStateEtcd.property.cdktfStack"></a>
+##### ~~`cdktf_stack`~~<sup>Required</sup> <a name="cdktf_stack" id="cdktf.DataTerraformRemoteStateEtcd.property.cdktfStack"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 cdktf_stack: TerraformStack
@@ -4784,7 +4842,9 @@ cdktf_stack: TerraformStack
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateEtcd.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateEtcd.property.fqn"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 fqn: str
@@ -4794,7 +4854,9 @@ fqn: str
 
 ---
 
-##### `friendly_unique_id`<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.DataTerraformRemoteStateEtcd.property.friendlyUniqueId"></a>
+##### ~~`friendly_unique_id`~~<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.DataTerraformRemoteStateEtcd.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 friendly_unique_id: str
@@ -4812,7 +4874,9 @@ friendly_unique_id: str
 
 ---
 
-##### `tfResourceType`<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateEtcd.property.tfResourceType"></a>
+##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateEtcd.property.tfResourceType"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 tfResourceType: str
@@ -4874,19 +4938,25 @@ cdktf.DataTerraformRemoteStateEtcdV3(
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.defaults"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ typing.Mapping[typing.Any]
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.workspace"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `endpoints`<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.endpoints"></a>
+##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.endpoints"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ typing.List[str]
 
@@ -4894,7 +4964,9 @@ cdktf.DataTerraformRemoteStateEtcdV3(
 
 ---
 
-##### `cacert_path`<sup>Optional</sup> <a name="cacert_path" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.cacertPath"></a>
+##### ~~`cacert_path`~~<sup>Optional</sup> <a name="cacert_path" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.cacertPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -4902,7 +4974,9 @@ cdktf.DataTerraformRemoteStateEtcdV3(
 
 ---
 
-##### `cert_path`<sup>Optional</sup> <a name="cert_path" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.certPath"></a>
+##### ~~`cert_path`~~<sup>Optional</sup> <a name="cert_path" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.certPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -4910,7 +4984,9 @@ cdktf.DataTerraformRemoteStateEtcdV3(
 
 ---
 
-##### `key_path`<sup>Optional</sup> <a name="key_path" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.keyPath"></a>
+##### ~~`key_path`~~<sup>Optional</sup> <a name="key_path" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.keyPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -4918,7 +4994,9 @@ cdktf.DataTerraformRemoteStateEtcdV3(
 
 ---
 
-##### `lock`<sup>Optional</sup> <a name="lock" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.lock"></a>
+##### ~~`lock`~~<sup>Optional</sup> <a name="lock" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.lock"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ bool
 
@@ -4928,7 +5006,9 @@ Defaults to true.
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.password"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -4936,7 +5016,9 @@ Defaults to true.
 
 ---
 
-##### `prefix`<sup>Optional</sup> <a name="prefix" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.prefix"></a>
+##### ~~`prefix`~~<sup>Optional</sup> <a name="prefix" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.prefix"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -4946,7 +5028,9 @@ Defaults to "".
 
 ---
 
-##### `username`<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.username"></a>
+##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdV3.Initializer.parameter.username"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -4972,7 +5056,7 @@ Defaults to "".
 
 ---
 
-##### `to_string` <a name="to_string" id="cdktf.DataTerraformRemoteStateEtcdV3.toString"></a>
+##### ~~`to_string`~~ <a name="to_string" id="cdktf.DataTerraformRemoteStateEtcdV3.toString"></a>
 
 ```python
 def to_string() - > str
@@ -4980,7 +5064,7 @@ def to_string() - > str
 
 Returns a string representation of this construct.
 
-##### `add_override` <a name="add_override" id="cdktf.DataTerraformRemoteStateEtcdV3.addOverride"></a>
+##### ~~`add_override`~~ <a name="add_override" id="cdktf.DataTerraformRemoteStateEtcdV3.addOverride"></a>
 
 ```python
 def add_override(
@@ -5001,7 +5085,7 @@ def add_override(
 
 ---
 
-##### `override_logical_id` <a name="override_logical_id" id="cdktf.DataTerraformRemoteStateEtcdV3.overrideLogicalId"></a>
+##### ~~`override_logical_id`~~ <a name="override_logical_id" id="cdktf.DataTerraformRemoteStateEtcdV3.overrideLogicalId"></a>
 
 ```python
 def override_logical_id(
@@ -5019,7 +5103,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `reset_override_logical_id` <a name="reset_override_logical_id" id="cdktf.DataTerraformRemoteStateEtcdV3.resetOverrideLogicalId"></a>
+##### ~~`reset_override_logical_id`~~ <a name="reset_override_logical_id" id="cdktf.DataTerraformRemoteStateEtcdV3.resetOverrideLogicalId"></a>
 
 ```python
 def reset_override_logical_id() - > None
@@ -5027,13 +5111,13 @@ def reset_override_logical_id() - > None
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `to_metadata` <a name="to_metadata" id="cdktf.DataTerraformRemoteStateEtcdV3.toMetadata"></a>
+##### ~~`to_metadata`~~ <a name="to_metadata" id="cdktf.DataTerraformRemoteStateEtcdV3.toMetadata"></a>
 
 ```python
 def to_metadata() - > typing.Any
 ```
 
-##### `to_terraform` <a name="to_terraform" id="cdktf.DataTerraformRemoteStateEtcdV3.toTerraform"></a>
+##### ~~`to_terraform`~~ <a name="to_terraform" id="cdktf.DataTerraformRemoteStateEtcdV3.toTerraform"></a>
 
 ```python
 def to_terraform() - > typing.Any
@@ -5041,7 +5125,7 @@ def to_terraform() - > typing.Any
 
 Adds this resource to the terraform JSON output.
 
-##### `get` <a name="get" id="cdktf.DataTerraformRemoteStateEtcdV3.get"></a>
+##### ~~`get`~~ <a name="get" id="cdktf.DataTerraformRemoteStateEtcdV3.get"></a>
 
 ```python
 def get(
@@ -5055,7 +5139,7 @@ def get(
 
 ---
 
-##### `get_boolean` <a name="get_boolean" id="cdktf.DataTerraformRemoteStateEtcdV3.getBoolean"></a>
+##### ~~`get_boolean`~~ <a name="get_boolean" id="cdktf.DataTerraformRemoteStateEtcdV3.getBoolean"></a>
 
 ```python
 def get_boolean(
@@ -5069,7 +5153,7 @@ def get_boolean(
 
 ---
 
-##### `get_list` <a name="get_list" id="cdktf.DataTerraformRemoteStateEtcdV3.getList"></a>
+##### ~~`get_list`~~ <a name="get_list" id="cdktf.DataTerraformRemoteStateEtcdV3.getList"></a>
 
 ```python
 def get_list(
@@ -5083,7 +5167,7 @@ def get_list(
 
 ---
 
-##### `get_number` <a name="get_number" id="cdktf.DataTerraformRemoteStateEtcdV3.getNumber"></a>
+##### ~~`get_number`~~ <a name="get_number" id="cdktf.DataTerraformRemoteStateEtcdV3.getNumber"></a>
 
 ```python
 def get_number(
@@ -5097,7 +5181,7 @@ def get_number(
 
 ---
 
-##### `get_string` <a name="get_string" id="cdktf.DataTerraformRemoteStateEtcdV3.getString"></a>
+##### ~~`get_string`~~ <a name="get_string" id="cdktf.DataTerraformRemoteStateEtcdV3.getString"></a>
 
 ```python
 def get_string(
@@ -5120,7 +5204,7 @@ def get_string(
 
 ---
 
-##### `is_construct` <a name="is_construct" id="cdktf.DataTerraformRemoteStateEtcdV3.isConstruct"></a>
+##### ~~`is_construct`~~ <a name="is_construct" id="cdktf.DataTerraformRemoteStateEtcdV3.isConstruct"></a>
 
 ```python
 import cdktf
@@ -5154,7 +5238,7 @@ Any object.
 
 ---
 
-##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement"></a>
+##### ~~`is_terraform_element`~~ <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement"></a>
 
 ```python
 import cdktf
@@ -5181,7 +5265,9 @@ cdktf.DataTerraformRemoteStateEtcdV3.is_terraform_element(
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateEtcdV3.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateEtcdV3.property.node"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 node: Node
@@ -5193,7 +5279,9 @@ The tree node.
 
 ---
 
-##### `cdktf_stack`<sup>Required</sup> <a name="cdktf_stack" id="cdktf.DataTerraformRemoteStateEtcdV3.property.cdktfStack"></a>
+##### ~~`cdktf_stack`~~<sup>Required</sup> <a name="cdktf_stack" id="cdktf.DataTerraformRemoteStateEtcdV3.property.cdktfStack"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 cdktf_stack: TerraformStack
@@ -5203,7 +5291,9 @@ cdktf_stack: TerraformStack
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateEtcdV3.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateEtcdV3.property.fqn"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 fqn: str
@@ -5213,7 +5303,9 @@ fqn: str
 
 ---
 
-##### `friendly_unique_id`<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.DataTerraformRemoteStateEtcdV3.property.friendlyUniqueId"></a>
+##### ~~`friendly_unique_id`~~<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.DataTerraformRemoteStateEtcdV3.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 friendly_unique_id: str
@@ -5231,7 +5323,9 @@ friendly_unique_id: str
 
 ---
 
-##### `tfResourceType`<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateEtcdV3.property.tfResourceType"></a>
+##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateEtcdV3.property.tfResourceType"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 tfResourceType: str
@@ -6541,61 +6635,81 @@ cdktf.DataTerraformRemoteStateManta(
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.defaults"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ typing.Mapping[typing.Any]
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.workspace"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `account`<sup>Required</sup> <a name="account" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.account"></a>
+##### ~~`account`~~<sup>Required</sup> <a name="account" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.account"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `key_id`<sup>Required</sup> <a name="key_id" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.keyId"></a>
+##### ~~`key_id`~~<sup>Required</sup> <a name="key_id" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.keyId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `path`<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.path"></a>
+##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.path"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `insecure_skip_tls_verify`<sup>Optional</sup> <a name="insecure_skip_tls_verify" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.insecureSkipTlsVerify"></a>
+##### ~~`insecure_skip_tls_verify`~~<sup>Optional</sup> <a name="insecure_skip_tls_verify" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.insecureSkipTlsVerify"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ bool
 
 ---
 
-##### `key_material`<sup>Optional</sup> <a name="key_material" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.keyMaterial"></a>
+##### ~~`key_material`~~<sup>Optional</sup> <a name="key_material" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.keyMaterial"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `object_name`<sup>Optional</sup> <a name="object_name" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.objectName"></a>
+##### ~~`object_name`~~<sup>Optional</sup> <a name="object_name" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.objectName"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `url`<sup>Optional</sup> <a name="url" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.url"></a>
+##### ~~`url`~~<sup>Optional</sup> <a name="url" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.url"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `user`<sup>Optional</sup> <a name="user" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.user"></a>
+##### ~~`user`~~<sup>Optional</sup> <a name="user" id="cdktf.DataTerraformRemoteStateManta.Initializer.parameter.user"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -6619,7 +6733,7 @@ cdktf.DataTerraformRemoteStateManta(
 
 ---
 
-##### `to_string` <a name="to_string" id="cdktf.DataTerraformRemoteStateManta.toString"></a>
+##### ~~`to_string`~~ <a name="to_string" id="cdktf.DataTerraformRemoteStateManta.toString"></a>
 
 ```python
 def to_string() - > str
@@ -6627,7 +6741,7 @@ def to_string() - > str
 
 Returns a string representation of this construct.
 
-##### `add_override` <a name="add_override" id="cdktf.DataTerraformRemoteStateManta.addOverride"></a>
+##### ~~`add_override`~~ <a name="add_override" id="cdktf.DataTerraformRemoteStateManta.addOverride"></a>
 
 ```python
 def add_override(
@@ -6648,7 +6762,7 @@ def add_override(
 
 ---
 
-##### `override_logical_id` <a name="override_logical_id" id="cdktf.DataTerraformRemoteStateManta.overrideLogicalId"></a>
+##### ~~`override_logical_id`~~ <a name="override_logical_id" id="cdktf.DataTerraformRemoteStateManta.overrideLogicalId"></a>
 
 ```python
 def override_logical_id(
@@ -6666,7 +6780,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `reset_override_logical_id` <a name="reset_override_logical_id" id="cdktf.DataTerraformRemoteStateManta.resetOverrideLogicalId"></a>
+##### ~~`reset_override_logical_id`~~ <a name="reset_override_logical_id" id="cdktf.DataTerraformRemoteStateManta.resetOverrideLogicalId"></a>
 
 ```python
 def reset_override_logical_id() - > None
@@ -6674,13 +6788,13 @@ def reset_override_logical_id() - > None
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `to_metadata` <a name="to_metadata" id="cdktf.DataTerraformRemoteStateManta.toMetadata"></a>
+##### ~~`to_metadata`~~ <a name="to_metadata" id="cdktf.DataTerraformRemoteStateManta.toMetadata"></a>
 
 ```python
 def to_metadata() - > typing.Any
 ```
 
-##### `to_terraform` <a name="to_terraform" id="cdktf.DataTerraformRemoteStateManta.toTerraform"></a>
+##### ~~`to_terraform`~~ <a name="to_terraform" id="cdktf.DataTerraformRemoteStateManta.toTerraform"></a>
 
 ```python
 def to_terraform() - > typing.Any
@@ -6688,7 +6802,7 @@ def to_terraform() - > typing.Any
 
 Adds this resource to the terraform JSON output.
 
-##### `get` <a name="get" id="cdktf.DataTerraformRemoteStateManta.get"></a>
+##### ~~`get`~~ <a name="get" id="cdktf.DataTerraformRemoteStateManta.get"></a>
 
 ```python
 def get(
@@ -6702,7 +6816,7 @@ def get(
 
 ---
 
-##### `get_boolean` <a name="get_boolean" id="cdktf.DataTerraformRemoteStateManta.getBoolean"></a>
+##### ~~`get_boolean`~~ <a name="get_boolean" id="cdktf.DataTerraformRemoteStateManta.getBoolean"></a>
 
 ```python
 def get_boolean(
@@ -6716,7 +6830,7 @@ def get_boolean(
 
 ---
 
-##### `get_list` <a name="get_list" id="cdktf.DataTerraformRemoteStateManta.getList"></a>
+##### ~~`get_list`~~ <a name="get_list" id="cdktf.DataTerraformRemoteStateManta.getList"></a>
 
 ```python
 def get_list(
@@ -6730,7 +6844,7 @@ def get_list(
 
 ---
 
-##### `get_number` <a name="get_number" id="cdktf.DataTerraformRemoteStateManta.getNumber"></a>
+##### ~~`get_number`~~ <a name="get_number" id="cdktf.DataTerraformRemoteStateManta.getNumber"></a>
 
 ```python
 def get_number(
@@ -6744,7 +6858,7 @@ def get_number(
 
 ---
 
-##### `get_string` <a name="get_string" id="cdktf.DataTerraformRemoteStateManta.getString"></a>
+##### ~~`get_string`~~ <a name="get_string" id="cdktf.DataTerraformRemoteStateManta.getString"></a>
 
 ```python
 def get_string(
@@ -6767,7 +6881,7 @@ def get_string(
 
 ---
 
-##### `is_construct` <a name="is_construct" id="cdktf.DataTerraformRemoteStateManta.isConstruct"></a>
+##### ~~`is_construct`~~ <a name="is_construct" id="cdktf.DataTerraformRemoteStateManta.isConstruct"></a>
 
 ```python
 import cdktf
@@ -6801,7 +6915,7 @@ Any object.
 
 ---
 
-##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStateManta.isTerraformElement"></a>
+##### ~~`is_terraform_element`~~ <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStateManta.isTerraformElement"></a>
 
 ```python
 import cdktf
@@ -6828,7 +6942,9 @@ cdktf.DataTerraformRemoteStateManta.is_terraform_element(
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateManta.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateManta.property.node"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 node: Node
@@ -6840,7 +6956,9 @@ The tree node.
 
 ---
 
-##### `cdktf_stack`<sup>Required</sup> <a name="cdktf_stack" id="cdktf.DataTerraformRemoteStateManta.property.cdktfStack"></a>
+##### ~~`cdktf_stack`~~<sup>Required</sup> <a name="cdktf_stack" id="cdktf.DataTerraformRemoteStateManta.property.cdktfStack"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 cdktf_stack: TerraformStack
@@ -6850,7 +6968,9 @@ cdktf_stack: TerraformStack
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateManta.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateManta.property.fqn"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 fqn: str
@@ -6860,7 +6980,9 @@ fqn: str
 
 ---
 
-##### `friendly_unique_id`<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.DataTerraformRemoteStateManta.property.friendlyUniqueId"></a>
+##### ~~`friendly_unique_id`~~<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.DataTerraformRemoteStateManta.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 friendly_unique_id: str
@@ -6878,7 +7000,9 @@ friendly_unique_id: str
 
 ---
 
-##### `tfResourceType`<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateManta.property.tfResourceType"></a>
+##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateManta.property.tfResourceType"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 tfResourceType: str
@@ -8480,175 +8604,233 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.defaults"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ typing.Mapping[typing.Any]
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.workspace"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `container`<sup>Required</sup> <a name="container" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.container"></a>
+##### ~~`container`~~<sup>Required</sup> <a name="container" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.container"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `application_credential_id`<sup>Optional</sup> <a name="application_credential_id" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.applicationCredentialId"></a>
+##### ~~`application_credential_id`~~<sup>Optional</sup> <a name="application_credential_id" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.applicationCredentialId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `application_credential_name`<sup>Optional</sup> <a name="application_credential_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.applicationCredentialName"></a>
+##### ~~`application_credential_name`~~<sup>Optional</sup> <a name="application_credential_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.applicationCredentialName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `application_credential_secret`<sup>Optional</sup> <a name="application_credential_secret" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.applicationCredentialSecret"></a>
+##### ~~`application_credential_secret`~~<sup>Optional</sup> <a name="application_credential_secret" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.applicationCredentialSecret"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `archive_container`<sup>Optional</sup> <a name="archive_container" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.archiveContainer"></a>
+##### ~~`archive_container`~~<sup>Optional</sup> <a name="archive_container" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.archiveContainer"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `auth_url`<sup>Optional</sup> <a name="auth_url" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.authUrl"></a>
+##### ~~`auth_url`~~<sup>Optional</sup> <a name="auth_url" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.authUrl"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `cacert_file`<sup>Optional</sup> <a name="cacert_file" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.cacertFile"></a>
+##### ~~`cacert_file`~~<sup>Optional</sup> <a name="cacert_file" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.cacertFile"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `cert`<sup>Optional</sup> <a name="cert" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.cert"></a>
+##### ~~`cert`~~<sup>Optional</sup> <a name="cert" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.cert"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `cloud`<sup>Optional</sup> <a name="cloud" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.cloud"></a>
+##### ~~`cloud`~~<sup>Optional</sup> <a name="cloud" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.cloud"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `default_domain`<sup>Optional</sup> <a name="default_domain" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.defaultDomain"></a>
+##### ~~`default_domain`~~<sup>Optional</sup> <a name="default_domain" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.defaultDomain"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `domain_id`<sup>Optional</sup> <a name="domain_id" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.domainId"></a>
+##### ~~`domain_id`~~<sup>Optional</sup> <a name="domain_id" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.domainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `domain_name`<sup>Optional</sup> <a name="domain_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.domainName"></a>
+##### ~~`domain_name`~~<sup>Optional</sup> <a name="domain_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.domainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `expire_after`<sup>Optional</sup> <a name="expire_after" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.expireAfter"></a>
+##### ~~`expire_after`~~<sup>Optional</sup> <a name="expire_after" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.expireAfter"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `insecure`<sup>Optional</sup> <a name="insecure" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.insecure"></a>
+##### ~~`insecure`~~<sup>Optional</sup> <a name="insecure" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.insecure"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ bool
 
 ---
 
-##### `key`<sup>Optional</sup> <a name="key" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.key"></a>
+##### ~~`key`~~<sup>Optional</sup> <a name="key" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.key"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.password"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `project_domain_id`<sup>Optional</sup> <a name="project_domain_id" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.projectDomainId"></a>
+##### ~~`project_domain_id`~~<sup>Optional</sup> <a name="project_domain_id" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.projectDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `project_domain_name`<sup>Optional</sup> <a name="project_domain_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.projectDomainName"></a>
+##### ~~`project_domain_name`~~<sup>Optional</sup> <a name="project_domain_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.projectDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `region_name`<sup>Optional</sup> <a name="region_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.regionName"></a>
+##### ~~`region_name`~~<sup>Optional</sup> <a name="region_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.regionName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `state_name`<sup>Optional</sup> <a name="state_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.stateName"></a>
+##### ~~`state_name`~~<sup>Optional</sup> <a name="state_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.stateName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `tenant_id`<sup>Optional</sup> <a name="tenant_id" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.tenantId"></a>
+##### ~~`tenant_id`~~<sup>Optional</sup> <a name="tenant_id" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.tenantId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `tenant_name`<sup>Optional</sup> <a name="tenant_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.tenantName"></a>
+##### ~~`tenant_name`~~<sup>Optional</sup> <a name="tenant_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.tenantName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `token`<sup>Optional</sup> <a name="token" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.token"></a>
+##### ~~`token`~~<sup>Optional</sup> <a name="token" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.token"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `user_domain_id`<sup>Optional</sup> <a name="user_domain_id" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userDomainId"></a>
+##### ~~`user_domain_id`~~<sup>Optional</sup> <a name="user_domain_id" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `user_domain_name`<sup>Optional</sup> <a name="user_domain_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userDomainName"></a>
+##### ~~`user_domain_name`~~<sup>Optional</sup> <a name="user_domain_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `user_id`<sup>Optional</sup> <a name="user_id" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userId"></a>
+##### ~~`user_id`~~<sup>Optional</sup> <a name="user_id" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `user_name`<sup>Optional</sup> <a name="user_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userName"></a>
+##### ~~`user_name`~~<sup>Optional</sup> <a name="user_name" id="cdktf.DataTerraformRemoteStateSwift.Initializer.parameter.userName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -8672,7 +8854,7 @@ cdktf.DataTerraformRemoteStateSwift(
 
 ---
 
-##### `to_string` <a name="to_string" id="cdktf.DataTerraformRemoteStateSwift.toString"></a>
+##### ~~`to_string`~~ <a name="to_string" id="cdktf.DataTerraformRemoteStateSwift.toString"></a>
 
 ```python
 def to_string() - > str
@@ -8680,7 +8862,7 @@ def to_string() - > str
 
 Returns a string representation of this construct.
 
-##### `add_override` <a name="add_override" id="cdktf.DataTerraformRemoteStateSwift.addOverride"></a>
+##### ~~`add_override`~~ <a name="add_override" id="cdktf.DataTerraformRemoteStateSwift.addOverride"></a>
 
 ```python
 def add_override(
@@ -8701,7 +8883,7 @@ def add_override(
 
 ---
 
-##### `override_logical_id` <a name="override_logical_id" id="cdktf.DataTerraformRemoteStateSwift.overrideLogicalId"></a>
+##### ~~`override_logical_id`~~ <a name="override_logical_id" id="cdktf.DataTerraformRemoteStateSwift.overrideLogicalId"></a>
 
 ```python
 def override_logical_id(
@@ -8719,7 +8901,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `reset_override_logical_id` <a name="reset_override_logical_id" id="cdktf.DataTerraformRemoteStateSwift.resetOverrideLogicalId"></a>
+##### ~~`reset_override_logical_id`~~ <a name="reset_override_logical_id" id="cdktf.DataTerraformRemoteStateSwift.resetOverrideLogicalId"></a>
 
 ```python
 def reset_override_logical_id() - > None
@@ -8727,13 +8909,13 @@ def reset_override_logical_id() - > None
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `to_metadata` <a name="to_metadata" id="cdktf.DataTerraformRemoteStateSwift.toMetadata"></a>
+##### ~~`to_metadata`~~ <a name="to_metadata" id="cdktf.DataTerraformRemoteStateSwift.toMetadata"></a>
 
 ```python
 def to_metadata() - > typing.Any
 ```
 
-##### `to_terraform` <a name="to_terraform" id="cdktf.DataTerraformRemoteStateSwift.toTerraform"></a>
+##### ~~`to_terraform`~~ <a name="to_terraform" id="cdktf.DataTerraformRemoteStateSwift.toTerraform"></a>
 
 ```python
 def to_terraform() - > typing.Any
@@ -8741,7 +8923,7 @@ def to_terraform() - > typing.Any
 
 Adds this resource to the terraform JSON output.
 
-##### `get` <a name="get" id="cdktf.DataTerraformRemoteStateSwift.get"></a>
+##### ~~`get`~~ <a name="get" id="cdktf.DataTerraformRemoteStateSwift.get"></a>
 
 ```python
 def get(
@@ -8755,7 +8937,7 @@ def get(
 
 ---
 
-##### `get_boolean` <a name="get_boolean" id="cdktf.DataTerraformRemoteStateSwift.getBoolean"></a>
+##### ~~`get_boolean`~~ <a name="get_boolean" id="cdktf.DataTerraformRemoteStateSwift.getBoolean"></a>
 
 ```python
 def get_boolean(
@@ -8769,7 +8951,7 @@ def get_boolean(
 
 ---
 
-##### `get_list` <a name="get_list" id="cdktf.DataTerraformRemoteStateSwift.getList"></a>
+##### ~~`get_list`~~ <a name="get_list" id="cdktf.DataTerraformRemoteStateSwift.getList"></a>
 
 ```python
 def get_list(
@@ -8783,7 +8965,7 @@ def get_list(
 
 ---
 
-##### `get_number` <a name="get_number" id="cdktf.DataTerraformRemoteStateSwift.getNumber"></a>
+##### ~~`get_number`~~ <a name="get_number" id="cdktf.DataTerraformRemoteStateSwift.getNumber"></a>
 
 ```python
 def get_number(
@@ -8797,7 +8979,7 @@ def get_number(
 
 ---
 
-##### `get_string` <a name="get_string" id="cdktf.DataTerraformRemoteStateSwift.getString"></a>
+##### ~~`get_string`~~ <a name="get_string" id="cdktf.DataTerraformRemoteStateSwift.getString"></a>
 
 ```python
 def get_string(
@@ -8820,7 +9002,7 @@ def get_string(
 
 ---
 
-##### `is_construct` <a name="is_construct" id="cdktf.DataTerraformRemoteStateSwift.isConstruct"></a>
+##### ~~`is_construct`~~ <a name="is_construct" id="cdktf.DataTerraformRemoteStateSwift.isConstruct"></a>
 
 ```python
 import cdktf
@@ -8854,7 +9036,7 @@ Any object.
 
 ---
 
-##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStateSwift.isTerraformElement"></a>
+##### ~~`is_terraform_element`~~ <a name="is_terraform_element" id="cdktf.DataTerraformRemoteStateSwift.isTerraformElement"></a>
 
 ```python
 import cdktf
@@ -8881,7 +9063,9 @@ cdktf.DataTerraformRemoteStateSwift.is_terraform_element(
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateSwift.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateSwift.property.node"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 node: Node
@@ -8893,7 +9077,9 @@ The tree node.
 
 ---
 
-##### `cdktf_stack`<sup>Required</sup> <a name="cdktf_stack" id="cdktf.DataTerraformRemoteStateSwift.property.cdktfStack"></a>
+##### ~~`cdktf_stack`~~<sup>Required</sup> <a name="cdktf_stack" id="cdktf.DataTerraformRemoteStateSwift.property.cdktfStack"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 cdktf_stack: TerraformStack
@@ -8903,7 +9089,9 @@ cdktf_stack: TerraformStack
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateSwift.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateSwift.property.fqn"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 fqn: str
@@ -8913,7 +9101,9 @@ fqn: str
 
 ---
 
-##### `friendly_unique_id`<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.DataTerraformRemoteStateSwift.property.friendlyUniqueId"></a>
+##### ~~`friendly_unique_id`~~<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.DataTerraformRemoteStateSwift.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 friendly_unique_id: str
@@ -8931,7 +9121,9 @@ friendly_unique_id: str
 
 ---
 
-##### `tfResourceType`<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateSwift.property.tfResourceType"></a>
+##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateSwift.property.tfResourceType"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 tfResourceType: str
@@ -8973,7 +9165,9 @@ cdktf.EtcdBackend(
 
 ---
 
-##### `endpoints`<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdBackend.Initializer.parameter.endpoints"></a>
+##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdBackend.Initializer.parameter.endpoints"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -8981,7 +9175,9 @@ cdktf.EtcdBackend(
 
 ---
 
-##### `path`<sup>Required</sup> <a name="path" id="cdktf.EtcdBackend.Initializer.parameter.path"></a>
+##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.EtcdBackend.Initializer.parameter.path"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -8989,7 +9185,9 @@ cdktf.EtcdBackend(
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.EtcdBackend.Initializer.parameter.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.EtcdBackend.Initializer.parameter.password"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -8997,7 +9195,9 @@ cdktf.EtcdBackend(
 
 ---
 
-##### `username`<sup>Optional</sup> <a name="username" id="cdktf.EtcdBackend.Initializer.parameter.username"></a>
+##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.EtcdBackend.Initializer.parameter.username"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -9019,7 +9219,7 @@ cdktf.EtcdBackend(
 
 ---
 
-##### `to_string` <a name="to_string" id="cdktf.EtcdBackend.toString"></a>
+##### ~~`to_string`~~ <a name="to_string" id="cdktf.EtcdBackend.toString"></a>
 
 ```python
 def to_string() - > str
@@ -9027,7 +9227,7 @@ def to_string() - > str
 
 Returns a string representation of this construct.
 
-##### `add_override` <a name="add_override" id="cdktf.EtcdBackend.addOverride"></a>
+##### ~~`add_override`~~ <a name="add_override" id="cdktf.EtcdBackend.addOverride"></a>
 
 ```python
 def add_override(
@@ -9048,7 +9248,7 @@ def add_override(
 
 ---
 
-##### `override_logical_id` <a name="override_logical_id" id="cdktf.EtcdBackend.overrideLogicalId"></a>
+##### ~~`override_logical_id`~~ <a name="override_logical_id" id="cdktf.EtcdBackend.overrideLogicalId"></a>
 
 ```python
 def override_logical_id(
@@ -9066,7 +9266,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `reset_override_logical_id` <a name="reset_override_logical_id" id="cdktf.EtcdBackend.resetOverrideLogicalId"></a>
+##### ~~`reset_override_logical_id`~~ <a name="reset_override_logical_id" id="cdktf.EtcdBackend.resetOverrideLogicalId"></a>
 
 ```python
 def reset_override_logical_id() - > None
@@ -9074,13 +9274,13 @@ def reset_override_logical_id() - > None
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `to_metadata` <a name="to_metadata" id="cdktf.EtcdBackend.toMetadata"></a>
+##### ~~`to_metadata`~~ <a name="to_metadata" id="cdktf.EtcdBackend.toMetadata"></a>
 
 ```python
 def to_metadata() - > typing.Any
 ```
 
-##### `to_terraform` <a name="to_terraform" id="cdktf.EtcdBackend.toTerraform"></a>
+##### ~~`to_terraform`~~ <a name="to_terraform" id="cdktf.EtcdBackend.toTerraform"></a>
 
 ```python
 def to_terraform() - > typing.Any
@@ -9088,7 +9288,7 @@ def to_terraform() - > typing.Any
 
 Adds this resource to the terraform JSON output.
 
-##### `get_remote_state_data_source` <a name="get_remote_state_data_source" id="cdktf.EtcdBackend.getRemoteStateDataSource"></a>
+##### ~~`get_remote_state_data_source`~~ <a name="get_remote_state_data_source" id="cdktf.EtcdBackend.getRemoteStateDataSource"></a>
 
 ```python
 def get_remote_state_data_source(
@@ -9128,7 +9328,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `is_construct` <a name="is_construct" id="cdktf.EtcdBackend.isConstruct"></a>
+##### ~~`is_construct`~~ <a name="is_construct" id="cdktf.EtcdBackend.isConstruct"></a>
 
 ```python
 import cdktf
@@ -9162,7 +9362,7 @@ Any object.
 
 ---
 
-##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.EtcdBackend.isTerraformElement"></a>
+##### ~~`is_terraform_element`~~ <a name="is_terraform_element" id="cdktf.EtcdBackend.isTerraformElement"></a>
 
 ```python
 import cdktf
@@ -9178,7 +9378,7 @@ cdktf.EtcdBackend.is_terraform_element(
 
 ---
 
-##### `is_backend` <a name="is_backend" id="cdktf.EtcdBackend.isBackend"></a>
+##### ~~`is_backend`~~ <a name="is_backend" id="cdktf.EtcdBackend.isBackend"></a>
 
 ```python
 import cdktf
@@ -9205,7 +9405,9 @@ cdktf.EtcdBackend.is_backend(
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.EtcdBackend.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.EtcdBackend.property.node"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 node: Node
@@ -9217,7 +9419,9 @@ The tree node.
 
 ---
 
-##### `cdktf_stack`<sup>Required</sup> <a name="cdktf_stack" id="cdktf.EtcdBackend.property.cdktfStack"></a>
+##### ~~`cdktf_stack`~~<sup>Required</sup> <a name="cdktf_stack" id="cdktf.EtcdBackend.property.cdktfStack"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 cdktf_stack: TerraformStack
@@ -9227,7 +9431,9 @@ cdktf_stack: TerraformStack
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.EtcdBackend.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.EtcdBackend.property.fqn"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 fqn: str
@@ -9237,7 +9443,9 @@ fqn: str
 
 ---
 
-##### `friendly_unique_id`<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.EtcdBackend.property.friendlyUniqueId"></a>
+##### ~~`friendly_unique_id`~~<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.EtcdBackend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 friendly_unique_id: str
@@ -9287,7 +9495,9 @@ cdktf.EtcdV3Backend(
 
 ---
 
-##### `endpoints`<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdV3Backend.Initializer.parameter.endpoints"></a>
+##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdV3Backend.Initializer.parameter.endpoints"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ typing.List[str]
 
@@ -9295,7 +9505,9 @@ cdktf.EtcdV3Backend(
 
 ---
 
-##### `cacert_path`<sup>Optional</sup> <a name="cacert_path" id="cdktf.EtcdV3Backend.Initializer.parameter.cacertPath"></a>
+##### ~~`cacert_path`~~<sup>Optional</sup> <a name="cacert_path" id="cdktf.EtcdV3Backend.Initializer.parameter.cacertPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -9303,7 +9515,9 @@ cdktf.EtcdV3Backend(
 
 ---
 
-##### `cert_path`<sup>Optional</sup> <a name="cert_path" id="cdktf.EtcdV3Backend.Initializer.parameter.certPath"></a>
+##### ~~`cert_path`~~<sup>Optional</sup> <a name="cert_path" id="cdktf.EtcdV3Backend.Initializer.parameter.certPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -9311,7 +9525,9 @@ cdktf.EtcdV3Backend(
 
 ---
 
-##### `key_path`<sup>Optional</sup> <a name="key_path" id="cdktf.EtcdV3Backend.Initializer.parameter.keyPath"></a>
+##### ~~`key_path`~~<sup>Optional</sup> <a name="key_path" id="cdktf.EtcdV3Backend.Initializer.parameter.keyPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -9319,7 +9535,9 @@ cdktf.EtcdV3Backend(
 
 ---
 
-##### `lock`<sup>Optional</sup> <a name="lock" id="cdktf.EtcdV3Backend.Initializer.parameter.lock"></a>
+##### ~~`lock`~~<sup>Optional</sup> <a name="lock" id="cdktf.EtcdV3Backend.Initializer.parameter.lock"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ bool
 
@@ -9329,7 +9547,9 @@ Defaults to true.
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.EtcdV3Backend.Initializer.parameter.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.EtcdV3Backend.Initializer.parameter.password"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -9337,7 +9557,9 @@ Defaults to true.
 
 ---
 
-##### `prefix`<sup>Optional</sup> <a name="prefix" id="cdktf.EtcdV3Backend.Initializer.parameter.prefix"></a>
+##### ~~`prefix`~~<sup>Optional</sup> <a name="prefix" id="cdktf.EtcdV3Backend.Initializer.parameter.prefix"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -9347,7 +9569,9 @@ Defaults to "".
 
 ---
 
-##### `username`<sup>Optional</sup> <a name="username" id="cdktf.EtcdV3Backend.Initializer.parameter.username"></a>
+##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.EtcdV3Backend.Initializer.parameter.username"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -9369,7 +9593,7 @@ Defaults to "".
 
 ---
 
-##### `to_string` <a name="to_string" id="cdktf.EtcdV3Backend.toString"></a>
+##### ~~`to_string`~~ <a name="to_string" id="cdktf.EtcdV3Backend.toString"></a>
 
 ```python
 def to_string() - > str
@@ -9377,7 +9601,7 @@ def to_string() - > str
 
 Returns a string representation of this construct.
 
-##### `add_override` <a name="add_override" id="cdktf.EtcdV3Backend.addOverride"></a>
+##### ~~`add_override`~~ <a name="add_override" id="cdktf.EtcdV3Backend.addOverride"></a>
 
 ```python
 def add_override(
@@ -9398,7 +9622,7 @@ def add_override(
 
 ---
 
-##### `override_logical_id` <a name="override_logical_id" id="cdktf.EtcdV3Backend.overrideLogicalId"></a>
+##### ~~`override_logical_id`~~ <a name="override_logical_id" id="cdktf.EtcdV3Backend.overrideLogicalId"></a>
 
 ```python
 def override_logical_id(
@@ -9416,7 +9640,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `reset_override_logical_id` <a name="reset_override_logical_id" id="cdktf.EtcdV3Backend.resetOverrideLogicalId"></a>
+##### ~~`reset_override_logical_id`~~ <a name="reset_override_logical_id" id="cdktf.EtcdV3Backend.resetOverrideLogicalId"></a>
 
 ```python
 def reset_override_logical_id() - > None
@@ -9424,13 +9648,13 @@ def reset_override_logical_id() - > None
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `to_metadata` <a name="to_metadata" id="cdktf.EtcdV3Backend.toMetadata"></a>
+##### ~~`to_metadata`~~ <a name="to_metadata" id="cdktf.EtcdV3Backend.toMetadata"></a>
 
 ```python
 def to_metadata() - > typing.Any
 ```
 
-##### `to_terraform` <a name="to_terraform" id="cdktf.EtcdV3Backend.toTerraform"></a>
+##### ~~`to_terraform`~~ <a name="to_terraform" id="cdktf.EtcdV3Backend.toTerraform"></a>
 
 ```python
 def to_terraform() - > typing.Any
@@ -9438,7 +9662,7 @@ def to_terraform() - > typing.Any
 
 Adds this resource to the terraform JSON output.
 
-##### `get_remote_state_data_source` <a name="get_remote_state_data_source" id="cdktf.EtcdV3Backend.getRemoteStateDataSource"></a>
+##### ~~`get_remote_state_data_source`~~ <a name="get_remote_state_data_source" id="cdktf.EtcdV3Backend.getRemoteStateDataSource"></a>
 
 ```python
 def get_remote_state_data_source(
@@ -9478,7 +9702,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `is_construct` <a name="is_construct" id="cdktf.EtcdV3Backend.isConstruct"></a>
+##### ~~`is_construct`~~ <a name="is_construct" id="cdktf.EtcdV3Backend.isConstruct"></a>
 
 ```python
 import cdktf
@@ -9512,7 +9736,7 @@ Any object.
 
 ---
 
-##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.EtcdV3Backend.isTerraformElement"></a>
+##### ~~`is_terraform_element`~~ <a name="is_terraform_element" id="cdktf.EtcdV3Backend.isTerraformElement"></a>
 
 ```python
 import cdktf
@@ -9528,7 +9752,7 @@ cdktf.EtcdV3Backend.is_terraform_element(
 
 ---
 
-##### `is_backend` <a name="is_backend" id="cdktf.EtcdV3Backend.isBackend"></a>
+##### ~~`is_backend`~~ <a name="is_backend" id="cdktf.EtcdV3Backend.isBackend"></a>
 
 ```python
 import cdktf
@@ -9555,7 +9779,9 @@ cdktf.EtcdV3Backend.is_backend(
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.EtcdV3Backend.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.EtcdV3Backend.property.node"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 node: Node
@@ -9567,7 +9793,9 @@ The tree node.
 
 ---
 
-##### `cdktf_stack`<sup>Required</sup> <a name="cdktf_stack" id="cdktf.EtcdV3Backend.property.cdktfStack"></a>
+##### ~~`cdktf_stack`~~<sup>Required</sup> <a name="cdktf_stack" id="cdktf.EtcdV3Backend.property.cdktfStack"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 cdktf_stack: TerraformStack
@@ -9577,7 +9805,9 @@ cdktf_stack: TerraformStack
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.EtcdV3Backend.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.EtcdV3Backend.property.fqn"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 fqn: str
@@ -9587,7 +9817,9 @@ fqn: str
 
 ---
 
-##### `friendly_unique_id`<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.EtcdV3Backend.property.friendlyUniqueId"></a>
+##### ~~`friendly_unique_id`~~<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.EtcdV3Backend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 friendly_unique_id: str
@@ -10678,49 +10910,65 @@ cdktf.MantaBackend(
 
 ---
 
-##### `account`<sup>Required</sup> <a name="account" id="cdktf.MantaBackend.Initializer.parameter.account"></a>
+##### ~~`account`~~<sup>Required</sup> <a name="account" id="cdktf.MantaBackend.Initializer.parameter.account"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `key_id`<sup>Required</sup> <a name="key_id" id="cdktf.MantaBackend.Initializer.parameter.keyId"></a>
+##### ~~`key_id`~~<sup>Required</sup> <a name="key_id" id="cdktf.MantaBackend.Initializer.parameter.keyId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `path`<sup>Required</sup> <a name="path" id="cdktf.MantaBackend.Initializer.parameter.path"></a>
+##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.MantaBackend.Initializer.parameter.path"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `insecure_skip_tls_verify`<sup>Optional</sup> <a name="insecure_skip_tls_verify" id="cdktf.MantaBackend.Initializer.parameter.insecureSkipTlsVerify"></a>
+##### ~~`insecure_skip_tls_verify`~~<sup>Optional</sup> <a name="insecure_skip_tls_verify" id="cdktf.MantaBackend.Initializer.parameter.insecureSkipTlsVerify"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ bool
 
 ---
 
-##### `key_material`<sup>Optional</sup> <a name="key_material" id="cdktf.MantaBackend.Initializer.parameter.keyMaterial"></a>
+##### ~~`key_material`~~<sup>Optional</sup> <a name="key_material" id="cdktf.MantaBackend.Initializer.parameter.keyMaterial"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `object_name`<sup>Optional</sup> <a name="object_name" id="cdktf.MantaBackend.Initializer.parameter.objectName"></a>
+##### ~~`object_name`~~<sup>Optional</sup> <a name="object_name" id="cdktf.MantaBackend.Initializer.parameter.objectName"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `url`<sup>Optional</sup> <a name="url" id="cdktf.MantaBackend.Initializer.parameter.url"></a>
+##### ~~`url`~~<sup>Optional</sup> <a name="url" id="cdktf.MantaBackend.Initializer.parameter.url"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `user`<sup>Optional</sup> <a name="user" id="cdktf.MantaBackend.Initializer.parameter.user"></a>
+##### ~~`user`~~<sup>Optional</sup> <a name="user" id="cdktf.MantaBackend.Initializer.parameter.user"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -10740,7 +10988,7 @@ cdktf.MantaBackend(
 
 ---
 
-##### `to_string` <a name="to_string" id="cdktf.MantaBackend.toString"></a>
+##### ~~`to_string`~~ <a name="to_string" id="cdktf.MantaBackend.toString"></a>
 
 ```python
 def to_string() - > str
@@ -10748,7 +10996,7 @@ def to_string() - > str
 
 Returns a string representation of this construct.
 
-##### `add_override` <a name="add_override" id="cdktf.MantaBackend.addOverride"></a>
+##### ~~`add_override`~~ <a name="add_override" id="cdktf.MantaBackend.addOverride"></a>
 
 ```python
 def add_override(
@@ -10769,7 +11017,7 @@ def add_override(
 
 ---
 
-##### `override_logical_id` <a name="override_logical_id" id="cdktf.MantaBackend.overrideLogicalId"></a>
+##### ~~`override_logical_id`~~ <a name="override_logical_id" id="cdktf.MantaBackend.overrideLogicalId"></a>
 
 ```python
 def override_logical_id(
@@ -10787,7 +11035,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `reset_override_logical_id` <a name="reset_override_logical_id" id="cdktf.MantaBackend.resetOverrideLogicalId"></a>
+##### ~~`reset_override_logical_id`~~ <a name="reset_override_logical_id" id="cdktf.MantaBackend.resetOverrideLogicalId"></a>
 
 ```python
 def reset_override_logical_id() - > None
@@ -10795,13 +11043,13 @@ def reset_override_logical_id() - > None
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `to_metadata` <a name="to_metadata" id="cdktf.MantaBackend.toMetadata"></a>
+##### ~~`to_metadata`~~ <a name="to_metadata" id="cdktf.MantaBackend.toMetadata"></a>
 
 ```python
 def to_metadata() - > typing.Any
 ```
 
-##### `to_terraform` <a name="to_terraform" id="cdktf.MantaBackend.toTerraform"></a>
+##### ~~`to_terraform`~~ <a name="to_terraform" id="cdktf.MantaBackend.toTerraform"></a>
 
 ```python
 def to_terraform() - > typing.Any
@@ -10809,7 +11057,7 @@ def to_terraform() - > typing.Any
 
 Adds this resource to the terraform JSON output.
 
-##### `get_remote_state_data_source` <a name="get_remote_state_data_source" id="cdktf.MantaBackend.getRemoteStateDataSource"></a>
+##### ~~`get_remote_state_data_source`~~ <a name="get_remote_state_data_source" id="cdktf.MantaBackend.getRemoteStateDataSource"></a>
 
 ```python
 def get_remote_state_data_source(
@@ -10849,7 +11097,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `is_construct` <a name="is_construct" id="cdktf.MantaBackend.isConstruct"></a>
+##### ~~`is_construct`~~ <a name="is_construct" id="cdktf.MantaBackend.isConstruct"></a>
 
 ```python
 import cdktf
@@ -10883,7 +11131,7 @@ Any object.
 
 ---
 
-##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.MantaBackend.isTerraformElement"></a>
+##### ~~`is_terraform_element`~~ <a name="is_terraform_element" id="cdktf.MantaBackend.isTerraformElement"></a>
 
 ```python
 import cdktf
@@ -10899,7 +11147,7 @@ cdktf.MantaBackend.is_terraform_element(
 
 ---
 
-##### `is_backend` <a name="is_backend" id="cdktf.MantaBackend.isBackend"></a>
+##### ~~`is_backend`~~ <a name="is_backend" id="cdktf.MantaBackend.isBackend"></a>
 
 ```python
 import cdktf
@@ -10926,7 +11174,9 @@ cdktf.MantaBackend.is_backend(
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.MantaBackend.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.MantaBackend.property.node"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 node: Node
@@ -10938,7 +11188,9 @@ The tree node.
 
 ---
 
-##### `cdktf_stack`<sup>Required</sup> <a name="cdktf_stack" id="cdktf.MantaBackend.property.cdktfStack"></a>
+##### ~~`cdktf_stack`~~<sup>Required</sup> <a name="cdktf_stack" id="cdktf.MantaBackend.property.cdktfStack"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 cdktf_stack: TerraformStack
@@ -10948,7 +11200,9 @@ cdktf_stack: TerraformStack
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.MantaBackend.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.MantaBackend.property.fqn"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 fqn: str
@@ -10958,7 +11212,9 @@ fqn: str
 
 ---
 
-##### `friendly_unique_id`<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.MantaBackend.property.friendlyUniqueId"></a>
+##### ~~`friendly_unique_id`~~<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.MantaBackend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 friendly_unique_id: str
@@ -12770,163 +13026,217 @@ cdktf.SwiftBackend(
 
 ---
 
-##### `container`<sup>Required</sup> <a name="container" id="cdktf.SwiftBackend.Initializer.parameter.container"></a>
+##### ~~`container`~~<sup>Required</sup> <a name="container" id="cdktf.SwiftBackend.Initializer.parameter.container"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `application_credential_id`<sup>Optional</sup> <a name="application_credential_id" id="cdktf.SwiftBackend.Initializer.parameter.applicationCredentialId"></a>
+##### ~~`application_credential_id`~~<sup>Optional</sup> <a name="application_credential_id" id="cdktf.SwiftBackend.Initializer.parameter.applicationCredentialId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `application_credential_name`<sup>Optional</sup> <a name="application_credential_name" id="cdktf.SwiftBackend.Initializer.parameter.applicationCredentialName"></a>
+##### ~~`application_credential_name`~~<sup>Optional</sup> <a name="application_credential_name" id="cdktf.SwiftBackend.Initializer.parameter.applicationCredentialName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `application_credential_secret`<sup>Optional</sup> <a name="application_credential_secret" id="cdktf.SwiftBackend.Initializer.parameter.applicationCredentialSecret"></a>
+##### ~~`application_credential_secret`~~<sup>Optional</sup> <a name="application_credential_secret" id="cdktf.SwiftBackend.Initializer.parameter.applicationCredentialSecret"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `archive_container`<sup>Optional</sup> <a name="archive_container" id="cdktf.SwiftBackend.Initializer.parameter.archiveContainer"></a>
+##### ~~`archive_container`~~<sup>Optional</sup> <a name="archive_container" id="cdktf.SwiftBackend.Initializer.parameter.archiveContainer"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `auth_url`<sup>Optional</sup> <a name="auth_url" id="cdktf.SwiftBackend.Initializer.parameter.authUrl"></a>
+##### ~~`auth_url`~~<sup>Optional</sup> <a name="auth_url" id="cdktf.SwiftBackend.Initializer.parameter.authUrl"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `cacert_file`<sup>Optional</sup> <a name="cacert_file" id="cdktf.SwiftBackend.Initializer.parameter.cacertFile"></a>
+##### ~~`cacert_file`~~<sup>Optional</sup> <a name="cacert_file" id="cdktf.SwiftBackend.Initializer.parameter.cacertFile"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `cert`<sup>Optional</sup> <a name="cert" id="cdktf.SwiftBackend.Initializer.parameter.cert"></a>
+##### ~~`cert`~~<sup>Optional</sup> <a name="cert" id="cdktf.SwiftBackend.Initializer.parameter.cert"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `cloud`<sup>Optional</sup> <a name="cloud" id="cdktf.SwiftBackend.Initializer.parameter.cloud"></a>
+##### ~~`cloud`~~<sup>Optional</sup> <a name="cloud" id="cdktf.SwiftBackend.Initializer.parameter.cloud"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `default_domain`<sup>Optional</sup> <a name="default_domain" id="cdktf.SwiftBackend.Initializer.parameter.defaultDomain"></a>
+##### ~~`default_domain`~~<sup>Optional</sup> <a name="default_domain" id="cdktf.SwiftBackend.Initializer.parameter.defaultDomain"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `domain_id`<sup>Optional</sup> <a name="domain_id" id="cdktf.SwiftBackend.Initializer.parameter.domainId"></a>
+##### ~~`domain_id`~~<sup>Optional</sup> <a name="domain_id" id="cdktf.SwiftBackend.Initializer.parameter.domainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `domain_name`<sup>Optional</sup> <a name="domain_name" id="cdktf.SwiftBackend.Initializer.parameter.domainName"></a>
+##### ~~`domain_name`~~<sup>Optional</sup> <a name="domain_name" id="cdktf.SwiftBackend.Initializer.parameter.domainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `expire_after`<sup>Optional</sup> <a name="expire_after" id="cdktf.SwiftBackend.Initializer.parameter.expireAfter"></a>
+##### ~~`expire_after`~~<sup>Optional</sup> <a name="expire_after" id="cdktf.SwiftBackend.Initializer.parameter.expireAfter"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `insecure`<sup>Optional</sup> <a name="insecure" id="cdktf.SwiftBackend.Initializer.parameter.insecure"></a>
+##### ~~`insecure`~~<sup>Optional</sup> <a name="insecure" id="cdktf.SwiftBackend.Initializer.parameter.insecure"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ bool
 
 ---
 
-##### `key`<sup>Optional</sup> <a name="key" id="cdktf.SwiftBackend.Initializer.parameter.key"></a>
+##### ~~`key`~~<sup>Optional</sup> <a name="key" id="cdktf.SwiftBackend.Initializer.parameter.key"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.SwiftBackend.Initializer.parameter.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.SwiftBackend.Initializer.parameter.password"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `project_domain_id`<sup>Optional</sup> <a name="project_domain_id" id="cdktf.SwiftBackend.Initializer.parameter.projectDomainId"></a>
+##### ~~`project_domain_id`~~<sup>Optional</sup> <a name="project_domain_id" id="cdktf.SwiftBackend.Initializer.parameter.projectDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `project_domain_name`<sup>Optional</sup> <a name="project_domain_name" id="cdktf.SwiftBackend.Initializer.parameter.projectDomainName"></a>
+##### ~~`project_domain_name`~~<sup>Optional</sup> <a name="project_domain_name" id="cdktf.SwiftBackend.Initializer.parameter.projectDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `region_name`<sup>Optional</sup> <a name="region_name" id="cdktf.SwiftBackend.Initializer.parameter.regionName"></a>
+##### ~~`region_name`~~<sup>Optional</sup> <a name="region_name" id="cdktf.SwiftBackend.Initializer.parameter.regionName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `state_name`<sup>Optional</sup> <a name="state_name" id="cdktf.SwiftBackend.Initializer.parameter.stateName"></a>
+##### ~~`state_name`~~<sup>Optional</sup> <a name="state_name" id="cdktf.SwiftBackend.Initializer.parameter.stateName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `tenant_id`<sup>Optional</sup> <a name="tenant_id" id="cdktf.SwiftBackend.Initializer.parameter.tenantId"></a>
+##### ~~`tenant_id`~~<sup>Optional</sup> <a name="tenant_id" id="cdktf.SwiftBackend.Initializer.parameter.tenantId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `tenant_name`<sup>Optional</sup> <a name="tenant_name" id="cdktf.SwiftBackend.Initializer.parameter.tenantName"></a>
+##### ~~`tenant_name`~~<sup>Optional</sup> <a name="tenant_name" id="cdktf.SwiftBackend.Initializer.parameter.tenantName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `token`<sup>Optional</sup> <a name="token" id="cdktf.SwiftBackend.Initializer.parameter.token"></a>
+##### ~~`token`~~<sup>Optional</sup> <a name="token" id="cdktf.SwiftBackend.Initializer.parameter.token"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `user_domain_id`<sup>Optional</sup> <a name="user_domain_id" id="cdktf.SwiftBackend.Initializer.parameter.userDomainId"></a>
+##### ~~`user_domain_id`~~<sup>Optional</sup> <a name="user_domain_id" id="cdktf.SwiftBackend.Initializer.parameter.userDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `user_domain_name`<sup>Optional</sup> <a name="user_domain_name" id="cdktf.SwiftBackend.Initializer.parameter.userDomainName"></a>
+##### ~~`user_domain_name`~~<sup>Optional</sup> <a name="user_domain_name" id="cdktf.SwiftBackend.Initializer.parameter.userDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `user_id`<sup>Optional</sup> <a name="user_id" id="cdktf.SwiftBackend.Initializer.parameter.userId"></a>
+##### ~~`user_id`~~<sup>Optional</sup> <a name="user_id" id="cdktf.SwiftBackend.Initializer.parameter.userId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
 ---
 
-##### `user_name`<sup>Optional</sup> <a name="user_name" id="cdktf.SwiftBackend.Initializer.parameter.userName"></a>
+##### ~~`user_name`~~<sup>Optional</sup> <a name="user_name" id="cdktf.SwiftBackend.Initializer.parameter.userName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 - _Type:_ str
 
@@ -12946,7 +13256,7 @@ cdktf.SwiftBackend(
 
 ---
 
-##### `to_string` <a name="to_string" id="cdktf.SwiftBackend.toString"></a>
+##### ~~`to_string`~~ <a name="to_string" id="cdktf.SwiftBackend.toString"></a>
 
 ```python
 def to_string() - > str
@@ -12954,7 +13264,7 @@ def to_string() - > str
 
 Returns a string representation of this construct.
 
-##### `add_override` <a name="add_override" id="cdktf.SwiftBackend.addOverride"></a>
+##### ~~`add_override`~~ <a name="add_override" id="cdktf.SwiftBackend.addOverride"></a>
 
 ```python
 def add_override(
@@ -12975,7 +13285,7 @@ def add_override(
 
 ---
 
-##### `override_logical_id` <a name="override_logical_id" id="cdktf.SwiftBackend.overrideLogicalId"></a>
+##### ~~`override_logical_id`~~ <a name="override_logical_id" id="cdktf.SwiftBackend.overrideLogicalId"></a>
 
 ```python
 def override_logical_id(
@@ -12993,7 +13303,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `reset_override_logical_id` <a name="reset_override_logical_id" id="cdktf.SwiftBackend.resetOverrideLogicalId"></a>
+##### ~~`reset_override_logical_id`~~ <a name="reset_override_logical_id" id="cdktf.SwiftBackend.resetOverrideLogicalId"></a>
 
 ```python
 def reset_override_logical_id() - > None
@@ -13001,13 +13311,13 @@ def reset_override_logical_id() - > None
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `to_metadata` <a name="to_metadata" id="cdktf.SwiftBackend.toMetadata"></a>
+##### ~~`to_metadata`~~ <a name="to_metadata" id="cdktf.SwiftBackend.toMetadata"></a>
 
 ```python
 def to_metadata() - > typing.Any
 ```
 
-##### `to_terraform` <a name="to_terraform" id="cdktf.SwiftBackend.toTerraform"></a>
+##### ~~`to_terraform`~~ <a name="to_terraform" id="cdktf.SwiftBackend.toTerraform"></a>
 
 ```python
 def to_terraform() - > typing.Any
@@ -13015,7 +13325,7 @@ def to_terraform() - > typing.Any
 
 Adds this resource to the terraform JSON output.
 
-##### `get_remote_state_data_source` <a name="get_remote_state_data_source" id="cdktf.SwiftBackend.getRemoteStateDataSource"></a>
+##### ~~`get_remote_state_data_source`~~ <a name="get_remote_state_data_source" id="cdktf.SwiftBackend.getRemoteStateDataSource"></a>
 
 ```python
 def get_remote_state_data_source(
@@ -13055,7 +13365,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `is_construct` <a name="is_construct" id="cdktf.SwiftBackend.isConstruct"></a>
+##### ~~`is_construct`~~ <a name="is_construct" id="cdktf.SwiftBackend.isConstruct"></a>
 
 ```python
 import cdktf
@@ -13089,7 +13399,7 @@ Any object.
 
 ---
 
-##### `is_terraform_element` <a name="is_terraform_element" id="cdktf.SwiftBackend.isTerraformElement"></a>
+##### ~~`is_terraform_element`~~ <a name="is_terraform_element" id="cdktf.SwiftBackend.isTerraformElement"></a>
 
 ```python
 import cdktf
@@ -13105,7 +13415,7 @@ cdktf.SwiftBackend.is_terraform_element(
 
 ---
 
-##### `is_backend` <a name="is_backend" id="cdktf.SwiftBackend.isBackend"></a>
+##### ~~`is_backend`~~ <a name="is_backend" id="cdktf.SwiftBackend.isBackend"></a>
 
 ```python
 import cdktf
@@ -13132,7 +13442,9 @@ cdktf.SwiftBackend.is_backend(
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.SwiftBackend.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.SwiftBackend.property.node"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 node: Node
@@ -13144,7 +13456,9 @@ The tree node.
 
 ---
 
-##### `cdktf_stack`<sup>Required</sup> <a name="cdktf_stack" id="cdktf.SwiftBackend.property.cdktfStack"></a>
+##### ~~`cdktf_stack`~~<sup>Required</sup> <a name="cdktf_stack" id="cdktf.SwiftBackend.property.cdktfStack"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 cdktf_stack: TerraformStack
@@ -13154,7 +13468,9 @@ cdktf_stack: TerraformStack
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.SwiftBackend.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.SwiftBackend.property.fqn"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 fqn: str
@@ -13164,7 +13480,9 @@ fqn: str
 
 ---
 
-##### `friendly_unique_id`<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.SwiftBackend.property.friendlyUniqueId"></a>
+##### ~~`friendly_unique_id`~~<sup>Required</sup> <a name="friendly_unique_id" id="cdktf.SwiftBackend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 friendly_unique_id: str
@@ -18038,7 +18356,9 @@ cdktf.ArtifactoryBackendProps(
 
 ---
 
-##### `password`<sup>Required</sup> <a name="password" id="cdktf.ArtifactoryBackendProps.property.password"></a>
+##### ~~`password`~~<sup>Required</sup> <a name="password" id="cdktf.ArtifactoryBackendProps.property.password"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 password: str
@@ -18050,7 +18370,9 @@ password: str
 
 ---
 
-##### `repo`<sup>Required</sup> <a name="repo" id="cdktf.ArtifactoryBackendProps.property.repo"></a>
+##### ~~`repo`~~<sup>Required</sup> <a name="repo" id="cdktf.ArtifactoryBackendProps.property.repo"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 repo: str
@@ -18062,7 +18384,9 @@ repo: str
 
 ---
 
-##### `subpath`<sup>Required</sup> <a name="subpath" id="cdktf.ArtifactoryBackendProps.property.subpath"></a>
+##### ~~`subpath`~~<sup>Required</sup> <a name="subpath" id="cdktf.ArtifactoryBackendProps.property.subpath"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 subpath: str
@@ -18074,7 +18398,9 @@ subpath: str
 
 ---
 
-##### `url`<sup>Required</sup> <a name="url" id="cdktf.ArtifactoryBackendProps.property.url"></a>
+##### ~~`url`~~<sup>Required</sup> <a name="url" id="cdktf.ArtifactoryBackendProps.property.url"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 url: str
@@ -18088,7 +18414,9 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ---
 
-##### `username`<sup>Required</sup> <a name="username" id="cdktf.ArtifactoryBackendProps.property.username"></a>
+##### ~~`username`~~<sup>Required</sup> <a name="username" id="cdktf.ArtifactoryBackendProps.property.username"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 username: str
@@ -18951,7 +19279,9 @@ cdktf.DataTerraformRemoteStateArtifactoryConfig(
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.defaults"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 defaults: typing.Mapping[typing.Any]
@@ -18961,7 +19291,9 @@ defaults: typing.Mapping[typing.Any]
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.workspace"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 workspace: str
@@ -18971,7 +19303,9 @@ workspace: str
 
 ---
 
-##### `password`<sup>Required</sup> <a name="password" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.password"></a>
+##### ~~`password`~~<sup>Required</sup> <a name="password" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.password"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 password: str
@@ -18983,7 +19317,9 @@ password: str
 
 ---
 
-##### `repo`<sup>Required</sup> <a name="repo" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.repo"></a>
+##### ~~`repo`~~<sup>Required</sup> <a name="repo" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.repo"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 repo: str
@@ -18995,7 +19331,9 @@ repo: str
 
 ---
 
-##### `subpath`<sup>Required</sup> <a name="subpath" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.subpath"></a>
+##### ~~`subpath`~~<sup>Required</sup> <a name="subpath" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.subpath"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 subpath: str
@@ -19007,7 +19345,9 @@ subpath: str
 
 ---
 
-##### `url`<sup>Required</sup> <a name="url" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.url"></a>
+##### ~~`url`~~<sup>Required</sup> <a name="url" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.url"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 url: str
@@ -19021,7 +19361,9 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ---
 
-##### `username`<sup>Required</sup> <a name="username" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.username"></a>
+##### ~~`username`~~<sup>Required</sup> <a name="username" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.username"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 username: str
@@ -19886,7 +20228,9 @@ cdktf.DataTerraformRemoteStateEtcdConfig(
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.defaults"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 defaults: typing.Mapping[typing.Any]
@@ -19896,7 +20240,9 @@ defaults: typing.Mapping[typing.Any]
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.workspace"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 workspace: str
@@ -19906,7 +20252,9 @@ workspace: str
 
 ---
 
-##### `endpoints`<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.endpoints"></a>
+##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.endpoints"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 endpoints: str
@@ -19918,7 +20266,9 @@ endpoints: str
 
 ---
 
-##### `path`<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.path"></a>
+##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.path"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 path: str
@@ -19930,7 +20280,9 @@ path: str
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.password"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 password: str
@@ -19942,7 +20294,9 @@ password: str
 
 ---
 
-##### `username`<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.username"></a>
+##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.username"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 username: str
@@ -19992,7 +20346,9 @@ cdktf.DataTerraformRemoteStateEtcdV3Config(
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.defaults"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 defaults: typing.Mapping[typing.Any]
@@ -20002,7 +20358,9 @@ defaults: typing.Mapping[typing.Any]
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.workspace"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 workspace: str
@@ -20012,7 +20370,9 @@ workspace: str
 
 ---
 
-##### `endpoints`<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.endpoints"></a>
+##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.endpoints"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 endpoints: typing.List[str]
@@ -20024,7 +20384,9 @@ endpoints: typing.List[str]
 
 ---
 
-##### `cacert_path`<sup>Optional</sup> <a name="cacert_path" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.cacertPath"></a>
+##### ~~`cacert_path`~~<sup>Optional</sup> <a name="cacert_path" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.cacertPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 cacert_path: str
@@ -20036,7 +20398,9 @@ cacert_path: str
 
 ---
 
-##### `cert_path`<sup>Optional</sup> <a name="cert_path" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.certPath"></a>
+##### ~~`cert_path`~~<sup>Optional</sup> <a name="cert_path" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.certPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 cert_path: str
@@ -20048,7 +20412,9 @@ cert_path: str
 
 ---
 
-##### `key_path`<sup>Optional</sup> <a name="key_path" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.keyPath"></a>
+##### ~~`key_path`~~<sup>Optional</sup> <a name="key_path" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.keyPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 key_path: str
@@ -20060,7 +20426,9 @@ key_path: str
 
 ---
 
-##### `lock`<sup>Optional</sup> <a name="lock" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.lock"></a>
+##### ~~`lock`~~<sup>Optional</sup> <a name="lock" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.lock"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 lock: bool
@@ -20074,7 +20442,9 @@ Defaults to true.
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.password"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 password: str
@@ -20086,7 +20456,9 @@ password: str
 
 ---
 
-##### `prefix`<sup>Optional</sup> <a name="prefix" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.prefix"></a>
+##### ~~`prefix`~~<sup>Optional</sup> <a name="prefix" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.prefix"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 prefix: str
@@ -20100,7 +20472,9 @@ Defaults to "".
 
 ---
 
-##### `username`<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.username"></a>
+##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.username"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 username: str
@@ -20603,7 +20977,9 @@ cdktf.DataTerraformRemoteStateMantaConfig(
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateMantaConfig.property.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateMantaConfig.property.defaults"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 defaults: typing.Mapping[typing.Any]
@@ -20613,7 +20989,9 @@ defaults: typing.Mapping[typing.Any]
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateMantaConfig.property.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateMantaConfig.property.workspace"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 workspace: str
@@ -20623,7 +21001,9 @@ workspace: str
 
 ---
 
-##### `account`<sup>Required</sup> <a name="account" id="cdktf.DataTerraformRemoteStateMantaConfig.property.account"></a>
+##### ~~`account`~~<sup>Required</sup> <a name="account" id="cdktf.DataTerraformRemoteStateMantaConfig.property.account"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 account: str
@@ -20633,7 +21013,9 @@ account: str
 
 ---
 
-##### `key_id`<sup>Required</sup> <a name="key_id" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyId"></a>
+##### ~~`key_id`~~<sup>Required</sup> <a name="key_id" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 key_id: str
@@ -20643,7 +21025,9 @@ key_id: str
 
 ---
 
-##### `path`<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateMantaConfig.property.path"></a>
+##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateMantaConfig.property.path"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 path: str
@@ -20653,7 +21037,9 @@ path: str
 
 ---
 
-##### `insecure_skip_tls_verify`<sup>Optional</sup> <a name="insecure_skip_tls_verify" id="cdktf.DataTerraformRemoteStateMantaConfig.property.insecureSkipTlsVerify"></a>
+##### ~~`insecure_skip_tls_verify`~~<sup>Optional</sup> <a name="insecure_skip_tls_verify" id="cdktf.DataTerraformRemoteStateMantaConfig.property.insecureSkipTlsVerify"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 insecure_skip_tls_verify: bool
@@ -20663,7 +21049,9 @@ insecure_skip_tls_verify: bool
 
 ---
 
-##### `key_material`<sup>Optional</sup> <a name="key_material" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyMaterial"></a>
+##### ~~`key_material`~~<sup>Optional</sup> <a name="key_material" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyMaterial"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 key_material: str
@@ -20673,7 +21061,9 @@ key_material: str
 
 ---
 
-##### `object_name`<sup>Optional</sup> <a name="object_name" id="cdktf.DataTerraformRemoteStateMantaConfig.property.objectName"></a>
+##### ~~`object_name`~~<sup>Optional</sup> <a name="object_name" id="cdktf.DataTerraformRemoteStateMantaConfig.property.objectName"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 object_name: str
@@ -20683,7 +21073,9 @@ object_name: str
 
 ---
 
-##### `url`<sup>Optional</sup> <a name="url" id="cdktf.DataTerraformRemoteStateMantaConfig.property.url"></a>
+##### ~~`url`~~<sup>Optional</sup> <a name="url" id="cdktf.DataTerraformRemoteStateMantaConfig.property.url"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 url: str
@@ -20693,7 +21085,9 @@ url: str
 
 ---
 
-##### `user`<sup>Optional</sup> <a name="user" id="cdktf.DataTerraformRemoteStateMantaConfig.property.user"></a>
+##### ~~`user`~~<sup>Optional</sup> <a name="user" id="cdktf.DataTerraformRemoteStateMantaConfig.property.user"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 user: str
@@ -21688,7 +22082,9 @@ cdktf.DataTerraformRemoteStateSwiftConfig(
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaults"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 defaults: typing.Mapping[typing.Any]
@@ -21698,7 +22094,9 @@ defaults: typing.Mapping[typing.Any]
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.workspace"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 workspace: str
@@ -21708,7 +22106,9 @@ workspace: str
 
 ---
 
-##### `container`<sup>Required</sup> <a name="container" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.container"></a>
+##### ~~`container`~~<sup>Required</sup> <a name="container" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.container"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 container: str
@@ -21718,7 +22118,9 @@ container: str
 
 ---
 
-##### `application_credential_id`<sup>Optional</sup> <a name="application_credential_id" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialId"></a>
+##### ~~`application_credential_id`~~<sup>Optional</sup> <a name="application_credential_id" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 application_credential_id: str
@@ -21728,7 +22130,9 @@ application_credential_id: str
 
 ---
 
-##### `application_credential_name`<sup>Optional</sup> <a name="application_credential_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialName"></a>
+##### ~~`application_credential_name`~~<sup>Optional</sup> <a name="application_credential_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 application_credential_name: str
@@ -21738,7 +22142,9 @@ application_credential_name: str
 
 ---
 
-##### `application_credential_secret`<sup>Optional</sup> <a name="application_credential_secret" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialSecret"></a>
+##### ~~`application_credential_secret`~~<sup>Optional</sup> <a name="application_credential_secret" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialSecret"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 application_credential_secret: str
@@ -21748,7 +22154,9 @@ application_credential_secret: str
 
 ---
 
-##### `archive_container`<sup>Optional</sup> <a name="archive_container" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.archiveContainer"></a>
+##### ~~`archive_container`~~<sup>Optional</sup> <a name="archive_container" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.archiveContainer"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 archive_container: str
@@ -21758,7 +22166,9 @@ archive_container: str
 
 ---
 
-##### `auth_url`<sup>Optional</sup> <a name="auth_url" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.authUrl"></a>
+##### ~~`auth_url`~~<sup>Optional</sup> <a name="auth_url" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.authUrl"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 auth_url: str
@@ -21768,7 +22178,9 @@ auth_url: str
 
 ---
 
-##### `cacert_file`<sup>Optional</sup> <a name="cacert_file" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cacertFile"></a>
+##### ~~`cacert_file`~~<sup>Optional</sup> <a name="cacert_file" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cacertFile"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 cacert_file: str
@@ -21778,7 +22190,9 @@ cacert_file: str
 
 ---
 
-##### `cert`<sup>Optional</sup> <a name="cert" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cert"></a>
+##### ~~`cert`~~<sup>Optional</sup> <a name="cert" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cert"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 cert: str
@@ -21788,7 +22202,9 @@ cert: str
 
 ---
 
-##### `cloud`<sup>Optional</sup> <a name="cloud" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cloud"></a>
+##### ~~`cloud`~~<sup>Optional</sup> <a name="cloud" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cloud"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 cloud: str
@@ -21798,7 +22214,9 @@ cloud: str
 
 ---
 
-##### `default_domain`<sup>Optional</sup> <a name="default_domain" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaultDomain"></a>
+##### ~~`default_domain`~~<sup>Optional</sup> <a name="default_domain" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaultDomain"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 default_domain: str
@@ -21808,7 +22226,9 @@ default_domain: str
 
 ---
 
-##### `domain_id`<sup>Optional</sup> <a name="domain_id" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainId"></a>
+##### ~~`domain_id`~~<sup>Optional</sup> <a name="domain_id" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 domain_id: str
@@ -21818,7 +22238,9 @@ domain_id: str
 
 ---
 
-##### `domain_name`<sup>Optional</sup> <a name="domain_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainName"></a>
+##### ~~`domain_name`~~<sup>Optional</sup> <a name="domain_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 domain_name: str
@@ -21828,7 +22250,9 @@ domain_name: str
 
 ---
 
-##### `expire_after`<sup>Optional</sup> <a name="expire_after" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.expireAfter"></a>
+##### ~~`expire_after`~~<sup>Optional</sup> <a name="expire_after" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.expireAfter"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 expire_after: str
@@ -21838,7 +22262,9 @@ expire_after: str
 
 ---
 
-##### `insecure`<sup>Optional</sup> <a name="insecure" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.insecure"></a>
+##### ~~`insecure`~~<sup>Optional</sup> <a name="insecure" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.insecure"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 insecure: bool
@@ -21848,7 +22274,9 @@ insecure: bool
 
 ---
 
-##### `key`<sup>Optional</sup> <a name="key" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.key"></a>
+##### ~~`key`~~<sup>Optional</sup> <a name="key" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.key"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 key: str
@@ -21858,7 +22286,9 @@ key: str
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.password"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 password: str
@@ -21868,7 +22298,9 @@ password: str
 
 ---
 
-##### `project_domain_id`<sup>Optional</sup> <a name="project_domain_id" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainId"></a>
+##### ~~`project_domain_id`~~<sup>Optional</sup> <a name="project_domain_id" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 project_domain_id: str
@@ -21878,7 +22310,9 @@ project_domain_id: str
 
 ---
 
-##### `project_domain_name`<sup>Optional</sup> <a name="project_domain_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainName"></a>
+##### ~~`project_domain_name`~~<sup>Optional</sup> <a name="project_domain_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 project_domain_name: str
@@ -21888,7 +22322,9 @@ project_domain_name: str
 
 ---
 
-##### `region_name`<sup>Optional</sup> <a name="region_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.regionName"></a>
+##### ~~`region_name`~~<sup>Optional</sup> <a name="region_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.regionName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 region_name: str
@@ -21898,7 +22334,9 @@ region_name: str
 
 ---
 
-##### `state_name`<sup>Optional</sup> <a name="state_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.stateName"></a>
+##### ~~`state_name`~~<sup>Optional</sup> <a name="state_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.stateName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 state_name: str
@@ -21908,7 +22346,9 @@ state_name: str
 
 ---
 
-##### `tenant_id`<sup>Optional</sup> <a name="tenant_id" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantId"></a>
+##### ~~`tenant_id`~~<sup>Optional</sup> <a name="tenant_id" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 tenant_id: str
@@ -21918,7 +22358,9 @@ tenant_id: str
 
 ---
 
-##### `tenant_name`<sup>Optional</sup> <a name="tenant_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantName"></a>
+##### ~~`tenant_name`~~<sup>Optional</sup> <a name="tenant_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 tenant_name: str
@@ -21928,7 +22370,9 @@ tenant_name: str
 
 ---
 
-##### `token`<sup>Optional</sup> <a name="token" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.token"></a>
+##### ~~`token`~~<sup>Optional</sup> <a name="token" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.token"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 token: str
@@ -21938,7 +22382,9 @@ token: str
 
 ---
 
-##### `user_domain_id`<sup>Optional</sup> <a name="user_domain_id" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainId"></a>
+##### ~~`user_domain_id`~~<sup>Optional</sup> <a name="user_domain_id" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 user_domain_id: str
@@ -21948,7 +22394,9 @@ user_domain_id: str
 
 ---
 
-##### `user_domain_name`<sup>Optional</sup> <a name="user_domain_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainName"></a>
+##### ~~`user_domain_name`~~<sup>Optional</sup> <a name="user_domain_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 user_domain_name: str
@@ -21958,7 +22406,9 @@ user_domain_name: str
 
 ---
 
-##### `user_id`<sup>Optional</sup> <a name="user_id" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userId"></a>
+##### ~~`user_id`~~<sup>Optional</sup> <a name="user_id" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 user_id: str
@@ -21968,7 +22418,9 @@ user_id: str
 
 ---
 
-##### `user_name`<sup>Optional</sup> <a name="user_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userName"></a>
+##### ~~`user_name`~~<sup>Optional</sup> <a name="user_name" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 user_name: str
@@ -22046,7 +22498,9 @@ cdktf.EtcdBackendProps(
 
 ---
 
-##### `endpoints`<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdBackendProps.property.endpoints"></a>
+##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdBackendProps.property.endpoints"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 endpoints: str
@@ -22058,7 +22512,9 @@ endpoints: str
 
 ---
 
-##### `path`<sup>Required</sup> <a name="path" id="cdktf.EtcdBackendProps.property.path"></a>
+##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.EtcdBackendProps.property.path"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 path: str
@@ -22070,7 +22526,9 @@ path: str
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.EtcdBackendProps.property.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.EtcdBackendProps.property.password"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 password: str
@@ -22082,7 +22540,9 @@ password: str
 
 ---
 
-##### `username`<sup>Optional</sup> <a name="username" id="cdktf.EtcdBackendProps.property.username"></a>
+##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.EtcdBackendProps.property.username"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 username: str
@@ -22135,7 +22595,9 @@ cdktf.EtcdV3BackendProps(
 
 ---
 
-##### `endpoints`<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdV3BackendProps.property.endpoints"></a>
+##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdV3BackendProps.property.endpoints"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 endpoints: typing.List[str]
@@ -22147,7 +22609,9 @@ endpoints: typing.List[str]
 
 ---
 
-##### `cacert_path`<sup>Optional</sup> <a name="cacert_path" id="cdktf.EtcdV3BackendProps.property.cacertPath"></a>
+##### ~~`cacert_path`~~<sup>Optional</sup> <a name="cacert_path" id="cdktf.EtcdV3BackendProps.property.cacertPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 cacert_path: str
@@ -22159,7 +22623,9 @@ cacert_path: str
 
 ---
 
-##### `cert_path`<sup>Optional</sup> <a name="cert_path" id="cdktf.EtcdV3BackendProps.property.certPath"></a>
+##### ~~`cert_path`~~<sup>Optional</sup> <a name="cert_path" id="cdktf.EtcdV3BackendProps.property.certPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 cert_path: str
@@ -22171,7 +22637,9 @@ cert_path: str
 
 ---
 
-##### `key_path`<sup>Optional</sup> <a name="key_path" id="cdktf.EtcdV3BackendProps.property.keyPath"></a>
+##### ~~`key_path`~~<sup>Optional</sup> <a name="key_path" id="cdktf.EtcdV3BackendProps.property.keyPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 key_path: str
@@ -22183,7 +22651,9 @@ key_path: str
 
 ---
 
-##### `lock`<sup>Optional</sup> <a name="lock" id="cdktf.EtcdV3BackendProps.property.lock"></a>
+##### ~~`lock`~~<sup>Optional</sup> <a name="lock" id="cdktf.EtcdV3BackendProps.property.lock"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 lock: bool
@@ -22197,7 +22667,9 @@ Defaults to true.
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.EtcdV3BackendProps.property.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.EtcdV3BackendProps.property.password"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 password: str
@@ -22209,7 +22681,9 @@ password: str
 
 ---
 
-##### `prefix`<sup>Optional</sup> <a name="prefix" id="cdktf.EtcdV3BackendProps.property.prefix"></a>
+##### ~~`prefix`~~<sup>Optional</sup> <a name="prefix" id="cdktf.EtcdV3BackendProps.property.prefix"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 prefix: str
@@ -22223,7 +22697,9 @@ Defaults to "".
 
 ---
 
-##### `username`<sup>Optional</sup> <a name="username" id="cdktf.EtcdV3BackendProps.property.username"></a>
+##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.EtcdV3BackendProps.property.username"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 username: str
@@ -23040,7 +23516,9 @@ cdktf.MantaBackendProps(
 
 ---
 
-##### `account`<sup>Required</sup> <a name="account" id="cdktf.MantaBackendProps.property.account"></a>
+##### ~~`account`~~<sup>Required</sup> <a name="account" id="cdktf.MantaBackendProps.property.account"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 account: str
@@ -23050,7 +23528,9 @@ account: str
 
 ---
 
-##### `key_id`<sup>Required</sup> <a name="key_id" id="cdktf.MantaBackendProps.property.keyId"></a>
+##### ~~`key_id`~~<sup>Required</sup> <a name="key_id" id="cdktf.MantaBackendProps.property.keyId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 key_id: str
@@ -23060,7 +23540,9 @@ key_id: str
 
 ---
 
-##### `path`<sup>Required</sup> <a name="path" id="cdktf.MantaBackendProps.property.path"></a>
+##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.MantaBackendProps.property.path"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 path: str
@@ -23070,7 +23552,9 @@ path: str
 
 ---
 
-##### `insecure_skip_tls_verify`<sup>Optional</sup> <a name="insecure_skip_tls_verify" id="cdktf.MantaBackendProps.property.insecureSkipTlsVerify"></a>
+##### ~~`insecure_skip_tls_verify`~~<sup>Optional</sup> <a name="insecure_skip_tls_verify" id="cdktf.MantaBackendProps.property.insecureSkipTlsVerify"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 insecure_skip_tls_verify: bool
@@ -23080,7 +23564,9 @@ insecure_skip_tls_verify: bool
 
 ---
 
-##### `key_material`<sup>Optional</sup> <a name="key_material" id="cdktf.MantaBackendProps.property.keyMaterial"></a>
+##### ~~`key_material`~~<sup>Optional</sup> <a name="key_material" id="cdktf.MantaBackendProps.property.keyMaterial"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 key_material: str
@@ -23090,7 +23576,9 @@ key_material: str
 
 ---
 
-##### `object_name`<sup>Optional</sup> <a name="object_name" id="cdktf.MantaBackendProps.property.objectName"></a>
+##### ~~`object_name`~~<sup>Optional</sup> <a name="object_name" id="cdktf.MantaBackendProps.property.objectName"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 object_name: str
@@ -23100,7 +23588,9 @@ object_name: str
 
 ---
 
-##### `url`<sup>Optional</sup> <a name="url" id="cdktf.MantaBackendProps.property.url"></a>
+##### ~~`url`~~<sup>Optional</sup> <a name="url" id="cdktf.MantaBackendProps.property.url"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 url: str
@@ -23110,7 +23600,9 @@ url: str
 
 ---
 
-##### `user`<sup>Optional</sup> <a name="user" id="cdktf.MantaBackendProps.property.user"></a>
+##### ~~`user`~~<sup>Optional</sup> <a name="user" id="cdktf.MantaBackendProps.property.user"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 user: str
@@ -24823,7 +25315,9 @@ cdktf.SwiftBackendProps(
 
 ---
 
-##### `container`<sup>Required</sup> <a name="container" id="cdktf.SwiftBackendProps.property.container"></a>
+##### ~~`container`~~<sup>Required</sup> <a name="container" id="cdktf.SwiftBackendProps.property.container"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 container: str
@@ -24833,7 +25327,9 @@ container: str
 
 ---
 
-##### `application_credential_id`<sup>Optional</sup> <a name="application_credential_id" id="cdktf.SwiftBackendProps.property.applicationCredentialId"></a>
+##### ~~`application_credential_id`~~<sup>Optional</sup> <a name="application_credential_id" id="cdktf.SwiftBackendProps.property.applicationCredentialId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 application_credential_id: str
@@ -24843,7 +25339,9 @@ application_credential_id: str
 
 ---
 
-##### `application_credential_name`<sup>Optional</sup> <a name="application_credential_name" id="cdktf.SwiftBackendProps.property.applicationCredentialName"></a>
+##### ~~`application_credential_name`~~<sup>Optional</sup> <a name="application_credential_name" id="cdktf.SwiftBackendProps.property.applicationCredentialName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 application_credential_name: str
@@ -24853,7 +25351,9 @@ application_credential_name: str
 
 ---
 
-##### `application_credential_secret`<sup>Optional</sup> <a name="application_credential_secret" id="cdktf.SwiftBackendProps.property.applicationCredentialSecret"></a>
+##### ~~`application_credential_secret`~~<sup>Optional</sup> <a name="application_credential_secret" id="cdktf.SwiftBackendProps.property.applicationCredentialSecret"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 application_credential_secret: str
@@ -24863,7 +25363,9 @@ application_credential_secret: str
 
 ---
 
-##### `archive_container`<sup>Optional</sup> <a name="archive_container" id="cdktf.SwiftBackendProps.property.archiveContainer"></a>
+##### ~~`archive_container`~~<sup>Optional</sup> <a name="archive_container" id="cdktf.SwiftBackendProps.property.archiveContainer"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 archive_container: str
@@ -24873,7 +25375,9 @@ archive_container: str
 
 ---
 
-##### `auth_url`<sup>Optional</sup> <a name="auth_url" id="cdktf.SwiftBackendProps.property.authUrl"></a>
+##### ~~`auth_url`~~<sup>Optional</sup> <a name="auth_url" id="cdktf.SwiftBackendProps.property.authUrl"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 auth_url: str
@@ -24883,7 +25387,9 @@ auth_url: str
 
 ---
 
-##### `cacert_file`<sup>Optional</sup> <a name="cacert_file" id="cdktf.SwiftBackendProps.property.cacertFile"></a>
+##### ~~`cacert_file`~~<sup>Optional</sup> <a name="cacert_file" id="cdktf.SwiftBackendProps.property.cacertFile"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 cacert_file: str
@@ -24893,7 +25399,9 @@ cacert_file: str
 
 ---
 
-##### `cert`<sup>Optional</sup> <a name="cert" id="cdktf.SwiftBackendProps.property.cert"></a>
+##### ~~`cert`~~<sup>Optional</sup> <a name="cert" id="cdktf.SwiftBackendProps.property.cert"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 cert: str
@@ -24903,7 +25411,9 @@ cert: str
 
 ---
 
-##### `cloud`<sup>Optional</sup> <a name="cloud" id="cdktf.SwiftBackendProps.property.cloud"></a>
+##### ~~`cloud`~~<sup>Optional</sup> <a name="cloud" id="cdktf.SwiftBackendProps.property.cloud"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 cloud: str
@@ -24913,7 +25423,9 @@ cloud: str
 
 ---
 
-##### `default_domain`<sup>Optional</sup> <a name="default_domain" id="cdktf.SwiftBackendProps.property.defaultDomain"></a>
+##### ~~`default_domain`~~<sup>Optional</sup> <a name="default_domain" id="cdktf.SwiftBackendProps.property.defaultDomain"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 default_domain: str
@@ -24923,7 +25435,9 @@ default_domain: str
 
 ---
 
-##### `domain_id`<sup>Optional</sup> <a name="domain_id" id="cdktf.SwiftBackendProps.property.domainId"></a>
+##### ~~`domain_id`~~<sup>Optional</sup> <a name="domain_id" id="cdktf.SwiftBackendProps.property.domainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 domain_id: str
@@ -24933,7 +25447,9 @@ domain_id: str
 
 ---
 
-##### `domain_name`<sup>Optional</sup> <a name="domain_name" id="cdktf.SwiftBackendProps.property.domainName"></a>
+##### ~~`domain_name`~~<sup>Optional</sup> <a name="domain_name" id="cdktf.SwiftBackendProps.property.domainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 domain_name: str
@@ -24943,7 +25459,9 @@ domain_name: str
 
 ---
 
-##### `expire_after`<sup>Optional</sup> <a name="expire_after" id="cdktf.SwiftBackendProps.property.expireAfter"></a>
+##### ~~`expire_after`~~<sup>Optional</sup> <a name="expire_after" id="cdktf.SwiftBackendProps.property.expireAfter"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 expire_after: str
@@ -24953,7 +25471,9 @@ expire_after: str
 
 ---
 
-##### `insecure`<sup>Optional</sup> <a name="insecure" id="cdktf.SwiftBackendProps.property.insecure"></a>
+##### ~~`insecure`~~<sup>Optional</sup> <a name="insecure" id="cdktf.SwiftBackendProps.property.insecure"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 insecure: bool
@@ -24963,7 +25483,9 @@ insecure: bool
 
 ---
 
-##### `key`<sup>Optional</sup> <a name="key" id="cdktf.SwiftBackendProps.property.key"></a>
+##### ~~`key`~~<sup>Optional</sup> <a name="key" id="cdktf.SwiftBackendProps.property.key"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 key: str
@@ -24973,7 +25495,9 @@ key: str
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.SwiftBackendProps.property.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.SwiftBackendProps.property.password"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 password: str
@@ -24983,7 +25507,9 @@ password: str
 
 ---
 
-##### `project_domain_id`<sup>Optional</sup> <a name="project_domain_id" id="cdktf.SwiftBackendProps.property.projectDomainId"></a>
+##### ~~`project_domain_id`~~<sup>Optional</sup> <a name="project_domain_id" id="cdktf.SwiftBackendProps.property.projectDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 project_domain_id: str
@@ -24993,7 +25519,9 @@ project_domain_id: str
 
 ---
 
-##### `project_domain_name`<sup>Optional</sup> <a name="project_domain_name" id="cdktf.SwiftBackendProps.property.projectDomainName"></a>
+##### ~~`project_domain_name`~~<sup>Optional</sup> <a name="project_domain_name" id="cdktf.SwiftBackendProps.property.projectDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 project_domain_name: str
@@ -25003,7 +25531,9 @@ project_domain_name: str
 
 ---
 
-##### `region_name`<sup>Optional</sup> <a name="region_name" id="cdktf.SwiftBackendProps.property.regionName"></a>
+##### ~~`region_name`~~<sup>Optional</sup> <a name="region_name" id="cdktf.SwiftBackendProps.property.regionName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 region_name: str
@@ -25013,7 +25543,9 @@ region_name: str
 
 ---
 
-##### `state_name`<sup>Optional</sup> <a name="state_name" id="cdktf.SwiftBackendProps.property.stateName"></a>
+##### ~~`state_name`~~<sup>Optional</sup> <a name="state_name" id="cdktf.SwiftBackendProps.property.stateName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 state_name: str
@@ -25023,7 +25555,9 @@ state_name: str
 
 ---
 
-##### `tenant_id`<sup>Optional</sup> <a name="tenant_id" id="cdktf.SwiftBackendProps.property.tenantId"></a>
+##### ~~`tenant_id`~~<sup>Optional</sup> <a name="tenant_id" id="cdktf.SwiftBackendProps.property.tenantId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 tenant_id: str
@@ -25033,7 +25567,9 @@ tenant_id: str
 
 ---
 
-##### `tenant_name`<sup>Optional</sup> <a name="tenant_name" id="cdktf.SwiftBackendProps.property.tenantName"></a>
+##### ~~`tenant_name`~~<sup>Optional</sup> <a name="tenant_name" id="cdktf.SwiftBackendProps.property.tenantName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 tenant_name: str
@@ -25043,7 +25579,9 @@ tenant_name: str
 
 ---
 
-##### `token`<sup>Optional</sup> <a name="token" id="cdktf.SwiftBackendProps.property.token"></a>
+##### ~~`token`~~<sup>Optional</sup> <a name="token" id="cdktf.SwiftBackendProps.property.token"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 token: str
@@ -25053,7 +25591,9 @@ token: str
 
 ---
 
-##### `user_domain_id`<sup>Optional</sup> <a name="user_domain_id" id="cdktf.SwiftBackendProps.property.userDomainId"></a>
+##### ~~`user_domain_id`~~<sup>Optional</sup> <a name="user_domain_id" id="cdktf.SwiftBackendProps.property.userDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 user_domain_id: str
@@ -25063,7 +25603,9 @@ user_domain_id: str
 
 ---
 
-##### `user_domain_name`<sup>Optional</sup> <a name="user_domain_name" id="cdktf.SwiftBackendProps.property.userDomainName"></a>
+##### ~~`user_domain_name`~~<sup>Optional</sup> <a name="user_domain_name" id="cdktf.SwiftBackendProps.property.userDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 user_domain_name: str
@@ -25073,7 +25615,9 @@ user_domain_name: str
 
 ---
 
-##### `user_id`<sup>Optional</sup> <a name="user_id" id="cdktf.SwiftBackendProps.property.userId"></a>
+##### ~~`user_id`~~<sup>Optional</sup> <a name="user_id" id="cdktf.SwiftBackendProps.property.userId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 user_id: str
@@ -25083,7 +25627,9 @@ user_id: str
 
 ---
 
-##### `user_name`<sup>Optional</sup> <a name="user_name" id="cdktf.SwiftBackendProps.property.userName"></a>
+##### ~~`user_name`~~<sup>Optional</sup> <a name="user_name" id="cdktf.SwiftBackendProps.property.userName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```python
 user_name: str

--- a/website/docs/cdktf/api-reference/typescript.mdx
+++ b/website/docs/cdktf/api-reference/typescript.mdx
@@ -446,7 +446,7 @@ ArtifactoryBackend.isBackend(x: any)
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.ArtifactoryBackend.property.node"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly node: Node;
@@ -460,7 +460,7 @@ The tree node.
 
 ##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.ArtifactoryBackend.property.cdktfStack"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly cdktfStack: TerraformStack;
@@ -472,7 +472,7 @@ public readonly cdktfStack: TerraformStack;
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.ArtifactoryBackend.property.fqn"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly fqn: string;
@@ -484,7 +484,7 @@ public readonly fqn: string;
 
 ##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.ArtifactoryBackend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly friendlyUniqueId: string;
@@ -2070,7 +2070,7 @@ DataTerraformRemoteStateArtifactory.isTerraformElement(x: any)
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateArtifactory.property.node"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly node: Node;
@@ -2084,7 +2084,7 @@ The tree node.
 
 ##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateArtifactory.property.cdktfStack"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly cdktfStack: TerraformStack;
@@ -2096,7 +2096,7 @@ public readonly cdktfStack: TerraformStack;
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateArtifactory.property.fqn"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly fqn: string;
@@ -2108,7 +2108,7 @@ public readonly fqn: string;
 
 ##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateArtifactory.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly friendlyUniqueId: string;
@@ -2128,7 +2128,7 @@ public readonly friendlyUniqueId: string;
 
 ##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateArtifactory.property.tfResourceType"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly tfResourceType: string;
@@ -3296,7 +3296,7 @@ DataTerraformRemoteStateEtcd.isTerraformElement(x: any)
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateEtcd.property.node"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly node: Node;
@@ -3310,7 +3310,7 @@ The tree node.
 
 ##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateEtcd.property.cdktfStack"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly cdktfStack: TerraformStack;
@@ -3322,7 +3322,7 @@ public readonly cdktfStack: TerraformStack;
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateEtcd.property.fqn"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly fqn: string;
@@ -3334,7 +3334,7 @@ public readonly fqn: string;
 
 ##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcd.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly friendlyUniqueId: string;
@@ -3354,7 +3354,7 @@ public readonly friendlyUniqueId: string;
 
 ##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateEtcd.property.tfResourceType"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly tfResourceType: string;
@@ -3610,7 +3610,7 @@ DataTerraformRemoteStateEtcdV3.isTerraformElement(x: any)
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateEtcdV3.property.node"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly node: Node;
@@ -3624,7 +3624,7 @@ The tree node.
 
 ##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateEtcdV3.property.cdktfStack"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly cdktfStack: TerraformStack;
@@ -3636,7 +3636,7 @@ public readonly cdktfStack: TerraformStack;
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateEtcdV3.property.fqn"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly fqn: string;
@@ -3648,7 +3648,7 @@ public readonly fqn: string;
 
 ##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcdV3.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly friendlyUniqueId: string;
@@ -3668,7 +3668,7 @@ public readonly friendlyUniqueId: string;
 
 ##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateEtcdV3.property.tfResourceType"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly tfResourceType: string;
@@ -4836,7 +4836,7 @@ DataTerraformRemoteStateManta.isTerraformElement(x: any)
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateManta.property.node"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly node: Node;
@@ -4850,7 +4850,7 @@ The tree node.
 
 ##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateManta.property.cdktfStack"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly cdktfStack: TerraformStack;
@@ -4862,7 +4862,7 @@ public readonly cdktfStack: TerraformStack;
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateManta.property.fqn"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly fqn: string;
@@ -4874,7 +4874,7 @@ public readonly fqn: string;
 
 ##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateManta.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly friendlyUniqueId: string;
@@ -4894,7 +4894,7 @@ public readonly friendlyUniqueId: string;
 
 ##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateManta.property.tfResourceType"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly tfResourceType: string;
@@ -6062,7 +6062,7 @@ DataTerraformRemoteStateSwift.isTerraformElement(x: any)
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateSwift.property.node"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly node: Node;
@@ -6076,7 +6076,7 @@ The tree node.
 
 ##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateSwift.property.cdktfStack"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly cdktfStack: TerraformStack;
@@ -6088,7 +6088,7 @@ public readonly cdktfStack: TerraformStack;
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateSwift.property.fqn"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly fqn: string;
@@ -6100,7 +6100,7 @@ public readonly fqn: string;
 
 ##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateSwift.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly friendlyUniqueId: string;
@@ -6120,7 +6120,7 @@ public readonly friendlyUniqueId: string;
 
 ##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateSwift.property.tfResourceType"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly tfResourceType: string;
@@ -6346,7 +6346,7 @@ EtcdBackend.isBackend(x: any)
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.EtcdBackend.property.node"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly node: Node;
@@ -6360,7 +6360,7 @@ The tree node.
 
 ##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.EtcdBackend.property.cdktfStack"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly cdktfStack: TerraformStack;
@@ -6372,7 +6372,7 @@ public readonly cdktfStack: TerraformStack;
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.EtcdBackend.property.fqn"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly fqn: string;
@@ -6384,7 +6384,7 @@ public readonly fqn: string;
 
 ##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.EtcdBackend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly friendlyUniqueId: string;
@@ -6610,7 +6610,7 @@ EtcdV3Backend.isBackend(x: any)
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.EtcdV3Backend.property.node"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly node: Node;
@@ -6624,7 +6624,7 @@ The tree node.
 
 ##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.EtcdV3Backend.property.cdktfStack"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly cdktfStack: TerraformStack;
@@ -6636,7 +6636,7 @@ public readonly cdktfStack: TerraformStack;
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.EtcdV3Backend.property.fqn"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly fqn: string;
@@ -6648,7 +6648,7 @@ public readonly fqn: string;
 
 ##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.EtcdV3Backend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly friendlyUniqueId: string;
@@ -7642,7 +7642,7 @@ MantaBackend.isBackend(x: any)
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.MantaBackend.property.node"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly node: Node;
@@ -7656,7 +7656,7 @@ The tree node.
 
 ##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.MantaBackend.property.cdktfStack"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly cdktfStack: TerraformStack;
@@ -7668,7 +7668,7 @@ public readonly cdktfStack: TerraformStack;
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.MantaBackend.property.fqn"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly fqn: string;
@@ -7680,7 +7680,7 @@ public readonly fqn: string;
 
 ##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.MantaBackend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly friendlyUniqueId: string;
@@ -9056,7 +9056,7 @@ SwiftBackend.isBackend(x: any)
 
 ##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.SwiftBackend.property.node"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly node: Node;
@@ -9070,7 +9070,7 @@ The tree node.
 
 ##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.SwiftBackend.property.cdktfStack"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly cdktfStack: TerraformStack;
@@ -9082,7 +9082,7 @@ public readonly cdktfStack: TerraformStack;
 
 ##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.SwiftBackend.property.fqn"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly fqn: string;
@@ -9094,7 +9094,7 @@ public readonly fqn: string;
 
 ##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.SwiftBackend.property.friendlyUniqueId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly friendlyUniqueId: string;
@@ -13334,7 +13334,7 @@ const artifactoryBackendProps: ArtifactoryBackendProps = { ... }
 
 ##### ~~`password`~~<sup>Required</sup> <a name="password" id="cdktf.ArtifactoryBackendProps.property.password"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly password: string;
@@ -13348,7 +13348,7 @@ public readonly password: string;
 
 ##### ~~`repo`~~<sup>Required</sup> <a name="repo" id="cdktf.ArtifactoryBackendProps.property.repo"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly repo: string;
@@ -13362,7 +13362,7 @@ public readonly repo: string;
 
 ##### ~~`subpath`~~<sup>Required</sup> <a name="subpath" id="cdktf.ArtifactoryBackendProps.property.subpath"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly subpath: string;
@@ -13376,7 +13376,7 @@ public readonly subpath: string;
 
 ##### ~~`url`~~<sup>Required</sup> <a name="url" id="cdktf.ArtifactoryBackendProps.property.url"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly url: string;
@@ -13392,7 +13392,7 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ##### ~~`username`~~<sup>Required</sup> <a name="username" id="cdktf.ArtifactoryBackendProps.property.username"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly username: string;
@@ -14200,7 +14200,7 @@ const dataTerraformRemoteStateArtifactoryConfig: DataTerraformRemoteStateArtifac
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.defaults"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly defaults: {[ key: string ]: any};
@@ -14212,7 +14212,7 @@ public readonly defaults: {[ key: string ]: any};
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.workspace"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly workspace: string;
@@ -14224,7 +14224,7 @@ public readonly workspace: string;
 
 ##### ~~`password`~~<sup>Required</sup> <a name="password" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.password"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly password: string;
@@ -14238,7 +14238,7 @@ public readonly password: string;
 
 ##### ~~`repo`~~<sup>Required</sup> <a name="repo" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.repo"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly repo: string;
@@ -14252,7 +14252,7 @@ public readonly repo: string;
 
 ##### ~~`subpath`~~<sup>Required</sup> <a name="subpath" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.subpath"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly subpath: string;
@@ -14266,7 +14266,7 @@ public readonly subpath: string;
 
 ##### ~~`url`~~<sup>Required</sup> <a name="url" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.url"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly url: string;
@@ -14282,7 +14282,7 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ##### ~~`username`~~<sup>Required</sup> <a name="username" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.username"></a>
 
-- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the artifactory backend. Terraform deprecated artifactory in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly username: string;
@@ -15089,7 +15089,7 @@ const dataTerraformRemoteStateEtcdConfig: DataTerraformRemoteStateEtcdConfig = {
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.defaults"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly defaults: {[ key: string ]: any};
@@ -15101,7 +15101,7 @@ public readonly defaults: {[ key: string ]: any};
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.workspace"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly workspace: string;
@@ -15113,7 +15113,7 @@ public readonly workspace: string;
 
 ##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.endpoints"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly endpoints: string;
@@ -15127,7 +15127,7 @@ public readonly endpoints: string;
 
 ##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.path"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly path: string;
@@ -15141,7 +15141,7 @@ public readonly path: string;
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.password"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly password: string;
@@ -15155,7 +15155,7 @@ public readonly password: string;
 
 ##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.username"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly username: string;
@@ -15196,7 +15196,7 @@ const dataTerraformRemoteStateEtcdV3Config: DataTerraformRemoteStateEtcdV3Config
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.defaults"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly defaults: {[ key: string ]: any};
@@ -15208,7 +15208,7 @@ public readonly defaults: {[ key: string ]: any};
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.workspace"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly workspace: string;
@@ -15220,7 +15220,7 @@ public readonly workspace: string;
 
 ##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.endpoints"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly endpoints: string[];
@@ -15234,7 +15234,7 @@ public readonly endpoints: string[];
 
 ##### ~~`cacertPath`~~<sup>Optional</sup> <a name="cacertPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.cacertPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly cacertPath: string;
@@ -15248,7 +15248,7 @@ public readonly cacertPath: string;
 
 ##### ~~`certPath`~~<sup>Optional</sup> <a name="certPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.certPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly certPath: string;
@@ -15262,7 +15262,7 @@ public readonly certPath: string;
 
 ##### ~~`keyPath`~~<sup>Optional</sup> <a name="keyPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.keyPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly keyPath: string;
@@ -15276,7 +15276,7 @@ public readonly keyPath: string;
 
 ##### ~~`lock`~~<sup>Optional</sup> <a name="lock" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.lock"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly lock: boolean;
@@ -15292,7 +15292,7 @@ Defaults to true.
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.password"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly password: string;
@@ -15306,7 +15306,7 @@ public readonly password: string;
 
 ##### ~~`prefix`~~<sup>Optional</sup> <a name="prefix" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.prefix"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly prefix: string;
@@ -15322,7 +15322,7 @@ Defaults to "".
 
 ##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.username"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly username: string;
@@ -15786,7 +15786,7 @@ const dataTerraformRemoteStateMantaConfig: DataTerraformRemoteStateMantaConfig =
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateMantaConfig.property.defaults"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly defaults: {[ key: string ]: any};
@@ -15798,7 +15798,7 @@ public readonly defaults: {[ key: string ]: any};
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateMantaConfig.property.workspace"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly workspace: string;
@@ -15810,7 +15810,7 @@ public readonly workspace: string;
 
 ##### ~~`account`~~<sup>Required</sup> <a name="account" id="cdktf.DataTerraformRemoteStateMantaConfig.property.account"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly account: string;
@@ -15822,7 +15822,7 @@ public readonly account: string;
 
 ##### ~~`keyId`~~<sup>Required</sup> <a name="keyId" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly keyId: string;
@@ -15834,7 +15834,7 @@ public readonly keyId: string;
 
 ##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateMantaConfig.property.path"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly path: string;
@@ -15846,7 +15846,7 @@ public readonly path: string;
 
 ##### ~~`insecureSkipTlsVerify`~~<sup>Optional</sup> <a name="insecureSkipTlsVerify" id="cdktf.DataTerraformRemoteStateMantaConfig.property.insecureSkipTlsVerify"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly insecureSkipTlsVerify: boolean;
@@ -15858,7 +15858,7 @@ public readonly insecureSkipTlsVerify: boolean;
 
 ##### ~~`keyMaterial`~~<sup>Optional</sup> <a name="keyMaterial" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyMaterial"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly keyMaterial: string;
@@ -15870,7 +15870,7 @@ public readonly keyMaterial: string;
 
 ##### ~~`objectName`~~<sup>Optional</sup> <a name="objectName" id="cdktf.DataTerraformRemoteStateMantaConfig.property.objectName"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly objectName: string;
@@ -15882,7 +15882,7 @@ public readonly objectName: string;
 
 ##### ~~`url`~~<sup>Optional</sup> <a name="url" id="cdktf.DataTerraformRemoteStateMantaConfig.property.url"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly url: string;
@@ -15894,7 +15894,7 @@ public readonly url: string;
 
 ##### ~~`user`~~<sup>Optional</sup> <a name="user" id="cdktf.DataTerraformRemoteStateMantaConfig.property.user"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly user: string;
@@ -16796,7 +16796,7 @@ const dataTerraformRemoteStateSwiftConfig: DataTerraformRemoteStateSwiftConfig =
 
 ##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaults"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly defaults: {[ key: string ]: any};
@@ -16808,7 +16808,7 @@ public readonly defaults: {[ key: string ]: any};
 
 ##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.workspace"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly workspace: string;
@@ -16820,7 +16820,7 @@ public readonly workspace: string;
 
 ##### ~~`container`~~<sup>Required</sup> <a name="container" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.container"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly container: string;
@@ -16832,7 +16832,7 @@ public readonly container: string;
 
 ##### ~~`applicationCredentialId`~~<sup>Optional</sup> <a name="applicationCredentialId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly applicationCredentialId: string;
@@ -16844,7 +16844,7 @@ public readonly applicationCredentialId: string;
 
 ##### ~~`applicationCredentialName`~~<sup>Optional</sup> <a name="applicationCredentialName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly applicationCredentialName: string;
@@ -16856,7 +16856,7 @@ public readonly applicationCredentialName: string;
 
 ##### ~~`applicationCredentialSecret`~~<sup>Optional</sup> <a name="applicationCredentialSecret" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialSecret"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly applicationCredentialSecret: string;
@@ -16868,7 +16868,7 @@ public readonly applicationCredentialSecret: string;
 
 ##### ~~`archiveContainer`~~<sup>Optional</sup> <a name="archiveContainer" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.archiveContainer"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly archiveContainer: string;
@@ -16880,7 +16880,7 @@ public readonly archiveContainer: string;
 
 ##### ~~`authUrl`~~<sup>Optional</sup> <a name="authUrl" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.authUrl"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly authUrl: string;
@@ -16892,7 +16892,7 @@ public readonly authUrl: string;
 
 ##### ~~`cacertFile`~~<sup>Optional</sup> <a name="cacertFile" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cacertFile"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly cacertFile: string;
@@ -16904,7 +16904,7 @@ public readonly cacertFile: string;
 
 ##### ~~`cert`~~<sup>Optional</sup> <a name="cert" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cert"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly cert: string;
@@ -16916,7 +16916,7 @@ public readonly cert: string;
 
 ##### ~~`cloud`~~<sup>Optional</sup> <a name="cloud" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cloud"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly cloud: string;
@@ -16928,7 +16928,7 @@ public readonly cloud: string;
 
 ##### ~~`defaultDomain`~~<sup>Optional</sup> <a name="defaultDomain" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaultDomain"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly defaultDomain: string;
@@ -16940,7 +16940,7 @@ public readonly defaultDomain: string;
 
 ##### ~~`domainId`~~<sup>Optional</sup> <a name="domainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly domainId: string;
@@ -16952,7 +16952,7 @@ public readonly domainId: string;
 
 ##### ~~`domainName`~~<sup>Optional</sup> <a name="domainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly domainName: string;
@@ -16964,7 +16964,7 @@ public readonly domainName: string;
 
 ##### ~~`expireAfter`~~<sup>Optional</sup> <a name="expireAfter" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.expireAfter"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly expireAfter: string;
@@ -16976,7 +16976,7 @@ public readonly expireAfter: string;
 
 ##### ~~`insecure`~~<sup>Optional</sup> <a name="insecure" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.insecure"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly insecure: boolean;
@@ -16988,7 +16988,7 @@ public readonly insecure: boolean;
 
 ##### ~~`key`~~<sup>Optional</sup> <a name="key" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.key"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly key: string;
@@ -17000,7 +17000,7 @@ public readonly key: string;
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.password"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly password: string;
@@ -17012,7 +17012,7 @@ public readonly password: string;
 
 ##### ~~`projectDomainId`~~<sup>Optional</sup> <a name="projectDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly projectDomainId: string;
@@ -17024,7 +17024,7 @@ public readonly projectDomainId: string;
 
 ##### ~~`projectDomainName`~~<sup>Optional</sup> <a name="projectDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly projectDomainName: string;
@@ -17036,7 +17036,7 @@ public readonly projectDomainName: string;
 
 ##### ~~`regionName`~~<sup>Optional</sup> <a name="regionName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.regionName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly regionName: string;
@@ -17048,7 +17048,7 @@ public readonly regionName: string;
 
 ##### ~~`stateName`~~<sup>Optional</sup> <a name="stateName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.stateName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly stateName: string;
@@ -17060,7 +17060,7 @@ public readonly stateName: string;
 
 ##### ~~`tenantId`~~<sup>Optional</sup> <a name="tenantId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly tenantId: string;
@@ -17072,7 +17072,7 @@ public readonly tenantId: string;
 
 ##### ~~`tenantName`~~<sup>Optional</sup> <a name="tenantName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly tenantName: string;
@@ -17084,7 +17084,7 @@ public readonly tenantName: string;
 
 ##### ~~`token`~~<sup>Optional</sup> <a name="token" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.token"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly token: string;
@@ -17096,7 +17096,7 @@ public readonly token: string;
 
 ##### ~~`userDomainId`~~<sup>Optional</sup> <a name="userDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly userDomainId: string;
@@ -17108,7 +17108,7 @@ public readonly userDomainId: string;
 
 ##### ~~`userDomainName`~~<sup>Optional</sup> <a name="userDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly userDomainName: string;
@@ -17120,7 +17120,7 @@ public readonly userDomainName: string;
 
 ##### ~~`userId`~~<sup>Optional</sup> <a name="userId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly userId: string;
@@ -17132,7 +17132,7 @@ public readonly userId: string;
 
 ##### ~~`userName`~~<sup>Optional</sup> <a name="userName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly userName: string;
@@ -17205,7 +17205,7 @@ const etcdBackendProps: EtcdBackendProps = { ... }
 
 ##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdBackendProps.property.endpoints"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly endpoints: string;
@@ -17219,7 +17219,7 @@ public readonly endpoints: string;
 
 ##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.EtcdBackendProps.property.path"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly path: string;
@@ -17233,7 +17233,7 @@ public readonly path: string;
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.EtcdBackendProps.property.password"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly password: string;
@@ -17247,7 +17247,7 @@ public readonly password: string;
 
 ##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.EtcdBackendProps.property.username"></a>
 
-- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcd backend. Terraform deprecated etcd in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly username: string;
@@ -17293,7 +17293,7 @@ const etcdV3BackendProps: EtcdV3BackendProps = { ... }
 
 ##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdV3BackendProps.property.endpoints"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly endpoints: string[];
@@ -17307,7 +17307,7 @@ public readonly endpoints: string[];
 
 ##### ~~`cacertPath`~~<sup>Optional</sup> <a name="cacertPath" id="cdktf.EtcdV3BackendProps.property.cacertPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly cacertPath: string;
@@ -17321,7 +17321,7 @@ public readonly cacertPath: string;
 
 ##### ~~`certPath`~~<sup>Optional</sup> <a name="certPath" id="cdktf.EtcdV3BackendProps.property.certPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly certPath: string;
@@ -17335,7 +17335,7 @@ public readonly certPath: string;
 
 ##### ~~`keyPath`~~<sup>Optional</sup> <a name="keyPath" id="cdktf.EtcdV3BackendProps.property.keyPath"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly keyPath: string;
@@ -17349,7 +17349,7 @@ public readonly keyPath: string;
 
 ##### ~~`lock`~~<sup>Optional</sup> <a name="lock" id="cdktf.EtcdV3BackendProps.property.lock"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly lock: boolean;
@@ -17365,7 +17365,7 @@ Defaults to true.
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.EtcdV3BackendProps.property.password"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly password: string;
@@ -17379,7 +17379,7 @@ public readonly password: string;
 
 ##### ~~`prefix`~~<sup>Optional</sup> <a name="prefix" id="cdktf.EtcdV3BackendProps.property.prefix"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly prefix: string;
@@ -17395,7 +17395,7 @@ Defaults to "".
 
 ##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.EtcdV3BackendProps.property.username"></a>
 
-- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the etcdv3 backend. Terraform deprecated etcdv3 in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly username: string;
@@ -18160,7 +18160,7 @@ const mantaBackendProps: MantaBackendProps = { ... }
 
 ##### ~~`account`~~<sup>Required</sup> <a name="account" id="cdktf.MantaBackendProps.property.account"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly account: string;
@@ -18172,7 +18172,7 @@ public readonly account: string;
 
 ##### ~~`keyId`~~<sup>Required</sup> <a name="keyId" id="cdktf.MantaBackendProps.property.keyId"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly keyId: string;
@@ -18184,7 +18184,7 @@ public readonly keyId: string;
 
 ##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.MantaBackendProps.property.path"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly path: string;
@@ -18196,7 +18196,7 @@ public readonly path: string;
 
 ##### ~~`insecureSkipTlsVerify`~~<sup>Optional</sup> <a name="insecureSkipTlsVerify" id="cdktf.MantaBackendProps.property.insecureSkipTlsVerify"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly insecureSkipTlsVerify: boolean;
@@ -18208,7 +18208,7 @@ public readonly insecureSkipTlsVerify: boolean;
 
 ##### ~~`keyMaterial`~~<sup>Optional</sup> <a name="keyMaterial" id="cdktf.MantaBackendProps.property.keyMaterial"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly keyMaterial: string;
@@ -18220,7 +18220,7 @@ public readonly keyMaterial: string;
 
 ##### ~~`objectName`~~<sup>Optional</sup> <a name="objectName" id="cdktf.MantaBackendProps.property.objectName"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly objectName: string;
@@ -18232,7 +18232,7 @@ public readonly objectName: string;
 
 ##### ~~`url`~~<sup>Optional</sup> <a name="url" id="cdktf.MantaBackendProps.property.url"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly url: string;
@@ -18244,7 +18244,7 @@ public readonly url: string;
 
 ##### ~~`user`~~<sup>Optional</sup> <a name="user" id="cdktf.MantaBackendProps.property.user"></a>
 
-- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the manta backend. Terraform deprecated manta in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly user: string;
@@ -19821,7 +19821,7 @@ const swiftBackendProps: SwiftBackendProps = { ... }
 
 ##### ~~`container`~~<sup>Required</sup> <a name="container" id="cdktf.SwiftBackendProps.property.container"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly container: string;
@@ -19833,7 +19833,7 @@ public readonly container: string;
 
 ##### ~~`applicationCredentialId`~~<sup>Optional</sup> <a name="applicationCredentialId" id="cdktf.SwiftBackendProps.property.applicationCredentialId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly applicationCredentialId: string;
@@ -19845,7 +19845,7 @@ public readonly applicationCredentialId: string;
 
 ##### ~~`applicationCredentialName`~~<sup>Optional</sup> <a name="applicationCredentialName" id="cdktf.SwiftBackendProps.property.applicationCredentialName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly applicationCredentialName: string;
@@ -19857,7 +19857,7 @@ public readonly applicationCredentialName: string;
 
 ##### ~~`applicationCredentialSecret`~~<sup>Optional</sup> <a name="applicationCredentialSecret" id="cdktf.SwiftBackendProps.property.applicationCredentialSecret"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly applicationCredentialSecret: string;
@@ -19869,7 +19869,7 @@ public readonly applicationCredentialSecret: string;
 
 ##### ~~`archiveContainer`~~<sup>Optional</sup> <a name="archiveContainer" id="cdktf.SwiftBackendProps.property.archiveContainer"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly archiveContainer: string;
@@ -19881,7 +19881,7 @@ public readonly archiveContainer: string;
 
 ##### ~~`authUrl`~~<sup>Optional</sup> <a name="authUrl" id="cdktf.SwiftBackendProps.property.authUrl"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly authUrl: string;
@@ -19893,7 +19893,7 @@ public readonly authUrl: string;
 
 ##### ~~`cacertFile`~~<sup>Optional</sup> <a name="cacertFile" id="cdktf.SwiftBackendProps.property.cacertFile"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly cacertFile: string;
@@ -19905,7 +19905,7 @@ public readonly cacertFile: string;
 
 ##### ~~`cert`~~<sup>Optional</sup> <a name="cert" id="cdktf.SwiftBackendProps.property.cert"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly cert: string;
@@ -19917,7 +19917,7 @@ public readonly cert: string;
 
 ##### ~~`cloud`~~<sup>Optional</sup> <a name="cloud" id="cdktf.SwiftBackendProps.property.cloud"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly cloud: string;
@@ -19929,7 +19929,7 @@ public readonly cloud: string;
 
 ##### ~~`defaultDomain`~~<sup>Optional</sup> <a name="defaultDomain" id="cdktf.SwiftBackendProps.property.defaultDomain"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly defaultDomain: string;
@@ -19941,7 +19941,7 @@ public readonly defaultDomain: string;
 
 ##### ~~`domainId`~~<sup>Optional</sup> <a name="domainId" id="cdktf.SwiftBackendProps.property.domainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly domainId: string;
@@ -19953,7 +19953,7 @@ public readonly domainId: string;
 
 ##### ~~`domainName`~~<sup>Optional</sup> <a name="domainName" id="cdktf.SwiftBackendProps.property.domainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly domainName: string;
@@ -19965,7 +19965,7 @@ public readonly domainName: string;
 
 ##### ~~`expireAfter`~~<sup>Optional</sup> <a name="expireAfter" id="cdktf.SwiftBackendProps.property.expireAfter"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly expireAfter: string;
@@ -19977,7 +19977,7 @@ public readonly expireAfter: string;
 
 ##### ~~`insecure`~~<sup>Optional</sup> <a name="insecure" id="cdktf.SwiftBackendProps.property.insecure"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly insecure: boolean;
@@ -19989,7 +19989,7 @@ public readonly insecure: boolean;
 
 ##### ~~`key`~~<sup>Optional</sup> <a name="key" id="cdktf.SwiftBackendProps.property.key"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly key: string;
@@ -20001,7 +20001,7 @@ public readonly key: string;
 
 ##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.SwiftBackendProps.property.password"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly password: string;
@@ -20013,7 +20013,7 @@ public readonly password: string;
 
 ##### ~~`projectDomainId`~~<sup>Optional</sup> <a name="projectDomainId" id="cdktf.SwiftBackendProps.property.projectDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly projectDomainId: string;
@@ -20025,7 +20025,7 @@ public readonly projectDomainId: string;
 
 ##### ~~`projectDomainName`~~<sup>Optional</sup> <a name="projectDomainName" id="cdktf.SwiftBackendProps.property.projectDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly projectDomainName: string;
@@ -20037,7 +20037,7 @@ public readonly projectDomainName: string;
 
 ##### ~~`regionName`~~<sup>Optional</sup> <a name="regionName" id="cdktf.SwiftBackendProps.property.regionName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly regionName: string;
@@ -20049,7 +20049,7 @@ public readonly regionName: string;
 
 ##### ~~`stateName`~~<sup>Optional</sup> <a name="stateName" id="cdktf.SwiftBackendProps.property.stateName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly stateName: string;
@@ -20061,7 +20061,7 @@ public readonly stateName: string;
 
 ##### ~~`tenantId`~~<sup>Optional</sup> <a name="tenantId" id="cdktf.SwiftBackendProps.property.tenantId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly tenantId: string;
@@ -20073,7 +20073,7 @@ public readonly tenantId: string;
 
 ##### ~~`tenantName`~~<sup>Optional</sup> <a name="tenantName" id="cdktf.SwiftBackendProps.property.tenantName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly tenantName: string;
@@ -20085,7 +20085,7 @@ public readonly tenantName: string;
 
 ##### ~~`token`~~<sup>Optional</sup> <a name="token" id="cdktf.SwiftBackendProps.property.token"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly token: string;
@@ -20097,7 +20097,7 @@ public readonly token: string;
 
 ##### ~~`userDomainId`~~<sup>Optional</sup> <a name="userDomainId" id="cdktf.SwiftBackendProps.property.userDomainId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly userDomainId: string;
@@ -20109,7 +20109,7 @@ public readonly userDomainId: string;
 
 ##### ~~`userDomainName`~~<sup>Optional</sup> <a name="userDomainName" id="cdktf.SwiftBackendProps.property.userDomainName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly userDomainName: string;
@@ -20121,7 +20121,7 @@ public readonly userDomainName: string;
 
 ##### ~~`userId`~~<sup>Optional</sup> <a name="userId" id="cdktf.SwiftBackendProps.property.userId"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly userId: string;
@@ -20133,7 +20133,7 @@ public readonly userId: string;
 
 ##### ~~`userName`~~<sup>Optional</sup> <a name="userName" id="cdktf.SwiftBackendProps.property.userName"></a>
 
-- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
+- _Deprecated:_ CDK for Terraform no longer supports the swift backend. Terraform deprecated swift in v1.2.3 and removed it in v1.3.
 
 ```typescript
 public readonly userName: string;

--- a/website/docs/cdktf/api-reference/typescript.mdx
+++ b/website/docs/cdktf/api-reference/typescript.mdx
@@ -273,7 +273,7 @@ new ArtifactoryBackend(scope: Construct, props: ArtifactoryBackendProps)
 
 ---
 
-##### `toString` <a name="toString" id="cdktf.ArtifactoryBackend.toString"></a>
+##### ~~`toString`~~ <a name="toString" id="cdktf.ArtifactoryBackend.toString"></a>
 
 ```typescript
 public toString(): string
@@ -281,7 +281,7 @@ public toString(): string
 
 Returns a string representation of this construct.
 
-##### `addOverride` <a name="addOverride" id="cdktf.ArtifactoryBackend.addOverride"></a>
+##### ~~`addOverride`~~ <a name="addOverride" id="cdktf.ArtifactoryBackend.addOverride"></a>
 
 ```typescript
 public addOverride(path: string, value: any): void
@@ -299,7 +299,7 @@ public addOverride(path: string, value: any): void
 
 ---
 
-##### `overrideLogicalId` <a name="overrideLogicalId" id="cdktf.ArtifactoryBackend.overrideLogicalId"></a>
+##### ~~`overrideLogicalId`~~ <a name="overrideLogicalId" id="cdktf.ArtifactoryBackend.overrideLogicalId"></a>
 
 ```typescript
 public overrideLogicalId(newLogicalId: string): void
@@ -315,7 +315,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `resetOverrideLogicalId` <a name="resetOverrideLogicalId" id="cdktf.ArtifactoryBackend.resetOverrideLogicalId"></a>
+##### ~~`resetOverrideLogicalId`~~ <a name="resetOverrideLogicalId" id="cdktf.ArtifactoryBackend.resetOverrideLogicalId"></a>
 
 ```typescript
 public resetOverrideLogicalId(): void
@@ -323,13 +323,13 @@ public resetOverrideLogicalId(): void
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `toMetadata` <a name="toMetadata" id="cdktf.ArtifactoryBackend.toMetadata"></a>
+##### ~~`toMetadata`~~ <a name="toMetadata" id="cdktf.ArtifactoryBackend.toMetadata"></a>
 
 ```typescript
 public toMetadata(): any
 ```
 
-##### `toTerraform` <a name="toTerraform" id="cdktf.ArtifactoryBackend.toTerraform"></a>
+##### ~~`toTerraform`~~ <a name="toTerraform" id="cdktf.ArtifactoryBackend.toTerraform"></a>
 
 ```typescript
 public toTerraform(): any
@@ -337,7 +337,7 @@ public toTerraform(): any
 
 Adds this resource to the terraform JSON output.
 
-##### `getRemoteStateDataSource` <a name="getRemoteStateDataSource" id="cdktf.ArtifactoryBackend.getRemoteStateDataSource"></a>
+##### ~~`getRemoteStateDataSource`~~ <a name="getRemoteStateDataSource" id="cdktf.ArtifactoryBackend.getRemoteStateDataSource"></a>
 
 ```typescript
 public getRemoteStateDataSource(scope: Construct, name: string, _fromStack: string): TerraformRemoteState
@@ -373,7 +373,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdktf.ArtifactoryBackend.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdktf.ArtifactoryBackend.isConstruct"></a>
 
 ```typescript
 import { ArtifactoryBackend } from 'cdktf'
@@ -405,7 +405,7 @@ Any object.
 
 ---
 
-##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.ArtifactoryBackend.isTerraformElement"></a>
+##### ~~`isTerraformElement`~~ <a name="isTerraformElement" id="cdktf.ArtifactoryBackend.isTerraformElement"></a>
 
 ```typescript
 import { ArtifactoryBackend } from 'cdktf'
@@ -419,7 +419,7 @@ ArtifactoryBackend.isTerraformElement(x: any)
 
 ---
 
-##### `isBackend` <a name="isBackend" id="cdktf.ArtifactoryBackend.isBackend"></a>
+##### ~~`isBackend`~~ <a name="isBackend" id="cdktf.ArtifactoryBackend.isBackend"></a>
 
 ```typescript
 import { ArtifactoryBackend } from 'cdktf'
@@ -444,7 +444,9 @@ ArtifactoryBackend.isBackend(x: any)
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.ArtifactoryBackend.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.ArtifactoryBackend.property.node"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly node: Node;
@@ -456,7 +458,9 @@ The tree node.
 
 ---
 
-##### `cdktfStack`<sup>Required</sup> <a name="cdktfStack" id="cdktf.ArtifactoryBackend.property.cdktfStack"></a>
+##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.ArtifactoryBackend.property.cdktfStack"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly cdktfStack: TerraformStack;
@@ -466,7 +470,9 @@ public readonly cdktfStack: TerraformStack;
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.ArtifactoryBackend.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.ArtifactoryBackend.property.fqn"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly fqn: string;
@@ -476,7 +482,9 @@ public readonly fqn: string;
 
 ---
 
-##### `friendlyUniqueId`<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.ArtifactoryBackend.property.friendlyUniqueId"></a>
+##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.ArtifactoryBackend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly friendlyUniqueId: string;
@@ -1870,7 +1878,7 @@ new DataTerraformRemoteStateArtifactory(scope: Construct, id: string, config: Da
 
 ---
 
-##### `toString` <a name="toString" id="cdktf.DataTerraformRemoteStateArtifactory.toString"></a>
+##### ~~`toString`~~ <a name="toString" id="cdktf.DataTerraformRemoteStateArtifactory.toString"></a>
 
 ```typescript
 public toString(): string
@@ -1878,7 +1886,7 @@ public toString(): string
 
 Returns a string representation of this construct.
 
-##### `addOverride` <a name="addOverride" id="cdktf.DataTerraformRemoteStateArtifactory.addOverride"></a>
+##### ~~`addOverride`~~ <a name="addOverride" id="cdktf.DataTerraformRemoteStateArtifactory.addOverride"></a>
 
 ```typescript
 public addOverride(path: string, value: any): void
@@ -1896,7 +1904,7 @@ public addOverride(path: string, value: any): void
 
 ---
 
-##### `overrideLogicalId` <a name="overrideLogicalId" id="cdktf.DataTerraformRemoteStateArtifactory.overrideLogicalId"></a>
+##### ~~`overrideLogicalId`~~ <a name="overrideLogicalId" id="cdktf.DataTerraformRemoteStateArtifactory.overrideLogicalId"></a>
 
 ```typescript
 public overrideLogicalId(newLogicalId: string): void
@@ -1912,7 +1920,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `resetOverrideLogicalId` <a name="resetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateArtifactory.resetOverrideLogicalId"></a>
+##### ~~`resetOverrideLogicalId`~~ <a name="resetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateArtifactory.resetOverrideLogicalId"></a>
 
 ```typescript
 public resetOverrideLogicalId(): void
@@ -1920,13 +1928,13 @@ public resetOverrideLogicalId(): void
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `toMetadata` <a name="toMetadata" id="cdktf.DataTerraformRemoteStateArtifactory.toMetadata"></a>
+##### ~~`toMetadata`~~ <a name="toMetadata" id="cdktf.DataTerraformRemoteStateArtifactory.toMetadata"></a>
 
 ```typescript
 public toMetadata(): any
 ```
 
-##### `toTerraform` <a name="toTerraform" id="cdktf.DataTerraformRemoteStateArtifactory.toTerraform"></a>
+##### ~~`toTerraform`~~ <a name="toTerraform" id="cdktf.DataTerraformRemoteStateArtifactory.toTerraform"></a>
 
 ```typescript
 public toTerraform(): any
@@ -1934,7 +1942,7 @@ public toTerraform(): any
 
 Adds this resource to the terraform JSON output.
 
-##### `get` <a name="get" id="cdktf.DataTerraformRemoteStateArtifactory.get"></a>
+##### ~~`get`~~ <a name="get" id="cdktf.DataTerraformRemoteStateArtifactory.get"></a>
 
 ```typescript
 public get(output: string): IResolvable
@@ -1946,7 +1954,7 @@ public get(output: string): IResolvable
 
 ---
 
-##### `getBoolean` <a name="getBoolean" id="cdktf.DataTerraformRemoteStateArtifactory.getBoolean"></a>
+##### ~~`getBoolean`~~ <a name="getBoolean" id="cdktf.DataTerraformRemoteStateArtifactory.getBoolean"></a>
 
 ```typescript
 public getBoolean(output: string): IResolvable
@@ -1958,7 +1966,7 @@ public getBoolean(output: string): IResolvable
 
 ---
 
-##### `getList` <a name="getList" id="cdktf.DataTerraformRemoteStateArtifactory.getList"></a>
+##### ~~`getList`~~ <a name="getList" id="cdktf.DataTerraformRemoteStateArtifactory.getList"></a>
 
 ```typescript
 public getList(output: string): string[]
@@ -1970,7 +1978,7 @@ public getList(output: string): string[]
 
 ---
 
-##### `getNumber` <a name="getNumber" id="cdktf.DataTerraformRemoteStateArtifactory.getNumber"></a>
+##### ~~`getNumber`~~ <a name="getNumber" id="cdktf.DataTerraformRemoteStateArtifactory.getNumber"></a>
 
 ```typescript
 public getNumber(output: string): number
@@ -1982,7 +1990,7 @@ public getNumber(output: string): number
 
 ---
 
-##### `getString` <a name="getString" id="cdktf.DataTerraformRemoteStateArtifactory.getString"></a>
+##### ~~`getString`~~ <a name="getString" id="cdktf.DataTerraformRemoteStateArtifactory.getString"></a>
 
 ```typescript
 public getString(output: string): string
@@ -2003,7 +2011,7 @@ public getString(output: string): string
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdktf.DataTerraformRemoteStateArtifactory.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdktf.DataTerraformRemoteStateArtifactory.isConstruct"></a>
 
 ```typescript
 import { DataTerraformRemoteStateArtifactory } from 'cdktf'
@@ -2035,7 +2043,7 @@ Any object.
 
 ---
 
-##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement"></a>
+##### ~~`isTerraformElement`~~ <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateArtifactory.isTerraformElement"></a>
 
 ```typescript
 import { DataTerraformRemoteStateArtifactory } from 'cdktf'
@@ -2060,7 +2068,9 @@ DataTerraformRemoteStateArtifactory.isTerraformElement(x: any)
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateArtifactory.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateArtifactory.property.node"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly node: Node;
@@ -2072,7 +2082,9 @@ The tree node.
 
 ---
 
-##### `cdktfStack`<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateArtifactory.property.cdktfStack"></a>
+##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateArtifactory.property.cdktfStack"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly cdktfStack: TerraformStack;
@@ -2082,7 +2094,9 @@ public readonly cdktfStack: TerraformStack;
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateArtifactory.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateArtifactory.property.fqn"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly fqn: string;
@@ -2092,7 +2106,9 @@ public readonly fqn: string;
 
 ---
 
-##### `friendlyUniqueId`<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateArtifactory.property.friendlyUniqueId"></a>
+##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateArtifactory.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly friendlyUniqueId: string;
@@ -2110,7 +2126,9 @@ public readonly friendlyUniqueId: string;
 
 ---
 
-##### `tfResourceType`<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateArtifactory.property.tfResourceType"></a>
+##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateArtifactory.property.tfResourceType"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly tfResourceType: string;
@@ -3086,7 +3104,7 @@ new DataTerraformRemoteStateEtcd(scope: Construct, id: string, config: DataTerra
 
 ---
 
-##### `toString` <a name="toString" id="cdktf.DataTerraformRemoteStateEtcd.toString"></a>
+##### ~~`toString`~~ <a name="toString" id="cdktf.DataTerraformRemoteStateEtcd.toString"></a>
 
 ```typescript
 public toString(): string
@@ -3094,7 +3112,7 @@ public toString(): string
 
 Returns a string representation of this construct.
 
-##### `addOverride` <a name="addOverride" id="cdktf.DataTerraformRemoteStateEtcd.addOverride"></a>
+##### ~~`addOverride`~~ <a name="addOverride" id="cdktf.DataTerraformRemoteStateEtcd.addOverride"></a>
 
 ```typescript
 public addOverride(path: string, value: any): void
@@ -3112,7 +3130,7 @@ public addOverride(path: string, value: any): void
 
 ---
 
-##### `overrideLogicalId` <a name="overrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcd.overrideLogicalId"></a>
+##### ~~`overrideLogicalId`~~ <a name="overrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcd.overrideLogicalId"></a>
 
 ```typescript
 public overrideLogicalId(newLogicalId: string): void
@@ -3128,7 +3146,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `resetOverrideLogicalId` <a name="resetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcd.resetOverrideLogicalId"></a>
+##### ~~`resetOverrideLogicalId`~~ <a name="resetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcd.resetOverrideLogicalId"></a>
 
 ```typescript
 public resetOverrideLogicalId(): void
@@ -3136,13 +3154,13 @@ public resetOverrideLogicalId(): void
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `toMetadata` <a name="toMetadata" id="cdktf.DataTerraformRemoteStateEtcd.toMetadata"></a>
+##### ~~`toMetadata`~~ <a name="toMetadata" id="cdktf.DataTerraformRemoteStateEtcd.toMetadata"></a>
 
 ```typescript
 public toMetadata(): any
 ```
 
-##### `toTerraform` <a name="toTerraform" id="cdktf.DataTerraformRemoteStateEtcd.toTerraform"></a>
+##### ~~`toTerraform`~~ <a name="toTerraform" id="cdktf.DataTerraformRemoteStateEtcd.toTerraform"></a>
 
 ```typescript
 public toTerraform(): any
@@ -3150,7 +3168,7 @@ public toTerraform(): any
 
 Adds this resource to the terraform JSON output.
 
-##### `get` <a name="get" id="cdktf.DataTerraformRemoteStateEtcd.get"></a>
+##### ~~`get`~~ <a name="get" id="cdktf.DataTerraformRemoteStateEtcd.get"></a>
 
 ```typescript
 public get(output: string): IResolvable
@@ -3162,7 +3180,7 @@ public get(output: string): IResolvable
 
 ---
 
-##### `getBoolean` <a name="getBoolean" id="cdktf.DataTerraformRemoteStateEtcd.getBoolean"></a>
+##### ~~`getBoolean`~~ <a name="getBoolean" id="cdktf.DataTerraformRemoteStateEtcd.getBoolean"></a>
 
 ```typescript
 public getBoolean(output: string): IResolvable
@@ -3174,7 +3192,7 @@ public getBoolean(output: string): IResolvable
 
 ---
 
-##### `getList` <a name="getList" id="cdktf.DataTerraformRemoteStateEtcd.getList"></a>
+##### ~~`getList`~~ <a name="getList" id="cdktf.DataTerraformRemoteStateEtcd.getList"></a>
 
 ```typescript
 public getList(output: string): string[]
@@ -3186,7 +3204,7 @@ public getList(output: string): string[]
 
 ---
 
-##### `getNumber` <a name="getNumber" id="cdktf.DataTerraformRemoteStateEtcd.getNumber"></a>
+##### ~~`getNumber`~~ <a name="getNumber" id="cdktf.DataTerraformRemoteStateEtcd.getNumber"></a>
 
 ```typescript
 public getNumber(output: string): number
@@ -3198,7 +3216,7 @@ public getNumber(output: string): number
 
 ---
 
-##### `getString` <a name="getString" id="cdktf.DataTerraformRemoteStateEtcd.getString"></a>
+##### ~~`getString`~~ <a name="getString" id="cdktf.DataTerraformRemoteStateEtcd.getString"></a>
 
 ```typescript
 public getString(output: string): string
@@ -3219,7 +3237,7 @@ public getString(output: string): string
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdktf.DataTerraformRemoteStateEtcd.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdktf.DataTerraformRemoteStateEtcd.isConstruct"></a>
 
 ```typescript
 import { DataTerraformRemoteStateEtcd } from 'cdktf'
@@ -3251,7 +3269,7 @@ Any object.
 
 ---
 
-##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateEtcd.isTerraformElement"></a>
+##### ~~`isTerraformElement`~~ <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateEtcd.isTerraformElement"></a>
 
 ```typescript
 import { DataTerraformRemoteStateEtcd } from 'cdktf'
@@ -3276,7 +3294,9 @@ DataTerraformRemoteStateEtcd.isTerraformElement(x: any)
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateEtcd.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateEtcd.property.node"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly node: Node;
@@ -3288,7 +3308,9 @@ The tree node.
 
 ---
 
-##### `cdktfStack`<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateEtcd.property.cdktfStack"></a>
+##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateEtcd.property.cdktfStack"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly cdktfStack: TerraformStack;
@@ -3298,7 +3320,9 @@ public readonly cdktfStack: TerraformStack;
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateEtcd.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateEtcd.property.fqn"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly fqn: string;
@@ -3308,7 +3332,9 @@ public readonly fqn: string;
 
 ---
 
-##### `friendlyUniqueId`<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcd.property.friendlyUniqueId"></a>
+##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcd.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly friendlyUniqueId: string;
@@ -3326,7 +3352,9 @@ public readonly friendlyUniqueId: string;
 
 ---
 
-##### `tfResourceType`<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateEtcd.property.tfResourceType"></a>
+##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateEtcd.property.tfResourceType"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly tfResourceType: string;
@@ -3390,7 +3418,7 @@ new DataTerraformRemoteStateEtcdV3(scope: Construct, id: string, config: DataTer
 
 ---
 
-##### `toString` <a name="toString" id="cdktf.DataTerraformRemoteStateEtcdV3.toString"></a>
+##### ~~`toString`~~ <a name="toString" id="cdktf.DataTerraformRemoteStateEtcdV3.toString"></a>
 
 ```typescript
 public toString(): string
@@ -3398,7 +3426,7 @@ public toString(): string
 
 Returns a string representation of this construct.
 
-##### `addOverride` <a name="addOverride" id="cdktf.DataTerraformRemoteStateEtcdV3.addOverride"></a>
+##### ~~`addOverride`~~ <a name="addOverride" id="cdktf.DataTerraformRemoteStateEtcdV3.addOverride"></a>
 
 ```typescript
 public addOverride(path: string, value: any): void
@@ -3416,7 +3444,7 @@ public addOverride(path: string, value: any): void
 
 ---
 
-##### `overrideLogicalId` <a name="overrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcdV3.overrideLogicalId"></a>
+##### ~~`overrideLogicalId`~~ <a name="overrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcdV3.overrideLogicalId"></a>
 
 ```typescript
 public overrideLogicalId(newLogicalId: string): void
@@ -3432,7 +3460,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `resetOverrideLogicalId` <a name="resetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcdV3.resetOverrideLogicalId"></a>
+##### ~~`resetOverrideLogicalId`~~ <a name="resetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateEtcdV3.resetOverrideLogicalId"></a>
 
 ```typescript
 public resetOverrideLogicalId(): void
@@ -3440,13 +3468,13 @@ public resetOverrideLogicalId(): void
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `toMetadata` <a name="toMetadata" id="cdktf.DataTerraformRemoteStateEtcdV3.toMetadata"></a>
+##### ~~`toMetadata`~~ <a name="toMetadata" id="cdktf.DataTerraformRemoteStateEtcdV3.toMetadata"></a>
 
 ```typescript
 public toMetadata(): any
 ```
 
-##### `toTerraform` <a name="toTerraform" id="cdktf.DataTerraformRemoteStateEtcdV3.toTerraform"></a>
+##### ~~`toTerraform`~~ <a name="toTerraform" id="cdktf.DataTerraformRemoteStateEtcdV3.toTerraform"></a>
 
 ```typescript
 public toTerraform(): any
@@ -3454,7 +3482,7 @@ public toTerraform(): any
 
 Adds this resource to the terraform JSON output.
 
-##### `get` <a name="get" id="cdktf.DataTerraformRemoteStateEtcdV3.get"></a>
+##### ~~`get`~~ <a name="get" id="cdktf.DataTerraformRemoteStateEtcdV3.get"></a>
 
 ```typescript
 public get(output: string): IResolvable
@@ -3466,7 +3494,7 @@ public get(output: string): IResolvable
 
 ---
 
-##### `getBoolean` <a name="getBoolean" id="cdktf.DataTerraformRemoteStateEtcdV3.getBoolean"></a>
+##### ~~`getBoolean`~~ <a name="getBoolean" id="cdktf.DataTerraformRemoteStateEtcdV3.getBoolean"></a>
 
 ```typescript
 public getBoolean(output: string): IResolvable
@@ -3478,7 +3506,7 @@ public getBoolean(output: string): IResolvable
 
 ---
 
-##### `getList` <a name="getList" id="cdktf.DataTerraformRemoteStateEtcdV3.getList"></a>
+##### ~~`getList`~~ <a name="getList" id="cdktf.DataTerraformRemoteStateEtcdV3.getList"></a>
 
 ```typescript
 public getList(output: string): string[]
@@ -3490,7 +3518,7 @@ public getList(output: string): string[]
 
 ---
 
-##### `getNumber` <a name="getNumber" id="cdktf.DataTerraformRemoteStateEtcdV3.getNumber"></a>
+##### ~~`getNumber`~~ <a name="getNumber" id="cdktf.DataTerraformRemoteStateEtcdV3.getNumber"></a>
 
 ```typescript
 public getNumber(output: string): number
@@ -3502,7 +3530,7 @@ public getNumber(output: string): number
 
 ---
 
-##### `getString` <a name="getString" id="cdktf.DataTerraformRemoteStateEtcdV3.getString"></a>
+##### ~~`getString`~~ <a name="getString" id="cdktf.DataTerraformRemoteStateEtcdV3.getString"></a>
 
 ```typescript
 public getString(output: string): string
@@ -3523,7 +3551,7 @@ public getString(output: string): string
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdktf.DataTerraformRemoteStateEtcdV3.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdktf.DataTerraformRemoteStateEtcdV3.isConstruct"></a>
 
 ```typescript
 import { DataTerraformRemoteStateEtcdV3 } from 'cdktf'
@@ -3555,7 +3583,7 @@ Any object.
 
 ---
 
-##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement"></a>
+##### ~~`isTerraformElement`~~ <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateEtcdV3.isTerraformElement"></a>
 
 ```typescript
 import { DataTerraformRemoteStateEtcdV3 } from 'cdktf'
@@ -3580,7 +3608,9 @@ DataTerraformRemoteStateEtcdV3.isTerraformElement(x: any)
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateEtcdV3.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateEtcdV3.property.node"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly node: Node;
@@ -3592,7 +3622,9 @@ The tree node.
 
 ---
 
-##### `cdktfStack`<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateEtcdV3.property.cdktfStack"></a>
+##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateEtcdV3.property.cdktfStack"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly cdktfStack: TerraformStack;
@@ -3602,7 +3634,9 @@ public readonly cdktfStack: TerraformStack;
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateEtcdV3.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateEtcdV3.property.fqn"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly fqn: string;
@@ -3612,7 +3646,9 @@ public readonly fqn: string;
 
 ---
 
-##### `friendlyUniqueId`<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcdV3.property.friendlyUniqueId"></a>
+##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateEtcdV3.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly friendlyUniqueId: string;
@@ -3630,7 +3666,9 @@ public readonly friendlyUniqueId: string;
 
 ---
 
-##### `tfResourceType`<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateEtcdV3.property.tfResourceType"></a>
+##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateEtcdV3.property.tfResourceType"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly tfResourceType: string;
@@ -4606,7 +4644,7 @@ new DataTerraformRemoteStateManta(scope: Construct, id: string, config: DataTerr
 
 ---
 
-##### `toString` <a name="toString" id="cdktf.DataTerraformRemoteStateManta.toString"></a>
+##### ~~`toString`~~ <a name="toString" id="cdktf.DataTerraformRemoteStateManta.toString"></a>
 
 ```typescript
 public toString(): string
@@ -4614,7 +4652,7 @@ public toString(): string
 
 Returns a string representation of this construct.
 
-##### `addOverride` <a name="addOverride" id="cdktf.DataTerraformRemoteStateManta.addOverride"></a>
+##### ~~`addOverride`~~ <a name="addOverride" id="cdktf.DataTerraformRemoteStateManta.addOverride"></a>
 
 ```typescript
 public addOverride(path: string, value: any): void
@@ -4632,7 +4670,7 @@ public addOverride(path: string, value: any): void
 
 ---
 
-##### `overrideLogicalId` <a name="overrideLogicalId" id="cdktf.DataTerraformRemoteStateManta.overrideLogicalId"></a>
+##### ~~`overrideLogicalId`~~ <a name="overrideLogicalId" id="cdktf.DataTerraformRemoteStateManta.overrideLogicalId"></a>
 
 ```typescript
 public overrideLogicalId(newLogicalId: string): void
@@ -4648,7 +4686,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `resetOverrideLogicalId` <a name="resetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateManta.resetOverrideLogicalId"></a>
+##### ~~`resetOverrideLogicalId`~~ <a name="resetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateManta.resetOverrideLogicalId"></a>
 
 ```typescript
 public resetOverrideLogicalId(): void
@@ -4656,13 +4694,13 @@ public resetOverrideLogicalId(): void
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `toMetadata` <a name="toMetadata" id="cdktf.DataTerraformRemoteStateManta.toMetadata"></a>
+##### ~~`toMetadata`~~ <a name="toMetadata" id="cdktf.DataTerraformRemoteStateManta.toMetadata"></a>
 
 ```typescript
 public toMetadata(): any
 ```
 
-##### `toTerraform` <a name="toTerraform" id="cdktf.DataTerraformRemoteStateManta.toTerraform"></a>
+##### ~~`toTerraform`~~ <a name="toTerraform" id="cdktf.DataTerraformRemoteStateManta.toTerraform"></a>
 
 ```typescript
 public toTerraform(): any
@@ -4670,7 +4708,7 @@ public toTerraform(): any
 
 Adds this resource to the terraform JSON output.
 
-##### `get` <a name="get" id="cdktf.DataTerraformRemoteStateManta.get"></a>
+##### ~~`get`~~ <a name="get" id="cdktf.DataTerraformRemoteStateManta.get"></a>
 
 ```typescript
 public get(output: string): IResolvable
@@ -4682,7 +4720,7 @@ public get(output: string): IResolvable
 
 ---
 
-##### `getBoolean` <a name="getBoolean" id="cdktf.DataTerraformRemoteStateManta.getBoolean"></a>
+##### ~~`getBoolean`~~ <a name="getBoolean" id="cdktf.DataTerraformRemoteStateManta.getBoolean"></a>
 
 ```typescript
 public getBoolean(output: string): IResolvable
@@ -4694,7 +4732,7 @@ public getBoolean(output: string): IResolvable
 
 ---
 
-##### `getList` <a name="getList" id="cdktf.DataTerraformRemoteStateManta.getList"></a>
+##### ~~`getList`~~ <a name="getList" id="cdktf.DataTerraformRemoteStateManta.getList"></a>
 
 ```typescript
 public getList(output: string): string[]
@@ -4706,7 +4744,7 @@ public getList(output: string): string[]
 
 ---
 
-##### `getNumber` <a name="getNumber" id="cdktf.DataTerraformRemoteStateManta.getNumber"></a>
+##### ~~`getNumber`~~ <a name="getNumber" id="cdktf.DataTerraformRemoteStateManta.getNumber"></a>
 
 ```typescript
 public getNumber(output: string): number
@@ -4718,7 +4756,7 @@ public getNumber(output: string): number
 
 ---
 
-##### `getString` <a name="getString" id="cdktf.DataTerraformRemoteStateManta.getString"></a>
+##### ~~`getString`~~ <a name="getString" id="cdktf.DataTerraformRemoteStateManta.getString"></a>
 
 ```typescript
 public getString(output: string): string
@@ -4739,7 +4777,7 @@ public getString(output: string): string
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdktf.DataTerraformRemoteStateManta.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdktf.DataTerraformRemoteStateManta.isConstruct"></a>
 
 ```typescript
 import { DataTerraformRemoteStateManta } from 'cdktf'
@@ -4771,7 +4809,7 @@ Any object.
 
 ---
 
-##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateManta.isTerraformElement"></a>
+##### ~~`isTerraformElement`~~ <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateManta.isTerraformElement"></a>
 
 ```typescript
 import { DataTerraformRemoteStateManta } from 'cdktf'
@@ -4796,7 +4834,9 @@ DataTerraformRemoteStateManta.isTerraformElement(x: any)
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateManta.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateManta.property.node"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly node: Node;
@@ -4808,7 +4848,9 @@ The tree node.
 
 ---
 
-##### `cdktfStack`<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateManta.property.cdktfStack"></a>
+##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateManta.property.cdktfStack"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly cdktfStack: TerraformStack;
@@ -4818,7 +4860,9 @@ public readonly cdktfStack: TerraformStack;
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateManta.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateManta.property.fqn"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly fqn: string;
@@ -4828,7 +4872,9 @@ public readonly fqn: string;
 
 ---
 
-##### `friendlyUniqueId`<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateManta.property.friendlyUniqueId"></a>
+##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateManta.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly friendlyUniqueId: string;
@@ -4846,7 +4892,9 @@ public readonly friendlyUniqueId: string;
 
 ---
 
-##### `tfResourceType`<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateManta.property.tfResourceType"></a>
+##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateManta.property.tfResourceType"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly tfResourceType: string;
@@ -5822,7 +5870,7 @@ new DataTerraformRemoteStateSwift(scope: Construct, id: string, config: DataTerr
 
 ---
 
-##### `toString` <a name="toString" id="cdktf.DataTerraformRemoteStateSwift.toString"></a>
+##### ~~`toString`~~ <a name="toString" id="cdktf.DataTerraformRemoteStateSwift.toString"></a>
 
 ```typescript
 public toString(): string
@@ -5830,7 +5878,7 @@ public toString(): string
 
 Returns a string representation of this construct.
 
-##### `addOverride` <a name="addOverride" id="cdktf.DataTerraformRemoteStateSwift.addOverride"></a>
+##### ~~`addOverride`~~ <a name="addOverride" id="cdktf.DataTerraformRemoteStateSwift.addOverride"></a>
 
 ```typescript
 public addOverride(path: string, value: any): void
@@ -5848,7 +5896,7 @@ public addOverride(path: string, value: any): void
 
 ---
 
-##### `overrideLogicalId` <a name="overrideLogicalId" id="cdktf.DataTerraformRemoteStateSwift.overrideLogicalId"></a>
+##### ~~`overrideLogicalId`~~ <a name="overrideLogicalId" id="cdktf.DataTerraformRemoteStateSwift.overrideLogicalId"></a>
 
 ```typescript
 public overrideLogicalId(newLogicalId: string): void
@@ -5864,7 +5912,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `resetOverrideLogicalId` <a name="resetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateSwift.resetOverrideLogicalId"></a>
+##### ~~`resetOverrideLogicalId`~~ <a name="resetOverrideLogicalId" id="cdktf.DataTerraformRemoteStateSwift.resetOverrideLogicalId"></a>
 
 ```typescript
 public resetOverrideLogicalId(): void
@@ -5872,13 +5920,13 @@ public resetOverrideLogicalId(): void
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `toMetadata` <a name="toMetadata" id="cdktf.DataTerraformRemoteStateSwift.toMetadata"></a>
+##### ~~`toMetadata`~~ <a name="toMetadata" id="cdktf.DataTerraformRemoteStateSwift.toMetadata"></a>
 
 ```typescript
 public toMetadata(): any
 ```
 
-##### `toTerraform` <a name="toTerraform" id="cdktf.DataTerraformRemoteStateSwift.toTerraform"></a>
+##### ~~`toTerraform`~~ <a name="toTerraform" id="cdktf.DataTerraformRemoteStateSwift.toTerraform"></a>
 
 ```typescript
 public toTerraform(): any
@@ -5886,7 +5934,7 @@ public toTerraform(): any
 
 Adds this resource to the terraform JSON output.
 
-##### `get` <a name="get" id="cdktf.DataTerraformRemoteStateSwift.get"></a>
+##### ~~`get`~~ <a name="get" id="cdktf.DataTerraformRemoteStateSwift.get"></a>
 
 ```typescript
 public get(output: string): IResolvable
@@ -5898,7 +5946,7 @@ public get(output: string): IResolvable
 
 ---
 
-##### `getBoolean` <a name="getBoolean" id="cdktf.DataTerraformRemoteStateSwift.getBoolean"></a>
+##### ~~`getBoolean`~~ <a name="getBoolean" id="cdktf.DataTerraformRemoteStateSwift.getBoolean"></a>
 
 ```typescript
 public getBoolean(output: string): IResolvable
@@ -5910,7 +5958,7 @@ public getBoolean(output: string): IResolvable
 
 ---
 
-##### `getList` <a name="getList" id="cdktf.DataTerraformRemoteStateSwift.getList"></a>
+##### ~~`getList`~~ <a name="getList" id="cdktf.DataTerraformRemoteStateSwift.getList"></a>
 
 ```typescript
 public getList(output: string): string[]
@@ -5922,7 +5970,7 @@ public getList(output: string): string[]
 
 ---
 
-##### `getNumber` <a name="getNumber" id="cdktf.DataTerraformRemoteStateSwift.getNumber"></a>
+##### ~~`getNumber`~~ <a name="getNumber" id="cdktf.DataTerraformRemoteStateSwift.getNumber"></a>
 
 ```typescript
 public getNumber(output: string): number
@@ -5934,7 +5982,7 @@ public getNumber(output: string): number
 
 ---
 
-##### `getString` <a name="getString" id="cdktf.DataTerraformRemoteStateSwift.getString"></a>
+##### ~~`getString`~~ <a name="getString" id="cdktf.DataTerraformRemoteStateSwift.getString"></a>
 
 ```typescript
 public getString(output: string): string
@@ -5955,7 +6003,7 @@ public getString(output: string): string
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdktf.DataTerraformRemoteStateSwift.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdktf.DataTerraformRemoteStateSwift.isConstruct"></a>
 
 ```typescript
 import { DataTerraformRemoteStateSwift } from 'cdktf'
@@ -5987,7 +6035,7 @@ Any object.
 
 ---
 
-##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateSwift.isTerraformElement"></a>
+##### ~~`isTerraformElement`~~ <a name="isTerraformElement" id="cdktf.DataTerraformRemoteStateSwift.isTerraformElement"></a>
 
 ```typescript
 import { DataTerraformRemoteStateSwift } from 'cdktf'
@@ -6012,7 +6060,9 @@ DataTerraformRemoteStateSwift.isTerraformElement(x: any)
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateSwift.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.DataTerraformRemoteStateSwift.property.node"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly node: Node;
@@ -6024,7 +6074,9 @@ The tree node.
 
 ---
 
-##### `cdktfStack`<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateSwift.property.cdktfStack"></a>
+##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.DataTerraformRemoteStateSwift.property.cdktfStack"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly cdktfStack: TerraformStack;
@@ -6034,7 +6086,9 @@ public readonly cdktfStack: TerraformStack;
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateSwift.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.DataTerraformRemoteStateSwift.property.fqn"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly fqn: string;
@@ -6044,7 +6098,9 @@ public readonly fqn: string;
 
 ---
 
-##### `friendlyUniqueId`<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateSwift.property.friendlyUniqueId"></a>
+##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.DataTerraformRemoteStateSwift.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly friendlyUniqueId: string;
@@ -6062,7 +6118,9 @@ public readonly friendlyUniqueId: string;
 
 ---
 
-##### `tfResourceType`<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateSwift.property.tfResourceType"></a>
+##### ~~`tfResourceType`~~<sup>Required</sup> <a name="tfResourceType" id="cdktf.DataTerraformRemoteStateSwift.property.tfResourceType"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly tfResourceType: string;
@@ -6115,7 +6173,7 @@ new EtcdBackend(scope: Construct, props: EtcdBackendProps)
 
 ---
 
-##### `toString` <a name="toString" id="cdktf.EtcdBackend.toString"></a>
+##### ~~`toString`~~ <a name="toString" id="cdktf.EtcdBackend.toString"></a>
 
 ```typescript
 public toString(): string
@@ -6123,7 +6181,7 @@ public toString(): string
 
 Returns a string representation of this construct.
 
-##### `addOverride` <a name="addOverride" id="cdktf.EtcdBackend.addOverride"></a>
+##### ~~`addOverride`~~ <a name="addOverride" id="cdktf.EtcdBackend.addOverride"></a>
 
 ```typescript
 public addOverride(path: string, value: any): void
@@ -6141,7 +6199,7 @@ public addOverride(path: string, value: any): void
 
 ---
 
-##### `overrideLogicalId` <a name="overrideLogicalId" id="cdktf.EtcdBackend.overrideLogicalId"></a>
+##### ~~`overrideLogicalId`~~ <a name="overrideLogicalId" id="cdktf.EtcdBackend.overrideLogicalId"></a>
 
 ```typescript
 public overrideLogicalId(newLogicalId: string): void
@@ -6157,7 +6215,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `resetOverrideLogicalId` <a name="resetOverrideLogicalId" id="cdktf.EtcdBackend.resetOverrideLogicalId"></a>
+##### ~~`resetOverrideLogicalId`~~ <a name="resetOverrideLogicalId" id="cdktf.EtcdBackend.resetOverrideLogicalId"></a>
 
 ```typescript
 public resetOverrideLogicalId(): void
@@ -6165,13 +6223,13 @@ public resetOverrideLogicalId(): void
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `toMetadata` <a name="toMetadata" id="cdktf.EtcdBackend.toMetadata"></a>
+##### ~~`toMetadata`~~ <a name="toMetadata" id="cdktf.EtcdBackend.toMetadata"></a>
 
 ```typescript
 public toMetadata(): any
 ```
 
-##### `toTerraform` <a name="toTerraform" id="cdktf.EtcdBackend.toTerraform"></a>
+##### ~~`toTerraform`~~ <a name="toTerraform" id="cdktf.EtcdBackend.toTerraform"></a>
 
 ```typescript
 public toTerraform(): any
@@ -6179,7 +6237,7 @@ public toTerraform(): any
 
 Adds this resource to the terraform JSON output.
 
-##### `getRemoteStateDataSource` <a name="getRemoteStateDataSource" id="cdktf.EtcdBackend.getRemoteStateDataSource"></a>
+##### ~~`getRemoteStateDataSource`~~ <a name="getRemoteStateDataSource" id="cdktf.EtcdBackend.getRemoteStateDataSource"></a>
 
 ```typescript
 public getRemoteStateDataSource(scope: Construct, name: string, _fromStack: string): TerraformRemoteState
@@ -6215,7 +6273,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdktf.EtcdBackend.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdktf.EtcdBackend.isConstruct"></a>
 
 ```typescript
 import { EtcdBackend } from 'cdktf'
@@ -6247,7 +6305,7 @@ Any object.
 
 ---
 
-##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.EtcdBackend.isTerraformElement"></a>
+##### ~~`isTerraformElement`~~ <a name="isTerraformElement" id="cdktf.EtcdBackend.isTerraformElement"></a>
 
 ```typescript
 import { EtcdBackend } from 'cdktf'
@@ -6261,7 +6319,7 @@ EtcdBackend.isTerraformElement(x: any)
 
 ---
 
-##### `isBackend` <a name="isBackend" id="cdktf.EtcdBackend.isBackend"></a>
+##### ~~`isBackend`~~ <a name="isBackend" id="cdktf.EtcdBackend.isBackend"></a>
 
 ```typescript
 import { EtcdBackend } from 'cdktf'
@@ -6286,7 +6344,9 @@ EtcdBackend.isBackend(x: any)
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.EtcdBackend.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.EtcdBackend.property.node"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly node: Node;
@@ -6298,7 +6358,9 @@ The tree node.
 
 ---
 
-##### `cdktfStack`<sup>Required</sup> <a name="cdktfStack" id="cdktf.EtcdBackend.property.cdktfStack"></a>
+##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.EtcdBackend.property.cdktfStack"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly cdktfStack: TerraformStack;
@@ -6308,7 +6370,9 @@ public readonly cdktfStack: TerraformStack;
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.EtcdBackend.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.EtcdBackend.property.fqn"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly fqn: string;
@@ -6318,7 +6382,9 @@ public readonly fqn: string;
 
 ---
 
-##### `friendlyUniqueId`<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.EtcdBackend.property.friendlyUniqueId"></a>
+##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.EtcdBackend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly friendlyUniqueId: string;
@@ -6371,7 +6437,7 @@ new EtcdV3Backend(scope: Construct, props: EtcdV3BackendProps)
 
 ---
 
-##### `toString` <a name="toString" id="cdktf.EtcdV3Backend.toString"></a>
+##### ~~`toString`~~ <a name="toString" id="cdktf.EtcdV3Backend.toString"></a>
 
 ```typescript
 public toString(): string
@@ -6379,7 +6445,7 @@ public toString(): string
 
 Returns a string representation of this construct.
 
-##### `addOverride` <a name="addOverride" id="cdktf.EtcdV3Backend.addOverride"></a>
+##### ~~`addOverride`~~ <a name="addOverride" id="cdktf.EtcdV3Backend.addOverride"></a>
 
 ```typescript
 public addOverride(path: string, value: any): void
@@ -6397,7 +6463,7 @@ public addOverride(path: string, value: any): void
 
 ---
 
-##### `overrideLogicalId` <a name="overrideLogicalId" id="cdktf.EtcdV3Backend.overrideLogicalId"></a>
+##### ~~`overrideLogicalId`~~ <a name="overrideLogicalId" id="cdktf.EtcdV3Backend.overrideLogicalId"></a>
 
 ```typescript
 public overrideLogicalId(newLogicalId: string): void
@@ -6413,7 +6479,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `resetOverrideLogicalId` <a name="resetOverrideLogicalId" id="cdktf.EtcdV3Backend.resetOverrideLogicalId"></a>
+##### ~~`resetOverrideLogicalId`~~ <a name="resetOverrideLogicalId" id="cdktf.EtcdV3Backend.resetOverrideLogicalId"></a>
 
 ```typescript
 public resetOverrideLogicalId(): void
@@ -6421,13 +6487,13 @@ public resetOverrideLogicalId(): void
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `toMetadata` <a name="toMetadata" id="cdktf.EtcdV3Backend.toMetadata"></a>
+##### ~~`toMetadata`~~ <a name="toMetadata" id="cdktf.EtcdV3Backend.toMetadata"></a>
 
 ```typescript
 public toMetadata(): any
 ```
 
-##### `toTerraform` <a name="toTerraform" id="cdktf.EtcdV3Backend.toTerraform"></a>
+##### ~~`toTerraform`~~ <a name="toTerraform" id="cdktf.EtcdV3Backend.toTerraform"></a>
 
 ```typescript
 public toTerraform(): any
@@ -6435,7 +6501,7 @@ public toTerraform(): any
 
 Adds this resource to the terraform JSON output.
 
-##### `getRemoteStateDataSource` <a name="getRemoteStateDataSource" id="cdktf.EtcdV3Backend.getRemoteStateDataSource"></a>
+##### ~~`getRemoteStateDataSource`~~ <a name="getRemoteStateDataSource" id="cdktf.EtcdV3Backend.getRemoteStateDataSource"></a>
 
 ```typescript
 public getRemoteStateDataSource(scope: Construct, name: string, _fromStack: string): TerraformRemoteState
@@ -6471,7 +6537,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdktf.EtcdV3Backend.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdktf.EtcdV3Backend.isConstruct"></a>
 
 ```typescript
 import { EtcdV3Backend } from 'cdktf'
@@ -6503,7 +6569,7 @@ Any object.
 
 ---
 
-##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.EtcdV3Backend.isTerraformElement"></a>
+##### ~~`isTerraformElement`~~ <a name="isTerraformElement" id="cdktf.EtcdV3Backend.isTerraformElement"></a>
 
 ```typescript
 import { EtcdV3Backend } from 'cdktf'
@@ -6517,7 +6583,7 @@ EtcdV3Backend.isTerraformElement(x: any)
 
 ---
 
-##### `isBackend` <a name="isBackend" id="cdktf.EtcdV3Backend.isBackend"></a>
+##### ~~`isBackend`~~ <a name="isBackend" id="cdktf.EtcdV3Backend.isBackend"></a>
 
 ```typescript
 import { EtcdV3Backend } from 'cdktf'
@@ -6542,7 +6608,9 @@ EtcdV3Backend.isBackend(x: any)
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.EtcdV3Backend.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.EtcdV3Backend.property.node"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly node: Node;
@@ -6554,7 +6622,9 @@ The tree node.
 
 ---
 
-##### `cdktfStack`<sup>Required</sup> <a name="cdktfStack" id="cdktf.EtcdV3Backend.property.cdktfStack"></a>
+##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.EtcdV3Backend.property.cdktfStack"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly cdktfStack: TerraformStack;
@@ -6564,7 +6634,9 @@ public readonly cdktfStack: TerraformStack;
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.EtcdV3Backend.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.EtcdV3Backend.property.fqn"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly fqn: string;
@@ -6574,7 +6646,9 @@ public readonly fqn: string;
 
 ---
 
-##### `friendlyUniqueId`<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.EtcdV3Backend.property.friendlyUniqueId"></a>
+##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.EtcdV3Backend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly friendlyUniqueId: string;
@@ -7395,7 +7469,7 @@ new MantaBackend(scope: Construct, props: MantaBackendProps)
 
 ---
 
-##### `toString` <a name="toString" id="cdktf.MantaBackend.toString"></a>
+##### ~~`toString`~~ <a name="toString" id="cdktf.MantaBackend.toString"></a>
 
 ```typescript
 public toString(): string
@@ -7403,7 +7477,7 @@ public toString(): string
 
 Returns a string representation of this construct.
 
-##### `addOverride` <a name="addOverride" id="cdktf.MantaBackend.addOverride"></a>
+##### ~~`addOverride`~~ <a name="addOverride" id="cdktf.MantaBackend.addOverride"></a>
 
 ```typescript
 public addOverride(path: string, value: any): void
@@ -7421,7 +7495,7 @@ public addOverride(path: string, value: any): void
 
 ---
 
-##### `overrideLogicalId` <a name="overrideLogicalId" id="cdktf.MantaBackend.overrideLogicalId"></a>
+##### ~~`overrideLogicalId`~~ <a name="overrideLogicalId" id="cdktf.MantaBackend.overrideLogicalId"></a>
 
 ```typescript
 public overrideLogicalId(newLogicalId: string): void
@@ -7437,7 +7511,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `resetOverrideLogicalId` <a name="resetOverrideLogicalId" id="cdktf.MantaBackend.resetOverrideLogicalId"></a>
+##### ~~`resetOverrideLogicalId`~~ <a name="resetOverrideLogicalId" id="cdktf.MantaBackend.resetOverrideLogicalId"></a>
 
 ```typescript
 public resetOverrideLogicalId(): void
@@ -7445,13 +7519,13 @@ public resetOverrideLogicalId(): void
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `toMetadata` <a name="toMetadata" id="cdktf.MantaBackend.toMetadata"></a>
+##### ~~`toMetadata`~~ <a name="toMetadata" id="cdktf.MantaBackend.toMetadata"></a>
 
 ```typescript
 public toMetadata(): any
 ```
 
-##### `toTerraform` <a name="toTerraform" id="cdktf.MantaBackend.toTerraform"></a>
+##### ~~`toTerraform`~~ <a name="toTerraform" id="cdktf.MantaBackend.toTerraform"></a>
 
 ```typescript
 public toTerraform(): any
@@ -7459,7 +7533,7 @@ public toTerraform(): any
 
 Adds this resource to the terraform JSON output.
 
-##### `getRemoteStateDataSource` <a name="getRemoteStateDataSource" id="cdktf.MantaBackend.getRemoteStateDataSource"></a>
+##### ~~`getRemoteStateDataSource`~~ <a name="getRemoteStateDataSource" id="cdktf.MantaBackend.getRemoteStateDataSource"></a>
 
 ```typescript
 public getRemoteStateDataSource(scope: Construct, name: string, _fromStack: string): TerraformRemoteState
@@ -7495,7 +7569,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdktf.MantaBackend.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdktf.MantaBackend.isConstruct"></a>
 
 ```typescript
 import { MantaBackend } from 'cdktf'
@@ -7527,7 +7601,7 @@ Any object.
 
 ---
 
-##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.MantaBackend.isTerraformElement"></a>
+##### ~~`isTerraformElement`~~ <a name="isTerraformElement" id="cdktf.MantaBackend.isTerraformElement"></a>
 
 ```typescript
 import { MantaBackend } from 'cdktf'
@@ -7541,7 +7615,7 @@ MantaBackend.isTerraformElement(x: any)
 
 ---
 
-##### `isBackend` <a name="isBackend" id="cdktf.MantaBackend.isBackend"></a>
+##### ~~`isBackend`~~ <a name="isBackend" id="cdktf.MantaBackend.isBackend"></a>
 
 ```typescript
 import { MantaBackend } from 'cdktf'
@@ -7566,7 +7640,9 @@ MantaBackend.isBackend(x: any)
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.MantaBackend.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.MantaBackend.property.node"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly node: Node;
@@ -7578,7 +7654,9 @@ The tree node.
 
 ---
 
-##### `cdktfStack`<sup>Required</sup> <a name="cdktfStack" id="cdktf.MantaBackend.property.cdktfStack"></a>
+##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.MantaBackend.property.cdktfStack"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly cdktfStack: TerraformStack;
@@ -7588,7 +7666,9 @@ public readonly cdktfStack: TerraformStack;
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.MantaBackend.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.MantaBackend.property.fqn"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly fqn: string;
@@ -7598,7 +7678,9 @@ public readonly fqn: string;
 
 ---
 
-##### `friendlyUniqueId`<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.MantaBackend.property.friendlyUniqueId"></a>
+##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.MantaBackend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly friendlyUniqueId: string;
@@ -8801,7 +8883,7 @@ new SwiftBackend(scope: Construct, props: SwiftBackendProps)
 
 ---
 
-##### `toString` <a name="toString" id="cdktf.SwiftBackend.toString"></a>
+##### ~~`toString`~~ <a name="toString" id="cdktf.SwiftBackend.toString"></a>
 
 ```typescript
 public toString(): string
@@ -8809,7 +8891,7 @@ public toString(): string
 
 Returns a string representation of this construct.
 
-##### `addOverride` <a name="addOverride" id="cdktf.SwiftBackend.addOverride"></a>
+##### ~~`addOverride`~~ <a name="addOverride" id="cdktf.SwiftBackend.addOverride"></a>
 
 ```typescript
 public addOverride(path: string, value: any): void
@@ -8827,7 +8909,7 @@ public addOverride(path: string, value: any): void
 
 ---
 
-##### `overrideLogicalId` <a name="overrideLogicalId" id="cdktf.SwiftBackend.overrideLogicalId"></a>
+##### ~~`overrideLogicalId`~~ <a name="overrideLogicalId" id="cdktf.SwiftBackend.overrideLogicalId"></a>
 
 ```typescript
 public overrideLogicalId(newLogicalId: string): void
@@ -8843,7 +8925,7 @@ The new logical ID to use for this stack element.
 
 ---
 
-##### `resetOverrideLogicalId` <a name="resetOverrideLogicalId" id="cdktf.SwiftBackend.resetOverrideLogicalId"></a>
+##### ~~`resetOverrideLogicalId`~~ <a name="resetOverrideLogicalId" id="cdktf.SwiftBackend.resetOverrideLogicalId"></a>
 
 ```typescript
 public resetOverrideLogicalId(): void
@@ -8851,13 +8933,13 @@ public resetOverrideLogicalId(): void
 
 Resets a previously passed logical Id to use the auto-generated logical id again.
 
-##### `toMetadata` <a name="toMetadata" id="cdktf.SwiftBackend.toMetadata"></a>
+##### ~~`toMetadata`~~ <a name="toMetadata" id="cdktf.SwiftBackend.toMetadata"></a>
 
 ```typescript
 public toMetadata(): any
 ```
 
-##### `toTerraform` <a name="toTerraform" id="cdktf.SwiftBackend.toTerraform"></a>
+##### ~~`toTerraform`~~ <a name="toTerraform" id="cdktf.SwiftBackend.toTerraform"></a>
 
 ```typescript
 public toTerraform(): any
@@ -8865,7 +8947,7 @@ public toTerraform(): any
 
 Adds this resource to the terraform JSON output.
 
-##### `getRemoteStateDataSource` <a name="getRemoteStateDataSource" id="cdktf.SwiftBackend.getRemoteStateDataSource"></a>
+##### ~~`getRemoteStateDataSource`~~ <a name="getRemoteStateDataSource" id="cdktf.SwiftBackend.getRemoteStateDataSource"></a>
 
 ```typescript
 public getRemoteStateDataSource(scope: Construct, name: string, _fromStack: string): TerraformRemoteState
@@ -8901,7 +8983,7 @@ Creates a TerraformRemoteState resource that accesses this backend.
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="cdktf.SwiftBackend.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="cdktf.SwiftBackend.isConstruct"></a>
 
 ```typescript
 import { SwiftBackend } from 'cdktf'
@@ -8933,7 +9015,7 @@ Any object.
 
 ---
 
-##### `isTerraformElement` <a name="isTerraformElement" id="cdktf.SwiftBackend.isTerraformElement"></a>
+##### ~~`isTerraformElement`~~ <a name="isTerraformElement" id="cdktf.SwiftBackend.isTerraformElement"></a>
 
 ```typescript
 import { SwiftBackend } from 'cdktf'
@@ -8947,7 +9029,7 @@ SwiftBackend.isTerraformElement(x: any)
 
 ---
 
-##### `isBackend` <a name="isBackend" id="cdktf.SwiftBackend.isBackend"></a>
+##### ~~`isBackend`~~ <a name="isBackend" id="cdktf.SwiftBackend.isBackend"></a>
 
 ```typescript
 import { SwiftBackend } from 'cdktf'
@@ -8972,7 +9054,9 @@ SwiftBackend.isBackend(x: any)
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="cdktf.SwiftBackend.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="cdktf.SwiftBackend.property.node"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly node: Node;
@@ -8984,7 +9068,9 @@ The tree node.
 
 ---
 
-##### `cdktfStack`<sup>Required</sup> <a name="cdktfStack" id="cdktf.SwiftBackend.property.cdktfStack"></a>
+##### ~~`cdktfStack`~~<sup>Required</sup> <a name="cdktfStack" id="cdktf.SwiftBackend.property.cdktfStack"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly cdktfStack: TerraformStack;
@@ -8994,7 +9080,9 @@ public readonly cdktfStack: TerraformStack;
 
 ---
 
-##### `fqn`<sup>Required</sup> <a name="fqn" id="cdktf.SwiftBackend.property.fqn"></a>
+##### ~~`fqn`~~<sup>Required</sup> <a name="fqn" id="cdktf.SwiftBackend.property.fqn"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly fqn: string;
@@ -9004,7 +9092,9 @@ public readonly fqn: string;
 
 ---
 
-##### `friendlyUniqueId`<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.SwiftBackend.property.friendlyUniqueId"></a>
+##### ~~`friendlyUniqueId`~~<sup>Required</sup> <a name="friendlyUniqueId" id="cdktf.SwiftBackend.property.friendlyUniqueId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly friendlyUniqueId: string;
@@ -13242,7 +13332,9 @@ const artifactoryBackendProps: ArtifactoryBackendProps = { ... }
 
 ---
 
-##### `password`<sup>Required</sup> <a name="password" id="cdktf.ArtifactoryBackendProps.property.password"></a>
+##### ~~`password`~~<sup>Required</sup> <a name="password" id="cdktf.ArtifactoryBackendProps.property.password"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly password: string;
@@ -13254,7 +13346,9 @@ public readonly password: string;
 
 ---
 
-##### `repo`<sup>Required</sup> <a name="repo" id="cdktf.ArtifactoryBackendProps.property.repo"></a>
+##### ~~`repo`~~<sup>Required</sup> <a name="repo" id="cdktf.ArtifactoryBackendProps.property.repo"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly repo: string;
@@ -13266,7 +13360,9 @@ public readonly repo: string;
 
 ---
 
-##### `subpath`<sup>Required</sup> <a name="subpath" id="cdktf.ArtifactoryBackendProps.property.subpath"></a>
+##### ~~`subpath`~~<sup>Required</sup> <a name="subpath" id="cdktf.ArtifactoryBackendProps.property.subpath"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly subpath: string;
@@ -13278,7 +13374,9 @@ public readonly subpath: string;
 
 ---
 
-##### `url`<sup>Required</sup> <a name="url" id="cdktf.ArtifactoryBackendProps.property.url"></a>
+##### ~~`url`~~<sup>Required</sup> <a name="url" id="cdktf.ArtifactoryBackendProps.property.url"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly url: string;
@@ -13292,7 +13390,9 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ---
 
-##### `username`<sup>Required</sup> <a name="username" id="cdktf.ArtifactoryBackendProps.property.username"></a>
+##### ~~`username`~~<sup>Required</sup> <a name="username" id="cdktf.ArtifactoryBackendProps.property.username"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly username: string;
@@ -14098,7 +14198,9 @@ const dataTerraformRemoteStateArtifactoryConfig: DataTerraformRemoteStateArtifac
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.defaults"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly defaults: {[ key: string ]: any};
@@ -14108,7 +14210,9 @@ public readonly defaults: {[ key: string ]: any};
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.workspace"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly workspace: string;
@@ -14118,7 +14222,9 @@ public readonly workspace: string;
 
 ---
 
-##### `password`<sup>Required</sup> <a name="password" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.password"></a>
+##### ~~`password`~~<sup>Required</sup> <a name="password" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.password"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly password: string;
@@ -14130,7 +14236,9 @@ public readonly password: string;
 
 ---
 
-##### `repo`<sup>Required</sup> <a name="repo" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.repo"></a>
+##### ~~`repo`~~<sup>Required</sup> <a name="repo" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.repo"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly repo: string;
@@ -14142,7 +14250,9 @@ public readonly repo: string;
 
 ---
 
-##### `subpath`<sup>Required</sup> <a name="subpath" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.subpath"></a>
+##### ~~`subpath`~~<sup>Required</sup> <a name="subpath" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.subpath"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly subpath: string;
@@ -14154,7 +14264,9 @@ public readonly subpath: string;
 
 ---
 
-##### `url`<sup>Required</sup> <a name="url" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.url"></a>
+##### ~~`url`~~<sup>Required</sup> <a name="url" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.url"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly url: string;
@@ -14168,7 +14280,9 @@ Note that this is the base url to artifactory not the full repo and subpath.
 
 ---
 
-##### `username`<sup>Required</sup> <a name="username" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.username"></a>
+##### ~~`username`~~<sup>Required</sup> <a name="username" id="cdktf.DataTerraformRemoteStateArtifactoryConfig.property.username"></a>
+
+- _Deprecated:_ the artifactory backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly username: string;
@@ -14973,7 +15087,9 @@ const dataTerraformRemoteStateEtcdConfig: DataTerraformRemoteStateEtcdConfig = {
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.defaults"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly defaults: {[ key: string ]: any};
@@ -14983,7 +15099,9 @@ public readonly defaults: {[ key: string ]: any};
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.workspace"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly workspace: string;
@@ -14993,7 +15111,9 @@ public readonly workspace: string;
 
 ---
 
-##### `endpoints`<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.endpoints"></a>
+##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.endpoints"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly endpoints: string;
@@ -15005,7 +15125,9 @@ public readonly endpoints: string;
 
 ---
 
-##### `path`<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.path"></a>
+##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.path"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly path: string;
@@ -15017,7 +15139,9 @@ public readonly path: string;
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.password"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly password: string;
@@ -15029,7 +15153,9 @@ public readonly password: string;
 
 ---
 
-##### `username`<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.username"></a>
+##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdConfig.property.username"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly username: string;
@@ -15068,7 +15194,9 @@ const dataTerraformRemoteStateEtcdV3Config: DataTerraformRemoteStateEtcdV3Config
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.defaults"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly defaults: {[ key: string ]: any};
@@ -15078,7 +15206,9 @@ public readonly defaults: {[ key: string ]: any};
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.workspace"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly workspace: string;
@@ -15088,7 +15218,9 @@ public readonly workspace: string;
 
 ---
 
-##### `endpoints`<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.endpoints"></a>
+##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.endpoints"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly endpoints: string[];
@@ -15100,7 +15232,9 @@ public readonly endpoints: string[];
 
 ---
 
-##### `cacertPath`<sup>Optional</sup> <a name="cacertPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.cacertPath"></a>
+##### ~~`cacertPath`~~<sup>Optional</sup> <a name="cacertPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.cacertPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly cacertPath: string;
@@ -15112,7 +15246,9 @@ public readonly cacertPath: string;
 
 ---
 
-##### `certPath`<sup>Optional</sup> <a name="certPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.certPath"></a>
+##### ~~`certPath`~~<sup>Optional</sup> <a name="certPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.certPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly certPath: string;
@@ -15124,7 +15260,9 @@ public readonly certPath: string;
 
 ---
 
-##### `keyPath`<sup>Optional</sup> <a name="keyPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.keyPath"></a>
+##### ~~`keyPath`~~<sup>Optional</sup> <a name="keyPath" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.keyPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly keyPath: string;
@@ -15136,7 +15274,9 @@ public readonly keyPath: string;
 
 ---
 
-##### `lock`<sup>Optional</sup> <a name="lock" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.lock"></a>
+##### ~~`lock`~~<sup>Optional</sup> <a name="lock" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.lock"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly lock: boolean;
@@ -15150,7 +15290,9 @@ Defaults to true.
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.password"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly password: string;
@@ -15162,7 +15304,9 @@ public readonly password: string;
 
 ---
 
-##### `prefix`<sup>Optional</sup> <a name="prefix" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.prefix"></a>
+##### ~~`prefix`~~<sup>Optional</sup> <a name="prefix" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.prefix"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly prefix: string;
@@ -15176,7 +15320,9 @@ Defaults to "".
 
 ---
 
-##### `username`<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.username"></a>
+##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.DataTerraformRemoteStateEtcdV3Config.property.username"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly username: string;
@@ -15638,7 +15784,9 @@ const dataTerraformRemoteStateMantaConfig: DataTerraformRemoteStateMantaConfig =
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateMantaConfig.property.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateMantaConfig.property.defaults"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly defaults: {[ key: string ]: any};
@@ -15648,7 +15796,9 @@ public readonly defaults: {[ key: string ]: any};
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateMantaConfig.property.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateMantaConfig.property.workspace"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly workspace: string;
@@ -15658,7 +15808,9 @@ public readonly workspace: string;
 
 ---
 
-##### `account`<sup>Required</sup> <a name="account" id="cdktf.DataTerraformRemoteStateMantaConfig.property.account"></a>
+##### ~~`account`~~<sup>Required</sup> <a name="account" id="cdktf.DataTerraformRemoteStateMantaConfig.property.account"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly account: string;
@@ -15668,7 +15820,9 @@ public readonly account: string;
 
 ---
 
-##### `keyId`<sup>Required</sup> <a name="keyId" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyId"></a>
+##### ~~`keyId`~~<sup>Required</sup> <a name="keyId" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly keyId: string;
@@ -15678,7 +15832,9 @@ public readonly keyId: string;
 
 ---
 
-##### `path`<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateMantaConfig.property.path"></a>
+##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.DataTerraformRemoteStateMantaConfig.property.path"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly path: string;
@@ -15688,7 +15844,9 @@ public readonly path: string;
 
 ---
 
-##### `insecureSkipTlsVerify`<sup>Optional</sup> <a name="insecureSkipTlsVerify" id="cdktf.DataTerraformRemoteStateMantaConfig.property.insecureSkipTlsVerify"></a>
+##### ~~`insecureSkipTlsVerify`~~<sup>Optional</sup> <a name="insecureSkipTlsVerify" id="cdktf.DataTerraformRemoteStateMantaConfig.property.insecureSkipTlsVerify"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly insecureSkipTlsVerify: boolean;
@@ -15698,7 +15856,9 @@ public readonly insecureSkipTlsVerify: boolean;
 
 ---
 
-##### `keyMaterial`<sup>Optional</sup> <a name="keyMaterial" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyMaterial"></a>
+##### ~~`keyMaterial`~~<sup>Optional</sup> <a name="keyMaterial" id="cdktf.DataTerraformRemoteStateMantaConfig.property.keyMaterial"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly keyMaterial: string;
@@ -15708,7 +15868,9 @@ public readonly keyMaterial: string;
 
 ---
 
-##### `objectName`<sup>Optional</sup> <a name="objectName" id="cdktf.DataTerraformRemoteStateMantaConfig.property.objectName"></a>
+##### ~~`objectName`~~<sup>Optional</sup> <a name="objectName" id="cdktf.DataTerraformRemoteStateMantaConfig.property.objectName"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly objectName: string;
@@ -15718,7 +15880,9 @@ public readonly objectName: string;
 
 ---
 
-##### `url`<sup>Optional</sup> <a name="url" id="cdktf.DataTerraformRemoteStateMantaConfig.property.url"></a>
+##### ~~`url`~~<sup>Optional</sup> <a name="url" id="cdktf.DataTerraformRemoteStateMantaConfig.property.url"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly url: string;
@@ -15728,7 +15892,9 @@ public readonly url: string;
 
 ---
 
-##### `user`<sup>Optional</sup> <a name="user" id="cdktf.DataTerraformRemoteStateMantaConfig.property.user"></a>
+##### ~~`user`~~<sup>Optional</sup> <a name="user" id="cdktf.DataTerraformRemoteStateMantaConfig.property.user"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly user: string;
@@ -16628,7 +16794,9 @@ const dataTerraformRemoteStateSwiftConfig: DataTerraformRemoteStateSwiftConfig =
 
 ---
 
-##### `defaults`<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaults"></a>
+##### ~~`defaults`~~<sup>Optional</sup> <a name="defaults" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaults"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly defaults: {[ key: string ]: any};
@@ -16638,7 +16806,9 @@ public readonly defaults: {[ key: string ]: any};
 
 ---
 
-##### `workspace`<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.workspace"></a>
+##### ~~`workspace`~~<sup>Optional</sup> <a name="workspace" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.workspace"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly workspace: string;
@@ -16648,7 +16818,9 @@ public readonly workspace: string;
 
 ---
 
-##### `container`<sup>Required</sup> <a name="container" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.container"></a>
+##### ~~`container`~~<sup>Required</sup> <a name="container" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.container"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly container: string;
@@ -16658,7 +16830,9 @@ public readonly container: string;
 
 ---
 
-##### `applicationCredentialId`<sup>Optional</sup> <a name="applicationCredentialId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialId"></a>
+##### ~~`applicationCredentialId`~~<sup>Optional</sup> <a name="applicationCredentialId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly applicationCredentialId: string;
@@ -16668,7 +16842,9 @@ public readonly applicationCredentialId: string;
 
 ---
 
-##### `applicationCredentialName`<sup>Optional</sup> <a name="applicationCredentialName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialName"></a>
+##### ~~`applicationCredentialName`~~<sup>Optional</sup> <a name="applicationCredentialName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly applicationCredentialName: string;
@@ -16678,7 +16854,9 @@ public readonly applicationCredentialName: string;
 
 ---
 
-##### `applicationCredentialSecret`<sup>Optional</sup> <a name="applicationCredentialSecret" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialSecret"></a>
+##### ~~`applicationCredentialSecret`~~<sup>Optional</sup> <a name="applicationCredentialSecret" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.applicationCredentialSecret"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly applicationCredentialSecret: string;
@@ -16688,7 +16866,9 @@ public readonly applicationCredentialSecret: string;
 
 ---
 
-##### `archiveContainer`<sup>Optional</sup> <a name="archiveContainer" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.archiveContainer"></a>
+##### ~~`archiveContainer`~~<sup>Optional</sup> <a name="archiveContainer" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.archiveContainer"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly archiveContainer: string;
@@ -16698,7 +16878,9 @@ public readonly archiveContainer: string;
 
 ---
 
-##### `authUrl`<sup>Optional</sup> <a name="authUrl" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.authUrl"></a>
+##### ~~`authUrl`~~<sup>Optional</sup> <a name="authUrl" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.authUrl"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly authUrl: string;
@@ -16708,7 +16890,9 @@ public readonly authUrl: string;
 
 ---
 
-##### `cacertFile`<sup>Optional</sup> <a name="cacertFile" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cacertFile"></a>
+##### ~~`cacertFile`~~<sup>Optional</sup> <a name="cacertFile" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cacertFile"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly cacertFile: string;
@@ -16718,7 +16902,9 @@ public readonly cacertFile: string;
 
 ---
 
-##### `cert`<sup>Optional</sup> <a name="cert" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cert"></a>
+##### ~~`cert`~~<sup>Optional</sup> <a name="cert" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cert"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly cert: string;
@@ -16728,7 +16914,9 @@ public readonly cert: string;
 
 ---
 
-##### `cloud`<sup>Optional</sup> <a name="cloud" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cloud"></a>
+##### ~~`cloud`~~<sup>Optional</sup> <a name="cloud" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.cloud"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly cloud: string;
@@ -16738,7 +16926,9 @@ public readonly cloud: string;
 
 ---
 
-##### `defaultDomain`<sup>Optional</sup> <a name="defaultDomain" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaultDomain"></a>
+##### ~~`defaultDomain`~~<sup>Optional</sup> <a name="defaultDomain" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.defaultDomain"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly defaultDomain: string;
@@ -16748,7 +16938,9 @@ public readonly defaultDomain: string;
 
 ---
 
-##### `domainId`<sup>Optional</sup> <a name="domainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainId"></a>
+##### ~~`domainId`~~<sup>Optional</sup> <a name="domainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly domainId: string;
@@ -16758,7 +16950,9 @@ public readonly domainId: string;
 
 ---
 
-##### `domainName`<sup>Optional</sup> <a name="domainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainName"></a>
+##### ~~`domainName`~~<sup>Optional</sup> <a name="domainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.domainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly domainName: string;
@@ -16768,7 +16962,9 @@ public readonly domainName: string;
 
 ---
 
-##### `expireAfter`<sup>Optional</sup> <a name="expireAfter" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.expireAfter"></a>
+##### ~~`expireAfter`~~<sup>Optional</sup> <a name="expireAfter" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.expireAfter"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly expireAfter: string;
@@ -16778,7 +16974,9 @@ public readonly expireAfter: string;
 
 ---
 
-##### `insecure`<sup>Optional</sup> <a name="insecure" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.insecure"></a>
+##### ~~`insecure`~~<sup>Optional</sup> <a name="insecure" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.insecure"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly insecure: boolean;
@@ -16788,7 +16986,9 @@ public readonly insecure: boolean;
 
 ---
 
-##### `key`<sup>Optional</sup> <a name="key" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.key"></a>
+##### ~~`key`~~<sup>Optional</sup> <a name="key" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.key"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly key: string;
@@ -16798,7 +16998,9 @@ public readonly key: string;
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.password"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly password: string;
@@ -16808,7 +17010,9 @@ public readonly password: string;
 
 ---
 
-##### `projectDomainId`<sup>Optional</sup> <a name="projectDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainId"></a>
+##### ~~`projectDomainId`~~<sup>Optional</sup> <a name="projectDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly projectDomainId: string;
@@ -16818,7 +17022,9 @@ public readonly projectDomainId: string;
 
 ---
 
-##### `projectDomainName`<sup>Optional</sup> <a name="projectDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainName"></a>
+##### ~~`projectDomainName`~~<sup>Optional</sup> <a name="projectDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.projectDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly projectDomainName: string;
@@ -16828,7 +17034,9 @@ public readonly projectDomainName: string;
 
 ---
 
-##### `regionName`<sup>Optional</sup> <a name="regionName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.regionName"></a>
+##### ~~`regionName`~~<sup>Optional</sup> <a name="regionName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.regionName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly regionName: string;
@@ -16838,7 +17046,9 @@ public readonly regionName: string;
 
 ---
 
-##### `stateName`<sup>Optional</sup> <a name="stateName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.stateName"></a>
+##### ~~`stateName`~~<sup>Optional</sup> <a name="stateName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.stateName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly stateName: string;
@@ -16848,7 +17058,9 @@ public readonly stateName: string;
 
 ---
 
-##### `tenantId`<sup>Optional</sup> <a name="tenantId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantId"></a>
+##### ~~`tenantId`~~<sup>Optional</sup> <a name="tenantId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly tenantId: string;
@@ -16858,7 +17070,9 @@ public readonly tenantId: string;
 
 ---
 
-##### `tenantName`<sup>Optional</sup> <a name="tenantName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantName"></a>
+##### ~~`tenantName`~~<sup>Optional</sup> <a name="tenantName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.tenantName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly tenantName: string;
@@ -16868,7 +17082,9 @@ public readonly tenantName: string;
 
 ---
 
-##### `token`<sup>Optional</sup> <a name="token" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.token"></a>
+##### ~~`token`~~<sup>Optional</sup> <a name="token" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.token"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly token: string;
@@ -16878,7 +17094,9 @@ public readonly token: string;
 
 ---
 
-##### `userDomainId`<sup>Optional</sup> <a name="userDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainId"></a>
+##### ~~`userDomainId`~~<sup>Optional</sup> <a name="userDomainId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly userDomainId: string;
@@ -16888,7 +17106,9 @@ public readonly userDomainId: string;
 
 ---
 
-##### `userDomainName`<sup>Optional</sup> <a name="userDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainName"></a>
+##### ~~`userDomainName`~~<sup>Optional</sup> <a name="userDomainName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly userDomainName: string;
@@ -16898,7 +17118,9 @@ public readonly userDomainName: string;
 
 ---
 
-##### `userId`<sup>Optional</sup> <a name="userId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userId"></a>
+##### ~~`userId`~~<sup>Optional</sup> <a name="userId" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly userId: string;
@@ -16908,7 +17130,9 @@ public readonly userId: string;
 
 ---
 
-##### `userName`<sup>Optional</sup> <a name="userName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userName"></a>
+##### ~~`userName`~~<sup>Optional</sup> <a name="userName" id="cdktf.DataTerraformRemoteStateSwiftConfig.property.userName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly userName: string;
@@ -16979,7 +17203,9 @@ const etcdBackendProps: EtcdBackendProps = { ... }
 
 ---
 
-##### `endpoints`<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdBackendProps.property.endpoints"></a>
+##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdBackendProps.property.endpoints"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly endpoints: string;
@@ -16991,7 +17217,9 @@ public readonly endpoints: string;
 
 ---
 
-##### `path`<sup>Required</sup> <a name="path" id="cdktf.EtcdBackendProps.property.path"></a>
+##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.EtcdBackendProps.property.path"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly path: string;
@@ -17003,7 +17231,9 @@ public readonly path: string;
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.EtcdBackendProps.property.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.EtcdBackendProps.property.password"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly password: string;
@@ -17015,7 +17245,9 @@ public readonly password: string;
 
 ---
 
-##### `username`<sup>Optional</sup> <a name="username" id="cdktf.EtcdBackendProps.property.username"></a>
+##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.EtcdBackendProps.property.username"></a>
+
+- _Deprecated:_ the etcd backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly username: string;
@@ -17059,7 +17291,9 @@ const etcdV3BackendProps: EtcdV3BackendProps = { ... }
 
 ---
 
-##### `endpoints`<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdV3BackendProps.property.endpoints"></a>
+##### ~~`endpoints`~~<sup>Required</sup> <a name="endpoints" id="cdktf.EtcdV3BackendProps.property.endpoints"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly endpoints: string[];
@@ -17071,7 +17305,9 @@ public readonly endpoints: string[];
 
 ---
 
-##### `cacertPath`<sup>Optional</sup> <a name="cacertPath" id="cdktf.EtcdV3BackendProps.property.cacertPath"></a>
+##### ~~`cacertPath`~~<sup>Optional</sup> <a name="cacertPath" id="cdktf.EtcdV3BackendProps.property.cacertPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly cacertPath: string;
@@ -17083,7 +17319,9 @@ public readonly cacertPath: string;
 
 ---
 
-##### `certPath`<sup>Optional</sup> <a name="certPath" id="cdktf.EtcdV3BackendProps.property.certPath"></a>
+##### ~~`certPath`~~<sup>Optional</sup> <a name="certPath" id="cdktf.EtcdV3BackendProps.property.certPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly certPath: string;
@@ -17095,7 +17333,9 @@ public readonly certPath: string;
 
 ---
 
-##### `keyPath`<sup>Optional</sup> <a name="keyPath" id="cdktf.EtcdV3BackendProps.property.keyPath"></a>
+##### ~~`keyPath`~~<sup>Optional</sup> <a name="keyPath" id="cdktf.EtcdV3BackendProps.property.keyPath"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly keyPath: string;
@@ -17107,7 +17347,9 @@ public readonly keyPath: string;
 
 ---
 
-##### `lock`<sup>Optional</sup> <a name="lock" id="cdktf.EtcdV3BackendProps.property.lock"></a>
+##### ~~`lock`~~<sup>Optional</sup> <a name="lock" id="cdktf.EtcdV3BackendProps.property.lock"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly lock: boolean;
@@ -17121,7 +17363,9 @@ Defaults to true.
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.EtcdV3BackendProps.property.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.EtcdV3BackendProps.property.password"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly password: string;
@@ -17133,7 +17377,9 @@ public readonly password: string;
 
 ---
 
-##### `prefix`<sup>Optional</sup> <a name="prefix" id="cdktf.EtcdV3BackendProps.property.prefix"></a>
+##### ~~`prefix`~~<sup>Optional</sup> <a name="prefix" id="cdktf.EtcdV3BackendProps.property.prefix"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly prefix: string;
@@ -17147,7 +17393,9 @@ Defaults to "".
 
 ---
 
-##### `username`<sup>Optional</sup> <a name="username" id="cdktf.EtcdV3BackendProps.property.username"></a>
+##### ~~`username`~~<sup>Optional</sup> <a name="username" id="cdktf.EtcdV3BackendProps.property.username"></a>
+
+- _Deprecated:_ the etcdv3 backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly username: string;
@@ -17910,7 +18158,9 @@ const mantaBackendProps: MantaBackendProps = { ... }
 
 ---
 
-##### `account`<sup>Required</sup> <a name="account" id="cdktf.MantaBackendProps.property.account"></a>
+##### ~~`account`~~<sup>Required</sup> <a name="account" id="cdktf.MantaBackendProps.property.account"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly account: string;
@@ -17920,7 +18170,9 @@ public readonly account: string;
 
 ---
 
-##### `keyId`<sup>Required</sup> <a name="keyId" id="cdktf.MantaBackendProps.property.keyId"></a>
+##### ~~`keyId`~~<sup>Required</sup> <a name="keyId" id="cdktf.MantaBackendProps.property.keyId"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly keyId: string;
@@ -17930,7 +18182,9 @@ public readonly keyId: string;
 
 ---
 
-##### `path`<sup>Required</sup> <a name="path" id="cdktf.MantaBackendProps.property.path"></a>
+##### ~~`path`~~<sup>Required</sup> <a name="path" id="cdktf.MantaBackendProps.property.path"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly path: string;
@@ -17940,7 +18194,9 @@ public readonly path: string;
 
 ---
 
-##### `insecureSkipTlsVerify`<sup>Optional</sup> <a name="insecureSkipTlsVerify" id="cdktf.MantaBackendProps.property.insecureSkipTlsVerify"></a>
+##### ~~`insecureSkipTlsVerify`~~<sup>Optional</sup> <a name="insecureSkipTlsVerify" id="cdktf.MantaBackendProps.property.insecureSkipTlsVerify"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly insecureSkipTlsVerify: boolean;
@@ -17950,7 +18206,9 @@ public readonly insecureSkipTlsVerify: boolean;
 
 ---
 
-##### `keyMaterial`<sup>Optional</sup> <a name="keyMaterial" id="cdktf.MantaBackendProps.property.keyMaterial"></a>
+##### ~~`keyMaterial`~~<sup>Optional</sup> <a name="keyMaterial" id="cdktf.MantaBackendProps.property.keyMaterial"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly keyMaterial: string;
@@ -17960,7 +18218,9 @@ public readonly keyMaterial: string;
 
 ---
 
-##### `objectName`<sup>Optional</sup> <a name="objectName" id="cdktf.MantaBackendProps.property.objectName"></a>
+##### ~~`objectName`~~<sup>Optional</sup> <a name="objectName" id="cdktf.MantaBackendProps.property.objectName"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly objectName: string;
@@ -17970,7 +18230,9 @@ public readonly objectName: string;
 
 ---
 
-##### `url`<sup>Optional</sup> <a name="url" id="cdktf.MantaBackendProps.property.url"></a>
+##### ~~`url`~~<sup>Optional</sup> <a name="url" id="cdktf.MantaBackendProps.property.url"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly url: string;
@@ -17980,7 +18242,9 @@ public readonly url: string;
 
 ---
 
-##### `user`<sup>Optional</sup> <a name="user" id="cdktf.MantaBackendProps.property.user"></a>
+##### ~~`user`~~<sup>Optional</sup> <a name="user" id="cdktf.MantaBackendProps.property.user"></a>
+
+- _Deprecated:_ the manta backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly user: string;
@@ -19555,7 +19819,9 @@ const swiftBackendProps: SwiftBackendProps = { ... }
 
 ---
 
-##### `container`<sup>Required</sup> <a name="container" id="cdktf.SwiftBackendProps.property.container"></a>
+##### ~~`container`~~<sup>Required</sup> <a name="container" id="cdktf.SwiftBackendProps.property.container"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly container: string;
@@ -19565,7 +19831,9 @@ public readonly container: string;
 
 ---
 
-##### `applicationCredentialId`<sup>Optional</sup> <a name="applicationCredentialId" id="cdktf.SwiftBackendProps.property.applicationCredentialId"></a>
+##### ~~`applicationCredentialId`~~<sup>Optional</sup> <a name="applicationCredentialId" id="cdktf.SwiftBackendProps.property.applicationCredentialId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly applicationCredentialId: string;
@@ -19575,7 +19843,9 @@ public readonly applicationCredentialId: string;
 
 ---
 
-##### `applicationCredentialName`<sup>Optional</sup> <a name="applicationCredentialName" id="cdktf.SwiftBackendProps.property.applicationCredentialName"></a>
+##### ~~`applicationCredentialName`~~<sup>Optional</sup> <a name="applicationCredentialName" id="cdktf.SwiftBackendProps.property.applicationCredentialName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly applicationCredentialName: string;
@@ -19585,7 +19855,9 @@ public readonly applicationCredentialName: string;
 
 ---
 
-##### `applicationCredentialSecret`<sup>Optional</sup> <a name="applicationCredentialSecret" id="cdktf.SwiftBackendProps.property.applicationCredentialSecret"></a>
+##### ~~`applicationCredentialSecret`~~<sup>Optional</sup> <a name="applicationCredentialSecret" id="cdktf.SwiftBackendProps.property.applicationCredentialSecret"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly applicationCredentialSecret: string;
@@ -19595,7 +19867,9 @@ public readonly applicationCredentialSecret: string;
 
 ---
 
-##### `archiveContainer`<sup>Optional</sup> <a name="archiveContainer" id="cdktf.SwiftBackendProps.property.archiveContainer"></a>
+##### ~~`archiveContainer`~~<sup>Optional</sup> <a name="archiveContainer" id="cdktf.SwiftBackendProps.property.archiveContainer"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly archiveContainer: string;
@@ -19605,7 +19879,9 @@ public readonly archiveContainer: string;
 
 ---
 
-##### `authUrl`<sup>Optional</sup> <a name="authUrl" id="cdktf.SwiftBackendProps.property.authUrl"></a>
+##### ~~`authUrl`~~<sup>Optional</sup> <a name="authUrl" id="cdktf.SwiftBackendProps.property.authUrl"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly authUrl: string;
@@ -19615,7 +19891,9 @@ public readonly authUrl: string;
 
 ---
 
-##### `cacertFile`<sup>Optional</sup> <a name="cacertFile" id="cdktf.SwiftBackendProps.property.cacertFile"></a>
+##### ~~`cacertFile`~~<sup>Optional</sup> <a name="cacertFile" id="cdktf.SwiftBackendProps.property.cacertFile"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly cacertFile: string;
@@ -19625,7 +19903,9 @@ public readonly cacertFile: string;
 
 ---
 
-##### `cert`<sup>Optional</sup> <a name="cert" id="cdktf.SwiftBackendProps.property.cert"></a>
+##### ~~`cert`~~<sup>Optional</sup> <a name="cert" id="cdktf.SwiftBackendProps.property.cert"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly cert: string;
@@ -19635,7 +19915,9 @@ public readonly cert: string;
 
 ---
 
-##### `cloud`<sup>Optional</sup> <a name="cloud" id="cdktf.SwiftBackendProps.property.cloud"></a>
+##### ~~`cloud`~~<sup>Optional</sup> <a name="cloud" id="cdktf.SwiftBackendProps.property.cloud"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly cloud: string;
@@ -19645,7 +19927,9 @@ public readonly cloud: string;
 
 ---
 
-##### `defaultDomain`<sup>Optional</sup> <a name="defaultDomain" id="cdktf.SwiftBackendProps.property.defaultDomain"></a>
+##### ~~`defaultDomain`~~<sup>Optional</sup> <a name="defaultDomain" id="cdktf.SwiftBackendProps.property.defaultDomain"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly defaultDomain: string;
@@ -19655,7 +19939,9 @@ public readonly defaultDomain: string;
 
 ---
 
-##### `domainId`<sup>Optional</sup> <a name="domainId" id="cdktf.SwiftBackendProps.property.domainId"></a>
+##### ~~`domainId`~~<sup>Optional</sup> <a name="domainId" id="cdktf.SwiftBackendProps.property.domainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly domainId: string;
@@ -19665,7 +19951,9 @@ public readonly domainId: string;
 
 ---
 
-##### `domainName`<sup>Optional</sup> <a name="domainName" id="cdktf.SwiftBackendProps.property.domainName"></a>
+##### ~~`domainName`~~<sup>Optional</sup> <a name="domainName" id="cdktf.SwiftBackendProps.property.domainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly domainName: string;
@@ -19675,7 +19963,9 @@ public readonly domainName: string;
 
 ---
 
-##### `expireAfter`<sup>Optional</sup> <a name="expireAfter" id="cdktf.SwiftBackendProps.property.expireAfter"></a>
+##### ~~`expireAfter`~~<sup>Optional</sup> <a name="expireAfter" id="cdktf.SwiftBackendProps.property.expireAfter"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly expireAfter: string;
@@ -19685,7 +19975,9 @@ public readonly expireAfter: string;
 
 ---
 
-##### `insecure`<sup>Optional</sup> <a name="insecure" id="cdktf.SwiftBackendProps.property.insecure"></a>
+##### ~~`insecure`~~<sup>Optional</sup> <a name="insecure" id="cdktf.SwiftBackendProps.property.insecure"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly insecure: boolean;
@@ -19695,7 +19987,9 @@ public readonly insecure: boolean;
 
 ---
 
-##### `key`<sup>Optional</sup> <a name="key" id="cdktf.SwiftBackendProps.property.key"></a>
+##### ~~`key`~~<sup>Optional</sup> <a name="key" id="cdktf.SwiftBackendProps.property.key"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly key: string;
@@ -19705,7 +19999,9 @@ public readonly key: string;
 
 ---
 
-##### `password`<sup>Optional</sup> <a name="password" id="cdktf.SwiftBackendProps.property.password"></a>
+##### ~~`password`~~<sup>Optional</sup> <a name="password" id="cdktf.SwiftBackendProps.property.password"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly password: string;
@@ -19715,7 +20011,9 @@ public readonly password: string;
 
 ---
 
-##### `projectDomainId`<sup>Optional</sup> <a name="projectDomainId" id="cdktf.SwiftBackendProps.property.projectDomainId"></a>
+##### ~~`projectDomainId`~~<sup>Optional</sup> <a name="projectDomainId" id="cdktf.SwiftBackendProps.property.projectDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly projectDomainId: string;
@@ -19725,7 +20023,9 @@ public readonly projectDomainId: string;
 
 ---
 
-##### `projectDomainName`<sup>Optional</sup> <a name="projectDomainName" id="cdktf.SwiftBackendProps.property.projectDomainName"></a>
+##### ~~`projectDomainName`~~<sup>Optional</sup> <a name="projectDomainName" id="cdktf.SwiftBackendProps.property.projectDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly projectDomainName: string;
@@ -19735,7 +20035,9 @@ public readonly projectDomainName: string;
 
 ---
 
-##### `regionName`<sup>Optional</sup> <a name="regionName" id="cdktf.SwiftBackendProps.property.regionName"></a>
+##### ~~`regionName`~~<sup>Optional</sup> <a name="regionName" id="cdktf.SwiftBackendProps.property.regionName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly regionName: string;
@@ -19745,7 +20047,9 @@ public readonly regionName: string;
 
 ---
 
-##### `stateName`<sup>Optional</sup> <a name="stateName" id="cdktf.SwiftBackendProps.property.stateName"></a>
+##### ~~`stateName`~~<sup>Optional</sup> <a name="stateName" id="cdktf.SwiftBackendProps.property.stateName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly stateName: string;
@@ -19755,7 +20059,9 @@ public readonly stateName: string;
 
 ---
 
-##### `tenantId`<sup>Optional</sup> <a name="tenantId" id="cdktf.SwiftBackendProps.property.tenantId"></a>
+##### ~~`tenantId`~~<sup>Optional</sup> <a name="tenantId" id="cdktf.SwiftBackendProps.property.tenantId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly tenantId: string;
@@ -19765,7 +20071,9 @@ public readonly tenantId: string;
 
 ---
 
-##### `tenantName`<sup>Optional</sup> <a name="tenantName" id="cdktf.SwiftBackendProps.property.tenantName"></a>
+##### ~~`tenantName`~~<sup>Optional</sup> <a name="tenantName" id="cdktf.SwiftBackendProps.property.tenantName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly tenantName: string;
@@ -19775,7 +20083,9 @@ public readonly tenantName: string;
 
 ---
 
-##### `token`<sup>Optional</sup> <a name="token" id="cdktf.SwiftBackendProps.property.token"></a>
+##### ~~`token`~~<sup>Optional</sup> <a name="token" id="cdktf.SwiftBackendProps.property.token"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly token: string;
@@ -19785,7 +20095,9 @@ public readonly token: string;
 
 ---
 
-##### `userDomainId`<sup>Optional</sup> <a name="userDomainId" id="cdktf.SwiftBackendProps.property.userDomainId"></a>
+##### ~~`userDomainId`~~<sup>Optional</sup> <a name="userDomainId" id="cdktf.SwiftBackendProps.property.userDomainId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly userDomainId: string;
@@ -19795,7 +20107,9 @@ public readonly userDomainId: string;
 
 ---
 
-##### `userDomainName`<sup>Optional</sup> <a name="userDomainName" id="cdktf.SwiftBackendProps.property.userDomainName"></a>
+##### ~~`userDomainName`~~<sup>Optional</sup> <a name="userDomainName" id="cdktf.SwiftBackendProps.property.userDomainName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly userDomainName: string;
@@ -19805,7 +20119,9 @@ public readonly userDomainName: string;
 
 ---
 
-##### `userId`<sup>Optional</sup> <a name="userId" id="cdktf.SwiftBackendProps.property.userId"></a>
+##### ~~`userId`~~<sup>Optional</sup> <a name="userId" id="cdktf.SwiftBackendProps.property.userId"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly userId: string;
@@ -19815,7 +20131,9 @@ public readonly userId: string;
 
 ---
 
-##### `userName`<sup>Optional</sup> <a name="userName" id="cdktf.SwiftBackendProps.property.userName"></a>
+##### ~~`userName`~~<sup>Optional</sup> <a name="userName" id="cdktf.SwiftBackendProps.property.userName"></a>
+
+- _Deprecated:_ the swift backend has been deprecated in Terraform v1.2.3 and was removed in Terraform v1.3
 
 ```typescript
 public readonly userName: string;

--- a/website/docs/cdktf/concepts/remote-backends.mdx
+++ b/website/docs/cdktf/concepts/remote-backends.mdx
@@ -167,10 +167,6 @@ In addition to Terraform Cloud, Terraform and CDKTF support the following backen
   ```typescript
   new LocalBackend(stack, {...});
   ```
-- [artifactory](/language/v1.2.x/settings/backends/artifactory)
-  ```typescript
-  new ArtifactoryBackend(stack, {...});
-  ```
 - [azurerm](/language/settings/backends/azurerm)
   ```typescript
   new AzurermBackend(stack, {...});
@@ -183,14 +179,6 @@ In addition to Terraform Cloud, Terraform and CDKTF support the following backen
   ```typescript
   new CosBackend(stack, {...});
   ```
-- [etcd](/language/v1.2.x/settings/backends/etcd)
-  ```typescript
-  new EtcdBackend(stack, {...});
-  ```
-- [etcdv3](/language/v1.2.x/settings/backends/etcdv3)
-  ```typescript
-  new EtcdV3Backend(stack, {...});
-  ```
 - [gcs](/language/settings/backends/gcs)
   ```typescript
   new GcsBackend(stack, {...});
@@ -198,10 +186,6 @@ In addition to Terraform Cloud, Terraform and CDKTF support the following backen
 - [http](/language/settings/backends/http)
   ```typescript
   new HttpBackend(stack, {...});
-  ```
-- [manta](/language/v1.2.x/settings/backends/manta)
-  ```typescript
-  new MantaBackend(stack, {...});
   ```
 - [oss](/language/settings/backends/oss)
   ```typescript
@@ -215,10 +199,8 @@ In addition to Terraform Cloud, Terraform and CDKTF support the following backen
   ```typescript
   new S3Backend(stack, {...});
   ```
-- [swift](/language/v1.2.x/settings/backends/swift)
-  ```typescript
-  new SwiftBackend(stack, {...});
-  ```
+
+->**Note**: CDK for Terraform v0.14 deprecated the artifactory, etcd, etcdv3, manta, and swift backends. Terraform removed these backends in v1.3. For migration paths from these removed backends, refer to [Upgrading to Terraform v1.3](/language/v1.3.x/upgrade-guides).
 
 ## Escape Hatches
 


### PR DESCRIPTION
Marks our backend constructs and their options as deprecated.
Closes #2244