### PR TITLE
chore: run CI more selectively

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,12 +1,19 @@
 name: Examples Integration
 on:
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "website/**"
-      - "cdk.tf/**"
-      - "tools/update-github-project-board/**"
+    paths:
+      # This workflow
+      - ".github/workflows/examples.yml"
+      # All packages under test
+      - "packages/**"
+      # Version changes might introduce bugs
+      - "package.json"
+      # All examples
+      - "examples/**"
+      # All scripts we use
+      - "tools/align-version.sh"
+      - "test/run-against-dist*"
+      - "tools/build-example.js"
 
 concurrency:
   group: examples-${{ github.head_ref }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,12 +1,19 @@
 name: Integration Tests
 on:
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "website/**"
-      - "cdk.tf/**"
-      - "tools/update-github-project-board/**"
+    paths:
+      # This workflow
+      - ".github/workflows/integration.yml"
+      # All packages under test
+      - "packages/**"
+      # Version changes might introduce bugs
+      - "package.json"
+      # All integration test changes
+      - "test/**"
+      # All scripts we use
+      - "tools/align-version.sh"
+      - "tools/build-test-matrix.sh"
+
   workflow_call:
     inputs:
       skip_setup:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,36 @@
+name: Linting
+on:
+  pull_request: {} # All changes need linting
+  workflow_call:
+    inputs:
+      concurrency_group_prefix:
+        default: pr
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ inputs.concurrency_group_prefix }}-linting-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: installing dependencies
+        run: |
+          yarn install
+      - name: run prettier
+        run: |
+          yarn lint:prettier
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: installing dependencies
+        run: |
+          yarn install
+      - name: run workspace linting
+        run: |
+          yarn lint:workspace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,14 @@ jobs:
       concurrency_group_prefix: release
     secrets: inherit
 
+  linting:
+    needs:
+      - prepare-release
+    uses: ./.github/workflows/linting.yml
+    with:
+      concurrency_group_prefix: release
+    secrets: inherit
+
   unit_test:
     needs:
       - prepare-release

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -91,6 +91,14 @@ jobs:
       concurrency_group_prefix: release-next
     secrets: inherit
 
+  linting:
+    needs:
+      - prepare-release
+    uses: ./.github/workflows/linting.yml
+    with:
+      concurrency_group_prefix: release-next
+    secrets: inherit
+
   integration_test:
     needs:
       - prepare-release

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,12 +1,19 @@
 name: Unit Tests
 on:
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "website/**"
-      - "cdk.tf/**"
-      - "tools/update-github-project-board/**"
+    paths:
+      # This workflow
+      - ".github/workflows/unit.yml"
+      # All packages under test
+      - "packages/**"
+      # Prettier related config files
+      - ".prettier*"
+      # Version changes might introduce bugs
+      - "package.json"
+      # All scripts we use
+      - "tools/build-unit-test-matrix.sh"
+      - "tools/align-version.sh"
+
   workflow_call:
     inputs:
       concurrency_group_prefix:
@@ -19,28 +26,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  prettier:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: installing dependencies
-        run: |
-          yarn install
-      - name: run prettier
-        run: |
-          yarn lint:prettier
-
-  lin:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: installing dependencies
-        run: |
-          yarn install
-      - name: run prettier
-        run: |
-          yarn lint:workspace
-
   build-test-matrix:
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
For this I had to pull out linting from the unit workflow. I would love to reduce the examples down to only the changed example, but this does not seem to be trivial so I decoupled it from this change.
