### PR TITLE
feat(provider-generator): publish versions.json file for all languages

### DIFF
--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/versions-file.test.ts
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/versions-file.test.ts
@@ -1,22 +1,38 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import * as fs from "fs";
+import * as fs from "fs-extra";
 import * as os from "os";
 import * as path from "path";
 import { TerraformDependencyConstraint } from "../../../config";
+// Only imported for mocking purposes
+import "../../generator/provider-schema";
 import { ConstructsMaker, Language, GetOptions } from "../../constructs-maker";
+
+jest.mock("../../generator/provider-schema", () => {
+  const schema = JSON.parse(
+    fs.readFileSync(
+      path.join(__dirname, "fixtures", "versions-file.test.fixture.json"),
+      "utf8"
+    )
+  );
+
+  const originalModule = jest.requireActual("../../generator/provider-schema");
+  return {
+    __esmodule: true,
+    ...originalModule,
+    readProviderSchema: jest.fn().mockImplementation(async (_target) => {
+      return schema;
+    }),
+  };
+});
 
 jest.setTimeout(600_000);
 
-test("generates a versions file", async () => {
-  const workdir = await fs.mkdtempSync(
-    path.join(os.tmpdir(), "versions-file.test")
-  );
+global.setImmediate =
+  global.setImmediate || ((fn, ...args) => global.setTimeout(fn, 0, ...args));
 
-  const options: GetOptions = {
-    codeMakerOutput: workdir,
-    targetLanguage: Language.TYPESCRIPT,
-  };
+describe("versions.json file generation", () => {
+  const languages = [Language.TYPESCRIPT, Language.PYTHON];
   const constraints: TerraformDependencyConstraint[] = [
     {
       fqn: "hashicorp/aws",
@@ -37,13 +53,35 @@ test("generates a versions file", async () => {
       version: "2.16.0",
     },
   ];
-  const constructMaker = new ConstructsMaker(options, constraints);
-  await constructMaker.generate();
 
-  const output = fs.readFileSync(path.join(workdir, "versions.json"), "utf-8");
-  expect(Object.keys(JSON.parse(output))).toEqual(
-    expect.arrayContaining(
-      constraints.map((c) => `registry.terraform.io/${c.fqn}`)
-    )
+  beforeAll(() => {});
+
+  test.each(languages)(
+    "generates a file for the %s language",
+    async (language) => {
+      const workdir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "versions-file.test")
+      );
+
+      const options: GetOptions = {
+        codeMakerOutput: workdir,
+        targetLanguage: language,
+      };
+
+      // Ignore warnings to pop up from the generate function
+      process.env.NODE_OPTIONS = "--max-old-space-size=16384";
+      const constructMaker = new ConstructsMaker(options, constraints);
+      await constructMaker.generate();
+
+      const output = fs.readFileSync(
+        path.join(workdir, "versions.json"),
+        "utf-8"
+      );
+      expect(Object.keys(JSON.parse(output))).toEqual(
+        expect.arrayContaining(
+          constraints.map((c) => `registry.terraform.io/${c.fqn}`)
+        )
+      );
+    }
   );
 });

--- a/packages/@cdktf/provider-generator/lib/index.ts
+++ b/packages/@cdktf/provider-generator/lib/index.ts
@@ -29,7 +29,6 @@ import {
   readModuleSchema,
   readProviderSchema,
 } from "./get/generator/provider-schema";
-import path from "path";
 
 export { setLogger } from "./config";
 export { TerraformProviderGenerator, CodeMaker };
@@ -47,12 +46,9 @@ export async function generateProviderBindingsFromSchema(
   await code.save(targetPath);
 
   if (options) {
-    await generateAndCopyJsiiLanguage(
-      code,
-      options,
-      "versions.json",
-      path.join(targetPath, "versions.json")
-    );
+    // Since we're not generating the versions.json file here
+    // we'll prevent it from being copied
+    await generateAndCopyJsiiLanguage(code, options, false);
   }
 }
 

--- a/packages/@cdktf/provider-generator/lib/index.ts
+++ b/packages/@cdktf/provider-generator/lib/index.ts
@@ -19,7 +19,7 @@ import { CodeMaker } from "codemaker";
 import * as srcmak from "jsii-srcmak";
 import deepmerge from "deepmerge";
 import {
-  generateJsiiLanguage,
+  generateAndCopyJsiiLanguage,
   ConstructsMakerTarget,
 } from "./get/constructs-maker";
 export { escapeAttributeName } from "./get/generator/models";
@@ -29,6 +29,7 @@ import {
   readModuleSchema,
   readProviderSchema,
 } from "./get/generator/provider-schema";
+import path from "path";
 
 export { setLogger } from "./config";
 export { TerraformProviderGenerator, CodeMaker };
@@ -46,7 +47,12 @@ export async function generateProviderBindingsFromSchema(
   await code.save(targetPath);
 
   if (options) {
-    await generateJsiiLanguage(code, options);
+    await generateAndCopyJsiiLanguage(
+      code,
+      options,
+      "versions.json",
+      path.join(targetPath, "versions.json")
+    );
   }
 }
 


### PR DESCRIPTION
Currently we only publish the `versions.json` file for Typescript projects only. For other languages, there's currently no way to ascertain the version of the provider the bindings are built against. 

This is also important for the upcoming `cdktf provider list` feature, as we would like to present to the user the provider version for the locally generated binding.

 Caveat: This is me hacking around to find the simplest solution for getting the versions.json file published. If there's a much smarter way of doing this, please let me know. 🙏🏽 