### PR TITLE
chore: fix finalizing the Sentry release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,12 +280,12 @@ jobs:
       - name: release status
         id: get_release_status
         run: |
-          status=$(sentry-cli releases list | grep 'cdktf-cli-${{ steps.get_version.outputs.version }} ' && echo 'released' || echo 'unreleased')
+          status=$(sentry-cli releases list --org hashicorp | grep 'cdktf-cli-${{ steps.get_version.outputs.version }} ' | grep 'unreleased' > /dev/null && echo "unreleased" || echo "released")
           echo "Sentry returned: ${status}"
-          echo "release=$(echo $status | tr '\n' ' ')" >> $GITHUB_OUTPUT
+          echo "release=${status}" >> $GITHUB_OUTPUT
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_TOKEN }}
-      - name: Create a release
+      - name: Finalize the release
         if: steps.get_release_status.outputs.release == 'unreleased'
         run: sentry-cli releases finalize cdktf-cli-${{ steps.get_version.outputs.version }}
         env:

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -251,11 +251,12 @@ jobs:
       - name: release status
         id: get_release_status
         run: |
-          status=$(sentry-cli releases list | grep 'cdktf-cli-${{ steps.get_version.outputs.version }} ' && echo 'released' || echo 'unreleased')
+          status=$(sentry-cli releases list --org hashicorp | grep 'cdktf-cli-${{ steps.get_version.outputs.version }} ' | grep 'unreleased' > /dev/null && echo "unreleased" || echo "released")
+          echo "Sentry returned: ${status}"
           echo "release=${status}" >> $GITHUB_OUTPUT
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_TOKEN }}
-      - name: Create a release
+      - name: Finalize the release
         if: steps.get_release_status.outputs.release == 'unreleased'
         run: sentry-cli releases finalize cdktf-cli-${{ steps.get_version.outputs.version }}
         env:


### PR DESCRIPTION
By piping to `/dev/null` we can get rid of this Sentry output:
`| (unreleased) | cdktf-cli-0.14.1        | 7          | 7 hours ago    |`
which was part of `status` previously (and required the newline replacement).

By grepping for `unreleased` and inverting the expression, we catch the
expected unreleased release which is the right condition to be able to
finalize the release (the previous one was wrong, as at this time, there
should always have been a release as it is created by an earlier workflow step).
