### PR TITLE
chore: switch to SHA-based workflow pins

### DIFF
--- a/.github/workflows/gh-action-upgrade.yml
+++ b/.github/workflows/gh-action-upgrade.yml
@@ -22,3 +22,4 @@ jobs:
           commit_message: "chore: update github workflow actions"
           pull_request_title: "chore: update github workflow actions"
           pull_request_team_reviewers: cdktf
+          update_version_with: "release-commit-sha"


### PR DESCRIPTION
HashiCorp is in the process of rolling out a new security policy that requires us to pin the SHA hashes of any (external) GitHub Actions that we want to use in our workflows. I was very happy to see that `github-actions-version-updater` already has support for this built-in, thankfully!

Further reading (inside HashiCorp): https://docs.google.com/document/d/10TCefPVlhFuh5cKn75rMqNFKZyP8qUK-BWPaaSEO01Q/edit?usp=sharing