### PR TITLE
chore: autoclose older GHA updater PRs

### DIFF
--- a/.github/workflows/gh-action-upgrade.yml
+++ b/.github/workflows/gh-action-upgrade.yml
@@ -15,6 +15,13 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN_ACTIONS_UPDATER }}
 
+      - name: Autoclose older versions of this PR
+        uses: IndyV/IssueChecker@v1.0
+        with:
+          repo-token: ${{ secrets.GH_TOKEN_ACTIONS_UPDATER }}
+          issue-close-message: "Closing this because I'm about to open a newer PR."
+          issue-pattern: "chore: update github workflow actions"
+
       - name: Run GitHub Actions Version Updater
         uses: saadmk11/github-actions-version-updater@v0.7.2
         with:


### PR DESCRIPTION
This workflow can get a bit noisy if we don't stay on top of merging the PRs because it could potentially open a new PR every week even though there might be no changes. This closes any open old ones before opening a new PR.