### PR TITLE
fix: fix go build in pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: "Add Git safe.directory" # Go 1.18+ started embedding repo info in the build and e.g. building @cdktf/hcl2json fails without this
+        run: git config --global --add safe.directory /__w/terraform-cdk/terraform-cdk
       - name: Get yarn cache directory path
         id: global-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -39,6 +39,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3.1.0
+      - name: "Add Git safe.directory" # Go 1.18+ started embedding repo info in the build and e.g. building @cdktf/hcl2json fails without this
+        run: git config --global --add safe.directory /__w/terraform-cdk/terraform-cdk
       - name: Get yarn cache directory path
         id: global-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,6 +29,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3.1.0
+      - name: "Add Git safe.directory" # Go 1.18+ started embedding repo info in the build and e.g. building @cdktf/hcl2json fails without this
+        run: git config --global --add safe.directory /__w/terraform-cdk/terraform-cdk
       - name: Get yarn cache directory path
         id: global-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT

--- a/.github/workflows/provider-integration.yml
+++ b/.github/workflows/provider-integration.yml
@@ -29,6 +29,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3.1.0
+      - name: "Add Git safe.directory" # Go 1.18+ started embedding repo info in the build and e.g. building @cdktf/hcl2json fails without this
+        run: git config --global --add safe.directory /__w/terraform-cdk/terraform-cdk
       - name: Get yarn cache directory path
         id: global-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,13 +29,14 @@ jobs:
       - uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0 # gives sentry access to all previous commits
+      - name: "Add Git safe.directory" # Go 1.18+ started embedding repo info in the build and e.g. building @cdktf/hcl2json fails without this
+        # The Sentry CLI also requires this, https://github.com/actions/checkout/issues/760
+        run: git config --global --add safe.directory /__w/terraform-cdk/terraform-cdk
       - name: version
         id: get_version
         run: |
           version=$(node -p "require('./package.json').version")
           echo "version=${version}" >> $GITHUB_OUTPUT
-      - name: "Allow git access for Sentry CLI running in Docker" # https://github.com/actions/checkout/issues/760
-        run: git config --global --add safe.directory /__w/terraform-cdk/terraform-cdk
       - name: release status
         id: get_release_status
         run: |

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -27,6 +27,9 @@ jobs:
       - uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0 # gives standard-version access to all previous commits
+      - name: "Add Git safe.directory" # Go 1.18+ started embedding repo info in the build and e.g. building @cdktf/hcl2json fails without this
+        # The Sentry CLI also requires this, https://github.com/actions/checkout/issues/760
+        run: git config --global --add safe.directory /__w/terraform-cdk/terraform-cdk
       - name: installing dependencies
         run: yarn install --frozen-lockfile
       - name: Configure git user
@@ -41,8 +44,6 @@ jobs:
         run: |
           version=$(node -p "require('./package.json').version")
           echo "version=${version}" >> $GITHUB_OUTPUT
-      - name: "Allow git access for Sentry CLI running in Docker" # https://github.com/actions/checkout/issues/760
-        run: git config --global --add safe.directory /__w/terraform-cdk/terraform-cdk
       - name: release status
         id: get_release_status
         run: |

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -31,6 +31,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3.1.0
+      - name: "Add Git safe.directory" # Go 1.18+ started embedding repo info in the build and e.g. building @cdktf/hcl2json fails without this
+        run: git config --global --add safe.directory /__w/terraform-cdk/terraform-cdk
       - name: Get yarn cache directory path
         id: global-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -31,6 +31,8 @@ jobs:
       - uses: actions/checkout@v3.1.0
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
+      - name: "Add Git safe.directory" # Go 1.18+ started embedding repo info in the build and e.g. building @cdktf/hcl2json fails without this
+        run: git config --global --add safe.directory /__w/terraform-cdk/terraform-cdk
       - name: Get yarn cache directory path
         id: global-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT

--- a/packages/@cdktf/hcl2json/build-go.sh
+++ b/packages/@cdktf/hcl2json/build-go.sh
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 GOOS=js GOARCH=wasm go get .
-GOOS=js GOARCH=wasm go build  -ldflags="-s -w" -o main.wasm
+GOOS=js GOARCH=wasm go build -ldflags="-s -w" -o main.wasm
 gzip -9 -v -c main.wasm > main.wasm.gz

--- a/packages/@cdktf/hcl2json/build-go.sh
+++ b/packages/@cdktf/hcl2json/build-go.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+echo "Running go get.."
 GOOS=js GOARCH=wasm go get .
+echo "Running go build.."
 GOOS=js GOARCH=wasm go build -ldflags="-s -w" -o main.wasm
+echo "Zipping wasm build.."
 gzip -9 -v -c main.wasm > main.wasm.gz
+echo "Done."


### PR DESCRIPTION
Go 1.18+ started to embed repo information into builds which failed
without the safe.directory being set in Github Actions.

Husky (our Git hook tool) also printed a warning about safe.directory
being not set, but didn't fail.