### PR TITLE
fix(cli): windows fixes

### DIFF
--- a/packages/@cdktf/cli-core/src/lib/models/deploy-machine.ts
+++ b/packages/@cdktf/cli-core/src/lib/models/deploy-machine.ts
@@ -191,7 +191,7 @@ export const deployMachine = createMachine<
             APPROVE: {
               target: "processing",
               actions: send(
-                { type: "SEND_INPUT", input: "yes\n" },
+                { type: "SEND_INPUT", input: "yes\r\n" },
                 { to: "pty" }
               ),
             },

--- a/packages/@cdktf/cli-core/src/lib/models/deploy-machine.ts
+++ b/packages/@cdktf/cli-core/src/lib/models/deploy-machine.ts
@@ -5,6 +5,7 @@ import { createMachine, send, interpret, EventObject, assign } from "xstate";
 import * as pty from "node-pty-prebuilt-multiarch";
 import { Errors, logger } from "@cdktf/commons";
 import { missingVariable } from "../errors";
+import stripAnsi from "strip-ansi";
 
 interface PtySpawnConfig {
   file: Parameters<typeof pty.spawn>[0];
@@ -67,7 +68,8 @@ export type DeployState =
     };
 
 export function extractVariableNameFromPrompt(line: string) {
-  const lines = line.split("\n");
+  const noColorLine = stripAnsi(line);
+  const lines = noColorLine.split("\n");
   const lineWithVar = lines.find((line) => line.includes("var."));
   if (!lineWithVar) {
     throw Errors.Internal(

--- a/packages/cdktf-cli/src/bin/cmds/ui/hooks/cdktf-project.ts
+++ b/packages/cdktf-cli/src/bin/cmds/ui/hooks/cdktf-project.ts
@@ -113,6 +113,13 @@ export function useCdktfProject<T>(
       .then((value) => {
         setReturnValue(value);
         setStatus({ type: "done" });
+
+        if (process.platform === "win32") {
+          setTimeout(() => {
+            logger.debug("process.exit(0) called");
+            process.exit(0)
+          }, 100)
+        }
       })
       .catch((err) => {
         exit(new Error(err));

--- a/packages/cdktf-cli/src/bin/cmds/ui/hooks/cdktf-project.ts
+++ b/packages/cdktf-cli/src/bin/cmds/ui/hooks/cdktf-project.ts
@@ -117,8 +117,8 @@ export function useCdktfProject<T>(
         if (process.platform === "win32") {
           setTimeout(() => {
             logger.debug("process.exit(0) called");
-            process.exit(0)
-          }, 100)
+            process.exit(0);
+          }, 100);
         }
       })
       .catch((err) => {

--- a/packages/cdktf-cli/src/bin/cmds/ui/hooks/cdktf-project.ts
+++ b/packages/cdktf-cli/src/bin/cmds/ui/hooks/cdktf-project.ts
@@ -116,7 +116,6 @@ export function useCdktfProject<T>(
 
         if (process.platform === "win32") {
           setTimeout(() => {
-            logger.debug("process.exit(0) called");
             process.exit(0);
           }, 100);
         }


### PR DESCRIPTION
- fix(cli): force-stop the UI process on execution completion
- fix(cli): send addition \r to fix windows approval
- fix(cli): remove colors before extracting variable names
