### PR TITLE
chore(docs): prepare for code samples in multiple languages

### DIFF
--- a/website/docs/cdktf/concepts/aspects.mdx
+++ b/website/docs/cdktf/concepts/aspects.mdx
@@ -16,7 +16,7 @@ To create an aspect, you must import the `Aspects` class and the `IAspect` inter
 
 Everything within a CDKTF application descends from the `Construct` class, so you could call the construct on any instantiated element. This includes the entire application, a particular [stack](/cdktf/concepts/stacks), or all of the resources for a specific [provider](/cdktf/concepts/providers). When you call the aspect, CDKTF applies its methods to all of the the constructs that fall within the specified scope.
 
-The following TypeScript example defines an aspect to add tags to resources.
+The following example defines an aspect to add tags to resources.
 
 ```typescript
 import { IConstruct } from "constructs";
@@ -48,7 +48,7 @@ export class TagsAddingAspect implements IAspect {
 Aspects.of(myStack).add(new TagsAddingAspect({ createdBy: "cdktf" }));
 ```
 
-You can also use aspects for validation. The following TypeScript example defines an aspect that checks whether all S3 Buckets start with the correct prefix.
+You can also use aspects for validation. The following example defines an aspect that checks whether all S3 Buckets start with the correct prefix.
 
 ```typescript
 import { IConstruct } from "constructs";

--- a/website/docs/cdktf/concepts/assets.mdx
+++ b/website/docs/cdktf/concepts/assets.mdx
@@ -18,7 +18,7 @@ Assets are especially useful for:
 
 > **Hands-on:** Try the [Deploy Multiple Lambda Functions with TypeScript](https://learn.hashicorp.com/tutorials/terraform/cdktf-assets-stacks-lambda?in=terraform/cdktf) tutorial. This tutorial guides you through using a `TerraformAsset` to archive a Lambda function, uploading the archive to an S3 bucket, then deploying the Lambda function.
 
-The following TypeScript example uses `TerraformAsset` to upload the contents of the specified directory into an S3 Bucket. The `TerraformAsset` is responsible for making sure the directory ends up in the correct output folder as a zip file that the `S3BucketObject` can reference.
+The following example uses `TerraformAsset` to upload the contents of the specified directory into an S3 Bucket. The `TerraformAsset` is responsible for making sure the directory ends up in the correct output folder as a zip file that the `S3BucketObject` can reference.
 
 The stack output directory in `cdktf.out` contains all of the assets that `TerraformAsset` needs. This is important for workflows where you use synthesized configurations with Terraform directly. For example, you would only need to upload the contents of the stack output folder to Terraform Cloud or Terraform Enterprise.
 

--- a/website/docs/cdktf/concepts/constructs.mdx
+++ b/website/docs/cdktf/concepts/constructs.mdx
@@ -46,7 +46,7 @@ Constructs also provide a way to logically structure a set of resources, but you
 
 You can import any [CDKTF-compatible](#available-constructs) construct that is available in your project's programming language. Then, you can create new instances of the construct and use any exposed properties to customize the construct configuration.
 
-The following TypeScript example instantiates a construct called `KubernetesWebAppDeployment` and uses the available arguments to specify that the deployment will have two replicas.
+The following example instantiates a construct called `KubernetesWebAppDeployment` and uses the available arguments to specify that the deployment will have two replicas.
 
 <!-- #NEXT_CODE_BLOCK_SOURCE:ts examples/typescript/documentation#constructs -->
 <!-- #NEXT_CODE_BLOCK_SOURCE:python examples/python/documentation#constructs -->

--- a/website/docs/cdktf/concepts/data-sources.mdx
+++ b/website/docs/cdktf/concepts/data-sources.mdx
@@ -39,7 +39,7 @@ export class HelloTerraform extends TerraformStack {
 
 The [`terraform_remote_state` data source](/language/state/remote-state-data) retrieves state data from a remote [Terraform backend](/language/settings/backends/configuration). This allows you to use the root-level outputs of one or more Terraform configurations as input data for another configuration. For example, a core infrastructure team can handle building the core machines, networking, etc. and then expose some information to other teams that allows them to run their own infrastructure. Refer to the [Remote Backends page](/cdktf/concepts/remote-backends) for more details.
 
-The following TypeScript example uses the global `DataTerraformRemoteState` to reference a Terraform Output of another Terraform configuration.
+The following example uses the global `DataTerraformRemoteState` to reference a Terraform Output of another Terraform configuration.
 
 ```typescript
 // .....

