### PR TITLE
fix: iterator examples

### DIFF
--- a/examples/csharp/documentation/IteratorStack.cs
+++ b/examples/csharp/documentation/IteratorStack.cs
@@ -44,22 +44,28 @@ namespace Examples
 
             // DOCS_BLOCK_START:iterators-iterators-complex-types
             // We need a local to be able to pass the list to the iterator
-            TerraformLocal listLocal = new TerraformLocal(this, "listLocal", new[] {
-                new Dictionary<string, object> {
-                    { "name", "website-static-files" },
-                    { "tags", new Dictionary<string, string> {
-                        { "app", "website" }
-                    }}
+            TerraformLocal complexLocal = new TerraformLocal(this, "complex_local", new Dictionary<string, object> {
+                {
+                    "website ",
+                    new Dictionary<string, object> {
+                        { "name", "website-static-files" },
+                        { "tags", new Dictionary<string, string> {
+                            { "app", "website" }
+                        }}
+                    }
                 },
-                new Dictionary<string, object> {
-                    { "name", "images" },
-                    { "tags", new Dictionary<string, string> {
-                        { "app", "image-converter" }
-                    }}
+                {
+                    "images",
+                    new Dictionary<string, object> {
+                        { "name", "images" },
+                        { "tags", new Dictionary<string, string> {
+                            { "app", "image-converter" }
+                        }}
+                    }
                 }
             });
-            ListTerraformIterator listIterator = ListTerraformIterator.FromList(listLocal.AsList);
-            new S3Bucket(this, "listBucket", new S3BucketConfig
+            ListTerraformIterator listIterator = ListTerraformIterator.FromList(complexLocal.AsAnyMap);
+            new S3Bucket(this, "bucket", new S3BucketConfig
             {
                 ForEach = listIterator,
                 Bucket = listIterator.GetString("name"),

--- a/examples/csharp/documentation/IteratorStack.cs
+++ b/examples/csharp/documentation/IteratorStack.cs
@@ -64,12 +64,12 @@ namespace Examples
                     }
                 }
             });
-            ListTerraformIterator listIterator = ListTerraformIterator.FromList(complexLocal.AsAnyMap);
+            MapTerraformIterator mapIterator = MapTerraformIterator.FromMap(complexLocal.AsAnyMap);
             new S3Bucket(this, "bucket", new S3BucketConfig
             {
-                ForEach = listIterator,
-                Bucket = listIterator.GetString("name"),
-                Tags = listIterator.GetStringMap("tags")
+                ForEach = mapIterator,
+                Bucket = mapIterator.GetString("name"),
+                Tags = mapIterator.GetStringMap("tags")
             });
             // DOCS_BLOCK_END:iterators-iterators-complex-types
             // DOCS_BLOCK_START:iterators-list-attributes

--- a/examples/csharp/documentation/IteratorStack.cs
+++ b/examples/csharp/documentation/IteratorStack.cs
@@ -34,7 +34,7 @@ namespace Examples
             });
 
             ListTerraformIterator iterator = ListTerraformIterator.FromList(list.ListValue);
-            S3Bucket s3Bucket = new S3Bucket(this, "bucket", new S3BucketConfig
+            S3Bucket s3Bucket = new S3Bucket(this, "value-bucket", new S3BucketConfig
             {
                 ForEach = iterator,
                 Bucket = Token.AsString(iterator.Value)
@@ -65,7 +65,7 @@ namespace Examples
                 }
             });
             MapTerraformIterator mapIterator = MapTerraformIterator.FromMap(complexLocal.AsAnyMap);
-            new S3Bucket(this, "bucket", new S3BucketConfig
+            new S3Bucket(this, "tag-bucket", new S3BucketConfig
             {
                 ForEach = mapIterator,
                 Bucket = mapIterator.GetString("name"),

--- a/examples/csharp/documentation/MyTerraformStack.csproj
+++ b/examples/csharp/documentation/MyTerraformStack.csproj
@@ -43,4 +43,3 @@
   <ItemGroup>
     <ProjectReference Include=".gen\eks\eks.csproj" />
   </ItemGroup>
-</Project>

--- a/examples/csharp/documentation/MyTerraformStack.csproj
+++ b/examples/csharp/documentation/MyTerraformStack.csproj
@@ -43,3 +43,4 @@
   <ItemGroup>
     <ProjectReference Include=".gen\eks\eks.csproj" />
   </ItemGroup>
+</Project>

--- a/examples/java/documentation/src/main/java/com/mycompany/app/MainIterator.java
+++ b/examples/java/documentation/src/main/java/com/mycompany/app/MainIterator.java
@@ -42,7 +42,7 @@ public class MainIterator extends TerraformStack {
                 .build());
 
         // DOCS_BLOCK_START:iterators-iterators-complex-types
-        TerraformLocal myComplexLocal = new TerraformLocal(this, "my-map", new HashMap<String, HashMap<String, ?>>() {
+        TerraformLocal myComplexLocal = new TerraformLocal(this, "my-map", new HashMap() {
             {
                 put("website", new HashMap() {
                     {

--- a/examples/java/documentation/src/main/java/com/mycompany/app/MainIterator.java
+++ b/examples/java/documentation/src/main/java/com/mycompany/app/MainIterator.java
@@ -42,8 +42,9 @@ public class MainIterator extends TerraformStack {
                 .build());
 
         // DOCS_BLOCK_START:iterators-iterators-complex-types
-        TerraformLocal myList = new TerraformLocal(this, "my-list", Arrays.asList(
-                new HashMap() {
+        TerraformLocal myComplexLocal = new TerraformLocal(this, "my-map", new HashMap<String, HashMap<String, ?>>() {
+            {
+                put("website", new HashMap() {
                     {
                         put("name", "website-static-files");
                         put("tags", new HashMap<String, String>() {
@@ -52,8 +53,8 @@ public class MainIterator extends TerraformStack {
                             }
                         });
                     }
-                },
-                new HashMap() {
+                });
+                put("images", new HashMap() {
                     {
                         put("name", "images");
                         put("tags", new HashMap<String, String>() {
@@ -62,9 +63,11 @@ public class MainIterator extends TerraformStack {
                             }
                         });
                     }
-                }));
+                });
+            }
+        });
 
-        TerraformIterator iterator = TerraformIterator.fromList(myList.getAsList());
+        TerraformIterator iterator = TerraformIterator.fromMap(myComplexLocal.getAsAnyMap());
 
         S3Bucket s3Bucket = new S3Bucket(this, "bucket", S3BucketConfig.builder()
                 .forEach(iterator)

--- a/examples/java/gradle-shared-module/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/java/gradle-shared-module/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
-#Wed Dec 18 13:39:13 EST 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+#Wed Jan 04 09:19:33 PKT 2023
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/examples/python/documentation/Pipfile
+++ b/examples/python/documentation/Pipfile
@@ -7,3 +7,4 @@ verify_ssl = true
 python_version = "3.7"
 
 [packages]
+cdktf = "*"

--- a/examples/python/documentation/Pipfile.lock
+++ b/examples/python/documentation/Pipfile.lock
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "hash": {
-      "sha256": "4d795221fae1915a3c9346d1137bbd6adb709356a0278af165e98d47c32e6ded"
+      "sha256": "febf780d1824c47c5d752890c904475fb9bae7cf2ab7c4b232c05e0046eaceaa"
     },
     "pipfile-spec": 6,
     "requires": {
@@ -18,50 +18,51 @@
   "default": {
     "attrs": {
       "hashes": [
-        "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6",
-        "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"
+        "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836",
+        "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"
       ],
-      "markers": "python_version >= '3.5'",
-      "version": "==22.1.0"
+      "markers": "python_version >= '3.6'",
+      "version": "==22.2.0"
     },
     "cattrs": {
       "hashes": [
-        "sha256:94b67b64cf92c994f8784c40c082177dc916e0489a73a9a36b24eb18a9db40c6",
-        "sha256:d55c477b4672f93606e992049f15d526dc7867e6c756cd6256d4af92e2b1e364"
+        "sha256:bc12b1f0d000b9f9bee83335887d532a1d3e99a833d1bf0882151c97d3e68c21",
+        "sha256:f0eed5642399423cf656e7b66ce92cdc5b963ecafd041d1b24d136fdde7acf6d"
       ],
-      "markers": "python_version >= '3.7' and python_version < '4.0'",
-      "version": "==22.1.0"
+      "markers": "python_version >= '3.7'",
+      "version": "==22.2.0"
     },
     "cdktf": {
       "hashes": [
-        "sha256:cd72f5c5284abb86dbbac35101f19770048319b9c635b31840b2d2b3cbc810b3"
+        "sha256:8dc75a36291cd402b2db5574fde87966454e470c344c79bf2cd349b1c14288e8",
+        "sha256:eb4c75d2ae2f11f52d478ee5a532738fba5833f479b64264e8a0bd96197ab55c"
       ],
-      "path": "./../../../dist/python/cdktf-0.0.0-py3-none-any.whl",
-      "version": "==0.0.0"
+      "index": "pypi",
+      "version": "==0.14.3"
     },
     "constructs": {
       "hashes": [
-        "sha256:52017392877b7559741d2e0e26b5ace18ab2a85f02fc6f40cf6153ee7b6aa4b2",
-        "sha256:aaf8073049efc34a259b9a84fd5b4ea48544847fdf21ab18ed31d30642c874e7"
+        "sha256:679235f1d331f75fa170af8f6e7ed088bcd5114f91d48c6a971e266447491a6b",
+        "sha256:fb61b038e12f4f99550dd7537ba1f2a324e59242d0719ec5ef371b66492c7642"
       ],
       "markers": "python_version ~= '3.7'",
-      "version": "==10.1.115"
+      "version": "==10.1.209"
     },
     "exceptiongroup": {
       "hashes": [
-        "sha256:2e3c3fc1538a094aab74fad52d6c33fc94de3dfee3ee01f187c0e0c72aec5337",
-        "sha256:9086a4a21ef9b31c72181c77c040a074ba0889ee56a7b289ff0afb0d97655f96"
+        "sha256:327cbda3da756e2de031a3107b81ab7b3770a602c4d16ca618298c526f4bec1e",
+        "sha256:bcb67d800a4497e1b404c2dd44fca47d3b7a5e5433dbab67f96c1a685cdfdf23"
       ],
-      "markers": "python_version <= '3.10'",
-      "version": "==1.0.0rc9"
+      "markers": "python_version < '3.11'",
+      "version": "==1.1.0"
     },
     "jsii": {
       "hashes": [
-        "sha256:7c7ed2a913372add17d63322a640c6435324770eb78c6b89e4c701e07d9c84db",
-        "sha256:f3ae5cdf5e854b4d59256dc1f8818cd3fabb8eb43fbd3134a8e8aef962643005"
+        "sha256:4dcf65eca9400c15a6a7c9d85b27f4bfe15c96ad3e36272a502f391556858151",
+        "sha256:6daf1c17362bd07c50c299e08d9a4454075550eb78e035a160ecf9ea68ded3cf"
       ],
       "markers": "python_version ~= '3.7'",
-      "version": "==1.69.0"
+      "version": "==1.72.0"
     },
     "publication": {
       "hashes": [
@@ -75,7 +76,7 @@
         "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
         "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
       ],
-      "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+      "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
       "version": "==2.8.2"
     },
     "six": {
@@ -83,7 +84,7 @@
         "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
         "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
       ],
-      "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+      "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
       "version": "==1.16.0"
     },
     "typeguard": {
@@ -96,11 +97,11 @@
     },
     "typing-extensions": {
       "hashes": [
-        "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02",
-        "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"
+        "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa",
+        "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"
       ],
       "markers": "python_version >= '3.7'",
-      "version": "==4.3.0"
+      "version": "==4.4.0"
     }
   },
   "develop": {}

--- a/examples/python/documentation/iterators.py
+++ b/examples/python/documentation/iterators.py
@@ -33,7 +33,7 @@ class IteratorStackOne(TerraformStack):
             }
         })
 
-        iterator = TerraformIterator.from_list(
+        iterator = TerraformIterator.from_map(
             map=map.as_any_map
         )
 

--- a/examples/python/documentation/iterators.py
+++ b/examples/python/documentation/iterators.py
@@ -15,32 +15,33 @@ from imports.aws.s3_bucket import S3Bucket
 from cdktf import TerraformIterator, TerraformVariable, TerraformLocal
 # DOCS_BLOCK_END:iterators-define-iterators,iterators-iterators-complex-types
 
+
 class IteratorStackOne(TerraformStack):
     def __init__(self, scope: Construct, id: str):
         super().__init__(scope, id)
         AwsProvider(self, "aws", region="us-east-1")
 
         # DOCS_BLOCK_START:iterators-iterators-complex-types
-        list = TerraformLocal(self, "my-list", [
-            {
+        map = TerraformLocal(self, "my-map", {
+            "website": {
                 "name": "website-static-files",
                 "tags": {"app": "website"}
             },
-            {
+            "images": {
                 "name": "images",
                 "tags": {"app": "image-converter"}
             }
-        ])
+        })
 
         iterator = TerraformIterator.from_list(
-            list=list.as_list
+            map=map.as_any_map
         )
 
         s3Bucket = S3Bucket(self, "s3-bucket",
-            for_each=iterator,
-            bucket=iterator.get_string("name"),
-            tags=iterator.get_map("tags")
-        )
+                            for_each=iterator,
+                            bucket=iterator.get_string("name"),
+                            tags=iterator.get_map("tags")
+                            )
         # DOCS_BLOCK_END:iterators-iterators-complex-types
 
         # DOCS_BLOCK_START:iterators-count
@@ -66,42 +67,41 @@ class IteratorStackTwo(TerraformStack):
         AwsProvider(self, "aws", region="us-east-1")
         GithubProvider(self, "gh")
         # DOCS_BLOCK_START:iterators-define-iterators
-        
+
         list = TerraformVariable(self, "list",
-            type="list(string)"
-        )
+                                 type="list(string)"
+                                 )
 
         iterator = TerraformIterator.from_list(list=list.list_value)
 
         s3Bucket = S3Bucket(self, "bucket",
-            for_each=iterator,
-            bucket=Token.as_string(iterator.value)
-        )
+                            for_each=iterator,
+                            bucket=Token.as_string(iterator.value)
+                            )
         # DOCS_BLOCK_END:iterators-define-iterators
 
         # DOCS_BLOCK_START:iterators-list-attributes
         org_name = "my-org"
 
         GithubProvider(self, "github",
-            organization=org_name
-        )
+                       organization=org_name
+                       )
 
         github_team = Team(self, "core-team",
-            name="core"
-        )
+                           name="core"
+                           )
 
         org_members = DataGithubOrganization(self, "org",
-            name=org_name
-        )
+                                             name=org_name
+                                             )
 
         org_member_iterator = TerraformIterator.from_list(org_members.members)
 
         TeamMembers(self, "members",
-            team_id=github_team.id,
-            members=org_member_iterator.dynamic({
-                "username": Token().as_string(org_member_iterator.value),
-                "role": "maintainer"
-            })
-        )
+                    team_id=github_team.id,
+                    members=org_member_iterator.dynamic({
+                        "username": Token().as_string(org_member_iterator.value),
+                        "role": "maintainer"
+                    })
+                    )
         # DOCS_BLOCK_END:iterators-list-attributes
-

--- a/examples/typescript/documentation/iterators.ts
+++ b/examples/typescript/documentation/iterators.ts
@@ -60,16 +60,16 @@ export class IteratorsStack extends TerraformStack {
     // DOCS_BLOCK_END:iterators
 
     // DOCS_BLOCK_START:iterators-complex-types
-    const complexIterator = TerraformIterator.fromList([
-      {
+    const complexIterator = TerraformIterator.fromMap({
+      website: {
         name: "website-static-files",
         tags: { app: "website" },
       },
-      {
+      images: {
         name: "images",
         tags: { app: "image-converter" },
       },
-    ] as any);
+    });
 
     new S3Bucket(this, "complex-iterator-bucket", {
       forEach: complexIterator,

--- a/website/docs/cdktf/concepts/iterators.mdx
+++ b/website/docs/cdktf/concepts/iterators.mdx
@@ -166,8 +166,9 @@ export class IteratorsStack extends TerraformStack {
 import imports.aws.s3_bucket.S3Bucket;
 import imports.aws.s3_bucket.S3BucketConfig;
 
-        TerraformLocal myList = new TerraformLocal(this, "my-list", Arrays.asList(
-                new HashMap() {
+        TerraformLocal myComplexLocal = new TerraformLocal(this, "my-map", new HashMap<String, HashMap<String, ?>>() {
+            {
+                put("website", new HashMap() {
                     {
                         put("name", "website-static-files");
                         put("tags", new HashMap<String, String>() {
@@ -176,8 +177,8 @@ import imports.aws.s3_bucket.S3BucketConfig;
                             }
                         });
                     }
-                },
-                new HashMap() {
+                });
+                put("images", new HashMap() {
                     {
                         put("name", "images");
                         put("tags", new HashMap<String, String>() {
@@ -186,9 +187,11 @@ import imports.aws.s3_bucket.S3BucketConfig;
                             }
                         });
                     }
-                }));
+                });
+            }
+        });
 
-        TerraformIterator iterator = TerraformIterator.fromList(myList.getAsList());
+        TerraformIterator iterator = TerraformIterator.fromMap(myComplexLocal.getAsAnyMap());
 
         S3Bucket s3Bucket = new S3Bucket(this, "bucket", S3BucketConfig.builder()
                 .forEach(iterator)

--- a/website/docs/cdktf/concepts/iterators.mdx
+++ b/website/docs/cdktf/concepts/iterators.mdx
@@ -74,15 +74,15 @@ from imports.aws.s3_bucket import S3Bucket
 from cdktf import TerraformIterator, TerraformVariable, TerraformLocal
 
         list = TerraformVariable(self, "list",
-            type="list(string)"
-        )
+                                 type="list(string)"
+                                 )
 
         iterator = TerraformIterator.from_list(list=list.list_value)
 
         s3Bucket = S3Bucket(self, "bucket",
-            for_each=iterator,
-            bucket=Token.as_string(iterator.value)
-        )
+                            for_each=iterator,
+                            bucket=Token.as_string(iterator.value)
+                            )
 ```
 
 ```csharp
@@ -200,26 +200,26 @@ import imports.aws.s3_bucket.S3BucketConfig;
 ```python
 from imports.aws.s3_bucket import S3Bucket
 from cdktf import TerraformIterator, TerraformVariable, TerraformLocal
-        list = TerraformLocal(self, "my-list", [
-            {
+        map = TerraformLocal(self, "my-map", {
+            "website": {
                 "name": "website-static-files",
                 "tags": {"app": "website"}
             },
-            {
+            "images": {
                 "name": "images",
                 "tags": {"app": "image-converter"}
             }
-        ])
+        })
 
         iterator = TerraformIterator.from_list(
-            list=list.as_list
+            map=map.as_any_map
         )
 
         s3Bucket = S3Bucket(self, "s3-bucket",
-            for_each=iterator,
-            bucket=iterator.get_string("name"),
-            tags=iterator.get_map("tags")
-        )
+                            for_each=iterator,
+                            bucket=iterator.get_string("name"),
+                            tags=iterator.get_map("tags")
+                            )
 ```
 
 ```csharp
@@ -316,26 +316,26 @@ new TeamMembers(this, "members", {
         org_name = "my-org"
 
         GithubProvider(self, "github",
-            organization=org_name
-        )
+                       organization=org_name
+                       )
 
         github_team = Team(self, "core-team",
-            name="core"
-        )
+                           name="core"
+                           )
 
         org_members = DataGithubOrganization(self, "org",
-            name=org_name
-        )
+                                             name=org_name
+                                             )
 
         org_member_iterator = TerraformIterator.from_list(org_members.members)
 
         TeamMembers(self, "members",
-            team_id=github_team.id,
-            members=org_member_iterator.dynamic({
-                "username": Token().as_string(org_member_iterator.value),
-                "role": "maintainer"
-            })
-        )
+                    team_id=github_team.id,
+                    members=org_member_iterator.dynamic({
+                        "username": Token().as_string(org_member_iterator.value),
+                        "role": "maintainer"
+                    })
+                    )
 ```
 
 ```java

--- a/website/docs/cdktf/concepts/iterators.mdx
+++ b/website/docs/cdktf/concepts/iterators.mdx
@@ -227,22 +227,28 @@ from cdktf import TerraformIterator, TerraformVariable, TerraformLocal
 
 ```csharp
 // We need a local to be able to pass the list to the iterator
-TerraformLocal listLocal = new TerraformLocal(this, "listLocal", new[] {
-    new Dictionary<string, object> {
-        { "name", "website-static-files" },
-        { "tags", new Dictionary<string, string> {
-            { "app", "website" }
-        }}
+TerraformLocal complexLocal = new TerraformLocal(this, "complex_local", new Dictionary<string, object> {
+    {
+        "website ",
+        new Dictionary<string, object> {
+            { "name", "website-static-files" },
+            { "tags", new Dictionary<string, string> {
+                { "app", "website" }
+            }}
+        }
     },
-    new Dictionary<string, object> {
-        { "name", "images" },
-        { "tags", new Dictionary<string, string> {
-            { "app", "image-converter" }
-        }}
+    {
+        "images",
+        new Dictionary<string, object> {
+            { "name", "images" },
+            { "tags", new Dictionary<string, string> {
+                { "app", "image-converter" }
+            }}
+        }
     }
 });
-ListTerraformIterator listIterator = ListTerraformIterator.FromList(listLocal.AsList);
-new S3Bucket(this, "listBucket", new S3BucketConfig
+ListTerraformIterator listIterator = ListTerraformIterator.FromList(complexLocal.AsAnyMap);
+new S3Bucket(this, "bucket", new S3BucketConfig
 {
     ForEach = listIterator,
     Bucket = listIterator.GetString("name"),

--- a/website/docs/cdktf/concepts/iterators.mdx
+++ b/website/docs/cdktf/concepts/iterators.mdx
@@ -247,12 +247,12 @@ TerraformLocal complexLocal = new TerraformLocal(this, "complex_local", new Dict
         }
     }
 });
-ListTerraformIterator listIterator = ListTerraformIterator.FromList(complexLocal.AsAnyMap);
+MapTerraformIterator mapIterator = MapTerraformIterator.FromMap(complexLocal.AsAnyMap);
 new S3Bucket(this, "bucket", new S3BucketConfig
 {
-    ForEach = listIterator,
-    Bucket = listIterator.GetString("name"),
-    Tags = listIterator.GetStringMap("tags")
+    ForEach = mapIterator,
+    Bucket = mapIterator.GetString("name"),
+    Tags = mapIterator.GetStringMap("tags")
 });
 ```
 

--- a/website/docs/cdktf/concepts/iterators.mdx
+++ b/website/docs/cdktf/concepts/iterators.mdx
@@ -166,7 +166,7 @@ export class IteratorsStack extends TerraformStack {
 import imports.aws.s3_bucket.S3Bucket;
 import imports.aws.s3_bucket.S3BucketConfig;
 
-        TerraformLocal myComplexLocal = new TerraformLocal(this, "my-map", new HashMap<String, HashMap<String, ?>>() {
+        TerraformLocal myComplexLocal = new TerraformLocal(this, "my-map", new HashMap() {
             {
                 put("website", new HashMap() {
                     {

--- a/website/docs/cdktf/concepts/iterators.mdx
+++ b/website/docs/cdktf/concepts/iterators.mdx
@@ -214,7 +214,7 @@ from cdktf import TerraformIterator, TerraformVariable, TerraformLocal
             }
         })
 
-        iterator = TerraformIterator.from_list(
+        iterator = TerraformIterator.from_map(
             map=map.as_any_map
         )
 

--- a/website/docs/cdktf/concepts/iterators.mdx
+++ b/website/docs/cdktf/concepts/iterators.mdx
@@ -142,16 +142,16 @@ export class IteratorsStack extends TerraformStack {
       region: "us-west-2",
     });
 
-    const complexIterator = TerraformIterator.fromList([
-      {
+    const complexIterator = TerraformIterator.fromMap({
+      website: {
         name: "website-static-files",
         tags: { app: "website" },
       },
-      {
+      images: {
         name: "images",
         tags: { app: "image-converter" },
       },
-    ] as any);
+    });
 
     new S3Bucket(this, "complex-iterator-bucket", {
       forEach: complexIterator,


### PR DESCRIPTION
fixes #2452

Terraform only [supports a set of strings, and maps](https://developer.hashicorp.com/terraform/language/meta-arguments/for_each) with the `for_each` meta-argument.

The way for CDKTF to support complex list iterators would be to implement a kind of [for expression](https://developer.hashicorp.com/terraform/language/expressions/for) when synthesising the iterator with `for_each`, however that isn't currently supported. 

For now, this PR updates the example code to use maps instead of a complex list, until we implement the above.