### PR TITLE
chore: support aborting node-pty commands

### DIFF
--- a/packages/@cdktf/cli-core/src/lib/cdktf-stack.ts
+++ b/packages/@cdktf/cli-core/src/lib/cdktf-stack.ts
@@ -10,6 +10,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { ProviderConstraint } from "./dependencies/dependency-manager";
 import { terraformJsonSchema, TerraformStack } from "./terraform-json";
+import { AbortSignal } from "node-abort-controller";
 
 export type StackUpdate =
   | {

--- a/packages/@cdktf/cli-core/src/lib/models/terraform-cli.ts
+++ b/packages/@cdktf/cli-core/src/lib/models/terraform-cli.ts
@@ -21,6 +21,7 @@ import {
   isDeployEvent,
 } from "./deploy-machine";
 import { waitFor } from "xstate/lib/waitFor";
+import { AbortSignal } from "node-abort-controller";
 
 export class TerraformCliPlan
   extends AbstractTerraformPlan
@@ -72,7 +73,7 @@ export class TerraformCli implements Terraform {
       {
         cwd: this.workdir,
         env: process.env,
-        signal: this.abortSignal,
+        signal: this.abortSignal as any,
       },
       this.onStdout("init"),
       this.onStderr("init")
@@ -93,7 +94,7 @@ export class TerraformCli implements Terraform {
       {
         cwd: this.workdir,
         env: process.env,
-        signal: this.abortSignal,
+        signal: this.abortSignal as any,
       },
       this.onStdout("init"),
       this.onStderr("init")
@@ -123,7 +124,7 @@ export class TerraformCli implements Terraform {
       {
         cwd: this.workdir,
         env: process.env,
-        signal: this.abortSignal,
+        signal: this.abortSignal as any,
       },
       this.onStdout("plan"),
       this.onStderr("plan")
@@ -147,6 +148,7 @@ export class TerraformCli implements Terraform {
       autoApprove,
       parallelism,
       extraOptions,
+      abortSignal: this.abortSignal,
     });
     return this.handleService("deploy", service, callback);
   }
@@ -162,6 +164,7 @@ export class TerraformCli implements Terraform {
       autoApprove,
       parallelism,
       extraOptions,
+      abortSignal: this.abortSignal,
     });
     return this.handleService("destroy", service, callback);
   }
@@ -253,7 +256,7 @@ export class TerraformCli implements Terraform {
         {
           cwd: this.workdir,
           env: process.env,
-          signal: this.abortSignal,
+          signal: this.abortSignal as any,
         },
         this.onStdout("version"),
         this.onStderr("version")
@@ -272,7 +275,7 @@ export class TerraformCli implements Terraform {
       {
         cwd: this.workdir,
         env: process.env,
-        signal: this.abortSignal,
+        signal: this.abortSignal as any,
       },
       // We don't need to log the output here since we use it later on
       () => {}, // eslint-disable-line @typescript-eslint/no-empty-function


### PR DESCRIPTION
Please note:

- I had to cast some parts as any since the global node abort controller definition collides with the polyfilled one we use and I'd like to be consistent in using the polyfilled definitions, since we use the polyfilled implementation
- I formatted the log output for the commands called, mainly to remove the environment. These logs might get sent to sentry so logging the environment is dangerous
- This implementation does not work, after killing the terraform process it asks if the run should be cleaned up, so this working is blocked by https://github.com/hashicorp/terraform-cdk/issues/2425#issuecomment-1353263687 


Closes #2429