--- a/website/docs/cdktf/concepts/functions.mdx
+++ b/website/docs/cdktf/concepts/functions.mdx
@@ -17,7 +17,7 @@ When inputs are available before [synthesizing your code](/cdktf/cli-reference/c
 
 ## Usage Example
 
-The following TypeScript example uses a Data Source from the AWS Provider to fetch the Availability Zones of the given region. As this data is unknown until Terraform applies the configuration, this CDKTF application uses both [Terraform Outputs](/cdktf/concepts/variables-and-outputs#output-values) and the Terraform [`element`](/language/functions/element) function.
+The following example uses a Data Source from the AWS Provider to fetch the Availability Zones of the given region. As this data is unknown until Terraform applies the configuration, this CDKTF application uses both [Terraform Outputs](/cdktf/concepts/variables-and-outputs#output-values) and the Terraform [`element`](/language/functions/element) function.
 
 The `element` function gets the first element from the list of Availability Zone names.
 

--- a/website/docs/cdktf/concepts/hcl-interoperability.mdx
+++ b/website/docs/cdktf/concepts/hcl-interoperability.mdx
@@ -18,7 +18,7 @@ This page shows how you can interoperate HCL and CDK for Terraform configuration
 
 ## CDKTF to HCL
 
-The following TypeScript example is a CDKTF application that uses the `hashicorp/random` provider to generate a random name.
+The following example is a CDKTF application that uses the `hashicorp/random` provider to generate a random name.
 
 ```typescript
 import { Construct } from "constructs";

--- a/website/docs/cdktf/concepts/modules.mdx
+++ b/website/docs/cdktf/concepts/modules.mdx
@@ -103,7 +103,7 @@ Modules often return data that you can use as inputs to other modules or resourc
 
 ### Examples
 
-The following TypeScript example uses a local module and references its output as a Terraform output.
+The following example uses a local module and references its output as a Terraform output.
 
 ```typescript
 import { Construct } from "constructs";
@@ -149,7 +149,7 @@ class MyStack(TerraformStack):
 
 While we generally recommend generating code bindings for modules, you can also use the `TerraformHclModule` class to reference any module that Terraform supports. Both methods create identical synthesized Terraform configuration files, but using `TerraformHclModule` does not generate any types or type-safe inputs or outputs.
 
-The following TypeScript example uses `TerraformHclModule` to import an AWS module.
+The following example uses `TerraformHclModule` to import an AWS module.
 
 ```typescript
 const provider = new AwsProvider(stack, "provider", {

--- a/website/docs/cdktf/concepts/providers.mdx
+++ b/website/docs/cdktf/concepts/providers.mdx
@@ -80,7 +80,7 @@ Generated typescript constructs in the output directory: .gen
 
 #### Import Classes
 
-Import and use the generated classes in your application. The following TypeScript example imports the `DnsimpleProvider` and `Record` resources from `./.gen/providers/dnsimple` and defines them.
+Import and use the generated classes in your application. The following example imports the `DnsimpleProvider` and `Record` resources from `./.gen/providers/dnsimple` and defines them.
 
 ```typescript
 import { Construct } from "constructs";

--- a/website/docs/cdktf/concepts/remote-backends.mdx
+++ b/website/docs/cdktf/concepts/remote-backends.mdx
@@ -24,7 +24,7 @@ Consider using a remote backend when multiple individuals or teams need access t
 You can define a [JSON configuration for a remote backend](/language/syntax/json#terraform-blocks)
 with a `TerraformBackend` subclass or a JSON configuration file.
 
-The following TypeScript example uses the `TerraformBackend` subclass `CloudBackend`.
+The following example uses the `TerraformBackend` subclass `CloudBackend`.
 
 ```typescript
 import { Construct } from "constructs";

--- a/website/docs/cdktf/concepts/resources.mdx
+++ b/website/docs/cdktf/concepts/resources.mdx
@@ -14,7 +14,7 @@ In your CDK for Terraform (CDKTF) application, you will use your preferred progr
 
 Resource definitions and properties vary depending on the type of resource and the provider. Consult your provider's documentation for a full list of available resources and their configuration options.
 
-The following TypeScript example defines a [DynamoDB table](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) resource on the AWS provider.
+The following example defines a [DynamoDB table](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) resource on the AWS provider.
 
 ```typescript
 export class HelloTerra extends TerraformStack {
@@ -51,7 +51,7 @@ You can reference resource properties throughout your configuration. For example
 
 To create references, call `myResource.<propertyName>` on the resource instance. For example, you could use `myResource.name` to retrieve the `name` property from `myResource`. Terraform does not support passing an entire block (e.g. `exampleNamespace.metadata`) into a resource or data source, so you must create a reference for each individual property.
 
-References are also useful when you need to track logical dependencies. For example, Kubernetes resources live in a namespace, so a namespace must exist before Terraform can provision the associated resources. The following TypeScript example uses a reference for the namespace property in the the deployment. This reference tells Terraform that it needs to create the namespace before creating the resources.
+References are also useful when you need to track logical dependencies. For example, Kubernetes resources live in a namespace, so a namespace must exist before Terraform can provision the associated resources. The following example uses a reference for the namespace property in the the deployment. This reference tells Terraform that it needs to create the namespace before creating the resources.
 
 ```typescript
 
@@ -81,7 +81,7 @@ If you need to use the special [`self` object](/language/resources/provisioners/
 
 Terraform provides [meta-arguments](/language/resources/syntax#meta-arguments) to change resource behavior. For example, the `for_each` meta-argument creates multiple resource instances according to a map, or set of strings. The escape hatch allows you to use these meta-arguments to your CDKTF application and to override attributes that CDKTF cannot yet fully express.
 
-The following TypeScript example defines a provisioner for a resource using the `addOverride` method.
+The following example defines a provisioner for a resource using the `addOverride` method.
 
 ```typescript
 const tableName = "my-table";
@@ -166,7 +166,7 @@ To use an escape hatch to loop over dynamic data, you must:
 - Create a `for_each` value for the second argument and set it to the list you want to iterate over.
 - Take the attribute as base for the reference when you reference values from the list. For example, use `"${<attribute_name>.value.nested_value}"`.
 
-The following TypeScript example adds ingress values by looping through the ports passed as `TerraformVariable`.
+The following example adds ingress values by looping through the ports passed as `TerraformVariable`.
 
 ```typescript
 const ports = new TerraformVariable(this, "ports", {
@@ -199,7 +199,7 @@ sg.addOverride("dynamic.ingress", {
 
 You should only use escape hatches when you need to work with dynamic values that are unknown until after Terraform provisions your infrastructure. If you are working with static values, we recommend using the functionality available in your preferred programming language to iterate through the array.
 
-The following TypeScript example loops through the ports without using an escape hatch.
+The following example loops through the ports without using an escape hatch.
 
 ```typescript
 const ports = [22, 80, 443, 5432];

--- a/website/docs/cdktf/concepts/variables-and-outputs.mdx
+++ b/website/docs/cdktf/concepts/variables-and-outputs.mdx
@@ -31,7 +31,7 @@ If you plan to use CDKTF to manage your infrastructure, we recommend using your 
 
 You must specify values in exactly the same way as you would in an HCL configuration file. Refer to the [Terraform variables documentation](/language/values/variables#variables-on-the-command-line) for details. The CDKTF CLI currently also supports configuration via [environment variables](/language/values/variables#environment-variables).
 
-The following TypeScript example uses `TerraformVariable` to provide inputs to resources.
+The following example uses `TerraformVariable` to provide inputs to resources.
 
 ```typescript
 const imageId = new TerraformVariable(this, "imageId", {
@@ -57,7 +57,7 @@ When values are available before [synthesizing your code](/cdktf/cli-reference/c
 
 ### Define Local Values
 
-The following TypeScript example uses `TerraformLocal` to create a local value.
+The following example uses `TerraformLocal` to create a local value.
 
 ```typescript
 const commonTags = new TerraformLocal(this, "common_tags", {
@@ -99,7 +99,7 @@ Use outputs to make data from [Terraform resources](/cdktf/concepts/resources) a
 
 When values are available before [synthesizing your code](/cdktf/cli-reference/commands#synth), we recommend using the functionality in your preferred programming language to supply this data as direct inputs.
 
-The following TypeScript example uses a `TerraformOutput` to create an output.
+The following example uses a `TerraformOutput` to create an output.
 
 ```typescript
 import { Construct } from "constructs";
@@ -184,7 +184,7 @@ Output: random-pet = choice-haddock
 
 ### Define & Reference Outputs via Remote State
 
-The following TypeScript example uses outputs to share data between stacks, each of which has a [remote backend](/cdktf/concepts/remote-backends) to store the Terraform state files remotely.
+The following example uses outputs to share data between stacks, each of which has a [remote backend](/cdktf/concepts/remote-backends) to store the Terraform state files remotely.
 
 ```typescript
 import { RandomProvider } from "@cdktf/provider-random/lib/provider";

--- a/website/docs/cdktf/create-and-deploy/project-setup.mdx
+++ b/website/docs/cdktf/create-and-deploy/project-setup.mdx
@@ -70,7 +70,7 @@ You can also provide context when instantiating the `App` class.
 const app = new App({ context: { myConfig: "value" } });
 ```
 
-The following TypeScript example uses `App` context to provide a custom tag value to an AWS EC2 instance.
+The following example uses `App` context to provide a custom tag value to an AWS EC2 instance.
 
 ```typescript
 import { Construct } from "constructs";

--- a/website/docs/cdktf/create-and-deploy/remote-templates.mdx
+++ b/website/docs/cdktf/create-and-deploy/remote-templates.mdx
@@ -23,7 +23,7 @@ A template can use substitutions for filenames and file content. To specify your
 
 These variables hold user input. For example, you can use them in project files like `package.json`. CDKTF collects the required data from users when they run `cdktf init` with the template.
 
-The following TypeScript example specifies that `Name` and `Description` are mandatory, but `OrganizationName` and `WorkspaceName` will only be required for projects that are set up to use a Terraform Cloud [remote backend](/cdktf/concepts/remote-backends).
+The following example specifies that `Name` and `Description` are mandatory, but `OrganizationName` and `WorkspaceName` will only be required for projects that are set up to use a Terraform Cloud [remote backend](/cdktf/concepts/remote-backends).
 
 ```typescript
 Name: string;


### PR DESCRIPTION
I happened to look at the docs today and noticed that even in the places where we already have CodeTabs set up with code samples in multiple languages, our docs consistently have the text:

> The following TypeScript example ...

Since we are actively working on translating all the code samples to multiple languages and are hoping to start merging those changes very soon, I think it's okay to do away with the "TypeScript" qualifier now.

This PR is just a result of running the following on the command line:

```
grep -RlI 'The following TypeScript example' ./website | xargs sed -i "" 's/The following TypeScript example/The following example/g'
```

I did not do a manual check for other phrasings.

(re: #1929)