### PR TITLE
chore: create TFC/TFE workspace using the Terraform CLI

### DIFF
--- a/packages/@cdktf/cli-core/src/lib/init.ts
+++ b/packages/@cdktf/cli-core/src/lib/init.ts
@@ -27,6 +27,7 @@ export interface LocalProject {
 export interface RemoteProject extends LocalProject {
   OrganizationName: string;
   WorkspaceName: string;
+  TerraformRemoteHostname: string;
 }
 export type Project = LocalProject | RemoteProject;
 

--- a/packages/cdktf-cli/src/bin/cmds/helper/init.ts
+++ b/packages/cdktf-cli/src/bin/cmds/helper/init.ts
@@ -367,12 +367,9 @@ async function gatherInfo(
   };
 
   if (isRemote) {
-    const remoteType = useTerraformEnterprise ? "Enterprise" : "Cloud";
+    console.log(chalkColour`\nDetected {blueBright Terraform Cloud} token.`);
     console.log(
-      chalkColour`\nDetected {blueBright Terraform ${remoteType}} token.`
-    );
-    console.log(
-      chalkColour`\nWe will now set up {blueBright Terraform ${remoteType}} for your project.\n`
+      chalkColour`\nWe will now set up {blueBright Terraform Cloud} for your project.\n`
     );
     const organizationIds = await terraformCloudClient.getOrganizationIds(
       terraformRemoteHostname,
@@ -384,13 +381,13 @@ async function gatherInfo(
       {
         type: "list",
         name: "organization",
-        message: `Terraform ${remoteType} Organization Name`,
+        message: `Terraform Cloud Organization Name`,
         choices: organizationIds,
       },
     ]);
 
     console.log(
-      chalkColour`\nWe are going to create a new {blueBright Terraform ${remoteType} Workspace} for your project.\n`
+      chalkColour`\nWe are going to create a new {blueBright Terraform Cloud Workspace} for your project.\n`
     );
 
     let workspaceName;
@@ -398,7 +395,7 @@ async function gatherInfo(
       const { workspace: tryWorkspaceName } = await inquirer.prompt([
         {
           name: "workspace",
-          message: `Terraform ${remoteType} Workspace Name`,
+          message: `Terraform Cloud Workspace Name`,
           default: project.Name,
         },
       ]);

--- a/packages/cdktf-cli/src/bin/cmds/init.ts
+++ b/packages/cdktf-cli/src/bin/cmds/init.ts
@@ -60,6 +60,10 @@ class Command extends BaseCommand {
         type: "boolean",
         desc: "Force local installation of provider specified in init",
       })
+      .option("tfe-hostname", {
+        type: "string",
+        desc: "The hostname of the Terraform Enterprise instance to use for remote state storage",
+      })
       .strict();
 
   public async handleCommand(argv: any) {

--- a/packages/cdktf-cli/templates/csharp/.hooks.sscaff.js
+++ b/packages/cdktf-cli/templates/csharp/.hooks.sscaff.js
@@ -26,7 +26,7 @@ exports.post = options => {
   // Terraform Cloud configuration settings if the organization name and workspace is set.
   if (options.OrganizationName != '') {
     console.log(`\nGenerating Terraform Cloud configuration for '${options.OrganizationName}' organization and '${options.WorkspaceName}' workspace.....`)
-    terraformCloudConfig(options.$base, options.OrganizationName, options.WorkspaceName)
+    terraformCloudConfig(options.$base, options.OrganizationName, options.WorkspaceName, options.TerraformRemoteHostname)
   }
 
   // dist package
@@ -48,11 +48,11 @@ exports.post = options => {
   console.log(readFileSync('./help', 'utf-8'));
 };
 
-function terraformCloudConfig(baseName, organizationName, workspaceName) {
+function terraformCloudConfig(baseName, organizationName, workspaceName, terraformRemoteHostname) {
   template = readFileSync('./Program.cs', 'utf-8');
 
   result = template.replace(`new MainStack(app, "${baseName}");`, `MainStack stack = new MainStack(app, "${baseName}");
-            new CloudBackend(stack, new CloudBackendProps { Hostname = "app.terraform.io", Organization = "${organizationName}", Workspaces = new NamedCloudWorkspace("${workspaceName}") });`);
+            new CloudBackend(stack, new CloudBackendProps { Hostname = "${terraformRemoteHostname}", Organization = "${organizationName}", Workspaces = new NamedCloudWorkspace("${workspaceName}") });`);
 
   writeFileSync('./Program.cs', result, 'utf-8');
 }

--- a/packages/cdktf-cli/templates/go/.hooks.sscaff.js
+++ b/packages/cdktf-cli/templates/go/.hooks.sscaff.js
@@ -28,7 +28,7 @@ exports.post = options => {
   // Terraform Cloud configuration settings if the organization name and workspace is set.
   if (options.OrganizationName != '') {
     console.log(`\nGenerating Terraform Cloud configuration for '${options.OrganizationName}' organization and '${options.WorkspaceName}' workspace.....`)
-    terraformCloudConfig(options.$base, options.OrganizationName, options.WorkspaceName)
+    terraformCloudConfig(options.$base, options.OrganizationName, options.WorkspaceName, options.TerraformRemoteHostname)
   }
 
   // dist package
@@ -48,12 +48,12 @@ exports.post = options => {
   console.log(readFileSync('./help', 'utf-8'));
 };
 
-function terraformCloudConfig(baseName, organizationName, workspaceName) {
+function terraformCloudConfig(baseName, organizationName, workspaceName, terraformRemoteHostname) {
   template = readFileSync('./main.go', 'utf-8');
 
   result = template.replace(`NewMyStack(app, "${baseName}")`, `stack := NewMyStack(app, "${baseName}")
 	cdktf.NewCloudBackend(stack, &cdktf.CloudBackendProps{
-		Hostname:     jsii.String("app.terraform.io"),
+		Hostname:     jsii.String("${terraformRemoteHostname}"),
 		Organization: jsii.String("${organizationName}"),
 		Workspaces:   cdktf.NewNamedCloudWorkspace(jsii.String("${workspaceName}")),
 	})`);

--- a/packages/cdktf-cli/templates/java/.hooks.sscaff.js
+++ b/packages/cdktf-cli/templates/java/.hooks.sscaff.js
@@ -26,7 +26,7 @@ exports.post = options => {
   // Terraform Cloud configuration settings if the organization name and workspace is set.
   if (options.OrganizationName != '') {
     console.log(`\nGenerating Terraform Cloud configuration for '${options.OrganizationName}' organization and '${options.WorkspaceName}' workspace.....`)
-    terraformCloudConfig(options.$base, options.OrganizationName, options.WorkspaceName)
+    terraformCloudConfig(options.$base, options.OrganizationName, options.WorkspaceName, options.TerraformRemoteHostname)
   }
 
   // This is used for installing artifacts that are local (not from Maven)
@@ -39,7 +39,7 @@ exports.post = options => {
   console.log(readFileSync('./help', 'utf-8'));
 };
 
-function terraformCloudConfig(baseName, organizationName, workspaceName) {
+function terraformCloudConfig(baseName, organizationName, workspaceName, terraformRemoteHostname) {
   template = readFileSync('./src/main/java/com/mycompany/app/Main.java', 'utf-8');
 
   result = template.replace(`import com.hashicorp.cdktf.App;`, `import com.hashicorp.cdktf.App;
@@ -47,7 +47,7 @@ import com.hashicorp.cdktf.NamedCloudWorkspace;
 import com.hashicorp.cdktf.CloudBackend;
 import com.hashicorp.cdktf.CloudBackendProps;`);
   result = result.replace(`new MainStack(app, "${baseName}");`, `MainStack stack = new MainStack(app, "${baseName}");
-        new CloudBackend(stack, CloudBackendProps.builder().hostname("app.terraform.io").organization("${organizationName}").workspaces(new NamedCloudWorkspace("${workspaceName}")).build());`);
+        new CloudBackend(stack, CloudBackendProps.builder().hostname("${terraformRemoteHostname}").organization("${organizationName}").workspaces(new NamedCloudWorkspace("${workspaceName}")).build());`);
 
   writeFileSync('./src/main/java/com/mycompany/app/Main.java', result, 'utf-8');
 }

--- a/packages/cdktf-cli/templates/python-pip/.hooks.sscaff.js
+++ b/packages/cdktf-cli/templates/python-pip/.hooks.sscaff.js
@@ -21,7 +21,7 @@ exports.post = options => {
   // Terraform Cloud configuration settings if the organization name and workspace is set.
   if (options.OrganizationName != '') {
     console.log(`\nGenerating Terraform Cloud configuration for '${options.OrganizationName}' organization and '${options.WorkspaceName}' workspace.....`)
-    terraformCloudConfig(options.$base, options.OrganizationName, options.WorkspaceName)
+    terraformCloudConfig(options.$base, options.OrganizationName, options.WorkspaceName, options.TerraformRemoteHostname);
   }
 
   const pypi_cdktf = options.pypi_cdktf;
@@ -30,7 +30,7 @@ exports.post = options => {
   }
 
   writeFileSync('requirements.txt', pypi_cdktf + '\r\npytest\r\n', 'utf-8');
-  
+
   let installArgs = '';
   if (!process.env.VIRTUAL_ENV) {
     installArgs += '--user'
@@ -41,7 +41,7 @@ exports.post = options => {
   console.log(readFileSync('./help', 'utf-8'));
 };
 
-function terraformCloudConfig(baseName, organizationName, workspaceName) {
+function terraformCloudConfig(baseName, organizationName, workspaceName, terraformRemoteHostname) {
   template = readFileSync('./main.py', 'utf-8');
 
   const templateWithImports = template.replace(`from cdktf import App, TerraformStack`,
@@ -49,7 +49,7 @@ function terraformCloudConfig(baseName, organizationName, workspaceName) {
 
   const result = templateWithImports.replace(`MyStack(app, "${baseName}")`, `stack = MyStack(app, "${baseName}")
 CloudBackend(stack,
-  hostname='app.terraform.io',
+  hostname='${terraformRemoteHostname}',
   organization='${organizationName}',
   workspaces=NamedCloudWorkspace('${workspaceName}')
 )`);

--- a/packages/cdktf-cli/templates/python/.hooks.sscaff.js
+++ b/packages/cdktf-cli/templates/python/.hooks.sscaff.js
@@ -21,7 +21,7 @@ exports.post = options => {
   // Terraform Cloud configuration settings if the organization name and workspace is set.
   if (options.OrganizationName != '') {
     console.log(`\nGenerating Terraform Cloud configuration for '${options.OrganizationName}' organization and '${options.WorkspaceName}' workspace.....`)
-    terraformCloudConfig(options.$base, options.OrganizationName, options.WorkspaceName)
+    terraformCloudConfig(options.$base, options.OrganizationName, options.WorkspaceName, options.TerraformRemoteHostname)
   }
 
   const pypi_cdktf = options.pypi_cdktf;
@@ -37,7 +37,7 @@ exports.post = options => {
   console.log(readFileSync('./help', 'utf-8'));
 };
 
-function terraformCloudConfig(baseName, organizationName, workspaceName) {
+function terraformCloudConfig(baseName, organizationName, workspaceName, terraformRemoteHostname) {
   template = readFileSync('./main.py', 'utf-8');
 
   const templateWithImports = template.replace(`from cdktf import App, TerraformStack`,
@@ -45,7 +45,7 @@ function terraformCloudConfig(baseName, organizationName, workspaceName) {
 
   const result = templateWithImports.replace(`MyStack(app, "${baseName}")`, `stack = MyStack(app, "${baseName}")
 CloudBackend(stack,
-  hostname='app.terraform.io',
+  hostname='${terraformRemoteHostname}',
   organization='${organizationName}',
   workspaces=NamedCloudWorkspace('${workspaceName}')
 )`);

--- a/packages/cdktf-cli/templates/typescript/.hooks.sscaff.js
+++ b/packages/cdktf-cli/templates/typescript/.hooks.sscaff.js
@@ -5,7 +5,7 @@ exports.post = ctx => {
   // Terraform Cloud configuration settings if the organization name and workspace is set.
   if (ctx.OrganizationName != '') {
     console.log(`\nGenerating Terraform Cloud configuration for '${ctx.OrganizationName}' organization and '${ctx.WorkspaceName}' workspace.....`)
-    terraformCloudConfig(ctx.$base, ctx.OrganizationName, ctx.WorkspaceName);
+    terraformCloudConfig(ctx.$base, ctx.OrganizationName, ctx.WorkspaceName, ctx.TerraformRemoteHostname);
   }
 
   const npm_cdktf = ctx.npm_cdktf;
@@ -26,13 +26,13 @@ function installDeps(deps, isDev) {
   execSync(`npm install ${devDep} ${deps.join(' ')}`, { stdio: 'inherit', env });
 }
 
-function terraformCloudConfig(baseName, organizationName, workspaceName) {
+function terraformCloudConfig(baseName, organizationName, workspaceName, terraformRemoteHostname) {
   template = readFileSync('./main.ts', 'utf-8');
 
   result = template.replace(`import { App, TerraformStack } from "cdktf";`, `import { App, TerraformStack, CloudBackend, NamedCloudWorkspace } from "cdktf";`);
   result = result.replace(`new MyStack(app, "${baseName}");`, `const stack = new MyStack(app, "${baseName}");
 new CloudBackend(stack, {
-  hostname: "app.terraform.io",
+  hostname: "${terraformRemoteHostname}",
   organization: "${organizationName}",
   workspaces: new NamedCloudWorkspace("${workspaceName}")
 });`);

--- a/website/docs/cdktf/cli-reference/commands.mdx
+++ b/website/docs/cdktf/cli-reference/commands.mdx
@@ -371,20 +371,23 @@ cdktf init [OPTIONS]
 Create a new cdktf project from a template.
 
 Options:
-      --version                   Show version number                                                                                                                  [boolean]
+      --version                   Show version number                                                                                                                               [boolean]
       --disable-plugin-cache-env  Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env
-                                  CDKTF_DISABLE_PLUGIN_CACHE_ENV.                                                                                     [boolean] [default: false]
-      --log-level                 Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL                                                 [string]
-      --template                  The template to be used to create a new project. Either URL to zip file or one of the built-in templates: ["csharp", "go", "java", "python",
-                                  "python-pip", "typescript"]                                                                                                           [string]
-      --project-name              The name of the project.                                                                                                              [string]
-      --project-description       The description of the project.                                                                                                       [string]
-      --dist                      Install dependencies from a "dist" directory (for development)                                                                        [string]
-      --local                     Use local state storage for generated Terraform.                                                                    [boolean] [default: false]
-      --cdktf-version             The cdktf version to use while creating a new project.                                                             [string] [default: "0.0.0"]
-      --from-terraform-project    Use a terraform project as the basis, CDK constructs will be generated based on the .tf files in the path                             [string]
-      --enable-crash-reporting    Enable crash reporting for the CLI, refer to https://cdk.tf/crash-reporting for more details                    [boolean]
-  -h, --help                      Show help                                                                                                                            [boolean]
+                                  CDKTF_DISABLE_PLUGIN_CACHE_ENV.                                                                                                  [boolean] [default: false]
+      --log-level                 Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL                                                              [string]
+      --template                  The template to be used to create a new project. Either URL to zip file or one of the built-in templates: ["csharp", "go", "java", "python", "python-pip",
+                                  "typescript"]                                                                                                                                      [string]
+      --project-name              The name of the project.                                                                                                                           [string]
+      --project-description       The description of the project.                                                                                                                    [string]
+      --dist                      Install dependencies from a "dist" directory (for development)                                                                                     [string]
+      --local                     Use local state storage for generated Terraform.                                                                                 [boolean] [default: false]
+      --cdktf-version             The cdktf version to use while creating a new project.                                                                          [string] [default: "0.0.0"]
+      --from-terraform-project    Use a terraform project as the basis, CDK constructs will be generated based on the .tf files in the path                                          [string]
+      --enable-crash-reporting    Enable crash reporting for the CLI, refer to https://cdk.tf/crash-reporting for more details                                                      [boolean]
+      --providers                 Providers to add to your project                                                                                                      [array] [default: []]
+      --providers-force-local     Force local installation of provider specified in init                                                                                            [boolean]
+      --tfe-hostname              The hostname of the Terraform Enterprise instance to use for remote state storage                                                                  [string]
+  -h, --help                      Show help                                                                                                                                         [boolean]
 ```
 
 **Examples**


### PR DESCRIPTION
Since we're moving to using TF CLI for Terraform Cloud, this PR removes the additional API call we make to TFC/TFE to create a workspace. Instead, it relies on the first `cdktf diff` or `cdktf deploy` by the developer to create a workspace on TFC.

The reason for this change is that by default workspaces created by the TFC API are set to use 'local execution', but when using the TF CLI and the `CloudBackend`, the created workspace uses 'remote execution'.

### Other Improvements: 
- The CLI checks the user's selected organisation if the selected workspace name already exists, and if so, allows the user to select a new name.
- Adding a `tfe-hostname` to the `init` command (Maybe I missed something, but I didn't see how TFE customers could use CDKTF before without going from local to remote?)
- Updating templates to respect `tfe-hostname` when generating the `CloudBackend` on init

### Notes on Testing
I've only tested the PR on the latest release of TFE, however, it seems like the version that supports `CloudBackend` on TFE bundles with TF version 1.1.3 which is behind our new TF version support, so it should be safe to use.