### PR TITLE
fix: add `required_version` to json schema

### DIFF
--- a/packages/@cdktf/cli-core/src/lib/terraform-json.ts
+++ b/packages/@cdktf/cli-core/src/lib/terraform-json.ts
@@ -49,6 +49,7 @@ export const terraformJsonSchema = z
       required_providers: z.record(
         z.object({ source: z.string(), version: z.string() }).nonstrict()
       ),
+      required_version: z.string(),
     }),
     data: z.record(z.any()),
     provider: z.record(z.any()),


### PR DESCRIPTION
## Context

https://github.com/hashicorp/terraform-cdk/commit/8b069eb7db3b536b7de8fd7a189afd8ed3c549eb added validation on the `cdk.tf.json` file. However, the schema is missing [required_version](https://developer.hashicorp.com/terraform/language/settings#specifying-a-required-terraform-version) in the `terraform` block

hence when running `cdktf [deploy|plan|destroy]` will result in the following error

```
0 Stacks deploying     0 Stacks done     0 Stacks waiting
1 validation issue(s)

  Issue #0: unrecognized_keys at terraform
  Unrecognized key(s) in object: 'required_version'
```

## Note

There is another terraform json schema at https://sourcegraph.com/github.com/daniel-laszlo/terraform-cdk/-/blob/packages/@cdktf/hcl2cdk/lib/schema.ts?L22

I do not have any historical context on this project, but should there only be one?

## Another note

`required_version` is not supported by cdktf natively yet (at least last time I check), we currently use the escape hatch in an aspect to add `required_version` in every stack