### PR TITLE
chore: release 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.15.1
+
+### fix
+
+- fix(provider-generator): fix resources named 'provider' breaking the code generation [\#2504](https://github.com/hashicorp/terraform-cdk/pull/2504)
+
+### chore
+
+- chore: autoclose older GHA updater PRs [\#2505](https://github.com/hashicorp/terraform-cdk/pull/2505)
+
 ## 0.15.0
 
 **Breaking changes**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "private": true,
   "scripts": {
     "build": "lerna run --scope 'cdktf*' --scope @cdktf/* build",


### PR DESCRIPTION
## 0.15.1

### fix

- fix(provider-generator): fix resources named 'provider' breaking the code generation [\#2504](https://github.com/hashicorp/terraform-cdk/pull/2504)


### chore

- chore: autoclose older GHA updater PRs [\#2505](https://github.com/hashicorp/terraform-cdk/pull/2505)
