### PR TITLE
fix(cli): don't enquote args as they will be escaped and end up in the calls to Terraform

### DIFF
--- a/packages/@cdktf/cli-core/src/lib/models/deploy-machine.ts
+++ b/packages/@cdktf/cli-core/src/lib/models/deploy-machine.ts
@@ -247,13 +247,11 @@ export function createAndStartDeployService(options: {
   ];
 
   options.vars?.forEach((v) => {
-    args.push(`-var='${v}'`);
+    args.push(`-var=${v}`);
   });
 
   options.varFiles?.forEach((v) => {
-    args.push(
-      os.platform() === "win32" ? `-var-file=${v}` : `-var-file='${v}'`
-    );
+    args.push(`-var-file=${v}`);
   });
 
   logger.debug(
@@ -303,9 +301,7 @@ export function createAndStartDestroyService(options: {
   });
 
   options.varFiles?.forEach((v) => {
-    args.push(
-      os.platform() === "win32" ? `-var-file=${v}` : `-var-file='${v}'`
-    );
+    args.push(`-var-file=${v}`);
   });
 
   logger.debug(

--- a/packages/@cdktf/cli-core/src/lib/models/terraform-cli.ts
+++ b/packages/@cdktf/cli-core/src/lib/models/terraform-cli.ts
@@ -172,8 +172,8 @@ export class TerraformCli implements Terraform {
       options.push(`-parallelism=${parallelism}`);
     }
 
-    vars.forEach((v) => options.push(`-var='${v}'`));
-    varFiles.forEach((v) => options.push(`-var-file='${v}'`));
+    vars.forEach((v) => options.push(`-var=${v}`));
+    varFiles.forEach((v) => options.push(`-var-file=${v}`));
 
     logger.debug(
       `Executing ${terraformBinaryName} ${options.join(" ")} in ${this.workdir}`

--- a/test/test-helper.ts
+++ b/test/test-helper.ts
@@ -199,11 +199,16 @@ export class TestDriver {
     );
   };
 
-  diff = (stackName?: string) => {
+  diff = (stackName?: string, otherFlags?: string[]) => {
     return stripAnsi(
-      execSyncLogErrors(`cdktf diff ${stackName ? stackName : ""}`, {
-        env: this.env,
-      }).toString()
+      execSyncLogErrors(
+        `cdktf diff ${stackName ? stackName : ""} ${
+          otherFlags?.length ? otherFlags.join(" ") : ""
+        }`,
+        {
+          env: this.env,
+        }
+      ).toString()
     );
   };
 

--- a/test/typescript/variables/test.ts
+++ b/test/typescript/variables/test.ts
@@ -19,7 +19,7 @@ process.on("unhandledRejection", (err) => {
 describe("variables", () => {
   let driver: TestDriver;
 
-  const deployFlags = [
+  const cliFlags = [
     "--var='explicitlyset=via-variable'",
     "--var-file=explicit.tfvars",
   ];
@@ -35,8 +35,19 @@ describe("variables", () => {
     console.log(driver.workingDirectory);
   });
 
+  it("plans locally", async () => {
+    const planOutput = await driver.diff("stack", cliFlags);
+
+    expect(planOutput).toContain("Plan: 1 to add, 0 to change, 0 to destroy.");
+    expect(planOutput).toContain("hello = world");
+    expect(planOutput).toContain("explicitlyset = via-variable");
+    expect(planOutput).toContain("explicitly = set-through-file");
+    expect(planOutput).toContain("setthrough = auto-loading-file");
+    expect(planOutput).toContain("thisextension = auto-loads");
+  });
+
   it("deploys locally", async () => {
-    expect(await driver.deploy(["stack"], undefined, deployFlags)).toContain(
+    expect(await driver.deploy(["stack"], undefined, cliFlags)).toContain(
       "Apply complete!"
     );
     const output = fs.readFileSync(


### PR DESCRIPTION
- fix(cli): don't enquote args as they will be escaped and end up in the calls to Terraform
- feat(tests): add test for passing args to diff as well
