### PR TITLE
refactor(provider-generator): Refactor AttributeTypeModel to handle more complex types

### DIFF
--- a/packages/@cdktf/provider-generator/lib/__tests__/__snapshots__/edge-provider-schema.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/__tests__/__snapshots__/edge-provider-schema.test.ts.snap
@@ -8,7 +8,7 @@ export * as optionalComputedAttributeResource from './optional-computed-attribut
 export * as listBlockResource from './list-block-resource';
 export * as mapResource from './map-resource';
 export * as setBlockResource from './set-block-resource';
-export * as anotherResource from './another-resource';
+export * as mapListResource from './map-list-resource';
 export * as provider from './provider';
 
 "

--- a/packages/@cdktf/provider-generator/lib/__tests__/__snapshots__/edge-provider-schema.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/__tests__/__snapshots__/edge-provider-schema.test.ts.snap
@@ -8,6 +8,7 @@ export * as optionalComputedAttributeResource from './optional-computed-attribut
 export * as listBlockResource from './list-block-resource';
 export * as mapResource from './map-resource';
 export * as setBlockResource from './set-block-resource';
+export * as anotherResource from './another-resource';
 export * as provider from './provider';
 
 "

--- a/packages/@cdktf/provider-generator/lib/__tests__/edge-provider-schema/index.ts
+++ b/packages/@cdktf/provider-generator/lib/__tests__/edge-provider-schema/index.ts
@@ -97,9 +97,9 @@ const list_block_resource = new S()
   })
   .build();
 
-const another_resource = new S()
+const map_list_resource = new S()
   .attribute({
-    name: "foo",
+    name: "mapListOfObject",
     type: [
       "map",
       [
@@ -155,7 +155,7 @@ export const edgeSchema: ProviderSchema = schema({
     list_block_resource,
     map_resource,
     set_block_resource,
-    another_resource,
+    map_list_resource,
   },
   dataSources: {},
 });

--- a/packages/@cdktf/provider-generator/lib/__tests__/edge-provider-schema/index.ts
+++ b/packages/@cdktf/provider-generator/lib/__tests__/edge-provider-schema/index.ts
@@ -77,6 +77,24 @@ const list_block_resource = new S()
     computed: true,
     optional: false,
   })
+  .attribute({
+    name: "computedListOfMapOfObject",
+    type: [
+      "list",
+      [
+        "map",
+        [
+          "object",
+          {
+            str: "string",
+            other: "string",
+          },
+        ],
+      ],
+    ],
+    computed: true,
+    optional: false,
+  })
   .build();
 
 const map_resource = new S()

--- a/packages/@cdktf/provider-generator/lib/__tests__/edge-provider-schema/index.ts
+++ b/packages/@cdktf/provider-generator/lib/__tests__/edge-provider-schema/index.ts
@@ -97,6 +97,26 @@ const list_block_resource = new S()
   })
   .build();
 
