### PR TITLE
fix: scoped packages need a publish config to be published to npm

### DIFF
--- a/packages/@cdktf/cli-core/package.json
+++ b/packages/@cdktf/cli-core/package.json
@@ -18,6 +18,9 @@
   },
   "main": "src/lib/index.js",
   "types": "src/lib/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/hashicorp/terraform-cdk.git",


### PR DESCRIPTION
The release currently fails due to this: https://github.com/hashicorp/terraform-cdk/actions/runs/3542799009/jobs/5949276900