### PR TITLE
chore: improve release pipelines

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,24 +89,18 @@ jobs:
     secrets: inherit
 
   examples:
-    needs:
-      - prepare-release
     uses: ./.github/workflows/examples.yml
     with:
       concurrency_group_prefix: release
     secrets: inherit
 
   linting:
-    needs:
-      - prepare-release
     uses: ./.github/workflows/linting.yml
     with:
       concurrency_group_prefix: release
     secrets: inherit
 
   unit_test:
-    needs:
-      - prepare-release
     uses: ./.github/workflows/unit.yml
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,8 @@ jobs:
             "@cdktf/hcl2cdk",
             "@cdktf/hcl2json",
             "@cdktf/provider-generator",
+            "@cdktf/commons",
+            "@cdktf/cli-core",
           ]
         terraform_version: ["1.1.9", "1.2.8"]
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,11 @@ on:
     branches:
       - main
       - backport-release-*
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "website/**"
-      - "cdk.tf/**"
-      - "tools/update-github-project-board/**"
+    paths:
+      - "packages/**"
+      - "tools/**"
+      - "package.json"
+      - "yarn.lock"
 
 env:
   SENTRY_ORG: hashicorp

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -98,6 +98,8 @@ jobs:
             "@cdktf/hcl2cdk",
             "@cdktf/hcl2json",
             "@cdktf/provider-generator",
+            "@cdktf/commons",
+            "@cdktf/cli-core",
           ]
         terraform_version: ["1.1.9", "1.2.8"]
     with:

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -3,12 +3,11 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "website/**"
-      - "cdk.tf/**"
-      - "tools/update-github-project-board/**"
+    paths:
+      - "packages/**"
+      - "tools/**"
+      - "package.json"
+      - "yarn.lock"
 
 env:
   SENTRY_ORG: hashicorp

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -87,8 +87,6 @@ jobs:
         run: git push --follow-tags
 
   unit_test:
-    needs:
-      - prepare-release
     uses: ./.github/workflows/unit.yml
     strategy:
       fail-fast: false
@@ -109,8 +107,6 @@ jobs:
     secrets: inherit
 
   linting:
-    needs:
-      - prepare-release
     uses: ./.github/workflows/linting.yml
     with:
       concurrency_group_prefix: release-next
@@ -126,8 +122,6 @@ jobs:
     secrets: inherit
 
   examples:
-    needs:
-      - prepare-release
     uses: ./.github/workflows/examples.yml
     with:
       concurrency_group_prefix: release-next


### PR DESCRIPTION
Consists of these parts, trying to solve the problem where the unit tests won't get started

- chore: use paths instead of paths ignore
- chore: these tests don't rely on the release setup
- chore: add new packages
