### PR TITLE
chore: increase parallel limit (10->30) to speed up integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{fromJSON(needs.prepare-integration-tests.outputs.tests)}}
-      max-parallel: 10 # too many in parallel will give HTTP 429 errors from GH when checking out the source for example
+      max-parallel: 30 # too many in parallel will give HTTP 429 errors from GH when checking out the source for example
     container:
       image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     env:
@@ -129,7 +129,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{fromJSON(needs.prepare-integration-tests.outputs.tests)}}
-      max-parallel: 10 # too many in parallel will give HTTP 429 errors from GH when checking out the source for example
+      max-parallel: 30 # too many in parallel will give HTTP 429 errors from GH when checking out the source for example
     env:
       CHECKPOINT_DISABLE: "1"
       TERRAFORM_VERSION: ${{ matrix.terraform }}


### PR DESCRIPTION
10 turned out to be a bit too low, so I'm raising that one a bit
