### PR TITLE
fix: scoped packages need a publish config to be published to npm

### DIFF
--- a/packages/@cdktf/commons/package.json
+++ b/packages/@cdktf/commons/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@cdktf/commons",
   "version": "0.0.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "CDK for Terraform Common utilities",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Same as #2346 but for another package 😁