### PR TITLE
fix(hcl2json): don't overwrite crypto if it's set already

### DIFF
--- a/packages/@cdktf/hcl2json/wasm/bridge_wasm_exec.js
+++ b/packages/@cdktf/hcl2json/wasm/bridge_wasm_exec.js
@@ -18,11 +18,14 @@ globalThis.performance = {
 	},
 };
 
-const crypto = require("crypto");
-globalThis.crypto = {
-	getRandomValues(b) {
-		crypto.randomFillSync(b);
-	},
-};
+// Node >= 19 has a crypto function object, lower node versions need this polyfill
+if (!globalThis.crypto) { 
+	const crypto = require("crypto");
+	globalThis.crypto = {
+		getRandomValues(b) {
+			crypto.randomFillSync(b);
+		},
+	};
+}
 
 require("./wasm_exec");


### PR DESCRIPTION
Node 19 comes with [a stable crypto API that is exposed on globalThis](https://nodejs.org/en/blog/announcements/v19-release-announce/#stable-webcrypto), so we can only selectively overwrite the crypto object. I did not change our testing t include node 19 since some of our dev dependencies don't support node 19 yet.


Closes #2211
