### PR TITLE
fix: add completed tfc pending states

### DIFF
--- a/packages/@cdktf/cli-core/src/lib/models/terraform-cloud.ts
+++ b/packages/@cdktf/cli-core/src/lib/models/terraform-cloud.ts
@@ -356,12 +356,25 @@ export class TerraformCloud implements Terraform {
     const url = `https://${this.hostname}/app/${this.organizationName}/workspaces/${this.workspaceName}/runs/${result.id}`;
     sendLog(`Created speculative Terraform Cloud run: ${url}`);
 
+    // the source of truth of all pending states are from
+    // https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run#run-states
+    // any state before `apply_queued` is considered pending unless it is specified as a final state
     const pendingStates = [
       "pending",
+      "fetching",
+      "fetching_completed",
+      "pre_plan_running",
+      "pre_plan_completed",
+      "queuing",
       "plan_queued",
       "planning",
       "cost_estimating",
+      "cost_estimated",
       "policy_checking",
+      "policy_override",
+      "policy_checked",
+      "post_plan_running",
+      "post_plan_completed",
     ];
 
     while (pendingStates.includes(result.attributes.status)) {


### PR DESCRIPTION
related issues & pr:

- https://github.com/hashicorp/terraform-cdk/issues/2232
- https://github.com/hashicorp/terraform-cdk/pull/1955
- https://github.com/hashicorp/terraform-cdk/pull/2243
- https://github.com/hashicorp/terraform-cdk/pull/2360

While https://github.com/hashicorp/terraform-cdk/pull/1955 is currently being worked on, this is the workaround for various causes of the issue described in https://github.com/hashicorp/terraform-cdk/issues/2232

## Context

https://github.com/hashicorp/terraform-cdk/pull/2243 & https://github.com/hashicorp/terraform-cdk/pull/2360 are missing a few more pending states from TFC API

## Testing

This is tested internally across our TFC workspaces with and without auto-apply enabled. I can confirm no more `409` error from TFC and all stacks are deployed in one go.