### PR TITLE
feat: create a plan file for non-TFC runs

### DIFF
--- a/packages/@cdktf/cli-core/src/lib/synth-stack.ts
+++ b/packages/@cdktf/cli-core/src/lib/synth-stack.ts
@@ -10,7 +10,7 @@ import { logger, sendTelemetry, shell } from "@cdktf/commons";
 
 const chalkColour = new chalk.Instance();
 
-interface SynthesizedStackMetadata {
+export interface SynthesizedStackMetadata {
   "//"?: { [key: string]: TerraformStackMetadata };
 }
 


### PR DESCRIPTION
Closes #2506

**Note**: This will only add a plan file to non-tfc runs since there is no reliable way to determine if TFC is used as a state backend or with remote execution
