### PR TITLE
chore(docs): fix some docs

### DIFF
--- a/packages/cdktf/lib/app.ts
+++ b/packages/cdktf/lib/app.ts
@@ -61,20 +61,20 @@ export class App extends Construct {
 
   /**
    * Defines an app
-   * @param options configuration options
+   * @param config configuration
    */
-  constructor(options: AppConfig = {}) {
+  constructor(config: AppConfig = {}) {
     super(undefined as any, "");
     Object.defineProperty(this, APP_SYMBOL, { value: true });
 
-    this.outdir = process.env.CDKTF_OUTDIR ?? options.outdir ?? "cdktf.out";
+    this.outdir = process.env.CDKTF_OUTDIR ?? config.outdir ?? "cdktf.out";
     this.targetStackId = process.env.CDKTF_TARGET_STACK_ID;
-    this.skipValidation = options.skipValidation;
+    this.skipValidation = config.skipValidation;
 
-    this.loadContext(options.context);
+    this.loadContext(config.context);
 
     const node = this.node;
-    if (options.stackTraces === false) {
+    if (config.stackTraces === false) {
       node.setContext(DISABLE_STACK_TRACE_IN_METADATA, true);
     }
 

--- a/website/docs/cdktf/api-reference/csharp.mdx
+++ b/website/docs/cdktf/api-reference/csharp.mdx
@@ -19,20 +19,20 @@ Represents a cdktf application.
 ```csharp
 using HashiCorp.Cdktf;
 
-new App(AppConfig Options = null);
+new App(AppConfig Config = null);
 ```
 
-| **Name**                                                                    | **Type**                                              | **Description**        |
-| --------------------------------------------------------------------------- | ----------------------------------------------------- | ---------------------- |
-| <code><a href="#cdktf.App.Initializer.parameter.options">Options</a></code> | <code><a href="#cdktf.AppConfig">AppConfig</a></code> | configuration options. |
+| **Name**                                                                  | **Type**                                              | **Description** |
+| ------------------------------------------------------------------------- | ----------------------------------------------------- | --------------- |
+| <code><a href="#cdktf.App.Initializer.parameter.config">Config</a></code> | <code><a href="#cdktf.AppConfig">AppConfig</a></code> | configuration.  |
 
 ---
 
-##### `Options`<sup>Optional</sup> <a name="Options" id="cdktf.App.Initializer.parameter.options"></a>
+##### `Config`<sup>Optional</sup> <a name="Config" id="cdktf.App.Initializer.parameter.config"></a>
 
 - _Type:_ <a href="#cdktf.AppConfig">AppConfig</a>
 
-configuration options.
+configuration.
 
 ---
 
@@ -11371,7 +11371,7 @@ private object ToTerraform()
 | --------------------------------------------------------------------------------------- | ----------------------------- |
 | <code><a href="#cdktf.TerraformOutput.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
 | <code><a href="#cdktf.TerraformOutput.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
-| <code><a href="#cdktf.TerraformOutput.isTerrafromOutput">IsTerrafromOutput</a></code>   | _No description._             |
+| <code><a href="#cdktf.TerraformOutput.isTerraformOutput">IsTerraformOutput</a></code>   | _No description._             |
 
 ---
 
@@ -11421,15 +11421,15 @@ TerraformOutput.IsTerraformElement(object X);
 
 ---
 
-##### `IsTerrafromOutput` <a name="IsTerrafromOutput" id="cdktf.TerraformOutput.isTerrafromOutput"></a>
+##### `IsTerraformOutput` <a name="IsTerraformOutput" id="cdktf.TerraformOutput.isTerraformOutput"></a>
 
 ```csharp
 using HashiCorp.Cdktf;
 
-TerraformOutput.IsTerrafromOutput(object X);
+TerraformOutput.IsTerraformOutput(object X);
 ```
 
-###### `X`<sup>Required</sup> <a name="X" id="cdktf.TerraformOutput.isTerrafromOutput.parameter.x"></a>
+###### `X`<sup>Required</sup> <a name="X" id="cdktf.TerraformOutput.isTerraformOutput.parameter.x"></a>
 
 - _Type:_ object
 

--- a/website/docs/cdktf/api-reference/go.mdx
+++ b/website/docs/cdktf/api-reference/go.mdx
@@ -19,20 +19,20 @@ Represents a cdktf application.
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
-cdktf.NewApp(options AppConfig) App
+cdktf.NewApp(config AppConfig) App
 ```
 
-| **Name**                                                                    | **Type**                                              | **Description**        |
-| --------------------------------------------------------------------------- | ----------------------------------------------------- | ---------------------- |
-| <code><a href="#cdktf.App.Initializer.parameter.options">options</a></code> | <code><a href="#cdktf.AppConfig">AppConfig</a></code> | configuration options. |
+| **Name**                                                                  | **Type**                                              | **Description** |
+| ------------------------------------------------------------------------- | ----------------------------------------------------- | --------------- |
+| <code><a href="#cdktf.App.Initializer.parameter.config">config</a></code> | <code><a href="#cdktf.AppConfig">AppConfig</a></code> | configuration.  |
 
 ---
 
-##### `options`<sup>Optional</sup> <a name="options" id="cdktf.App.Initializer.parameter.options"></a>
+##### `config`<sup>Optional</sup> <a name="config" id="cdktf.App.Initializer.parameter.config"></a>
 
 - _Type:_ <a href="#cdktf.AppConfig">AppConfig</a>
 
-configuration options.
+configuration.
 
 ---
 
@@ -11371,7 +11371,7 @@ func ToTerraform() interface{}
 | --------------------------------------------------------------------------------------- | ----------------------------- |
 | <code><a href="#cdktf.TerraformOutput.isConstruct">IsConstruct</a></code>               | Checks if `x` is a construct. |
 | <code><a href="#cdktf.TerraformOutput.isTerraformElement">IsTerraformElement</a></code> | _No description._             |
-| <code><a href="#cdktf.TerraformOutput.isTerrafromOutput">IsTerrafromOutput</a></code>   | _No description._             |
+| <code><a href="#cdktf.TerraformOutput.isTerraformOutput">IsTerraformOutput</a></code>   | _No description._             |
 
 ---
 
@@ -11421,15 +11421,15 @@ cdktf.TerraformOutput_IsTerraformElement(x interface{}) *bool
 
 ---
 
-##### `IsTerrafromOutput` <a name="IsTerrafromOutput" id="cdktf.TerraformOutput.isTerrafromOutput"></a>
+##### `IsTerraformOutput` <a name="IsTerraformOutput" id="cdktf.TerraformOutput.isTerraformOutput"></a>
 
 ```go
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
-cdktf.TerraformOutput_IsTerrafromOutput(x interface{}) *bool
+cdktf.TerraformOutput_IsTerraformOutput(x interface{}) *bool
 ```
 
-###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformOutput.isTerrafromOutput.parameter.x"></a>
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformOutput.isTerraformOutput.parameter.x"></a>
 
 - _Type:_ interface{}
 

--- a/website/docs/cdktf/api-reference/java.mdx
+++ b/website/docs/cdktf/api-reference/java.mdx
@@ -15392,7 +15392,7 @@ public java.lang.Object toTerraform()
 | --------------------------------------------------------------------------------------- | ----------------------------- |
 | <code><a href="#cdktf.TerraformOutput.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
 | <code><a href="#cdktf.TerraformOutput.isTerraformElement">isTerraformElement</a></code> | _No description._             |
-| <code><a href="#cdktf.TerraformOutput.isTerrafromOutput">isTerrafromOutput</a></code>   | _No description._             |
+| <code><a href="#cdktf.TerraformOutput.isTerraformOutput">isTerraformOutput</a></code>   | _No description._             |
 
 ---
 
@@ -15442,15 +15442,15 @@ TerraformOutput.isTerraformElement(java.lang.Object x)
 
 ---
 
-##### `isTerrafromOutput` <a name="isTerrafromOutput" id="cdktf.TerraformOutput.isTerrafromOutput"></a>
+##### `isTerraformOutput` <a name="isTerraformOutput" id="cdktf.TerraformOutput.isTerraformOutput"></a>
 
 ```java
 import com.hashicorp.cdktf.TerraformOutput;
 
-TerraformOutput.isTerrafromOutput(java.lang.Object x)
+TerraformOutput.isTerraformOutput(java.lang.Object x)
 ```
 
-###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformOutput.isTerrafromOutput.parameter.x"></a>
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformOutput.isTerraformOutput.parameter.x"></a>
 
 - _Type:_ java.lang.Object
 

--- a/website/docs/cdktf/api-reference/python.mdx
+++ b/website/docs/cdktf/api-reference/python.mdx
@@ -16106,7 +16106,7 @@ def to_terraform() - > typing.Any
 | ----------------------------------------------------------------------------------------- | ----------------------------- |
 | <code><a href="#cdktf.TerraformOutput.isConstruct">is_construct</a></code>                | Checks if `x` is a construct. |
 | <code><a href="#cdktf.TerraformOutput.isTerraformElement">is_terraform_element</a></code> | _No description._             |
-| <code><a href="#cdktf.TerraformOutput.isTerrafromOutput">is_terrafrom_output</a></code>   | _No description._             |
+| <code><a href="#cdktf.TerraformOutput.isTerraformOutput">is_terraform_output</a></code>   | _No description._             |
 
 ---
 
@@ -16160,17 +16160,17 @@ cdktf.TerraformOutput.is_terraform_element(
 
 ---
 
-##### `is_terrafrom_output` <a name="is_terrafrom_output" id="cdktf.TerraformOutput.isTerrafromOutput"></a>
+##### `is_terraform_output` <a name="is_terraform_output" id="cdktf.TerraformOutput.isTerraformOutput"></a>
 
 ```python
 import cdktf
 
-cdktf.TerraformOutput.is_terrafrom_output(
+cdktf.TerraformOutput.is_terraform_output(
   x: typing.Any
 )
 ```
 
-###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformOutput.isTerrafromOutput.parameter.x"></a>
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformOutput.isTerraformOutput.parameter.x"></a>
 
 - _Type:_ typing.Any
 

--- a/website/docs/cdktf/api-reference/typescript.mdx
+++ b/website/docs/cdktf/api-reference/typescript.mdx
@@ -19,20 +19,20 @@ Represents a cdktf application.
 ```typescript
 import { App } from 'cdktf'
 
-new App(options?: AppConfig)
+new App(config?: AppConfig)
 ```
 
-| **Name**                                                                    | **Type**                                              | **Description**        |
-| --------------------------------------------------------------------------- | ----------------------------------------------------- | ---------------------- |
-| <code><a href="#cdktf.App.Initializer.parameter.options">options</a></code> | <code><a href="#cdktf.AppConfig">AppConfig</a></code> | configuration options. |
+| **Name**                                                                  | **Type**                                              | **Description** |
+| ------------------------------------------------------------------------- | ----------------------------------------------------- | --------------- |
+| <code><a href="#cdktf.App.Initializer.parameter.config">config</a></code> | <code><a href="#cdktf.AppConfig">AppConfig</a></code> | configuration.  |
 
 ---
 
-##### `options`<sup>Optional</sup> <a name="options" id="cdktf.App.Initializer.parameter.options"></a>
+##### `config`<sup>Optional</sup> <a name="config" id="cdktf.App.Initializer.parameter.config"></a>
 
 - _Type:_ <a href="#cdktf.AppConfig">AppConfig</a>
 
-configuration options.
+configuration.
 
 ---
 
@@ -11371,7 +11371,7 @@ public toTerraform(): any
 | --------------------------------------------------------------------------------------- | ----------------------------- |
 | <code><a href="#cdktf.TerraformOutput.isConstruct">isConstruct</a></code>               | Checks if `x` is a construct. |
 | <code><a href="#cdktf.TerraformOutput.isTerraformElement">isTerraformElement</a></code> | _No description._             |
-| <code><a href="#cdktf.TerraformOutput.isTerrafromOutput">isTerrafromOutput</a></code>   | _No description._             |
+| <code><a href="#cdktf.TerraformOutput.isTerraformOutput">isTerraformOutput</a></code>   | _No description._             |
 
 ---
 
@@ -11421,15 +11421,15 @@ TerraformOutput.isTerraformElement(x: any)
 
 ---
 
-##### `isTerrafromOutput` <a name="isTerrafromOutput" id="cdktf.TerraformOutput.isTerrafromOutput"></a>
+##### `isTerraformOutput` <a name="isTerraformOutput" id="cdktf.TerraformOutput.isTerraformOutput"></a>
 
 ```typescript
 import { TerraformOutput } from 'cdktf'
 
-TerraformOutput.isTerrafromOutput(x: any)
+TerraformOutput.isTerraformOutput(x: any)
 ```
 
-###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformOutput.isTerrafromOutput.parameter.x"></a>
+###### `x`<sup>Required</sup> <a name="x" id="cdktf.TerraformOutput.isTerraformOutput.parameter.x"></a>
 
 - _Type:_ any
 

--- a/website/docs/cdktf/concepts/modules.mdx
+++ b/website/docs/cdktf/concepts/modules.mdx
@@ -57,7 +57,7 @@ import com.hashicorp.cdktf.App;
 import imports.aws.provider.AwsProvider;
 import imports.aws.provider.AwsProviderConfig;
 import imports.vpc.Vpc;
-import imports.vpc.VpcOptions;
+import imports.vpc.VpcConfig;
 
 public class MainInstallModules extends TerraformStack {
 
@@ -69,7 +69,7 @@ public class MainInstallModules extends TerraformStack {
                 .build()
         );
 
-        new Vpc(this, "myVpc", VpcOptions.builder()
+        new Vpc(this, "myVpc", VpcConfig.builder()
                 .name("my-vpc")
                 .cidr("10.0.0.0/16")
                 .azs(Arrays.asList("us-west-2a", "us-west-2b", "us-west-2c"))
@@ -369,7 +369,7 @@ export class ModulesStack extends TerraformStack {
                 .build()
         );
 
-        TerraformHclModule module = new TerraformHclModule(stack, "Vpc", TerraformHclModuleOptions.builder()
+        TerraformHclModule module = new TerraformHclModule(stack, "Vpc", TerraformHclModuleConfig.builder()
                 .source("terraform-aws-modules/vpc/aws")
                 .variables(new HashMap<String, Object>(){{
                     put("name", "my-vpc");


### PR DESCRIPTION
- refactor(lib): rename AppConfig parameter from options to config to reflect its new typename
- chore(docs): Update snippet containing Options that now are named Config

Another small follow-up for #2471