### PR TITLE
fix: Revert 8eb985b3ca1398e85c538b745dc32a250c918781

### DIFF
--- a/packages/@cdktf/cli-core/src/lib/cdktf-project.ts
+++ b/packages/@cdktf/cli-core/src/lib/cdktf-project.ts
@@ -659,7 +659,7 @@ export class CdktfProject {
             this.stacksToRun.filter((stack) => stack.isPending)[0]
           )
       : () => getStackWithNoUnmetDependencies(this.stacksToRun);
-    
+
     await this.execute("deploy", next, opts);
 
     const unprocessedStacks = this.stacksToRun.filter(

--- a/packages/@cdktf/cli-core/src/lib/cdktf-stack.ts
+++ b/packages/@cdktf/cli-core/src/lib/cdktf-stack.ts
@@ -208,28 +208,10 @@ export class CdktfStack {
       this.options.stack,
       this.createTerraformLogHandler.bind(this)
     );
-    
+
     const needsUpgrade = await this.checkLockFile();
     await terraform.init(needsUpgrade, noColor);
-    await this.checkNeedsApply(terraform)
-
     return terraform;
-  }
-
-  private async checkNeedsApply(terraform: Terraform){
-    terraform.plan({
-      destroy: false,
-      outFile: "plan"
-    })
-    
-    terraform.show({
-      json: true,
-      filePath: "plan.plan"
-    })
-
-    // TODO: get plan file and through TerraformCLIPlan check if it needsApply- return whether it does, pass it back to deploy function and then filter for stacks that need apply.
-
-
   }
 
   private async checkLockFile(): Promise<boolean> {

--- a/packages/@cdktf/cli-core/src/lib/models/terraform-cli.ts
+++ b/packages/@cdktf/cli-core/src/lib/models/terraform-cli.ts
@@ -1,7 +1,6 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
 import stripAnsi from "strip-ansi";
-import * as path from "path";
 import {
   exec,
   logger,
@@ -127,46 +126,6 @@ export class TerraformCli implements Terraform {
       this.onStdout("init"),
       this.onStderr("init")
     );
-    
-    // get the planFile and use TerraformCLIPlan to check for "needs apply"
-    await exec(
-      terraformBinaryName,
-      [
-        "plan",
-        "-out=plan.plan"
-      ],
-      {
-        cwd: this.workdir,
-        env: process.env,
-        signal: this.abortSignal,
-      },
-      this.onStdout("init"),
-      this.onStderr("init")
-    );
-
-    const planFile = path.join(
-      this.stack.workingDirectory,
-      "plan.plan"
-    )
-
-    const result = await exec(
-      terraformBinaryName,
-      [
-        "show",
-        "-json",
-        planFile
-      ],
-      {
-        cwd: this.workdir,
-        env: process.env,
-        signal: this.abortSignal,
-      },
-      this.onStdout("init"),
-      this.onStderr("init")
-    );
-
-    console.log("result")
-    console.log(result)
 
     // TODO: this might have performance implications because we don't know if we're
     // running a remote plan or a local one (so we run it always for all platforms)
@@ -189,15 +148,12 @@ export class TerraformCli implements Terraform {
       this.onStdout("init"),
       this.onStderr("init")
     );
-    
-    // Find if any changes - return whether there are
   }
 
   public async plan(opts: {
     destroy: boolean;
     refreshOnly?: boolean;
     parallelism?: number;
-    outFile?: string;
     vars?: string[];
     varFiles?: string[];
     noColor?: boolean;
@@ -206,7 +162,6 @@ export class TerraformCli implements Terraform {
       destroy = false,
       refreshOnly = false,
       parallelism = -1,
-      outFile = false,
       vars = [],
       varFiles = [],
       noColor = false,
@@ -224,9 +179,6 @@ export class TerraformCli implements Terraform {
     }
     if (noColor) {
       options.push("-no-color");
-    }
-    if (outFile) {
-      options.push(`-out=${outFile}.plan`);
     }
 
     vars.forEach((v) => options.push(`-var=${v}`));
@@ -416,33 +368,6 @@ export class TerraformCli implements Terraform {
       this.onStderr("output")
     );
     return JSON.parse(output);
-  }
-
-  public async show({
-    json = false,
-    filePath = ""
-  }): Promise<{output: string}> {
-    const args = ["show"];
-
-    if(json){
-      args.push("-json")
-    }
-    // If you don't specify a file path, Terraform will show the latest state snapshot.
-    if(filePath){
-      args.push(filePath)
-    }
-
-    return {output: await exec(
-      terraformBinaryName,
-      args,
-      {
-        cwd: this.workdir,
-        env: process.env,
-        signal: this.abortSignal,
-      },
-      this.onStdout("show"),
-      this.onStderr("show")
-    )};
   }
 
   public async setUserAgent(): Promise<void> {

--- a/packages/@cdktf/cli-core/src/lib/models/terraform.ts
+++ b/packages/@cdktf/cli-core/src/lib/models/terraform.ts
@@ -128,7 +128,6 @@ export interface Terraform {
     destroy: boolean;
     refreshOnly?: boolean;
     parallelism?: number;
-    outFile?: string;
     vars?: string[];
     varFiles?: string[];
     noColor?: boolean;
@@ -154,13 +153,6 @@ export interface Terraform {
     },
     callback: (state: TerraformDeployState) => void
   ): Promise<{ cancelled: boolean }>;
-  show(
-    options: {
-      json: boolean;
-      filePath: string;
-    }
-  ): Promise<{output: string}>
   output(): Promise<{ [key: string]: TerraformOutput }>;
   abort: () => Promise<void>;
-  
 }


### PR DESCRIPTION
Reverts `8eb985b3ca1398e85c538b745dc32a250c918781` which was accidentally pushed to `main`