### PR TITLE
fix: Adds `environment` to keys to preserve case

### DIFF
--- a/packages/cdktf/lib/util.ts
+++ b/packages/cdktf/lib/util.ts
@@ -90,7 +90,7 @@ export function keysToSnakeCase(object: any): any {
   }
   const keys = Object.keys(object);
   return keys.reduce((newObject: any, key: string) => {
-    if (key === "tags") {
+    if (key === "tags" || key === "environment") {
       newObject[key] = object[key];
       return newObject;
     }


### PR DESCRIPTION
Adds `environment` to keys to preserve case.  When using `local-exec`, the environment would get lower cased.  This is unintuitive with how environment variables generally work.