### PR TITLE
feat(cli): only re-generate provider bindings on get if necessary

### DIFF
--- a/packages/@cdktf/provider-generator/lib/__tests__/provider.test.ts
+++ b/packages/@cdktf/provider-generator/lib/__tests__/provider.test.ts
@@ -45,15 +45,12 @@ describe("Provider", () => {
     );
     return await mkdtemp(async (workdir) => {
       const jsiiPath = path.join(workdir, ".jsii");
-      const maker = new ConstructsMaker(
-        {
-          codeMakerOutput: workdir,
-          outputJsii: jsiiPath,
-          targetLanguage: Language.TYPESCRIPT,
-        },
-        [constraint]
-      );
-      await maker.generate();
+      const maker = new ConstructsMaker({
+        codeMakerOutput: workdir,
+        outputJsii: jsiiPath,
+        targetLanguage: Language.TYPESCRIPT,
+      });
+      await maker.generate([constraint]);
       const snapshot = directorySnapshot(workdir);
       expect(snapshot).toMatchSnapshot();
     });

--- a/packages/@cdktf/provider-generator/lib/__tests__/provider.test.ts
+++ b/packages/@cdktf/provider-generator/lib/__tests__/provider.test.ts
@@ -28,6 +28,10 @@ function directorySnapshot(root: string) {
 
     if (path.extname(filePath) === ".json") {
       content = fs.readJsonSync(filePath);
+
+      if (path.basename(filePath) === "constraints.json") {
+        delete content.cdktf;
+      }
     } else {
       content = fs.readFileSync(filePath, "utf-8");
     }

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/module-generator.test.ts
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/module-generator.test.ts
@@ -17,11 +17,11 @@ test("generate some modules", async () => {
     "terraform-aws-modules/eks/aws@7.0.1"
   );
 
-  const maker = new ConstructsMaker(
-    { codeMakerOutput: workdir, targetLanguage: Language.TYPESCRIPT },
-    [constraint]
-  );
-  await maker.generate();
+  const maker = new ConstructsMaker({
+    codeMakerOutput: workdir,
+    targetLanguage: Language.TYPESCRIPT,
+  });
+  await maker.generate([constraint]);
 
   const output = fs.readFileSync(
     path.join(workdir, "modules/terraform-aws-modules/aws/eks.ts"),
@@ -54,11 +54,11 @@ test("generate multiple aws modules", async () => {
     new TerraformModuleConstraint("terraform-aws-modules/rds-aurora/aws@4.1.0"),
   ];
 
-  const maker = new ConstructsMaker(
-    { codeMakerOutput: workdir, targetLanguage: Language.TYPESCRIPT },
-    constraints
-  );
-  await maker.generate();
+  const maker = new ConstructsMaker({
+    codeMakerOutput: workdir,
+    targetLanguage: Language.TYPESCRIPT,
+  });
+  await maker.generate(constraints);
 
   const vpcOutput = fs.readFileSync(
     path.join(workdir, "modules/terraform-aws-modules/aws/vpc.ts"),
@@ -87,11 +87,11 @@ test("generate module that can't be initialized", async () => {
     "milliHQ/next-js/aws@1.0.0-canary.5"
   );
 
-  const maker = new ConstructsMaker(
-    { codeMakerOutput: workdir, targetLanguage: Language.TYPESCRIPT },
-    [constraint]
-  );
-  await maker.generate();
+  const maker = new ConstructsMaker({
+    codeMakerOutput: workdir,
+    targetLanguage: Language.TYPESCRIPT,
+  });
+  await maker.generate([constraint]);
 
   const output = fs.readFileSync(
     path.join(workdir, "modules/milliHQ/aws/next-js.ts"),

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/versions-file.test.ts
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/versions-file.test.ts
@@ -37,8 +37,8 @@ test("generates a versions file", async () => {
       version: "2.16.0",
     },
   ];
-  const constructMaker = new ConstructsMaker(options, constraints);
-  await constructMaker.generate();
+  const constructMaker = new ConstructsMaker(options);
+  await constructMaker.generate(constraints);
 
   const output = fs.readFileSync(path.join(workdir, "versions.json"), "utf-8");
   expect(Object.keys(JSON.parse(output))).toEqual(

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/versions-file.test.ts
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/versions-file.test.ts
@@ -1,22 +1,38 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import * as fs from "fs";
+import * as fs from "fs-extra";
 import * as os from "os";
 import * as path from "path";
 import { TerraformDependencyConstraint } from "../../../config";
+// Only imported for mocking purposes
+import "../../generator/provider-schema";
 import { ConstructsMaker, Language, GetOptions } from "../../constructs-maker";
 
-jest.setTimeout(600_000);
-
-test("generates a versions file", async () => {
-  const workdir = await fs.mkdtempSync(
-    path.join(os.tmpdir(), "versions-file.test")
+jest.mock("../../generator/provider-schema", () => {
+  const schema = JSON.parse(
+    fs.readFileSync(
+      path.join(__dirname, "fixtures", "versions-file.test.fixture.json"),
+      "utf8"
+    )
   );
 
-  const options: GetOptions = {
-    codeMakerOutput: workdir,
-    targetLanguage: Language.TYPESCRIPT,
+  const originalModule = jest.requireActual("../../generator/provider-schema");
+  return {
+    __esmodule: true,
+    ...originalModule,
+    readProviderSchema: jest.fn().mockImplementation(async (_target) => {
+      return schema;
+    }),
   };
+});
+
+jest.setTimeout(600_000);
+global.setImmediate =
+  global.setImmediate || ((fn, ...args) => global.setTimeout(fn, 0, ...args));
+
+describe("versions.json file generation", () => {
+  const languages = [Language.TYPESCRIPT, Language.PYTHON];
+
   const constraints: TerraformDependencyConstraint[] = [
     {
       fqn: "hashicorp/aws",
@@ -37,13 +53,35 @@ test("generates a versions file", async () => {
       version: "2.16.0",
     },
   ];
-  const constructMaker = new ConstructsMaker(options);
-  await constructMaker.generate(constraints);
 
-  const output = fs.readFileSync(path.join(workdir, "versions.json"), "utf-8");
-  expect(Object.keys(JSON.parse(output))).toEqual(
-    expect.arrayContaining(
-      constraints.map((c) => `registry.terraform.io/${c.fqn}`)
-    )
+  beforeAll(() => {});
+
+  test.each(languages)(
+    "generates a file for the %s language",
+    async (language) => {
+      const workdir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "versions-file.test")
+      );
+
+      const options: GetOptions = {
+        codeMakerOutput: workdir,
+        targetLanguage: language,
+      };
+
+      // Ignore warnings to pop up from the generate function
+      process.env.NODE_OPTIONS = "--max-old-space-size=16384";
+      const constructMaker = new ConstructsMaker(options);
+      await constructMaker.generate(constraints);
+
+      const output = fs.readFileSync(
+        path.join(workdir, "versions.json"),
+        "utf-8"
+      );
+      expect(Object.keys(JSON.parse(output))).toEqual(
+        expect.arrayContaining(
+          constraints.map((c) => `registry.terraform.io/${c.fqn}`)
+        )
+      );
+    }
   );
 });

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/util.ts
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/util.ts
@@ -33,11 +33,11 @@ export function expectModuleToMatchSnapshot(
       fs.mkdirSync("work");
       const workdir = path.join(curdir, "work");
 
-      const maker = new ConstructsMaker(
-        { codeMakerOutput: workdir, targetLanguage: Language.TYPESCRIPT },
-        [constraint]
-      );
-      await maker.generate();
+      const maker = new ConstructsMaker({
+        codeMakerOutput: workdir,
+        targetLanguage: Language.TYPESCRIPT,
+      });
+      await maker.generate([constraint]);
 
       const output = fs.readFileSync(
         path.join(workdir, "modules/module.ts"),

--- a/packages/@cdktf/provider-generator/lib/get/constructs-maker.ts
+++ b/packages/@cdktf/provider-generator/lib/get/constructs-maker.ts
@@ -429,7 +429,7 @@ export class ConstructsMaker {
       }
 
       return acc;
-    }, this.versions);
+    }, {});
 
     logger.debug(
       `Writing versions file (${filePath}): ${JSON.stringify(
@@ -440,7 +440,7 @@ export class ConstructsMaker {
     );
 
     this.code.openFile(filePath);
-    this.code.line(JSON.stringify(versions, null, 2));
+    this.code.line(JSON.stringify({ ...versions, ...this.versions }, null, 2));
     this.code.closeFile(filePath);
     return filePath;
   }

--- a/packages/@cdktf/provider-generator/lib/get/constructs-maker.ts
+++ b/packages/@cdktf/provider-generator/lib/get/constructs-maker.ts
@@ -19,6 +19,7 @@ import { TerraformProviderGenerator } from "./generator/provider-generator";
 import { ModuleGenerator } from "./generator/module-generator";
 import { ModuleSchema } from "./generator/module-schema";
 import { logTimespan } from "../config";
+import { DISPLAY_VERSION } from "../../../../cdktf-cli/src/lib/version";
 
 export enum Language {
   TYPESCRIPT = "typescript",
@@ -38,7 +39,8 @@ export const LANGUAGES = [
 
 export async function generateJsiiLanguage(
   code: CodeMaker,
-  opts: srcmak.Options
+  opts: srcmak.Options,
+  outputPath: string
 ) {
   await mkdtemp(async (staging) => {
     // this is not typescript, so we generate in a staging directory and
@@ -46,8 +48,13 @@ export async function generateJsiiLanguage(
     // into our project.
     await code.save(staging);
     await srcmak.srcmak(staging, opts);
+    ["versions.json", "constraints.json"].forEach((file) => {
+      fs.copySync(path.resolve(staging, file), path.resolve(outputPath, file));
+    });
   });
 }
+
+type ConstraintFile = { providers: Record<string, string>; cdktf: string };
 
 export interface GetOptions {
   readonly targetLanguage: Language;
@@ -214,20 +221,15 @@ export class ConstructsMakerProviderTarget extends ConstructsMakerTarget {
 export class ConstructsMaker {
   private readonly codeMakerOutdir: string;
   private readonly code: CodeMaker;
-  private readonly targets: ConstructsMakerTarget[];
   private versions: { [providerName: string]: string | undefined };
 
   constructor(
     private readonly options: GetOptions,
-    private readonly constraints: TerraformDependencyConstraint[],
     private readonly reportTelemetry: (params: any) => void = () => {}
   ) {
     this.codeMakerOutdir = path.resolve(this.options.codeMakerOutput);
     fs.mkdirpSync(this.codeMakerOutdir);
     this.code = new CodeMaker();
-    this.targets = this.constraints.map((constraint) =>
-      ConstructsMakerTarget.from(constraint, this.options.targetLanguage)
-    );
     this.versions = {};
   }
   private async generateTypescriptProvider(
@@ -243,6 +245,106 @@ export class ConstructsMaker {
 
     this.versions = { ...this.versions, ...generator.versions };
     endTSTimer();
+  }
+
+  public async filterAlreadyGenerated(
+    constraints: TerraformDependencyConstraint[]
+  ) {
+    let constraintsFile = "{}";
+    try {
+      constraintsFile = await fs.readFile(
+        path.join(this.codeMakerOutdir, "constraints.json"),
+        "utf8"
+      );
+    } catch (e) {
+      logger.info(
+        `Could not find constraints.json file while filtering: ${e}. This means no providers were generated, so all constraints need to be generated.`
+      );
+      return constraints;
+    }
+    logger.debug(`Found constraints.json file: ${constraintsFile}`);
+
+    let previousConstraints: Partial<ConstraintFile> = {};
+    try {
+      previousConstraints = JSON.parse(constraintsFile);
+    } catch (e) {
+      logger.info(
+        `Could not parse constraints.json file while filtering: ${e}. Generating all constraints.`
+      );
+      return constraints;
+    }
+
+    logger.debug(
+      `Found previous constraints: ${JSON.stringify(
+        previousConstraints,
+        null,
+        2
+      )}`
+    );
+
+    if (
+      !previousConstraints.providers ||
+      typeof previousConstraints.providers !== "object"
+    ) {
+      logger.info(
+        `Could not find providers in constraints.json file, generating all constraints. The constraints file was ${JSON.stringify(
+          previousConstraints,
+          null,
+          2
+        )}`
+      );
+      return constraints;
+    }
+
+    if (previousConstraints.cdktf !== DISPLAY_VERSION) {
+      logger.info(
+        `The CDKTF version has changed, generating all constraints. The previous version was ${previousConstraints.cdktf}, the current version is ${DISPLAY_VERSION}`
+      );
+      return constraints;
+    }
+
+    const constraintsToGenerate = constraints.filter((constraint) => {
+      const constraintMatches =
+        previousConstraints.providers![constraint.fqn] === constraint.version;
+      let providerFolderExists = false;
+
+      switch (this.options.targetLanguage) {
+        case Language.TYPESCRIPT:
+          providerFolderExists = fs.existsSync(
+            path.join(this.codeMakerOutdir, "providers", constraint.name)
+          );
+          break;
+        case Language.PYTHON:
+        case Language.JAVA:
+        case Language.CSHARP:
+          providerFolderExists = fs.existsSync(
+            path.join(this.codeMakerOutdir, constraint.name)
+          );
+          break;
+        case Language.GO:
+          providerFolderExists = fs.existsSync(
+            path.join(
+              this.codeMakerOutdir,
+              constraint.namespace || "hashicorp",
+              constraint.name
+            )
+          );
+          break;
+      }
+
+      const providerExists = constraintMatches && providerFolderExists;
+      return !providerExists;
+    });
+
+    logger.debug(
+      `Constraints to generate: ${JSON.stringify(
+        constraintsToGenerate,
+        null,
+        2
+      )}`
+    );
+
+    return constraintsToGenerate;
   }
 
   private async generateTypescriptModule(target: ConstructsMakerModuleTarget) {
@@ -273,10 +375,137 @@ export class ConstructsMaker {
   }
 
   // emits a versions.json file with a map of the used version for each provider fqpn
-  private emitVersionsFile() {
+  private updateVersionsFile(
+    allowedConstraints: TerraformDependencyConstraint[]
+  ) {
+    logger.debug(
+      `Updating versions file with generated versions ${JSON.stringify(
+        this.versions,
+        null,
+        2
+      )} with allowed constraints ${JSON.stringify(
+        allowedConstraints,
+        null,
+        2
+      )}`
+    );
     const filePath = "versions.json";
+    let previousVersions: Record<string, string> = {};
+    try {
+      previousVersions = JSON.parse(
+        fs.readFileSync(path.resolve(this.codeMakerOutdir, filePath), "utf8")
+      );
+
+      logger.debug(
+        `Read existing versions file: ${JSON.stringify(
+          previousVersions,
+          null,
+          2
+        )}`
+      );
+    } catch (e) {
+      // ignore
+      logger.debug(
+        `Could not read versions file, this is expected if there are no pre-existing local providers: ${e}`
+      );
+    }
+
+    const versions = allowedConstraints.reduce((acc, constraint) => {
+      const provider = Object.entries(previousVersions).find(([name]) =>
+        // This could be more refined, but it's good enough for now
+        name.endsWith(constraint.fqn)
+      );
+
+      if (provider) {
+        const [name, version] = provider;
+        return { ...acc, [name]: version };
+      }
+
+      return acc;
+    }, this.versions);
+
+    logger.debug(
+      `Writing versions file (${filePath}): ${JSON.stringify(
+        versions,
+        null,
+        2
+      )}`
+    );
+
     this.code.openFile(filePath);
-    this.code.line(JSON.stringify(this.versions, null, 2));
+    this.code.line(JSON.stringify(versions, null, 2));
+    this.code.closeFile(filePath);
+    return filePath;
+  }
+
+  public async removeFoldersThatShouldNotExist(
+    constraintsThatShouldExist: TerraformDependencyConstraint[]
+  ) {
+    logger.debug(
+      `Removing providers except for ${JSON.stringify(
+        constraintsThatShouldExist,
+        null,
+        2
+      )}`
+    );
+
+    // All languages besides TS keep their providers in the same folders as modules
+    // this makes it impossible for us to distinguish a no longer required provider
+    // from a manually written construct or a module
+    if (!this.isJavascriptTarget) {
+      return;
+    }
+
+    let filesInProviders: string[] = [];
+    const providersFolder = path.resolve(this.codeMakerOutdir, "providers");
+    try {
+      filesInProviders = await fs.readdir(providersFolder);
+    } catch (e) {
+      logger.debug(
+        `Error listing files in providers folder '${providersFolder}': ${e}`
+      );
+    }
+
+    const folders = filesInProviders.filter((file) =>
+      fs
+        .statSync(path.resolve(this.codeMakerOutdir, "providers", file))
+        .isDirectory()
+    );
+
+    return folders.forEach((folder) => {
+      const shouldExist = constraintsThatShouldExist.some(
+        (constraint) => constraint.name === folder
+      );
+
+      if (!shouldExist) {
+        logger.debug(`Removing folder ${folder} from providers`);
+        fs.removeSync(path.resolve(this.codeMakerOutdir, "providers", folder));
+      }
+    });
+  }
+
+  // emits a constraints.json file with a map of the used provider fqpns and version constraints
+  // this is used for caching purposes
+  private emitConstraintsFile(
+    allowedConstraints: TerraformDependencyConstraint[]
+  ) {
+    const filePath = "constraints.json";
+
+    const content: ConstraintFile = {
+      cdktf: DISPLAY_VERSION,
+      providers: allowedConstraints
+        .sort((a, b) => a.fqn.localeCompare(b.fqn))
+        .reduce(
+          (carry, item) => ({
+            ...carry,
+            [item.fqn]: item.version,
+          }),
+          {}
+        ),
+    };
+
+    this.code.openFile(filePath);
+    this.code.line(JSON.stringify(content, null, 2));
     this.code.closeFile(filePath);
     return filePath;
   }
@@ -348,18 +577,23 @@ a NODE_OPTIONS variable, we won't override it. Hence, the provider generation mi
     }
 
     const jsiiTimer = logTimespan("JSII");
-    await generateJsiiLanguage(this.code, opts);
+    await generateJsiiLanguage(this.code, opts, this.codeMakerOutdir);
     jsiiTimer();
   }
 
-  public async generate() {
-    const endGenerateTimer = logTimespan("Generate TS");
-    await Promise.all(
-      this.targets.map((target) => this.generateTypescript(target))
+  public async generate(
+    allConstraints: TerraformDependencyConstraint[],
+    constraintsToGenerate = allConstraints
+  ) {
+    const targets = constraintsToGenerate.map((constraint) =>
+      ConstructsMakerTarget.from(constraint, this.options.targetLanguage)
     );
+    const endGenerateTimer = logTimespan("Generate TS");
+    await Promise.all(targets.map((target) => this.generateTypescript(target)));
     endGenerateTimer();
 
-    this.emitVersionsFile();
+    this.updateVersionsFile(allConstraints);
+    this.emitConstraintsFile(allConstraints);
 
     if (this.isJavascriptTarget) {
       await this.save();
@@ -369,11 +603,11 @@ a NODE_OPTIONS variable, we won't override it. Hence, the provider generation mi
       const numberOfWorkers = Math.max(
         1,
         this.options.jsiiParallelism === -1
-          ? this.targets.length
+          ? targets.length
           : this.options.jsiiParallelism || 1
       );
 
-      const work = [...this.targets];
+      const work = [...targets];
       const workers = new Array(numberOfWorkers).fill(async () => {
         let target: ConstructsMakerTarget | undefined;
         while ((target = work.pop())) {
@@ -388,7 +622,7 @@ a NODE_OPTIONS variable, we won't override it. Hence, the provider generation mi
       await Promise.all(workers.map((fn) => fn()));
     }
 
-    for (const target of this.targets) {
+    for (const target of targets) {
       await this.reportTelemetry({
         payload: target.trackingPayload,
         language: target.targetLanguage,

--- a/packages/@cdktf/provider-generator/lib/get/constructs-maker.ts
+++ b/packages/@cdktf/provider-generator/lib/get/constructs-maker.ts
@@ -49,7 +49,14 @@ export async function generateJsiiLanguage(
     await code.save(staging);
     await srcmak.srcmak(staging, opts);
     ["versions.json", "constraints.json"].forEach((file) => {
-      fs.copySync(path.resolve(staging, file), path.resolve(outputPath, file));
+      try {
+        fs.copySync(
+          path.resolve(staging, file),
+          path.resolve(outputPath, file)
+        );
+      } catch (e) {
+        logger.debug(`Failed to copy ${file}: ${e}`);
+      }
     });
   });
 }

--- a/packages/@cdktf/provider-generator/lib/index.ts
+++ b/packages/@cdktf/provider-generator/lib/index.ts
@@ -46,7 +46,7 @@ export async function generateProviderBindingsFromSchema(
   await code.save(targetPath);
 
   if (options) {
-    await generateJsiiLanguage(code, options);
+    await generateJsiiLanguage(code, options, targetPath);
   }
 }
 

--- a/packages/cdktf-cli/src/bin/cmds/get.ts
+++ b/packages/cdktf-cli/src/bin/cmds/get.ts
@@ -29,6 +29,11 @@ class Command extends BaseCommand {
         alias: "l",
         choices: LANGUAGES,
       })
+      .option("force", {
+        default: false,
+        type: "boolean",
+        desc: "Regenerates all generated constructs",
+      })
       .option("parallelism", {
         type: "number",
         required: false,

--- a/packages/cdktf-cli/src/bin/cmds/handlers.ts
+++ b/packages/cdktf-cli/src/bin/cmds/handlers.ts
@@ -46,7 +46,10 @@ import { initializErrorReporting } from "../../lib/error-reporting";
 import { CdktfConfig, ProviderDependencySpec } from "../../lib/cdktf-config";
 import { providerAdd as providerAddLib } from "../../lib/provider-add";
 import { logger } from "../../lib/logging";
-import { DependencyManager, ProviderConstraint } from "../../lib/dependencies/dependency-manager";
+import {
+  DependencyManager,
+  ProviderConstraint,
+} from "../../lib/dependencies/dependency-manager";
 
 const chalkColour = new chalk.Instance();
 const config = cfg.readConfigSync();
@@ -196,6 +199,7 @@ export async function get(argv: {
   output: string;
   language: Language;
   parallelism: number;
+  force?: boolean;
 }) {
   throwIfNotProjectDirectory();
   await displayVersionMessage();
@@ -205,7 +209,7 @@ export async function get(argv: {
   const config = cfg.readConfigSync(); // read config again to be up-to-date (if called via 'add' command)
   const providers = config.terraformProviders ?? [];
   const modules = config.terraformModules ?? [];
-  const { output, language, parallelism } = argv;
+  const { output, language, parallelism, force } = argv;
 
   const constraints: cfg.TerraformDependencyConstraint[] = [
     ...providers,
@@ -225,6 +229,7 @@ export async function get(argv: {
       language: language,
       constraints,
       parallelism,
+      force,
     })
   );
 }
@@ -242,7 +247,7 @@ export async function init(argv: any) {
 
   checkForEmptyDirectory(".");
 
-  const {needsGet, codeMakerOutput, language} = await runInit(argv);
+  const { needsGet, codeMakerOutput, language } = await runInit(argv);
 
   if (needsGet) {
     console.log(

--- a/packages/cdktf-cli/src/bin/cmds/handlers.ts
+++ b/packages/cdktf-cli/src/bin/cmds/handlers.ts
@@ -473,11 +473,13 @@ export async function providerUpgrade(argv: any) {
   }
 
   if (constraintsToUpdate.length > 0) {
+    const singular = constraintsToUpdate.length === 1;
     console.log(
       `${constraintsToUpdate.length} local provider${
-        constraintsToUpdate.length === 1 ? "" : "s"
-      } have been updated. Running cdktf get to update...`
+        singular ? " has" : "s have"
+      } been updated. Running cdktf get to update...`
     );
+
     const config = cfg.readConfigSync(); // read config again to be up-to-date (if called via 'add' command)
     const providers = config.terraformProviders ?? [];
     const modules = config.terraformModules ?? [];

--- a/packages/cdktf-cli/src/bin/cmds/handlers.ts
+++ b/packages/cdktf-cli/src/bin/cmds/handlers.ts
@@ -52,6 +52,10 @@ import {
 } from "../../lib/dependencies/dependency-manager";
 import { get as getLib } from "../../lib/get";
 import { GetOptions } from "../../../../@cdktf/provider-generator/lib/get/constructs-maker";
+import {
+  TerraformModuleConstraint,
+  TerraformProviderConstraint,
+} from "../../../../@cdktf/provider-generator/lib/config";
 
 const chalkColour = new chalk.Instance();
 const config = cfg.readConfigSync();
@@ -214,8 +218,8 @@ export async function get(argv: {
   const { output, language, parallelism, force } = argv;
 
   const constraints: cfg.TerraformDependencyConstraint[] = [
-    ...providers,
-    ...modules,
+    ...providers.map((c) => new TerraformProviderConstraint(c)),
+    ...modules.map((c) => new TerraformModuleConstraint(c)),
   ];
 
   if (constraints.length === 0) {
@@ -498,7 +502,9 @@ export async function providerUpgrade(argv: any) {
       constructsOptions,
       constraints,
       cleanDirectory: false,
-      constraintsToGenerate: constraintsToUpdate.map((c) => c.toString()),
+      constraintsToGenerate: constraintsToUpdate.map(
+        (c) => new TerraformProviderConstraint(c)
+      ),
     });
   }
 }

--- a/packages/cdktf-cli/src/bin/cmds/helper/init.ts
+++ b/packages/cdktf-cli/src/bin/cmds/helper/init.ts
@@ -265,7 +265,7 @@ This means that your Terraform state file will be stored locally on disk in a fi
     needsGet,
     codeMakerOutput: cdktfConfig.codeMakerOutput,
     language: cdktfConfig.language,
-  }
+  };
 }
 
 async function askForProviders(): Promise<string[] | undefined> {
@@ -274,7 +274,9 @@ async function askForProviders(): Promise<string[] | undefined> {
   }
   const prebuiltProviders = await getAllPrebuiltProviders();
   const options = Object.keys(prebuiltProviders);
-  console.log(chalkColour`{yellow Note: You can always add providers using 'cdktf provider add' later on}`)
+  console.log(
+    chalkColour`{yellow Note: You can always add providers using 'cdktf provider add' later on}`
+  );
   const { providers: selection } = await inquirer.prompt([
     {
       type: "checkbox",

--- a/packages/cdktf-cli/src/bin/cmds/provider-upgrade.ts
+++ b/packages/cdktf-cli/src/bin/cmds/provider-upgrade.ts
@@ -8,7 +8,7 @@ import { BaseCommand } from "./helper/base-command";
 class Command extends BaseCommand {
   public readonly command = "upgrade <provider...>";
   public readonly describe = `Upgrade one or more Terraform providers in your project to the newest version compatible with your CDKTF version.
-    If your project has the associated pre-built provider already installed, CDKTF updates the pre-built provider. Otherwise, CDKTF adds the specified provider to the cdktf.json configuration file and generates local provider bindings.`
+    If your project has the associated pre-built provider already installed, CDKTF updates the pre-built provider. Otherwise, CDKTF adds the specified provider to the cdktf.json configuration file and generates local provider bindings.`;
 
   public readonly builder = (args: yargs.Argv) =>
     args.showHelpOnFail(true).positional("provider", {

--- a/packages/cdktf-cli/src/bin/cmds/ui/get.tsx
+++ b/packages/cdktf-cli/src/bin/cmds/ui/get.tsx
@@ -11,6 +11,7 @@ interface GetConfig {
   language: Language;
   constraints: config.TerraformDependencyConstraint[];
   parallelism: number;
+  force?: boolean;
 }
 
 export const Get = ({
@@ -18,6 +19,7 @@ export const Get = ({
   language,
   constraints,
   parallelism,
+  force,
 }: GetConfig): React.ReactElement => {
   const [currentStatus, setCurrentStatus] = React.useState<Status>(
     Status.STARTING
@@ -36,6 +38,7 @@ export const Get = ({
         await get({
           constraints,
           constructsOptions,
+          cleanDirectory: force,
           onUpdate: setCurrentStatus,
           reportTelemetry: (payload: {
             targetLanguage: string;

--- a/packages/cdktf-cli/src/lib/get.ts
+++ b/packages/cdktf-cli/src/lib/get.ts
@@ -21,7 +21,9 @@ export enum GetStatus {
 type StringDependencyConstraint = string; // e.g. hashicorp/aws@ ~> 2.0
 type DependencyConstraint =
   | config.TerraformDependencyConstraint
-  | StringDependencyConstraint;
+  | StringDependencyConstraint
+  | config.TerraformModuleConstraint
+  | config.TerraformProviderConstraint;
 
 interface GetConfig {
   // All existing constraints (to be able to remove no longer used ones)

--- a/packages/cdktf-cli/src/lib/get.ts
+++ b/packages/cdktf-cli/src/lib/get.ts
@@ -1,9 +1,15 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import { ConstructsMaker, GetOptions, config } from "@cdktf/provider-generator";
+import {
+  ConstructsMaker,
+  GetOptions,
+  config,
+  Language,
+} from "@cdktf/provider-generator";
 import {} from "@cdktf/provider-generator/lib/config";
 import * as fs from "fs-extra";
 import { logger } from "./logging";
+import * as path from "path";
 
 export enum GetStatus {
   STARTING = "starting",
@@ -18,8 +24,12 @@ type DependencyConstraint =
   | StringDependencyConstraint;
 
 interface GetConfig {
+  // All existing constraints (to be able to remove no longer used ones)
   constraints: DependencyConstraint[];
+  // The constraints that should be generated
+  constraintsToGenerate?: DependencyConstraint[];
   constructsOptions: GetOptions;
+  cleanDirectory?: boolean;
   onUpdate?: (payload: GetStatus) => void;
   reportTelemetry?: (telemetry: {
     targetLanguage: string;
@@ -30,21 +40,45 @@ interface GetConfig {
 export async function get({
   constructsOptions,
   constraints,
+  constraintsToGenerate,
+  cleanDirectory,
   onUpdate = () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
   reportTelemetry = () => {}, // eslint-disable-line @typescript-eslint/no-empty-function
 }: GetConfig) {
-  logger.debug(
-    `Starting get, removing output directory: '${constructsOptions.codeMakerOutput}'`
-  );
-  await fs.remove(constructsOptions.codeMakerOutput);
+  logger.debug(`Starting get with outdir ${constructsOptions.codeMakerOutput}`);
   const constructsMaker = new ConstructsMaker(
     constructsOptions,
-    constraints as config.TerraformDependencyConstraint[], // ConstructsMaker handles both string and extended form, but is not consistent type wise
     reportTelemetry
   );
+
+  if (cleanDirectory) {
+    await fs.remove(constructsOptions.codeMakerOutput);
+  } else {
+    // Remove all providers that are not in the new list
+    await constructsMaker.removeFoldersThatShouldNotExist(
+      constraints as config.TerraformDependencyConstraint[]
+    );
+    if (constructsOptions.targetLanguage === Language.TYPESCRIPT) {
+      // Remove all modules
+      await fs.remove(
+        path.resolve(constructsOptions.codeMakerOutput, "modules")
+      );
+    }
+  }
+
+  // Filter constraints to generate
+  const toGenerate =
+    (constraintsToGenerate as config.TerraformDependencyConstraint[]) ||
+    (await constructsMaker.filterAlreadyGenerated(
+      constraints as config.TerraformDependencyConstraint[]
+    ));
+
   onUpdate(GetStatus.DOWNLOADING);
   logger.debug("Generating provider bindings");
-  await constructsMaker.generate();
+  await constructsMaker.generate(
+    constraints as config.TerraformDependencyConstraint[], // ConstructsMaker handles both string and extended form, but is not consistent type wise
+    toGenerate
+  );
   logger.debug("Provider bindings generated");
 
   if (!(await fs.pathExists(constructsOptions.codeMakerOutput))) {

--- a/packages/cdktf-cli/src/lib/get.ts
+++ b/packages/cdktf-cli/src/lib/get.ts
@@ -6,7 +6,7 @@ import {
   config,
   Language,
 } from "@cdktf/provider-generator";
-import {} from "@cdktf/provider-generator/lib/config";
+import { TerraformProviderConstraint } from "@cdktf/provider-generator/lib/config";
 import * as fs from "fs-extra";
 import { logger } from "./logging";
 import * as path from "path";
@@ -67,20 +67,21 @@ export async function get({
       );
     }
   }
+  const dependencyConstraintsToGenerate = constraintsToGenerate?.map(
+    (c) => new TerraformProviderConstraint(c)
+  );
+  const dependencyConstraints = constraints.map(
+    (c) => new TerraformProviderConstraint(c)
+  );
 
   // Filter constraints to generate
   const toGenerate =
-    (constraintsToGenerate as config.TerraformDependencyConstraint[]) ||
-    (await constructsMaker.filterAlreadyGenerated(
-      constraints as config.TerraformDependencyConstraint[]
-    ));
+    dependencyConstraintsToGenerate ||
+    (await constructsMaker.filterAlreadyGenerated(dependencyConstraints));
 
   onUpdate(GetStatus.DOWNLOADING);
   logger.debug("Generating provider bindings");
-  await constructsMaker.generate(
-    constraints as config.TerraformDependencyConstraint[], // ConstructsMaker handles both string and extended form, but is not consistent type wise
-    toGenerate
-  );
+  await constructsMaker.generate(dependencyConstraints, toGenerate);
   logger.debug("Provider bindings generated");
 
   if (!(await fs.pathExists(constructsOptions.codeMakerOutput))) {

--- a/website/docs/cdktf/cli-reference/commands.mdx
+++ b/website/docs/cdktf/cli-reference/commands.mdx
@@ -302,6 +302,9 @@ $ cdktf diff
 
 This command downloads the providers and modules for an application and
 generates CDK constructs for them. It can use the `cdktf.json` configuration file to read the list of providers and modules.
+It only generates currently missing provider bindings, so it is very fast if nothing changed.
+If you specify loose version constraints in your `cdktf.json` file and have an existing version already generated locally it will not update the version.
+To update the version you can run `cdktf get --force` to recreate all bindings. If you change a version constraint the `cdktf get` command will recreate the bindings for this provider.
 
 ```bash
 $ cdktf get --help
@@ -315,15 +318,16 @@ cdktf get [OPTIONS]
 Generate CDK Constructs for Terraform providers and modules.
 
 Options:
-      --version                   Show version number                                                                                                                                                                [boolean]
+      --version                   Show version number                                                                                                                                                              [boolean]
       --disable-plugin-cache-env  Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env CDKTF_DISABLE_PLUGIN_CACHE_ENV.
-                                                                                                                                                                                                    [boolean] [default: false]
-      --log-level                 Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL                                                                                               [string]
-  -o, --output                    Output directory for generated Constructs                                                                                                                      [string] [default: "imports"]
-  -l, --language                  Output programming language                                                                [string] [required] [choices: "typescript", "python", "java", "csharp", "go"] [default: "python"]
+                                                                                                                                                                                                  [boolean] [default: false]
+      --log-level                 Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL                                                                                             [string]
+  -o, --output                    Output directory for generated Constructs                                                                                                                       [string] [default: ".gen"]
+  -l, --language                  Output programming language                                                          [string] [required] [choices: "typescript", "python", "java", "csharp", "go"] [default: "typescript"]
+      --force                     Regenerates all generated constructs                                                                                                                            [boolean] [default: false]
       --parallelism               Number of concurrently generated provider / module bindings. Only applies for languages that are not Typescript (translated by JSII). Defaults to infinity, denoted by -1
-                                                                                                                                                                                                        [number] [default: -1]
-  -h, --help                      Show help                                                                                                                                                                          [boolean]
+                                                                                                                                                                                                      [number] [default: -1]
+  -h, --help                      Show help                                                                                                                                                                        [boolean]
 ```
 
 **Examples**

--- a/website/docs/cdktf/cli-reference/commands.mdx
+++ b/website/docs/cdktf/cli-reference/commands.mdx
@@ -303,9 +303,9 @@ $ cdktf diff
 This command downloads the providers and modules for an application and
 generates CDK constructs for them. It can use the `cdktf.json` configuration file to read the list of providers and modules.
 This command only generates currently missing provider bindings, so it is very fast if nothing changed.
-The command does not update the version when you specify loose version constraints in your `cdktf.json` file and have already generated an existing version locally. To update the version anyway, run `cdktf get --force` to recreate all bindings. 
+The command does not update the version when you specify loose version constraints in your `cdktf.json` file and have already generated an existing version locally. To update the version anyway, run `cdktf get --force` to recreate all bindings.
 
-When you change a version constraint, the `cdktf get` command recreates the bindings for that provider. 
+When you change a version constraint, the `cdktf get` command recreates the bindings for that provider.
 
 ```bash
 $ cdktf get --help

--- a/website/docs/cdktf/cli-reference/commands.mdx
+++ b/website/docs/cdktf/cli-reference/commands.mdx
@@ -302,9 +302,10 @@ $ cdktf diff
 
 This command downloads the providers and modules for an application and
 generates CDK constructs for them. It can use the `cdktf.json` configuration file to read the list of providers and modules.
-It only generates currently missing provider bindings, so it is very fast if nothing changed.
-If you specify loose version constraints in your `cdktf.json` file and have an existing version already generated locally it will not update the version.
-To update the version you can run `cdktf get --force` to recreate all bindings. If you change a version constraint the `cdktf get` command will recreate the bindings for this provider.
+This command only generates currently missing provider bindings, so it is very fast if nothing changed.
+The command does not update the version when you specify loose version constraints in your `cdktf.json` file and have already generated an existing version locally. To update the version anyway, run `cdktf get --force` to recreate all bindings. 
+
+When you change a version constraint, the `cdktf get` command recreates the bindings for that provider. 
 
 ```bash
 $ cdktf get --help


### PR DESCRIPTION
I also try to clean up old providers when possible (only in TS to my knowledge 😢). I introduced a new file so that we can change the interface of this functionality later again.