+const another_resource = new S()
+  .attribute({
+    name: "foo",
+    type: [
+      "map",
+      [
+        "list",
+        [
+          "object",
+          {
+            hello: "string",
+          },
+        ],
+      ],
+    ],
+    computed: false,
+    optional: false,
+  })
+  .build();
+
 const map_resource = new S()
   .attribute({
     name: "optMap",
@@ -135,6 +155,7 @@ export const edgeSchema: ProviderSchema = schema({
     list_block_resource,
     map_resource,
     set_block_resource,
+    another_resource,
   },
   dataSources: {},
 });

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/resource-types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/resource-types.test.ts.snap
@@ -8040,7 +8040,7 @@ export interface SecurityGroupConfig extends cdktf.TerraformMetaArguments {
   * 
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#timeouts SecurityGroup#timeouts}
   */
-  readonly timeouts?: SecurityGroupTimeouts | cdktf.IResolvable;
+  readonly timeouts?: SecurityGroupTimeouts;
 }
 export interface SecurityGroupEgress {
   /**
@@ -8679,7 +8679,7 @@ export interface SecurityGroupTimeouts {
   readonly delete?: string;
 }
 
-export function securityGroupTimeoutsToTerraform(struct?: SecurityGroupTimeoutsOutputReference | SecurityGroupTimeouts | cdktf.IResolvable): any {
+export function securityGroupTimeoutsToTerraform(struct?: SecurityGroupTimeouts | cdktf.IResolvable): any {
   if (!cdktf.canInspect(struct) || cdktf.Tokenization.isResolvable(struct)) { return struct; }
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
@@ -8699,7 +8699,7 @@ export class SecurityGroupTimeoutsOutputReference extends cdktf.ComplexObject {
   * @param terraformAttribute The attribute on the parent resource this class is referencing
   */
   public constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string) {
-    super(terraformResource, terraformAttribute, false, 0);
+    super(terraformResource, terraformAttribute, false);
   }
 
   public get internalValue(): SecurityGroupTimeouts | cdktf.IResolvable | undefined {

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/resource-types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/resource-types.test.ts.snap
@@ -8040,7 +8040,7 @@ export interface SecurityGroupConfig extends cdktf.TerraformMetaArguments {
   * 
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#timeouts SecurityGroup#timeouts}
   */
-  readonly timeouts?: SecurityGroupTimeouts;
+  readonly timeouts?: SecurityGroupTimeouts | cdktf.IResolvable;
 }
 export interface SecurityGroupEgress {
   /**

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -2263,7 +2263,7 @@ export interface ListOfStringMapConfig extends cdktf.TerraformMetaArguments {
   * 
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/list_of_string_map#settable_keys ListOfStringMap#settable_keys}
   */
-  readonly settableKeys?: { [key: string]: string }[];
+  readonly settableKeys?: { [key: string]: string }[] | cdktf.IResolvable;
 }
 
 /**
@@ -2315,11 +2315,11 @@ export class ListOfStringMap extends cdktf.TerraformResource {
   }
 
   // settable_keys - computed: false, optional: true, required: false
-  private _settableKeys?: { [key: string]: string }[]; 
+  private _settableKeys?: { [key: string]: string }[] | cdktf.IResolvable; 
   public get settableKeys() {
     return this.interpolationForAttribute('settable_keys');
   }
-  public set settableKeys(value: { [key: string]: string }[]) {
+  public set settableKeys(value: { [key: string]: string }[] | cdktf.IResolvable) {
     this._settableKeys = value;
   }
   public resetSettableKeys() {

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -2258,6 +2258,12 @@ import * as cdktf from 'cdktf';
 // Configuration
 
 export interface ListOfStringMapConfig extends cdktf.TerraformMetaArguments {
+  /**
+  * List of key versions in the keyring.
+  * 
+  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/list_of_string_map#settable_keys ListOfStringMap#settable_keys}
+  */
+  readonly settableKeys?: { [key: string]: string }[];
 }
 
 /**
@@ -2295,6 +2301,7 @@ export class ListOfStringMap extends cdktf.TerraformResource {
       connection: config.connection,
       forEach: config.forEach
     });
+    this._settableKeys = config.settableKeys;
   }
 
   // ==========
@@ -2307,12 +2314,124 @@ export class ListOfStringMap extends cdktf.TerraformResource {
     return this._keys;
   }
 
+  // settable_keys - computed: false, optional: true, required: false
+  private _settableKeys?: { [key: string]: string }[]; 
+  public get settableKeys() {
+    return this.interpolationForAttribute('settable_keys');
+  }
+  public set settableKeys(value: { [key: string]: string }[]) {
+    this._settableKeys = value;
+  }
+  public resetSettableKeys() {
+    this._settableKeys = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get settableKeysInput() {
+    return this._settableKeys;
+  }
+
   // =========
   // SYNTHESIS
   // =========
 
   protected synthesizeAttributes(): { [name: string]: any } {
     return {
+      settable_keys: cdktf.listMapper(cdktf.hashMapper(cdktf.stringToTerraform), false)(this._settableKeys),
+    };
+  }
+}
+"
+`;
+
+exports[`map of string list attribute 1`] = `
+"// https://www.terraform.io/docs/providers/aws/r/map_of_string_list
+// generated from terraform resource schema
+
+import { Construct } from 'constructs';
+import * as cdktf from 'cdktf';
+
+// Configuration
+
+export interface MapOfStringListConfig extends cdktf.TerraformMetaArguments {
+  /**
+  * Map of String List.
+  * 
+  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/map_of_string_list#settable_keys MapOfStringList#settable_keys}
+  */
+  readonly settableKeys?: { [key: string]: stringList };
+}
+
+/**
+* Represents a {@link https://www.terraform.io/docs/providers/aws/r/map_of_string_list aws_map_of_string_list}
+*/
+export class MapOfStringList extends cdktf.TerraformResource {
+
+  // =================
+  // STATIC PROPERTIES
+  // =================
+  public static readonly tfResourceType = \\"aws_map_of_string_list\\";
+
+  // ===========
+  // INITIALIZER
+  // ===========
+
+  /**
+  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/map_of_string_list aws_map_of_string_list} Resource
+  *
+  * @param scope The scope in which to define this construct
+  * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
+  * @param options MapOfStringListConfig = {}
+  */
+  public constructor(scope: Construct, id: string, config: MapOfStringListConfig = {}) {
+    super(scope, id, {
+      terraformResourceType: 'aws_map_of_string_list',
+      terraformGeneratorMetadata: {
+        providerName: 'aws'
+      },
+      provider: config.provider,
+      dependsOn: config.dependsOn,
+      count: config.count,
+      lifecycle: config.lifecycle,
+      provisioners: config.provisioners,
+      connection: config.connection,
+      forEach: config.forEach
+    });
+    this._settableKeys = config.settableKeys;
+  }
+
+  // ==========
+  // ATTRIBUTES
+  // ==========
+
+  // keys - computed: true, optional: false, required: false
+  private _keys = new cdktf.StringListMap(this, \\"keys\\");
+  public get keys() {
+    return this._keys;
+  }
+
+  // settable_keys - computed: false, optional: true, required: false
+  private _settableKeys?: { [key: string]: stringList }; 
+  public get settableKeys() {
+    return this.getStringListMapAttribute('settable_keys');
+  }
+  public set settableKeys(value: { [key: string]: stringList }) {
+    this._settableKeys = value;
+  }
+  public resetSettableKeys() {
+    this._settableKeys = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get settableKeysInput() {
+    return this._settableKeys;
+  }
+
+  // =========
+  // SYNTHESIS
+  // =========
+
+  protected synthesizeAttributes(): { [name: string]: any } {
+    return {
+      settable_keys: cdktf.hashMapper(cdktf.listMapper(cdktf.stringToTerraform, false))(this._settableKeys),
     };
   }
 }

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -3934,19 +3934,6 @@ export class StringList extends cdktf.TerraformResource {
     return this._subjectAlternativeNamesOptional;
   }
 
-  // subject_alternative_names_required - computed: true, optional: false, required: true
-  private _subjectAlternativeNamesRequired?: { [key: string]: string }; 
-  public get subjectAlternativeNamesRequired() {
-    return this.getStringMapAttribute('subject_alternative_names_required');
-  }
-  public set subjectAlternativeNamesRequired(value: { [key: string]: string }) {
-    this._subjectAlternativeNamesRequired = value;
-  }
-  // Temporarily expose input value. Use with caution.
-  public get subjectAlternativeNamesRequiredInput() {
-    return this._subjectAlternativeNamesRequired;
-  }
-
   // =========
   // SYNTHESIS
   // =========
@@ -4066,6 +4053,19 @@ export class StringMap extends cdktf.TerraformResource {
   // Temporarily expose input value. Use with caution.
   public get subjectAlternativeNamesOptionalInput() {
     return this._subjectAlternativeNamesOptional;
+  }
+
+  // subject_alternative_names_required - computed: true, optional: false, required: true
+  private _subjectAlternativeNamesRequired?: { [key: string]: string }; 
+  public get subjectAlternativeNamesRequired() {
+    return this.getStringMapAttribute('subject_alternative_names_required');
+  }
+  public set subjectAlternativeNamesRequired(value: { [key: string]: string }) {
+    this._subjectAlternativeNamesRequired = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get subjectAlternativeNamesRequiredInput() {
+    return this._subjectAlternativeNamesRequired;
   }
 
   // =========

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -2254,6 +2254,447 @@ export class StringResource extends cdktf.TerraformResource {
 "
 `;
 
+exports[`list of list attributes 1`] = `
+"// https://www.terraform.io/docs/providers/test/r/complex
+// generated from terraform resource schema
+
+import { Construct } from 'constructs';
+import * as cdktf from 'cdktf';
+
+// Configuration
+
+export interface ComplexConfig extends cdktf.TerraformMetaArguments {
+}
+export interface ComplexLl {
+}
+
+export function complexLlToTerraform(struct?: ComplexLl): any {
+  if (!cdktf.canInspect(struct) || cdktf.Tokenization.isResolvable(struct)) { return struct; }
+  if (cdktf.isComplexElement(struct)) {
+    throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
+  }
+  return {
+  }
+}
+
+export class ComplexLlOutputReference extends cdktf.ComplexObject {
+  private isEmptyObject = false;
+
+  /**
+  * @param terraformResource The parent resource
+  * @param terraformAttribute The attribute on the parent resource this class is referencing
+  * @param complexObjectIndex the index of this item in the list
+  * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+  */
+  public constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean) {
+    super(terraformResource, terraformAttribute, complexObjectIsFromSet, complexObjectIndex);
+  }
+
+  public get internalValue(): ComplexLl | undefined {
+    let hasAnyValues = this.isEmptyObject;
+    const internalValueResult: any = {};
+    return hasAnyValues ? internalValueResult : undefined;
+  }
+
+  public set internalValue(value: ComplexLl | undefined) {
+    if (value === undefined) {
+      this.isEmptyObject = false;
+    }
+    else {
+      this.isEmptyObject = Object.keys(value).length === 0;
+    }
+  }
+
+  // coupon - computed: true, optional: false, required: false
+  public get coupon() {
+    return this.getStringAttribute('coupon');
+  }
+
+  // discount_amount - computed: true, optional: false, required: false
+  public get discountAmount() {
+    return this.getStringAttribute('discount_amount');
+  }
+}
+
+export class ComplexLlListList extends cdktf.ComplexList {
+
+  /**
+  * @param terraformResource The parent resource
+  * @param terraformAttribute The attribute on the parent resource this class is referencing
+  * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+  */
+  constructor(protected terraformResource: cdktf.IInterpolatingParent, protected terraformAttribute: string, protected wrapsSet: boolean) {
+    super(terraformResource, terraformAttribute, wrapsSet)
+  }
+
+  /**
+  * @param index the index of the item to return
+  */
+  public get(index: number): ComplexLlList {
+    return new ComplexLlList(this.terraformResource, \`\${this.terraformAttribute}\${index}[]\`, false);
+  }
+}
+
+export class ComplexLlList extends cdktf.ComplexList {
+
+  /**
+  * @param terraformResource The parent resource
+  * @param terraformAttribute The attribute on the parent resource this class is referencing
+  * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+  */
+  constructor(protected terraformResource: cdktf.IInterpolatingParent, protected terraformAttribute: string, protected wrapsSet: boolean) {
+    super(terraformResource, terraformAttribute, wrapsSet)
+  }
+
+  /**
+  * @param index the index of the item to return
+  */
+  public get(index: number): ComplexLlOutputReference {
+    return new ComplexLlOutputReference(this.terraformResource, this.terraformAttribute, index, this.wrapsSet);
+  }
+}
+export interface ComplexLs {
+}
+
+export function complexLsToTerraform(struct?: ComplexLs): any {
+  if (!cdktf.canInspect(struct) || cdktf.Tokenization.isResolvable(struct)) { return struct; }
+  if (cdktf.isComplexElement(struct)) {
+    throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
+  }
+  return {
+  }
+}
+
+export class ComplexLsOutputReference extends cdktf.ComplexObject {
+  private isEmptyObject = false;
+
+  /**
+  * @param terraformResource The parent resource
+  * @param terraformAttribute The attribute on the parent resource this class is referencing
+  * @param complexObjectIndex the index of this item in the list
+  * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+  */
+  public constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean) {
+    super(terraformResource, terraformAttribute, complexObjectIsFromSet, complexObjectIndex);
+  }
+
+  public get internalValue(): ComplexLs | undefined {
+    let hasAnyValues = this.isEmptyObject;
+    const internalValueResult: any = {};
+    return hasAnyValues ? internalValueResult : undefined;
+  }
+
+  public set internalValue(value: ComplexLs | undefined) {
+    if (value === undefined) {
+      this.isEmptyObject = false;
+    }
+    else {
+      this.isEmptyObject = Object.keys(value).length === 0;
+    }
+  }
+
+  // coupon - computed: true, optional: false, required: false
+  public get coupon() {
+    return this.getStringAttribute('coupon');
+  }
+
+  // discount_amount - computed: true, optional: false, required: false
+  public get discountAmount() {
+    return this.getStringAttribute('discount_amount');
+  }
+}
+
+export class ComplexLsListList extends cdktf.ComplexList {
+
+  /**
+  * @param terraformResource The parent resource
+  * @param terraformAttribute The attribute on the parent resource this class is referencing
+  * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+  */
+  constructor(protected terraformResource: cdktf.IInterpolatingParent, protected terraformAttribute: string, protected wrapsSet: boolean) {
+    super(terraformResource, terraformAttribute, wrapsSet)
+  }
+
+  /**
+  * @param index the index of the item to return
+  */
+  public get(index: number): ComplexLsList {
+    return new ComplexLsList(this.terraformResource, \`\${this.terraformAttribute}\${index}[]\`, false);
+  }
+}
+
+export class ComplexLsList extends cdktf.ComplexList {
+
+  /**
+  * @param terraformResource The parent resource
+  * @param terraformAttribute The attribute on the parent resource this class is referencing
+  * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+  */
+  constructor(protected terraformResource: cdktf.IInterpolatingParent, protected terraformAttribute: string, protected wrapsSet: boolean) {
+    super(terraformResource, terraformAttribute, wrapsSet)
+  }
+
+  /**
+  * @param index the index of the item to return
+  */
+  public get(index: number): ComplexLsOutputReference {
+    return new ComplexLsOutputReference(this.terraformResource, this.terraformAttribute, index, this.wrapsSet);
+  }
+}
+export interface ComplexSl {
+}
+
+export function complexSlToTerraform(struct?: ComplexSl): any {
+  if (!cdktf.canInspect(struct) || cdktf.Tokenization.isResolvable(struct)) { return struct; }
+  if (cdktf.isComplexElement(struct)) {
+    throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
+  }
+  return {
+  }
+}
+
+export class ComplexSlOutputReference extends cdktf.ComplexObject {
+  private isEmptyObject = false;
+
+  /**
+  * @param terraformResource The parent resource
+  * @param terraformAttribute The attribute on the parent resource this class is referencing
+  * @param complexObjectIndex the index of this item in the list
+  * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+  */
+  public constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean) {
+    super(terraformResource, terraformAttribute, complexObjectIsFromSet, complexObjectIndex);
+  }
+
+  public get internalValue(): ComplexSl | undefined {
+    let hasAnyValues = this.isEmptyObject;
+    const internalValueResult: any = {};
+    return hasAnyValues ? internalValueResult : undefined;
+  }
+
+  public set internalValue(value: ComplexSl | undefined) {
+    if (value === undefined) {
+      this.isEmptyObject = false;
+    }
+    else {
+      this.isEmptyObject = Object.keys(value).length === 0;
+    }
+  }
+
+  // coupon - computed: true, optional: false, required: false
+  public get coupon() {
+    return this.getStringAttribute('coupon');
+  }
+
+  // discount_amount - computed: true, optional: false, required: false
+  public get discountAmount() {
+    return this.getStringAttribute('discount_amount');
+  }
+}
+
+export class ComplexSlListList extends cdktf.ComplexList {
+
+  /**
+  * @param terraformResource The parent resource
+  * @param terraformAttribute The attribute on the parent resource this class is referencing
+  * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+  */
+  constructor(protected terraformResource: cdktf.IInterpolatingParent, protected terraformAttribute: string, protected wrapsSet: boolean) {
+    super(terraformResource, terraformAttribute, wrapsSet)
+  }
+
+  /**
+  * @param index the index of the item to return
+  */
+  public get(index: number): ComplexSlList {
+    return new ComplexSlList(this.terraformResource, \`\${this.terraformAttribute}\${index}[]\`, true);
+  }
+}
+
+export class ComplexSlList extends cdktf.ComplexList {
+
+  /**
+  * @param terraformResource The parent resource
+  * @param terraformAttribute The attribute on the parent resource this class is referencing
+  * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+  */
+  constructor(protected terraformResource: cdktf.IInterpolatingParent, protected terraformAttribute: string, protected wrapsSet: boolean) {
+    super(terraformResource, terraformAttribute, wrapsSet)
+  }
+
+  /**
+  * @param index the index of the item to return
+  */
+  public get(index: number): ComplexSlOutputReference {
+    return new ComplexSlOutputReference(this.terraformResource, this.terraformAttribute, index, this.wrapsSet);
+  }
+}
+export interface ComplexSs {
+}
+
+export function complexSsToTerraform(struct?: ComplexSs): any {
+  if (!cdktf.canInspect(struct) || cdktf.Tokenization.isResolvable(struct)) { return struct; }
+  if (cdktf.isComplexElement(struct)) {
+    throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
+  }
+  return {
+  }
+}
+
+export class ComplexSsOutputReference extends cdktf.ComplexObject {
+  private isEmptyObject = false;
+
+  /**
+  * @param terraformResource The parent resource
+  * @param terraformAttribute The attribute on the parent resource this class is referencing
+  * @param complexObjectIndex the index of this item in the list
+  * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+  */
+  public constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean) {
+    super(terraformResource, terraformAttribute, complexObjectIsFromSet, complexObjectIndex);
+  }
+
+  public get internalValue(): ComplexSs | undefined {
+    let hasAnyValues = this.isEmptyObject;
+    const internalValueResult: any = {};
+    return hasAnyValues ? internalValueResult : undefined;
+  }
+
+  public set internalValue(value: ComplexSs | undefined) {
+    if (value === undefined) {
+      this.isEmptyObject = false;
+    }
+    else {
+      this.isEmptyObject = Object.keys(value).length === 0;
+    }
+  }
+
+  // coupon - computed: true, optional: false, required: false
+  public get coupon() {
+    return this.getStringAttribute('coupon');
+  }
+
+  // discount_amount - computed: true, optional: false, required: false
+  public get discountAmount() {
+    return this.getStringAttribute('discount_amount');
+  }
+}
+
+export class ComplexSsListList extends cdktf.ComplexList {
+
+  /**
+  * @param terraformResource The parent resource
+  * @param terraformAttribute The attribute on the parent resource this class is referencing
+  * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+  */
+  constructor(protected terraformResource: cdktf.IInterpolatingParent, protected terraformAttribute: string, protected wrapsSet: boolean) {
+    super(terraformResource, terraformAttribute, wrapsSet)
+  }
+
+  /**
+  * @param index the index of the item to return
+  */
+  public get(index: number): ComplexSsList {
+    return new ComplexSsList(this.terraformResource, \`\${this.terraformAttribute}\${index}[]\`, true);
+  }
+}
+
+export class ComplexSsList extends cdktf.ComplexList {
+
+  /**
+  * @param terraformResource The parent resource
+  * @param terraformAttribute The attribute on the parent resource this class is referencing
+  * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+  */
+  constructor(protected terraformResource: cdktf.IInterpolatingParent, protected terraformAttribute: string, protected wrapsSet: boolean) {
+    super(terraformResource, terraformAttribute, wrapsSet)
+  }
+
+  /**
+  * @param index the index of the item to return
+  */
+  public get(index: number): ComplexSsOutputReference {
+    return new ComplexSsOutputReference(this.terraformResource, this.terraformAttribute, index, this.wrapsSet);
+  }
+}
+
+/**
+* Represents a {@link https://www.terraform.io/docs/providers/test/r/complex test_complex}
+*/
+export class Complex extends cdktf.TerraformResource {
+
+  // =================
+  // STATIC PROPERTIES
+  // =================
+  public static readonly tfResourceType = \\"test_complex\\";
+
+  // ===========
+  // INITIALIZER
+  // ===========
+
+  /**
+  * Create a new {@link https://www.terraform.io/docs/providers/test/r/complex test_complex} Resource
+  *
+  * @param scope The scope in which to define this construct
+  * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
+  * @param options ComplexConfig = {}
+  */
+  public constructor(scope: Construct, id: string, config: ComplexConfig = {}) {
+    super(scope, id, {
+      terraformResourceType: 'test_complex',
+      terraformGeneratorMetadata: {
+        providerName: 'test'
+      },
+      provider: config.provider,
+      dependsOn: config.dependsOn,
+      count: config.count,
+      lifecycle: config.lifecycle,
+      provisioners: config.provisioners,
+      connection: config.connection,
+      forEach: config.forEach
+    });
+  }
+
+  // ==========
+  // ATTRIBUTES
+  // ==========
+
+  // ll - computed: true, optional: false, required: false
+  private _ll = new ComplexLlListList(this, \\"ll\\", false);
+  public get ll() {
+    return this._ll;
+  }
+
+  // ls - computed: true, optional: false, required: false
+  private _ls = new ComplexLsListList(this, \\"ls\\", false);
+  public get ls() {
+    return this._ls;
+  }
+
+  // sl - computed: true, optional: false, required: false
+  private _sl = new ComplexSlListList(this, \\"sl\\", true);
+  public get sl() {
+    return this._sl;
+  }
+
+  // ss - computed: true, optional: false, required: false
+  private _ss = new ComplexSsListList(this, \\"ss\\", true);
+  public get ss() {
+    return this._ss;
+  }
+
+  // =========
+  // SYNTHESIS
+  // =========
+
+  protected synthesizeAttributes(): { [name: string]: any } {
+    return {
+    };
+  }
+}
+"
+`;
+
 exports[`list of string map attribute 1`] = `
 "// https://www.terraform.io/docs/providers/aws/r/list_of_string_map
 // generated from terraform resource schema

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -2316,7 +2316,7 @@ export class ComplexLlOutputReference extends cdktf.ComplexObject {
   }
 }
 
-export class ComplexLlListList extends cdktf.ComplexList {
+export class ComplexLlListList extends cdktf.MapList {
 
   /**
   * @param terraformResource The parent resource
@@ -2331,7 +2331,7 @@ export class ComplexLlListList extends cdktf.ComplexList {
   * @param index the index of the item to return
   */
   public get(index: number): ComplexLlList {
-    return new ComplexLlList(this.terraformResource, \`\${this.terraformAttribute}\${index}[]\`, false);
+    return new ComplexLlList(this, \`[\${index}]\`, false);
   }
 }
 
@@ -2404,7 +2404,7 @@ export class ComplexLsOutputReference extends cdktf.ComplexObject {
   }
 }
 
-export class ComplexLsListList extends cdktf.ComplexList {
+export class ComplexLsListList extends cdktf.MapList {
 
   /**
   * @param terraformResource The parent resource
@@ -2419,7 +2419,7 @@ export class ComplexLsListList extends cdktf.ComplexList {
   * @param index the index of the item to return
   */
   public get(index: number): ComplexLsList {
-    return new ComplexLsList(this.terraformResource, \`\${this.terraformAttribute}\${index}[]\`, false);
+    return new ComplexLsList(this, \`[\${index}]\`, true);
   }
 }
 
@@ -2492,7 +2492,7 @@ export class ComplexSlOutputReference extends cdktf.ComplexObject {
   }
 }
 
-export class ComplexSlListList extends cdktf.ComplexList {
+export class ComplexSlListList extends cdktf.MapList {
 
   /**
   * @param terraformResource The parent resource
@@ -2507,7 +2507,7 @@ export class ComplexSlListList extends cdktf.ComplexList {
   * @param index the index of the item to return
   */
   public get(index: number): ComplexSlList {
-    return new ComplexSlList(this.terraformResource, \`\${this.terraformAttribute}\${index}[]\`, true);
+    return new ComplexSlList(this, \`[\${index}]\`, false);
   }
 }
 
@@ -2580,7 +2580,7 @@ export class ComplexSsOutputReference extends cdktf.ComplexObject {
   }
 }
 
-export class ComplexSsListList extends cdktf.ComplexList {
+export class ComplexSsListList extends cdktf.MapList {
 
   /**
   * @param terraformResource The parent resource
@@ -2595,7 +2595,7 @@ export class ComplexSsListList extends cdktf.ComplexList {
   * @param index the index of the item to return
   */
   public get(index: number): ComplexSsList {
-    return new ComplexSsList(this.terraformResource, \`\${this.terraformAttribute}\${index}[]\`, true);
+    return new ComplexSsList(this, \`[\${index}]\`, true);
   }
 }
 

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -2358,7 +2358,7 @@ export interface MapOfStringListConfig extends cdktf.TerraformMetaArguments {
   * 
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/map_of_string_list#settable_keys MapOfStringList#settable_keys}
   */
-  readonly settableKeys?: { [key: string]: string[] };
+  readonly settableKeys?: { [key: string]: string[] } | cdktf.IResolvable;
 }
 
 /**
@@ -2410,11 +2410,11 @@ export class MapOfStringList extends cdktf.TerraformResource {
   }
 
   // settable_keys - computed: false, optional: true, required: false
-  private _settableKeys?: { [key: string]: string[] }; 
+  private _settableKeys?: { [key: string]: string[] } | cdktf.IResolvable; 
   public get settableKeys() {
-    return this.getStringListMapAttribute('settable_keys');
+    return this.interpolationForAttribute('settable_keys');
   }
-  public set settableKeys(value: { [key: string]: string[] }) {
+  public set settableKeys(value: { [key: string]: string[] } | cdktf.IResolvable) {
     this._settableKeys = value;
   }
   public resetSettableKeys() {

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -92,6 +92,12 @@ export class BooleanList extends cdktf.TerraformResource {
     return this._fooOptional;
   }
 
+  // foo_computed - computed: true, optional: false, required: false
+  private _fooComputed = new cdktf.BooleanList(this, \\"foo_computed\\", false);
+  public get fooComputed() {
+    return this._fooComputed;
+  }
+
   // =========
   // SYNTHESIS
   // =========

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -3548,7 +3548,7 @@ export interface SingleBlockTypeConfig extends cdktf.TerraformMetaArguments {
   * 
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/single_block_type#timeouts SingleBlockType#timeouts}
   */
-  readonly timeouts?: SingleBlockTypeTimeouts | cdktf.IResolvable;
+  readonly timeouts?: SingleBlockTypeTimeouts;
 }
 export interface SingleBlockTypeTimeouts {
   /**
@@ -3557,7 +3557,7 @@ export interface SingleBlockTypeTimeouts {
   readonly create?: string;
 }
 
-export function singleBlockTypeTimeoutsToTerraform(struct?: SingleBlockTypeTimeoutsOutputReference | SingleBlockTypeTimeouts | cdktf.IResolvable): any {
+export function singleBlockTypeTimeoutsToTerraform(struct?: SingleBlockTypeTimeouts | cdktf.IResolvable): any {
   if (!cdktf.canInspect(struct) || cdktf.Tokenization.isResolvable(struct)) { return struct; }
   if (cdktf.isComplexElement(struct)) {
     throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
@@ -3576,7 +3576,7 @@ export class SingleBlockTypeTimeoutsOutputReference extends cdktf.ComplexObject 
   * @param terraformAttribute The attribute on the parent resource this class is referencing
   */
   public constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string) {
-    super(terraformResource, terraformAttribute, false, 0);
+    super(terraformResource, terraformAttribute, false);
   }
 
   public get internalValue(): SingleBlockTypeTimeouts | cdktf.IResolvable | undefined {

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -66,7 +66,6 @@ export class BooleanList extends cdktf.TerraformResource {
   // foo_required - computed: false, optional: false, required: true
   private _fooRequired?: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable; 
   public get fooRequired() {
-    // Getting the computed value is not yet implemented
     return this.interpolationForAttribute('foo_required');
   }
   public set fooRequired(value: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable) {
@@ -80,7 +79,6 @@ export class BooleanList extends cdktf.TerraformResource {
   // foo_optional - computed: false, optional: true, required: false
   private _fooOptional?: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable; 
   public get fooOptional() {
-    // Getting the computed value is not yet implemented
     return this.interpolationForAttribute('foo_optional');
   }
   public set fooOptional(value: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable) {
@@ -3550,7 +3548,7 @@ export interface SingleBlockTypeConfig extends cdktf.TerraformMetaArguments {
   * 
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/single_block_type#timeouts SingleBlockType#timeouts}
   */
-  readonly timeouts?: SingleBlockTypeTimeouts;
+  readonly timeouts?: SingleBlockTypeTimeouts | cdktf.IResolvable;
 }
 export interface SingleBlockTypeTimeouts {
   /**

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -3934,6 +3934,19 @@ export class StringList extends cdktf.TerraformResource {
     return this._subjectAlternativeNamesOptional;
   }
 
+  // subject_alternative_names_required - computed: true, optional: false, required: true
+  private _subjectAlternativeNamesRequired?: { [key: string]: string }; 
+  public get subjectAlternativeNamesRequired() {
+    return this.getStringMapAttribute('subject_alternative_names_required');
+  }
+  public set subjectAlternativeNamesRequired(value: { [key: string]: string }) {
+    this._subjectAlternativeNamesRequired = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get subjectAlternativeNamesRequiredInput() {
+    return this._subjectAlternativeNamesRequired;
+  }
+
   // =========
   // SYNTHESIS
   // =========
@@ -3967,6 +3980,10 @@ export interface StringMapConfig extends cdktf.TerraformMetaArguments {
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/string_map#subject_alternative_names_optional StringMap#subject_alternative_names_optional}
   */
   readonly subjectAlternativeNamesOptional?: { [key: string]: string };
+  /**
+  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/string_map#subject_alternative_names_required StringMap#subject_alternative_names_required}
+  */
+  readonly subjectAlternativeNamesRequired: { [key: string]: string };
 }
 
 /**
@@ -4006,6 +4023,7 @@ export class StringMap extends cdktf.TerraformResource {
     });
     this._subjectAlternativeNamesComputedOptional = config.subjectAlternativeNamesComputedOptional;
     this._subjectAlternativeNamesOptional = config.subjectAlternativeNamesOptional;
+    this._subjectAlternativeNamesRequired = config.subjectAlternativeNamesRequired;
   }
 
   // ==========
@@ -4058,6 +4076,7 @@ export class StringMap extends cdktf.TerraformResource {
     return {
       subject_alternative_names_computed_optional: cdktf.hashMapper(cdktf.stringToTerraform)(this._subjectAlternativeNamesComputedOptional),
       subject_alternative_names_optional: cdktf.hashMapper(cdktf.stringToTerraform)(this._subjectAlternativeNamesOptional),
+      subject_alternative_names_required: cdktf.hashMapper(cdktf.stringToTerraform)(this._subjectAlternativeNamesRequired),
     };
   }
 }

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -2358,7 +2358,7 @@ export interface MapOfStringListConfig extends cdktf.TerraformMetaArguments {
   * 
   * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/map_of_string_list#settable_keys MapOfStringList#settable_keys}
   */
-  readonly settableKeys?: { [key: string]: stringList };
+  readonly settableKeys?: { [key: string]: string[] };
 }
 
 /**
@@ -2410,11 +2410,11 @@ export class MapOfStringList extends cdktf.TerraformResource {
   }
 
   // settable_keys - computed: false, optional: true, required: false
-  private _settableKeys?: { [key: string]: stringList }; 
+  private _settableKeys?: { [key: string]: string[] }; 
   public get settableKeys() {
     return this.getStringListMapAttribute('settable_keys');
   }
-  public set settableKeys(value: { [key: string]: stringList }) {
+  public set settableKeys(value: { [key: string]: string[] }) {
     this._settableKeys = value;
   }
   public resetSettableKeys() {

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/deep-nested-attributes.test.ts
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/deep-nested-attributes.test.ts
@@ -1,0 +1,58 @@
+// Copyright (c) HashiCorp, Inc // SPDX-License-Identifier: MPL-2.0
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { TerraformProviderGenerator } from "../../generator/provider-generator";
+import { CodeMaker } from "codemaker";
+
+test("generate a resource with attribute that's a list of a map of an object", async () => {
+  const code = new CodeMaker();
+  const workdir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "deep-nested-attributes.test")
+  );
+  const spec = JSON.parse(
+    fs.readFileSync(
+      path.join(__dirname, "fixtures", "stripe-schema.test.fixture.json"),
+      "utf-8"
+    )
+  );
+  new TerraformProviderGenerator(code, spec).generateAll();
+  await code.save(workdir);
+
+  const output = fs.readFileSync(
+    path.join(workdir, "providers/stripe/invoiceitems/index.ts"),
+    "utf-8"
+  );
+
+  expect(output).toEqual(
+    expect.stringContaining(
+      `export class InvoiceitemsDiscountsList extends cdktf.ComplexList {`
+    )
+  );
+});
+
+test("generate a resource with attribute that's a map of a list of an object", async () => {
+  const code = new CodeMaker();
+  const workdir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "deep-nested-attributes-list.test")
+  );
+  const spec = JSON.parse(
+    fs.readFileSync(
+      path.join(__dirname, "fixtures", "deep-attributes.test.fixture.json"),
+      "utf-8"
+    )
+  );
+  new TerraformProviderGenerator(code, spec).generateAll();
+  await code.save(workdir);
+
+  const output = fs.readFileSync(
+    path.join(workdir, "providers/stripe/invoiceitems/index.ts"),
+    "utf-8"
+  );
+
+  expect(output).toEqual(
+    expect.stringContaining(
+      `export class InvoiceitemsDiscountsMap extends cdktf.ComplexMap {`
+    )
+  );
+});

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/deep-nested-attributes.test.ts
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/deep-nested-attributes.test.ts
@@ -26,7 +26,7 @@ test("generate a resource with attribute that's a list of a map of an object", a
 
   expect(output).toEqual(
     expect.stringContaining(
-      `export class InvoiceitemsDiscountsList extends cdktf.ComplexList {`
+      `export class InvoiceitemsDiscountsMapList extends cdktf.MapList {`
     )
   );
 });
@@ -52,7 +52,7 @@ test("generate a resource with attribute that's a map of a list of an object", a
 
   expect(output).toEqual(
     expect.stringContaining(
-      `export class InvoiceitemsDiscountsMap extends cdktf.ComplexMap {`
+      `export class InvoiceitemsDiscountsListMap extends cdktf.ComplexMap {`
     )
   );
 });

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/boolean-list.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/boolean-list.test.fixture.json
@@ -19,6 +19,13 @@
                   "bool"
                 ],
                 "optional": true
+              },
+              "foo_computed": {
+                "type": [
+                  "list",
+                  "bool"
+                ],
+                "computed": true
               }
 
             }

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/deep-attributes.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/deep-attributes.test.fixture.json
@@ -1,0 +1,35 @@
+{
+  "format_version": "1.0",
+  "provider_schemas": {
+    "stripe": {
+      "resource_schemas": {
+        "stripe_invoiceitems": {
+          "version": 0,
+          "block": {
+            "attributes": {
+              "discounts": {
+                "type": [
+                  "map",
+                  [
+                    "list",
+                    [
+                      "object",
+                      {
+                        "coupon": "string",
+                        "discount_amount": "string"
+                      }
+                    ]
+                  ]
+                ],
+                "description": "The coupons to redeem into discounts for the invoice item or invoice line item.",
+                "description_kind": "plain",
+                "optional": true
+              }
+            },
+            "description_kind": "plain"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/list-list-object.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/list-list-object.test.fixture.json
@@ -1,0 +1,82 @@
+{
+    "format_version": "1.0",
+    "provider_schemas": {
+      "test": {
+        "resource_schemas": {
+          "test_complex": {
+            "version": 0,
+            "block": {
+              "attributes": {
+                "ll": {
+                  "type": [
+                    "list",
+                    [
+                      "list",
+                      [
+                        "object",
+                        {
+                          "coupon": "string",
+                          "discount_amount": "string"
+                        }
+                      ]
+                    ]
+                  ],
+                  "computed": true
+                },
+                "ls": {
+                    "type": [
+                      "list",
+                      [
+                        "set",
+                        [
+                          "object",
+                          {
+                            "coupon": "string",
+                            "discount_amount": "string"
+                          }
+                        ]
+                      ]
+                    ],
+                    "computed": true
+                  },
+                  "sl": {
+                    "type": [
+                      "set",
+                      [
+                        "list",
+                        [
+                          "object",
+                          {
+                            "coupon": "string",
+                            "discount_amount": "string"
+                          }
+                        ]
+                      ]
+                    ],
+                    "computed": true
+                  },
+                  "ss": {
+                    "type": [
+                      "set",
+                      [
+                        "set",
+                        [
+                          "object",
+                          {
+                            "coupon": "string",
+                            "discount_amount": "string"
+                          }
+                        ]
+                      ]
+                    ],
+                    "computed": true
+                  }
+              },
+              "description_kind": "plain"
+            }
+          }
+        }
+      }
+    }
+  }
+  

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/map-of-string-list.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/map-of-string-list.test.fixture.json
@@ -2,30 +2,30 @@
   "provider_schemas": {
     "aws": {
       "resource_schemas": {
-        "aws_list_of_string_map": {
+        "aws_map_of_string_list": {
           "version": 1,
           "block": {
             "attributes": {
               "keys": {
                 "type": [
-                  "list",
+                  "map",
                   [
-                    "map",
+                    "list",
                     "string"
                   ]
                 ],
-                "description": "List of key versions in the keyring.",
+                "description": "Map of String List.",
                 "computed": true
               },
               "settable_keys": {
                 "type": [
-                  "list",
+                  "map",
                   [
-                    "map",
+                    "list",
                     "string"
                   ]
                 ],
-                "description": "List of key versions in the keyring.",
+                "description": "Map of String List.",
                 "optional": true
               }
             }

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/string-map.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/string-map.test.fixture.json
@@ -27,6 +27,14 @@
                   "string"
                 ],
                 "optional": true
+              },
+              "subject_alternative_names_required": {
+                "type": [
+                  "map",
+                  "string"
+                ],
+                "required": true,
+                "computed": true
               }
             }
           },

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/stripe-schema.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/stripe-schema.test.fixture.json
@@ -1,0 +1,35 @@
+{
+  "format_version": "1.0",
+  "provider_schemas": {
+    "stripe": {
+      "resource_schemas": {
+        "stripe_invoiceitems": {
+          "version": 0,
+          "block": {
+            "attributes": {
+              "discounts": {
+                "type": [
+                  "list",
+                  [
+                    "map",
+                    [
+                      "object",
+                      {
+                        "coupon": "string",
+                        "discount_amount": "string"
+                      }
+                    ]
+                  ]
+                ],
+                "description": "The coupons to redeem into discounts for the invoice item or invoice line item.",
+                "description_kind": "plain",
+                "optional": true
+              }
+            },
+            "description_kind": "plain"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/types.test.ts
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/types.test.ts
@@ -477,6 +477,27 @@ test("list of string map attribute", async () => {
   expect(output).toMatchSnapshot();
 });
 
+test("map of string list attribute", async () => {
+  const code = new CodeMaker();
+  const workdir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "map-of-string-list.test")
+  );
+  const spec = JSON.parse(
+    fs.readFileSync(
+      path.join(__dirname, "fixtures", "map-of-string-list.test.fixture.json"),
+      "utf-8"
+    )
+  );
+  new TerraformProviderGenerator(code, spec).generateAll();
+  await code.save(workdir);
+
+  const output = fs.readFileSync(
+    path.join(workdir, "providers/aws/map-of-string-list/index.ts"),
+    "utf-8"
+  );
+  expect(output).toMatchSnapshot();
+});
+
 test("reset and input name conflicts", async () => {
   const code = new CodeMaker();
   const workdir = fs.mkdtempSync(path.join(os.tmpdir(), "name-conflict.test"));

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/types.test.ts
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/types.test.ts
@@ -516,3 +516,24 @@ test("reset and input name conflicts", async () => {
   );
   expect(output).toMatchSnapshot();
 });
+
+test("list of list attributes", async () => {
+  const code = new CodeMaker();
+  const workdir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "list-list-object.test")
+  );
+  const spec = JSON.parse(
+    fs.readFileSync(
+      path.join(__dirname, "fixtures", "list-list-object.test.fixture.json"),
+      "utf-8"
+    )
+  );
+  new TerraformProviderGenerator(code, spec).generateAll();
+  await code.save(workdir);
+
+  const output = fs.readFileSync(
+    path.join(workdir, "providers/test/complex/index.ts"),
+    "utf-8"
+  );
+  expect(output).toMatchSnapshot();
+});

--- a/packages/@cdktf/provider-generator/lib/get/generator/emitter/attributes-emitter.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/emitter/attributes-emitter.ts
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 import { CodeMaker } from "codemaker";
 import { AttributeModel } from "../models";
-import { downcaseFirst, uppercaseFirst } from "../../../util";
 import { CUSTOM_DEFAULTS } from "../custom-defaults";
-import { logger } from "@cdktf/commons";
 
 function titleCase(value: string) {
   return value[0].toUpperCase() + value.slice(1);
@@ -31,7 +29,9 @@ export class AttributesEmitter {
         `private ${att.storageName} = ${this.storedClassInit(att)};`
       );
     } else if (isStored) {
-      this.code.line(`private ${att.storageName}?: ${att.type.name}; `);
+      this.code.line(
+        `private ${att.storageName}?: ${att.newType.inputTypeDefinition}; `
+      );
     }
 
     switch (getterType._type) {
@@ -118,26 +118,7 @@ export class AttributesEmitter {
 
   // returns an invocation of a stored class, e.g. 'new DeplotmentMetadataOutputReference(this, "metadata")'
   private storedClassInit(att: AttributeModel) {
-    if ((att.type.isList || att.type.isSet) && !att.type.isSingleItem) {
-      // list/set
-      if (att.type.struct) {
-        return `new ${att.type.struct.name}List(this, "${att.terraformName}", ${att.type.isSet})`;
-      } else {
-        return `new ${att.type.name}List(this, "${att.terraformName}", ${att.type.isSet})`;
-      }
-    } else if (att.type.isMap) {
-      if (att.type.struct) {
-        return `new ${att.type.struct.name}Map(this, "${att.terraformName}")`;
-      } else {
-        return `new ${att.type.name}(this, "${att.terraformName}")`;
-      }
-    } else {
-      if (att.type.name.includes("IResolvable")) {
-        return `new ${att.type.innerType}OutputReference(this, "${att.terraformName}")`;
-      } else {
-        return `new ${att.type.name}OutputReference(this, "${att.terraformName}")`;
-      }
-    }
+    return att.newType.getStoredClassInitializer(att.terraformName);
   }
 
   public determineGetAttCall(att: AttributeModel): string {
@@ -145,66 +126,7 @@ export class AttributesEmitter {
       return `this.${att.storageName}`;
     }
 
-    const type = att.type;
-    if (type.isString) {
-      return `this.getStringAttribute('${att.terraformName}')`;
-    }
-    if (type.isStringList) {
-      return `this.getListAttribute('${att.terraformName}')`;
-    }
-    if (type.isNumberList) {
-      return `this.getNumberListAttribute('${att.terraformName}')`;
-    }
-    if (type.isStringSet) {
-      return `cdktf.Fn.tolist(this.getListAttribute('${att.terraformName}'))`;
-    }
-    if (type.isNumberSet) {
-      return `cdktf.Token.asNumberList(cdktf.Fn.tolist(this.getNumberListAttribute('${att.terraformName}')))`;
-    }
-    if (type.isNumber) {
-      return `this.getNumberAttribute('${att.terraformName}')`;
-    }
-    if (type.isBoolean) {
-      return `this.getBooleanAttribute('${att.terraformName}')`;
-    }
-
-    // TODO: enable this change once we want to release the next major version
-    // https://github.com/hashicorp/terraform-cdk/issues/2532
-    // return `this.getComputed${uppercaseFirst(att.mapType)}MapAttribute('${
-    //   att.terraformName
-    // }')`;
-    // if (type.isComputedStringMap) return `this.getComputedStringMapAttribute('${att.terraformName}')`;
-    // if (type.isComputedNumberMap) return `this.getComputedNumberMapAttribute('${att.terraformName}')`;
-    // if (type.isComputedBooleanMap) return `this.getComputedBooleanMapAttribute('${att.terraformName}')`;
-    // if (type.isComputedAnyMap) return `this.getComputedAnyMapAttribute('${att.terraformName}')`;
-
-    if (type.isComputedStringMap)
-      return `new cdktf.StringMap(this, '${att.terraformName}')`;
-    if (type.isComputedNumberMap)
-      return `new cdktf.NumberMap(this, '${att.terraformName}')`;
-    if (type.isComputedBooleanMap)
-      return `new cdktf.BooleanMap(this, '${att.terraformName}')`;
-    if (type.isComputedAnyMap)
-      return `new cdktf.AnyMap(this, '${att.terraformName}')`;
-
-    if (type.isMap) {
-      return `this.get${uppercaseFirst(att.mapType)}MapAttribute('${
-        att.terraformName
-      }')`;
-    }
-
-    logger.debug(`The attribute isn't implemented yet: ${JSON.stringify(att)}`);
-
-    this.code.line(`// Getting the computed value is not yet implemented`);
-    if (type.isSet) {
-      // Token.asAny is required because tolist returns an Array encoded token which the listMapper
-      // would try to map over when this is passed to another resource. With Token.asAny() it is left
-      // as is by the listMapper and is later properly resolved to a reference
-      // (this only works in TypeScript currently, same as for referencing lists
-      // [see "interpolationForAttribute(...)" further below])
-      return `cdktf.Token.asAny(cdktf.Fn.tolist(this.interpolationForAttribute('${att.terraformName}')))`;
-    }
-    return `this.interpolationForAttribute('${att.terraformName}')`;
+    return att.newType.getAttributeAccessFunction(att.terraformName);
   }
 
   public needsInputEscape(
@@ -247,7 +169,7 @@ export class AttributesEmitter {
   }
 
   public emitToTerraform(att: AttributeModel, isStruct: boolean) {
-    const type = att.type;
+    const type = att.newType;
     const context = isStruct ? "struct!" : "this";
     const name = isStruct ? att.name : att.storageName;
     const customDefault = CUSTOM_DEFAULTS[att.terraformFullName];
@@ -265,89 +187,8 @@ export class AttributesEmitter {
         ? `${varReference} === undefined ? ${customDefault} : `
         : "";
 
-    const isBlockType = att.type.isBlock;
-
-    switch (true) {
-      case type.isSet && type.isMap:
-        this.code.line(
-          `${att.terraformName}: ${defaultCheck}cdktf.listMapper(cdktf.hashMapper(cdktf.${att.mapType}ToTerraform), ${isBlockType})(${varReference}),`
-        );
-        break;
-      case type.isList && type.isMap:
-        this.code.line(
-          `${att.terraformName}: ${defaultCheck}cdktf.listMapper(cdktf.hashMapper(cdktf.${att.mapType}ToTerraform), ${isBlockType})(${varReference}),`
-        );
-        break;
-      case type.isStringSet || type.isNumberSet || type.isBooleanSet:
-        this.code.line(
-          `${
-            att.terraformName
-          }: ${defaultCheck}cdktf.listMapper(cdktf.${downcaseFirst(
-            type.innerType
-          )}ToTerraform, ${isBlockType})(${varReference}),`
-        );
-        break;
-      case type.isStringList || type.isNumberList || type.isBooleanList:
-        this.code.line(
-          `${
-            att.terraformName
-          }: ${defaultCheck}cdktf.listMapper(cdktf.${downcaseFirst(
-            type.innerType
-          )}ToTerraform, ${isBlockType})(${varReference}),`
-        );
-        break;
-      case type.isSet && !type.isSingleItem:
-        this.code.line(
-          `${
-            att.terraformName
-          }: ${defaultCheck}cdktf.listMapper(${downcaseFirst(
-            type.innerType
-          )}ToTerraform, ${isBlockType})(${varReference}),`
-        );
-        break;
-      case type.isList && !type.isSingleItem:
-        this.code.line(
-          `${
-            att.terraformName
-          }: ${defaultCheck}cdktf.listMapper(${downcaseFirst(
-            type.innerType
-          )}ToTerraform, ${isBlockType})(${varReference}),`
-        );
-        break;
-      case type.isMap:
-        this.code.line(
-          `${att.terraformName}: ${defaultCheck}cdktf.hashMapper(cdktf.${att.mapType}ToTerraform)(${varReference}),`
-        );
-        break;
-      case type.isString:
-        this.code.line(
-          `${att.terraformName}: ${defaultCheck}cdktf.stringToTerraform(${varReference}),`
-        );
-        break;
-      case type.isNumber:
-        this.code.line(
-          `${att.terraformName}: ${defaultCheck}cdktf.numberToTerraform(${varReference}),`
-        );
-        break;
-      case type.isBoolean:
-        this.code.line(
-          `${att.terraformName}: ${defaultCheck}cdktf.booleanToTerraform(${varReference}),`
-        );
-        break;
-      case type.isComplex && !type.struct?.isClass && !type.isSingleItem:
-        this.code.line(
-          `${att.terraformName}: ${defaultCheck}${downcaseFirst(
-            type.struct!.name
-          )}ToTerraform(${varReference}),`
-        );
-        break;
-      default:
-        this.code.line(
-          `${att.terraformName}: ${defaultCheck}${downcaseFirst(
-            type.name
-          )}ToTerraform(${varReference}),`
-        );
-        break;
-    }
+    this.code.line(
+      `${att.terraformName}: ${defaultCheck}${type.toTerraformFunction}(${varReference}),`
+    );
   }
 }

--- a/packages/@cdktf/provider-generator/lib/get/generator/emitter/attributes-emitter.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/emitter/attributes-emitter.ts
@@ -30,7 +30,7 @@ export class AttributesEmitter {
       );
     } else if (isStored) {
       this.code.line(
-        `private ${att.storageName}?: ${att.newType.inputTypeDefinition}; `
+        `private ${att.storageName}?: ${att.type.inputTypeDefinition}; `
       );
     }
 
@@ -118,7 +118,7 @@ export class AttributesEmitter {
 
   // returns an invocation of a stored class, e.g. 'new DeplotmentMetadataOutputReference(this, "metadata")'
   private storedClassInit(att: AttributeModel) {
-    return att.newType.getStoredClassInitializer(att.terraformName);
+    return att.type.getStoredClassInitializer(att.terraformName);
   }
 
   public determineGetAttCall(att: AttributeModel): string {
@@ -126,7 +126,7 @@ export class AttributesEmitter {
       return `this.${att.storageName}`;
     }
 
-    return att.newType.getAttributeAccessFunction(att.terraformName);
+    return att.type.getAttributeAccessFunction(att.terraformName);
   }
 
   public needsInputEscape(
@@ -169,7 +169,7 @@ export class AttributesEmitter {
   }
 
   public emitToTerraform(att: AttributeModel, isStruct: boolean) {
-    const type = att.newType;
+    const type = att.type;
     const context = isStruct ? "struct!" : "this";
     const name = isStruct ? att.name : att.storageName;
     const customDefault = CUSTOM_DEFAULTS[att.terraformFullName];

--- a/packages/@cdktf/provider-generator/lib/get/generator/emitter/attributes-emitter.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/emitter/attributes-emitter.ts
@@ -30,7 +30,7 @@ export class AttributesEmitter {
       );
     } else if (isStored) {
       this.code.line(
-        `private ${att.storageName}?: ${att.newType.inputTypeDefinition}; `
+        `private ${att.storageName}?: ${att.type.name}; ` //att.newType.inputTypeDefinition
       );
     }
 

--- a/packages/@cdktf/provider-generator/lib/get/generator/emitter/attributes-emitter.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/emitter/attributes-emitter.ts
@@ -30,7 +30,7 @@ export class AttributesEmitter {
       );
     } else if (isStored) {
       this.code.line(
-        `private ${att.storageName}?: ${att.type.name}; ` //att.newType.inputTypeDefinition
+        `private ${att.storageName}?: ${att.newType.inputTypeDefinition}; `
       );
     }
 

--- a/packages/@cdktf/provider-generator/lib/get/generator/emitter/struct-emitter.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/emitter/struct-emitter.ts
@@ -136,11 +136,11 @@ export class StructEmitter {
       // find all structs that need to be imported in this file
       structs.forEach((struct) => {
         struct.attributes.forEach((att) => {
-          const structTypeName = att.type.typeName;
-          const fileToImport = structImports[structTypeName];
+          const structTypeName = att.newType.struct?.name;
+          const fileToImport = structImports[structTypeName ?? ""];
 
           if (fileToImport && fileToImport !== structFilename) {
-            const attTypeStruct = att.type.struct;
+            const attTypeStruct = att.newType.struct;
             if (!attTypeStruct)
               throw new Error(`${structTypeName} is not a struct`);
 

--- a/packages/@cdktf/provider-generator/lib/get/generator/emitter/struct-emitter.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/emitter/struct-emitter.ts
@@ -422,9 +422,7 @@ export class StructEmitter {
     this.code.line(`* @param index the index of the item to return`);
     this.code.line(`*/`);
     this.code.openBlock(`public get(index: number): ${struct.mapName}`);
-    this.code.line(
-      `return new ${struct.mapName}(this.terraformResource, \`[\${index}]\`);`
-    );
+    this.code.line(`return new ${struct.mapName}(this, \`[\${index}]\`);`);
     this.code.closeBlock();
 
     this.code.closeBlock();
@@ -466,7 +464,7 @@ export class StructEmitter {
     this.code.line(`*/`);
     this.code.openBlock(`public get(key: string): ${struct.listName}`);
     this.code.line(
-      `return new ${struct.listName}(this.terraformResource, \`[\${key}]\`, ${isSet});`
+      `return new ${struct.listName}(this, \`[\${key}]\`, ${isSet});`
     );
     this.code.closeBlock();
 
@@ -481,7 +479,7 @@ export class StructEmitter {
   private emitComplexListListClass(struct: Struct) {
     this.code.line();
     this.code.openBlock(
-      `export class ${struct.listListName} extends cdktf.ComplexList`
+      `export class ${struct.listListName} extends cdktf.MapList` // despite name, need the same behavior
     );
 
     if (struct.assignable) {
@@ -512,10 +510,8 @@ export class StructEmitter {
     this.code.line(`*/`);
     this.code.openBlock(`public get(index: number): ${struct.listName}`);
     this.code.line(
-      `return new ${
-        struct.listName
-      }(this.terraformResource, \`\${this.terraformAttribute}\${index}[]\`, ${
-        struct.nestingMode === "listset" || struct.nestingMode === "setset"
+      `return new ${struct.listName}(this, \`[\${index}]\`, ${
+        struct.nestingMode === "setlist" || struct.nestingMode === "setset"
       });`
     );
     this.code.closeBlock();

--- a/packages/@cdktf/provider-generator/lib/get/generator/emitter/struct-emitter.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/emitter/struct-emitter.ts
@@ -291,7 +291,7 @@ export class StructEmitter {
     } else if (struct.nestingMode === "setmap") {
       this.emitComplexListMapClasses(struct, true);
     }
-    // TODO think if there's a good way to generalize these
+    // other types of nested collections aren't supported
   }
 
   private emitComplexListClass(struct: Struct) {

--- a/packages/@cdktf/provider-generator/lib/get/generator/emitter/struct-emitter.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/emitter/struct-emitter.ts
@@ -136,11 +136,11 @@ export class StructEmitter {
       // find all structs that need to be imported in this file
       structs.forEach((struct) => {
         struct.attributes.forEach((att) => {
-          const structTypeName = att.newType.struct?.name;
+          const structTypeName = att.type.struct?.name;
           const fileToImport = structImports[structTypeName ?? ""];
 
           if (fileToImport && fileToImport !== structFilename) {
-            const attTypeStruct = att.newType.struct;
+            const attTypeStruct = att.type.struct;
             if (!attTypeStruct)
               throw new Error(`${structTypeName} is not a struct`);
 

--- a/packages/@cdktf/provider-generator/lib/get/generator/loop-detection.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/loop-detection.ts
@@ -12,22 +12,20 @@ const equalAttributeIdentifiers = (
   [...x[1]].every((x) => y[1].has(x));
 
 function typeStructure(model: AttributeModel) {
-  if (!model.newType.isComplex) {
-    return model.newType.storedClassType;
+  if (!model.type.isComplex) {
+    return model.type.storedClassType;
   }
 
-  return `<complex:{${model.newType.struct?.attributes
+  return `<complex:{${model.type.struct?.attributes
     .map((att) => att.name)
-    .sort()}}${model.newType.typeModelType}>`;
+    .sort()}}${model.type.typeModelType}>`;
 }
 
 function getAttributeIdentifier(model: AttributeModel): AttributeIdentifier {
   return [
     model.terraformName,
     new Set(
-      model.newType.struct!.attributes.map(
-        (a) => `${a.name}:${typeStructure(a)}`
-      )
+      model.type.struct!.attributes.map((a) => `${a.name}:${typeStructure(a)}`)
     ),
   ];
 }
@@ -49,7 +47,7 @@ export function detectAttributeLoops(attributes: AttributeModel[]): {
     knownStructs: { [attributePath: string]: AttributeIdentifier } = {}
   ) {
     const name = attribute.terraformName;
-    const struct = attribute.newType.struct;
+    const struct = attribute.type.struct;
     if (!struct) {
       return;
     }

--- a/packages/@cdktf/provider-generator/lib/get/generator/loop-detection.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/loop-detection.ts
@@ -12,20 +12,22 @@ const equalAttributeIdentifiers = (
   [...x[1]].every((x) => y[1].has(x));
 
 function typeStructure(model: AttributeModel) {
-  if (model.type.isPrimitive) {
-    return model.type.name;
+  if (!model.newType.isComplex) {
+    return model.newType.storedClassType;
   }
 
-  return `<complex:{${model.type.struct?.attributes
+  return `<complex:{${model.newType.struct?.attributes
     .map((att) => att.name)
-    .sort()}}${model.type.isList ? "[]" : ""}>`;
+    .sort()}}${model.newType.typeModelType}>`;
 }
 
 function getAttributeIdentifier(model: AttributeModel): AttributeIdentifier {
   return [
     model.terraformName,
     new Set(
-      model.type.struct!.attributes.map((a) => `${a.name}:${typeStructure(a)}`)
+      model.newType.struct!.attributes.map(
+        (a) => `${a.name}:${typeStructure(a)}`
+      )
     ),
   ];
 }
@@ -47,7 +49,7 @@ export function detectAttributeLoops(attributes: AttributeModel[]): {
     knownStructs: { [attributePath: string]: AttributeIdentifier } = {}
   ) {
     const name = attribute.terraformName;
-    const struct = attribute.type.struct;
+    const struct = attribute.newType.struct;
     if (!struct) {
       return;
     }

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
@@ -1,6 +1,9 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import { AttributeTypeModel } from "./attribute-type-model";
+import {
+  AttributeTypeModel,
+  NewAttributeTypeModel,
+} from "./attribute-type-model";
 import { logger } from "@cdktf/commons";
 
 export type GetterType =
@@ -33,6 +36,7 @@ export interface AttributeModelOptions {
   getAttCall?: string;
   provider: boolean;
   required: boolean;
+  newType: NewAttributeTypeModel;
 }
 
 export function escapeAttributeName(name: string) {
@@ -62,6 +66,7 @@ export class AttributeModel {
   private _description?: string;
   public provider: boolean;
   public required: boolean;
+  public newType: NewAttributeTypeModel;
 
   constructor(options: AttributeModelOptions) {
     this.storageName = options.storageName;
@@ -74,6 +79,7 @@ export class AttributeModel {
     this._description = options.description;
     this.provider = options.provider;
     this.required = options.required;
+    this.newType = options.newType;
   }
 
   public get typeDefinition() {

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
@@ -1,9 +1,6 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import {
-  AttributeTypeModel,
-  NewAttributeTypeModel,
-} from "./attribute-type-model";
+import { AttributeTypeModel } from "./attribute-type-model";
 
 export type GetterType =
   | { _type: "plain" }
@@ -35,7 +32,6 @@ export interface AttributeModelOptions {
   getAttCall?: string;
   provider: boolean;
   required: boolean;
-  newType: NewAttributeTypeModel;
 }
 
 export function escapeAttributeName(name: string) {
@@ -65,7 +61,6 @@ export class AttributeModel {
   private _description?: string;
   public provider: boolean;
   public required: boolean;
-  public newType: NewAttributeTypeModel;
 
   constructor(options: AttributeModelOptions) {
     this.storageName = options.storageName;
@@ -78,12 +73,11 @@ export class AttributeModel {
     this._description = options.description;
     this.provider = options.provider;
     this.required = options.required;
-    this.newType = options.newType;
   }
 
   public get typeDefinition() {
     const optional = this.optional ? "?" : "";
-    return `${this.name}${optional}: ${this.newType.inputTypeDefinition}`;
+    return `${this.name}${optional}: ${this.type.inputTypeDefinition}`;
   }
 
   public get isAssignable() {
@@ -109,14 +103,14 @@ export class AttributeModel {
       return getterType;
     }
 
-    if (this.newType.hasReferenceClass) {
+    if (this.type.hasReferenceClass) {
       getterType = {
         _type: "stored_class",
       };
     } else if (
       this.computed &&
       !this.isAssignable &&
-      (!this.newType.isTokenizable || this.newType.typeModelType === "map")
+      (!this.type.isTokenizable || this.type.typeModelType === "map")
     ) {
       getterType = {
         _type: "stored_class",
@@ -138,13 +132,13 @@ export class AttributeModel {
     if (this.getterType._type === "stored_class") {
       return {
         _type: "stored_class",
-        type: this.newType.inputTypeDefinition,
+        type: this.type.inputTypeDefinition,
       };
     }
 
     return {
       _type: "set",
-      type: `${this.newType.inputTypeDefinition}${
+      type: `${this.type.inputTypeDefinition}${
         this.isProvider ? " | undefined" : ""
       }`,
     };
@@ -165,7 +159,7 @@ export class AttributeModel {
   }
 
   public getReferencedTypes(isConfigStruct: boolean): string[] | undefined {
-    const attTypeStruct = this.newType.struct;
+    const attTypeStruct = this.type.struct;
     if (!attTypeStruct) {
       return undefined;
     }

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
@@ -190,7 +190,7 @@ export class AttributeModel {
     } else if (!isConfigStruct) {
       types.push(attTypeStruct.outputReferenceName);
     }
-    // TODO think if there's a good way to generalize these
+    // other types of nested collections aren't supported
 
     return types;
   }

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
@@ -179,9 +179,18 @@ export class AttributeModel {
       types.push(attTypeStruct.listName);
     } else if (attTypeStruct.nestingMode === "map") {
       types.push(attTypeStruct.mapName);
+    } else if (attTypeStruct.nestingMode === "maplist") {
+      types.push(attTypeStruct.mapListName);
+    } else if (attTypeStruct.nestingMode === "mapset") {
+      types.push(attTypeStruct.mapListName);
+    } else if (attTypeStruct.nestingMode === "listmap") {
+      types.push(attTypeStruct.listMapName);
+    } else if (attTypeStruct.nestingMode === "setmap") {
+      types.push(attTypeStruct.listMapName);
     } else if (!isConfigStruct) {
       types.push(attTypeStruct.outputReferenceName);
     }
+    // TODO think if there's a good way to generalize these
 
     return types;
   }

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
@@ -187,6 +187,13 @@ export class AttributeModel {
       types.push(attTypeStruct.listMapName);
     } else if (attTypeStruct.nestingMode === "setmap") {
       types.push(attTypeStruct.listMapName);
+    } else if (
+      attTypeStruct.nestingMode === "listlist" ||
+      attTypeStruct.nestingMode === "listset" ||
+      attTypeStruct.nestingMode === "setlist" ||
+      attTypeStruct.nestingMode == "setset"
+    ) {
+      types.push(attTypeStruct.listListName);
     } else if (!isConfigStruct) {
       types.push(attTypeStruct.outputReferenceName);
     }

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
@@ -109,49 +109,18 @@ export class AttributeModel {
       return getterType;
     }
 
-    if (
-      // Complex Computed List Map
+    if (this.newType.hasReferenceClass) {
+      getterType = {
+        _type: "stored_class",
+      };
+    } else if (
+      this.computed &&
       !this.isAssignable &&
-      this.type.isComputedComplex &&
-      this.type.isList &&
-      this.type.isMap
+      (!this.newType.isTokenizable || this.newType.typeModelType === "map")
     ) {
       getterType = {
         _type: "stored_class",
       };
-    } else if (
-      // Complex List/Set
-      this.type.isComplex &&
-      (this.type.isList || this.type.isSet)
-    ) {
-      getterType = {
-        _type: "stored_class",
-      };
-    } else if (
-      // Complex Map
-      this.type.isComplex &&
-      this.type.isMap
-    ) {
-      getterType = {
-        _type: "stored_class",
-      };
-    } else if (
-      // Computed Map
-      this.type.isComputed &&
-      !this.isAssignable &&
-      this.type.isMap
-    ) {
-      getterType = {
-        _type: "stored_class",
-      };
-    }
-
-    if (this.type.isSingleItem) {
-      getterType = { _type: "stored_class" };
-    }
-
-    if (this.type.isNested) {
-      getterType = { _type: "stored_class" };
     }
 
     return getterType;
@@ -169,13 +138,15 @@ export class AttributeModel {
     if (this.getterType._type === "stored_class") {
       return {
         _type: "stored_class",
-        type: this.type.name,
+        type: this.newType.inputTypeDefinition,
       };
     }
 
     return {
       _type: "set",
-      type: `${this.type.name}${this.isProvider ? " | undefined" : ""}`,
+      type: `${this.newType.inputTypeDefinition}${
+        this.isProvider ? " | undefined" : ""
+      }`,
     };
   }
 

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
@@ -4,7 +4,6 @@ import {
   AttributeTypeModel,
   NewAttributeTypeModel,
 } from "./attribute-type-model";
-import { logger } from "@cdktf/commons";
 
 export type GetterType =
   | { _type: "plain" }
@@ -84,7 +83,7 @@ export class AttributeModel {
 
   public get typeDefinition() {
     const optional = this.optional ? "?" : "";
-    return `${this.name}${optional}: ${this.type.name}`;
+    return `${this.name}${optional}: ${this.newType.inputTypeDefinition}`;
   }
 
   public get isAssignable() {
@@ -97,10 +96,6 @@ export class AttributeModel {
 
   public get isRequired(): boolean {
     return this.required;
-  }
-
-  public get isTokenizable(): boolean {
-    return this.type.isTokenizable;
   }
 
   public get isProvider(): boolean {
@@ -162,37 +157,6 @@ export class AttributeModel {
     return getterType;
   }
 
-  public get mapType() {
-    const type = this.type;
-    if (type.isStringMap) {
-      return `string`;
-    }
-    if (type.isNumberMap) {
-      return `number`;
-    }
-    if (type.isBooleanMap) {
-      return `boolean`;
-    }
-    if (type.isAnyMap) {
-      return `any`;
-    }
-
-    logger.debug(
-      `The attribute isn't implemented yet: ${JSON.stringify(this)}`
-    );
-
-    return `any`;
-  }
-
-  public get mapReturnType(): string {
-    const mapDataType = this.mapType;
-    if (!this.isTokenizable) {
-      return `${mapDataType} | cdktf.IResolvable`;
-    }
-
-    return mapDataType;
-  }
-
   public get isStored(): boolean {
     return this.isAssignable;
   }
@@ -230,7 +194,7 @@ export class AttributeModel {
   }
 
   public getReferencedTypes(isConfigStruct: boolean): string[] | undefined {
-    const attTypeStruct = this.type.struct;
+    const attTypeStruct = this.newType.struct;
     if (!attTypeStruct) {
       return undefined;
     }
@@ -238,7 +202,7 @@ export class AttributeModel {
     const types: string[] = [];
 
     if (this.isAssignable) {
-      types.push(this.type.typeName);
+      types.push(attTypeStruct.name);
       types.push(attTypeStruct.mapperName);
     }
 

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
@@ -2,14 +2,33 @@
 // SPDX-License-Identifier: MPL-2.0
 import { Struct } from "./struct";
 
-export interface NewAttributeTypeModel {}
+export interface NewAttributeTypeModel {
+  readonly struct?: Struct; // complex object type contained within the type
+  readonly isComplex: boolean; // basically the same as having a struct
+  readonly storedClassType: string; // this is the type of object used to keep track of references accessed
+  readonly inputTypeDefinition: string; // this is the type used for inputting values
+  readonly attributeAccessFunction: string; // this is for getting reference for simple types
+  readonly toTerraformFunction: string; // this is for converting input values to Terraform syntax
+}
 
 export class SimpleAttributeTypeModel implements NewAttributeTypeModel {
   constructor(public readonly type: string) {}
+
+  get struct() {
+    return undefined;
+  }
+
+  get isComplex() {
+    return false;
+  }
 }
 
 export class StructAttributeTypeModel implements NewAttributeTypeModel {
   constructor(public readonly struct: Struct) {}
+
+  get isComplex() {
+    return true;
+  }
 }
 
 export interface CollectionAttributeTypeModel extends NewAttributeTypeModel {
@@ -18,14 +37,38 @@ export interface CollectionAttributeTypeModel extends NewAttributeTypeModel {
 
 export class ListAttributeTypeModel implements CollectionAttributeTypeModel {
   constructor(public readonly elementType: NewAttributeTypeModel) {}
+
+  get struct() {
+    return this.elementType.struct;
+  }
+
+  get isComplex() {
+    return this.elementType.isComplex;
+  }
 }
 
 export class SetAttributeTypeModel implements CollectionAttributeTypeModel {
   constructor(public readonly elementType: NewAttributeTypeModel) {}
+
+  get struct() {
+    return this.elementType.struct;
+  }
+
+  get isComplex() {
+    return this.elementType.isComplex;
+  }
 }
 
 export class MapAttributeTypeModel implements CollectionAttributeTypeModel {
   constructor(public readonly elementType: NewAttributeTypeModel) {}
+
+  get struct() {
+    return this.elementType.struct;
+  }
+
+  get isComplex() {
+    return this.elementType.isComplex;
+  }
 }
 
 export interface AttributeTypeModelOptions {

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
@@ -11,10 +11,15 @@ export interface NewAttributeTypeModel {
   readonly inputTypeDefinition: string; // this is the type used for inputting values
   getAttributeAccessFunction(name: string): string; // this is for getting reference for simple types
   readonly toTerraformFunction: string; // this is for converting input values to Terraform syntax
+  readonly typeModelType: string; // so we don't need to use instanceof
 }
 
 export class SimpleAttributeTypeModel implements NewAttributeTypeModel {
   constructor(public readonly type: string) {}
+
+  get typeModelType() {
+    return "simple";
+  }
 
   get struct() {
     return undefined;
@@ -52,6 +57,10 @@ export class SimpleAttributeTypeModel implements NewAttributeTypeModel {
 
 export class StructAttributeTypeModel implements NewAttributeTypeModel {
   constructor(public readonly struct: Struct) {}
+
+  get typeModelType() {
+    return "struct";
+  }
 
   get isComplex() {
     return true;
@@ -93,6 +102,10 @@ export class ListAttributeTypeModel implements CollectionAttributeTypeModel {
     public readonly isSingleItem: boolean,
     private readonly isBlock: boolean
   ) {}
+
+  get typeModelType() {
+    return "list";
+  }
 
   get struct() {
     return this.elementType.struct;
@@ -159,6 +172,10 @@ export class SetAttributeTypeModel implements CollectionAttributeTypeModel {
     private readonly isBlock: boolean
   ) {}
 
+  get typeModelType() {
+    return "set";
+  }
+
   get struct() {
     return this.elementType.struct;
   }
@@ -224,6 +241,10 @@ export class SetAttributeTypeModel implements CollectionAttributeTypeModel {
 
 export class MapAttributeTypeModel implements CollectionAttributeTypeModel {
   constructor(public readonly elementType: NewAttributeTypeModel) {}
+
+  get typeModelType() {
+    return "map";
+  }
 
   get struct() {
     return this.elementType.struct;

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
@@ -331,13 +331,17 @@ export class MapAttributeTypeModel implements CollectionAttributeTypeModel {
     } else if (this.isComplex) {
       return `{ [key: string]: ${this.elementType.storedClassType} } | cdktf.IResolvable`;
     } else if (this.elementType.typeModelType !== "simple") {
-      return `{ [key: string]: ${this.elementType.inputTypeDefinition} }`;
+      return `{ [key: string]: ${this.elementType.inputTypeDefinition} } | cdktf.IResolvable`;
     } else {
       return `{ [key: string]: ${this.elementType.storedClassType} }`;
     }
   }
 
   getAttributeAccessFunction(name: string) {
+    if (!this.isComplex && this.elementType.typeModelType !== "simple") {
+      return `this.interpolationForAttribute('${name}')`;
+    }
+
     return `this.get${uppercaseFirst(
       this.storedClassType
     )}Attribute('${name}')`;

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
@@ -23,8 +23,12 @@ export class SimpleAttributeTypeModel implements NewAttributeTypeModel {
     return false;
   }
 
-  getStoredClassInitializer(_name: string) {
-    // Not actually used
+  getStoredClassInitializer(name: string) {
+    // Only used for "any"
+    if (this.type === "any") {
+      return `new cdktf.AnyMap(this, "${name}")`;
+    }
+
     return "";
   }
 
@@ -32,7 +36,7 @@ export class SimpleAttributeTypeModel implements NewAttributeTypeModel {
     return "TODO"; //TODO implement
   }
 
-  getAttributeAccessFunction() {
+  getAttributeAccessFunction(name: string) {
     if (this.type === "any") {
       return `this.getAnyMapAttribute('${name}')`;
     } else {
@@ -64,7 +68,7 @@ export class StructAttributeTypeModel implements NewAttributeTypeModel {
     return "TODO"; //TODO implement
   }
 
-  getAttributeAccessFunction() {
+  getAttributeAccessFunction(name: string) {
     // This shouln't actually be called
     return `this.interpolationForAttribute('${name}')`;
   }
@@ -193,8 +197,13 @@ export class MapAttributeTypeModel implements CollectionAttributeTypeModel {
   }
 
   getStoredClassInitializer(name: string) {
-    // This shouldn't actually be called when there isn't a struct
-    return `new ${this.struct?.mapName}(this, "${name}")`;
+    if (this.isComplex) {
+      return `new ${this.struct?.mapName}(this, "${name}")`;
+    } else {
+      return `new cdktf.${uppercaseFirst(
+        this.supportedMapType
+      )}Map(this, "${name}")`;
+    }
   }
 
   get inputTypeDefinition() {

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
@@ -158,6 +158,8 @@ export class ListAttributeTypeModel implements CollectionAttributeTypeModel {
       return "Array<boolean | cdktf.IResolvable> | cdktf.IResolvable";
     } else if (this.isComplex) {
       return `${this.elementType.storedClassType}[] | cdktf.IResolvable`;
+    } else if (this.elementType.typeModelType !== "simple") {
+      return `${this.elementType.inputTypeDefinition}[] | cdktf.IResolvable`;
     } else {
       return `${this.elementType.inputTypeDefinition}[]`;
     }
@@ -246,6 +248,8 @@ export class SetAttributeTypeModel implements CollectionAttributeTypeModel {
       return "Array<boolean | cdktf.IResolvable> | cdktf.IResolvable";
     } else if (this.isComplex) {
       return `${this.elementType.storedClassType}[] | cdktf.IResolvable`;
+    } else if (this.elementType.typeModelType !== "simple") {
+      return `${this.elementType.inputTypeDefinition}[] | cdktf.IResolvable`;
     } else {
       return `${this.elementType.inputTypeDefinition}[]`;
     }

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
@@ -3,7 +3,7 @@
 import { Struct } from "./struct";
 import { uppercaseFirst, downcaseFirst } from "../../../util";
 
-export interface NewAttributeTypeModel {
+export interface AttributeTypeModel {
   readonly struct?: Struct; // complex object type contained within the type
   readonly isComplex: boolean; // basically the same as having a struct
   getStoredClassInitializer(name: string): string; // initializer for keeping class needed to keep track of reference access
@@ -16,7 +16,7 @@ export interface NewAttributeTypeModel {
   readonly isTokenizable: boolean; // can the type be represented by a token type
 }
 
-export class SimpleAttributeTypeModel implements NewAttributeTypeModel {
+export class SimpleAttributeTypeModel implements AttributeTypeModel {
   constructor(public readonly type: string) {}
 
   get typeModelType() {
@@ -65,7 +65,7 @@ export class SimpleAttributeTypeModel implements NewAttributeTypeModel {
   }
 }
 
-export class StructAttributeTypeModel implements NewAttributeTypeModel {
+export class StructAttributeTypeModel implements AttributeTypeModel {
   constructor(public readonly struct: Struct) {}
 
   get typeModelType() {
@@ -106,13 +106,13 @@ export class StructAttributeTypeModel implements NewAttributeTypeModel {
   }
 }
 
-export interface CollectionAttributeTypeModel extends NewAttributeTypeModel {
-  elementType: NewAttributeTypeModel;
+export interface CollectionAttributeTypeModel extends AttributeTypeModel {
+  elementType: AttributeTypeModel;
 }
 
 export class ListAttributeTypeModel implements CollectionAttributeTypeModel {
   constructor(
-    public readonly elementType: NewAttributeTypeModel,
+    public readonly elementType: AttributeTypeModel,
     public readonly isSingleItem: boolean,
     private readonly isBlock: boolean
   ) {
@@ -200,7 +200,7 @@ export class ListAttributeTypeModel implements CollectionAttributeTypeModel {
 
 export class SetAttributeTypeModel implements CollectionAttributeTypeModel {
   constructor(
-    public readonly elementType: NewAttributeTypeModel,
+    public readonly elementType: AttributeTypeModel,
     public readonly isSingleItem: boolean,
     private readonly isBlock: boolean
   ) {
@@ -292,7 +292,7 @@ export class SetAttributeTypeModel implements CollectionAttributeTypeModel {
 }
 
 export class MapAttributeTypeModel implements CollectionAttributeTypeModel {
-  constructor(public readonly elementType: NewAttributeTypeModel) {}
+  constructor(public readonly elementType: AttributeTypeModel) {}
 
   get typeModelType() {
     return "map";
@@ -358,243 +358,5 @@ export class MapAttributeTypeModel implements CollectionAttributeTypeModel {
       default:
         return false;
     }
-  }
-}
-
-export interface AttributeTypeModelOptions {
-  isBlock?: boolean;
-  struct?: Struct;
-  isList?: boolean;
-  isSet?: boolean;
-  isComputed?: boolean;
-  isOptional?: boolean;
-  isRequired?: boolean;
-  isSingleItem?: boolean;
-  isMap?: boolean;
-  level?: number;
-  isNested?: boolean;
-}
-
-export enum TokenizableTypes {
-  STRING = "string",
-  STRING_LIST = "string[]",
-  NUMBER = "number",
-  NUMBER_LIST = "number[]",
-  BOOLEAN = "boolean",
-}
-
-export interface ComputedComplexOptions {
-  name: string;
-  type: string;
-}
-
-export class AttributeTypeModel {
-  public isBlock?: boolean;
-  public isList: boolean;
-  public isSet: boolean;
-  public isComputed: boolean;
-  public isOptional: boolean;
-  public isRequired?: boolean;
-  public isSingleItem?: boolean; // a block with max one item in it
-  public isMap: boolean;
-  public struct?: Struct;
-  public level?: number;
-  public typeName: string;
-  public isNested?: boolean;
-
-  constructor(private _type: string, options: AttributeTypeModelOptions) {
-    this.typeName = _type;
-    this.isBlock = !!options.isBlock;
-    this.isList = !!options.isList;
-    this.isSet = !!options.isSet;
-    this.isMap = !!options.isMap;
-    this.isComputed = !!options.isComputed;
-    this.isOptional = !!options.isOptional;
-    this.isRequired = !!options.isRequired;
-    this.isSingleItem = !!options.isSingleItem;
-    this.level = options.level;
-    this.struct = options.struct;
-    this.isNested = !!options.isNested;
-    if (options.struct) {
-      // options.struct.isSingleItem = this.isSingleItem || false;
-    }
-  }
-
-  public get name(): string {
-    // computed map wrappers
-    if (this.isComputedStringMap) return `cdktf.StringMap`;
-    if (this.isComputedNumberMap) return `cdktf.NumberMap`;
-    if (this.isComputedBooleanMap) return `cdktf.BooleanMap`;
-    if (this.isComputedAnyMap) return `cdktf.AnyMap`;
-
-    // map of booleans has token support, but booleans don't
-    if (this.isBooleanMap)
-      return `{ [key: string]: (${this._type} | cdktf.IResolvable) }`;
-
-    // other maps with token support
-    if (this.isTokenizableMap) return `{ [key: string]: ${this._type} }`;
-
-    // maps without token support
-    if (this.isMap)
-      return `{ [key: string]: ${this._type} } | cdktf.IResolvable`;
-
-    const hasListRepresentation = this.isList || this.isSet;
-
-    // single item list
-    if (hasListRepresentation && !this.isComputed && this.isSingleItem)
-      return `${this._type}`;
-
-    // neither boolean nor boolean[] is tokenizable, so both parts need IResolvable
-    if (hasListRepresentation && this._type === TokenizableTypes.BOOLEAN)
-      return "Array<boolean | cdktf.IResolvable> | cdktf.IResolvable";
-
-    // non-computed list of primitives
-    if (hasListRepresentation && !this.isComputed && this.isPrimitive)
-      return `${this._type}[]`;
-
-    // non-computed list of non-primitives
-    if (hasListRepresentation && !this.isComputed && !this.isPrimitive)
-      return `${this._type}[] | cdktf.IResolvable`;
-
-    // computed lists of primitive types
-    if (hasListRepresentation && this.isComputed && this.isPrimitive)
-      return `${this._type}[]`;
-
-    // computed lists of simple types
-    if (hasListRepresentation && this.isComputed && !this.struct?.isClass)
-      return `${this._type}[] | cdktf.IResolvable`;
-
-    // complex computed list
-    if (hasListRepresentation && this.isComputed && this.isComplex)
-      return `${this._type}[]`;
-
-    // boolean
-    if (this._type === TokenizableTypes.BOOLEAN)
-      return `boolean | cdktf.IResolvable`;
-
-    // custom structs
-    if (this.isComplex && !this.struct?.isClass && !this.isSingleItem) {
-      return `${this._type} | cdktf.IResolvable`;
-    }
-
-    // all other types
-    return this._type;
-  }
-
-  public get storedName(): string {
-    let name = this.name;
-
-    return `${name}${this.isOptional ? " | undefined" : ""}`;
-  }
-
-  public get isComplex(): boolean {
-    return !!this.struct;
-  }
-
-  public get isPrimitive(): boolean {
-    return !this.isComplex;
-  }
-
-  public get isString(): boolean {
-    return this.name === TokenizableTypes.STRING;
-  }
-
-  public get isNumber(): boolean {
-    return this.name === TokenizableTypes.NUMBER;
-  }
-
-  public get isStringSet(): boolean {
-    return this.isSet && this.name === TokenizableTypes.STRING_LIST;
-  }
-
-  public get isNumberSet(): boolean {
-    return this.isSet && this._type === TokenizableTypes.NUMBER;
-  }
-
-  public get isBooleanSet(): boolean {
-    return this.isSet && this._type === TokenizableTypes.BOOLEAN;
-  }
-
-  public get isStringList(): boolean {
-    return this.isList && this.name === TokenizableTypes.STRING_LIST;
-  }
-
-  public get isNumberList(): boolean {
-    return this.isList && this._type === TokenizableTypes.NUMBER;
-  }
-
-  public get isBooleanList(): boolean {
-    return this.isList && this._type === TokenizableTypes.BOOLEAN;
-  }
-
-  public get isBoolean(): boolean {
-    return (
-      this._type === TokenizableTypes.BOOLEAN && !this.isList && !this.isMap
-    );
-  }
-
-  public get isStringMap(): boolean {
-    return this.isMap && this._type === TokenizableTypes.STRING;
-  }
-
-  public get isComputedStringMap(): boolean {
-    return this.isStringMap && this.isComputed && !this.isOptional;
-  }
-
-  public get isNumberMap(): boolean {
-    return this.isMap && this._type === TokenizableTypes.NUMBER;
-  }
-
-  public get isComputedNumberMap(): boolean {
-    return this.isNumberMap && this.isComputed && !this.isOptional;
-  }
-
-  public get isBooleanMap(): boolean {
-    return this.isMap && this._type === TokenizableTypes.BOOLEAN;
-  }
-
-  public get isComputedBooleanMap(): boolean {
-    return this.isBooleanMap && this.isComputed && !this.isOptional;
-  }
-
-  public get isAnyMap(): boolean {
-    return this.isMap && this._type === "any";
-  }
-
-  public get isComputedAnyMap(): boolean {
-    return this.isAnyMap && this.isComputed && !this.isOptional;
-  }
-
-  public get isTokenizableMap(): boolean {
-    return (
-      this.isMap &&
-      !this.isList &&
-      (Object.values(TokenizableTypes).includes(
-        this._type as TokenizableTypes
-      ) ||
-        this._type === "any")
-    );
-  }
-
-  public get isComputedComplex(): boolean {
-    return this.isComputed && this.isComplex;
-  }
-
-  public get isRootType(): boolean {
-    return this.level === 2;
-  }
-
-  public get isComputedPrimitive(): boolean {
-    return this.isComputed && this.isPrimitive;
-  }
-
-  public get isTokenizable(): boolean {
-    return Object.values(TokenizableTypes).includes(
-      this.name as TokenizableTypes
-    );
-  }
-
-  public get innerType() {
-    return this._type;
   }
 }

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
@@ -2,6 +2,32 @@
 // SPDX-License-Identifier: MPL-2.0
 import { Struct } from "./struct";
 
+export interface NewAttributeTypeModel {}
+
+export class SimpleAttributeTypeModel implements NewAttributeTypeModel {
+  constructor(public readonly type: string) {}
+}
+
+export class StructAttributeTypeModel implements NewAttributeTypeModel {
+  constructor(public readonly struct: Struct) {}
+}
+
+export interface CollectionAttributeTypeModel extends NewAttributeTypeModel {
+  elementType: NewAttributeTypeModel;
+}
+
+export class ListAttributeTypeModel implements CollectionAttributeTypeModel {
+  constructor(public readonly elementType: NewAttributeTypeModel) {}
+}
+
+export class SetAttributeTypeModel implements CollectionAttributeTypeModel {
+  constructor(public readonly elementType: NewAttributeTypeModel) {}
+}
+
+export class MapAttributeTypeModel implements CollectionAttributeTypeModel {
+  constructor(public readonly elementType: NewAttributeTypeModel) {}
+}
+
 export interface AttributeTypeModelOptions {
   isBlock?: boolean;
   struct?: Struct;

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
@@ -330,6 +330,8 @@ export class MapAttributeTypeModel implements CollectionAttributeTypeModel {
       return `{ [key: string]: (${this.elementType.storedClassType} | cdktf.IResolvable) }`;
     } else if (this.isComplex) {
       return `{ [key: string]: ${this.elementType.storedClassType} } | cdktf.IResolvable`;
+    } else if (this.elementType.typeModelType !== "simple") {
+      return `{ [key: string]: ${this.elementType.inputTypeDefinition} }`;
     } else {
       return `{ [key: string]: ${this.elementType.storedClassType} }`;
     }

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
@@ -121,7 +121,15 @@ export class ListAttributeTypeModel implements CollectionAttributeTypeModel {
   }
 
   get inputTypeDefinition() {
-    return "TODO"; //TODO implement
+    if (this.isSingleItem) {
+      return this.elementType.inputTypeDefinition;
+    } else if (this.elementType.storedClassType === "boolean") {
+      return "Array<boolean | cdktf.IResolvable> | cdktf.IResolvable";
+    } else if (this.isComplex) {
+      return `${this.elementType.storedClassType}[] | cdktf.IResolvable`;
+    } else {
+      return `${this.elementType.inputTypeDefinition}[]`;
+    }
   }
 
   getAttributeAccessFunction(name: string) {
@@ -178,7 +186,15 @@ export class SetAttributeTypeModel implements CollectionAttributeTypeModel {
   }
 
   get inputTypeDefinition() {
-    return "TODO"; //TODO implement
+    if (this.isSingleItem) {
+      return this.elementType.inputTypeDefinition;
+    } else if (this.elementType.storedClassType === "boolean") {
+      return "Array<boolean | cdktf.IResolvable> | cdktf.IResolvable";
+    } else if (this.isComplex) {
+      return `${this.elementType.storedClassType}[] | cdktf.IResolvable`;
+    } else {
+      return `${this.elementType.inputTypeDefinition}[]`;
+    }
   }
 
   getAttributeAccessFunction(name: string) {
@@ -232,7 +248,14 @@ export class MapAttributeTypeModel implements CollectionAttributeTypeModel {
   }
 
   get inputTypeDefinition() {
-    return "TODO"; //TODO implement
+    // map of booleans has token support, but booleans don't
+    if (this.elementType.storedClassType === "boolean") {
+      return `{ [key: string]: (${this.elementType.storedClassType} | cdktf.IResolvable) }`;
+    } else if (this.isComplex) {
+      return `{ [key: string]: ${this.elementType.storedClassType} } | cdktf.IResolvable`;
+    } else {
+      return `{ [key: string]: ${this.elementType.storedClassType} }`;
+    }
   }
 
   getAttributeAccessFunction(name: string) {

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/struct.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/struct.ts
@@ -56,6 +56,14 @@ export class Struct {
     return `${this.name}Map`;
   }
 
+  public get mapListName(): string {
+    return `${this.name}MapList`;
+  }
+
+  public get listMapName(): string {
+    return `${this.name}ListMap`;
+  }
+
   public get isProvider(): boolean {
     return this.attributes.some((att) => att.isProvider);
   }

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/struct.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/struct.ts
@@ -64,6 +64,10 @@ export class Struct {
     return `${this.name}ListMap`;
   }
 
+  public get listListName(): string {
+    return `${this.name}ListList`;
+  }
+
   public get isProvider(): boolean {
     return this.attributes.some((att) => att.isProvider);
   }

--- a/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
@@ -232,7 +232,7 @@ class Parser {
         const elementType = this.renderAttributeType(
           scope,
           type as AttributeType,
-          kind
+          [kind, parentKind].join("")
         );
         return kind === "list"
           ? new ListAttributeTypeModel(elementType, false, false)
@@ -243,7 +243,7 @@ class Parser {
         const valueType = this.renderAttributeType(
           scope,
           type as AttributeType,
-          kind
+          [kind, parentKind].join("")
         );
         return new MapAttributeTypeModel(valueType);
       }

--- a/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
@@ -136,13 +136,13 @@ class Parser {
         throw new Error(
           `Expected to find recursive attribute at path: ${path}`
         );
-      if (!attribute.type.struct)
+      if (!attribute.newType.struct)
         throw new Error(
-          `Expected to find struct type attribute at path: ${path} but got ${attribute.type.typeName}`
+          `Expected to find struct type attribute at path: ${path} but got ${attribute.newType.storedClassType}`
         );
       if (rest.length === 0) return attribute;
       return getStructAttribute(
-        attribute.type.struct?.attributes,
+        attribute.newType.struct.attributes,
         rest.join(".")
       );
     }
@@ -161,23 +161,25 @@ class Parser {
         const attributeName = parts.pop();
         const parentAttribute = getStructAttribute(attributes, parts.join("."));
         const indexToReplace =
-          parentAttribute.type.struct!.attributes.findIndex(
+          parentAttribute.newType.struct!.attributes.findIndex(
             (att) => att.terraformName === attributeName
           );
         if (indexToReplace === -1)
           throw new Error("Can't find attribute at path " + attributePath);
         const previousAttribute =
-          parentAttribute.type.struct!.attributes[indexToReplace];
+          parentAttribute.newType.struct!.attributes[indexToReplace];
 
-        parentAttribute.type.struct!.attributes[indexToReplace] =
+        parentAttribute.newType.struct!.attributes[indexToReplace] =
           recursionTargetStructAttribute; // introduce recursion
 
         // ugly, pls c̶a̶l̶l̶ refactor me maybe
         // we store all structs in this.structs – now we need to dispose all structs that are part of previousAttribute
         const disposeStructs = (attr: AttributeModel) => {
-          if (attr.type.struct) {
-            attr.type.struct.attributes.forEach(disposeStructs);
-            this.structs = this.structs.filter((s) => s !== attr.type.struct);
+          if (attr.newType.struct) {
+            attr.newType.struct.attributes.forEach(disposeStructs);
+            this.structs = this.structs.filter(
+              (s) => s !== attr.newType.struct
+            );
           }
         };
 

--- a/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
@@ -254,7 +254,7 @@ class Parser {
               level,
               isMap: true,
             }),
-            new SimpleAttributeTypeModel("any"),
+            new MapAttributeTypeModel(new SimpleAttributeTypeModel("any")),
           ];
         default:
           throw new Error(`invalid primitive type ${attributeType}`);

--- a/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
@@ -283,8 +283,8 @@ class Parser {
         return [
           attrType,
           kind === "list"
-            ? new ListAttributeTypeModel(elementType)
-            : new SetAttributeTypeModel(elementType),
+            ? new ListAttributeTypeModel(elementType, false, false)
+            : new SetAttributeTypeModel(elementType, false, false),
         ];
       }
 
@@ -339,7 +339,9 @@ class Parser {
             attributeType.nesting_mode
           );
           newType = new ListAttributeTypeModel(
-            new StructAttributeTypeModel(struct)
+            new StructAttributeTypeModel(struct),
+            false,
+            false
           );
           break;
         case "set":
@@ -350,7 +352,9 @@ class Parser {
             attributeType.nesting_mode
           );
           newType = new SetAttributeTypeModel(
-            new StructAttributeTypeModel(struct)
+            new StructAttributeTypeModel(struct),
+            false,
+            false
           );
           break;
         case "map":
@@ -566,10 +570,14 @@ class Parser {
             newType:
               blockType.nesting_mode === "list"
                 ? new ListAttributeTypeModel(
-                    new StructAttributeTypeModel(struct)
+                    new StructAttributeTypeModel(struct),
+                    blockType.max_items === 1,
+                    true
                   )
                 : new SetAttributeTypeModel(
-                    new StructAttributeTypeModel(struct)
+                    new StructAttributeTypeModel(struct),
+                    blockType.max_items === 1,
+                    true
                   ),
           });
       }

--- a/packages/cdktf/lib/complex-computed-list.ts
+++ b/packages/cdktf/lib/complex-computed-list.ts
@@ -539,10 +539,8 @@ export class BooleanListMap extends ComplexMap {
 
   public get(key: string) {
     // This isn't fully supported
-    return Token.asList(
-      this.terraformResource.interpolationForAttribute(
-        `${this.terraformAttribute}[${key}]`
-      )
+    return this.terraformResource.interpolationForAttribute(
+      `${this.terraformAttribute}[${key}]`
     );
   }
 }
@@ -558,10 +556,8 @@ export class AnyListMap extends ComplexMap {
 
   public get(key: string) {
     // This isn't fully supported
-    return Token.asList(
-      this.terraformResource.interpolationForAttribute(
-        `${this.terraformAttribute}[${key}]`
-      )
+    return this.terraformResource.interpolationForAttribute(
+      `${this.terraformAttribute}[${key}]`
     );
   }
 }

--- a/packages/cdktf/lib/complex-computed-list.ts
+++ b/packages/cdktf/lib/complex-computed-list.ts
@@ -294,6 +294,7 @@ export abstract class ComplexList
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export class BooleanList extends ComplexList {
   constructor(
     protected terraformResource: IInterpolatingParent,

--- a/packages/cdktf/lib/complex-computed-list.ts
+++ b/packages/cdktf/lib/complex-computed-list.ts
@@ -491,3 +491,77 @@ export class AnyMapList extends MapList {
     return new AnyMap(this, `[${index}]`);
   }
 }
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+export class StringListMap extends ComplexMap {
+  constructor(
+    protected terraformResource: IInterpolatingParent,
+    protected terraformAttribute: string
+  ) {
+    super(terraformResource, terraformAttribute);
+  }
+
+  public get(key: string) {
+    return Token.asList(
+      this.terraformResource.interpolationForAttribute(
+        `${this.terraformAttribute}[${key}]`
+      )
+    );
+  }
+}
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+export class NumberListMap extends ComplexMap {
+  constructor(
+    protected terraformResource: IInterpolatingParent,
+    protected terraformAttribute: string
+  ) {
+    super(terraformResource, terraformAttribute);
+  }
+
+  public get(key: string) {
+    return Token.asNumberList(
+      this.terraformResource.interpolationForAttribute(
+        `${this.terraformAttribute}[${key}]`
+      )
+    );
+  }
+}
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+export class BooleanListMap extends ComplexMap {
+  constructor(
+    protected terraformResource: IInterpolatingParent,
+    protected terraformAttribute: string
+  ) {
+    super(terraformResource, terraformAttribute);
+  }
+
+  public get(key: string) {
+    // This isn't fully supported
+    return Token.asList(
+      this.terraformResource.interpolationForAttribute(
+        `${this.terraformAttribute}[${key}]`
+      )
+    );
+  }
+}
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+export class AnyListMap extends ComplexMap {
+  constructor(
+    protected terraformResource: IInterpolatingParent,
+    protected terraformAttribute: string
+  ) {
+    super(terraformResource, terraformAttribute);
+  }
+
+  public get(key: string) {
+    // This isn't fully supported
+    return Token.asList(
+      this.terraformResource.interpolationForAttribute(
+        `${this.terraformAttribute}[${key}]`
+      )
+    );
+  }
+}

--- a/packages/cdktf/lib/complex-computed-list.ts
+++ b/packages/cdktf/lib/complex-computed-list.ts
@@ -294,6 +294,20 @@ export abstract class ComplexList
   }
 }
 
+export class BooleanList extends ComplexList {
+  constructor(
+    protected terraformResource: IInterpolatingParent,
+    protected terraformAttribute: string,
+    protected wrapsSet: boolean
+  ) {
+    super(terraformResource, terraformAttribute, wrapsSet);
+  }
+
+  public get(index: number): IResolvable {
+    return Fn.element(this, index);
+  }
+}
+
 // eslint-disable-next-line jsdoc/require-jsdoc
 export abstract class ComplexMap
   extends ComplexResolvable

--- a/packages/cdktf/lib/complex-computed-list.ts
+++ b/packages/cdktf/lib/complex-computed-list.ts
@@ -381,7 +381,7 @@ export class ComplexObject extends ComplexComputedAttribute {
 }
 
 // eslint-disable-next-line jsdoc/require-jsdoc
-abstract class MapList
+export abstract class MapList
   extends ComplexResolvable
   implements ITerraformAddressable, IInterpolatingParent
 {


### PR DESCRIPTION
Fixes #2310
Fixes #2333

Use a recursive type definition rather than simple flags so that more complex types can be handled. Also lean into object orientated notions to hopefully make attribute emitting more clear.

This is in conjunction with #2372 and one will likely be merged into the other before merging to main.