### PR TITLE
chore(cli): Prevent minification when watching cdktf-cli

### DIFF
--- a/packages/cdktf-cli/build.ts
+++ b/packages/cdktf-cli/build.ts
@@ -63,8 +63,8 @@ const nativeNodeModulesPlugin = {
     outdir: "./bundle",
     format: "cjs",
     target: "node14",
-    minify: true,
-    sourcemap: true,
+    minify: enableWatch ? false : true,
+    sourcemap: enableWatch ? false : true,
     watch: enableWatch && {
       onRebuild(error: Error) {
         if (error) console.error("Watch build failed: ", error);


### PR DESCRIPTION
We don't need to minify sources when we're watching as it's only used during development.

This is useful to get better stack traces and console logging.