### PR TITLE
chore(lib): Skipping deploy on stacks with no changes

### DIFF
--- a/packages/@cdktf/cli-core/src/lib/cdktf-project.ts
+++ b/packages/@cdktf/cli-core/src/lib/cdktf-project.ts
@@ -610,7 +610,6 @@ export class CdktfProject {
           method === "deploy"
             ? nextRunningExecutor.deploy(opts)
             : nextRunningExecutor.destroy(opts);
-
         allExecutions.push(promise);
       } catch (e) {
         // await next() threw an error because a stack failed to apply/destroy

--- a/packages/@cdktf/cli-core/src/lib/cdktf-stack.ts
+++ b/packages/@cdktf/cli-core/src/lib/cdktf-stack.ts
@@ -221,11 +221,12 @@ export class CdktfStack {
       destroy: false,
       outFile: "plan"
     })
-    
-    terraform.show({
+
+    const plan = terraform.show({
       json: true,
       filePath: "plan.plan"
     })
+    console.log(plan)
 
     // TODO: get plan file and through TerraformCLIPlan check if it needsApply- return whether it does, pass it back to deploy function and then filter for stacks that need apply.
 

--- a/packages/@cdktf/cli-core/src/lib/models/terraform-cli.ts
+++ b/packages/@cdktf/cli-core/src/lib/models/terraform-cli.ts
@@ -432,6 +432,23 @@ export class TerraformCli implements Terraform {
       args.push(filePath)
     }
 
+    const pwd = await exec(
+      terraformBinaryName,
+      [
+        "pwd"
+      ],
+      {
+        cwd: this.workdir,
+        env: process.env,
+        signal: this.abortSignal,
+      },
+      this.onStdout("show"),
+      this.onStderr("show")
+    )
+
+    console.log("pwd")
+    console.log(pwd)
+
     return {output: await exec(
       terraformBinaryName,
       args,

--- a/packages/@cdktf/cli-core/src/lib/models/terraform.ts
+++ b/packages/@cdktf/cli-core/src/lib/models/terraform.ts
@@ -132,6 +132,7 @@ export interface Terraform {
     vars?: string[];
     varFiles?: string[];
     noColor?: boolean;
+    showLogs?: boolean;
   }) => Promise<void>;
   deploy(
     options: {
@@ -159,7 +160,7 @@ export interface Terraform {
       json: boolean;
       filePath: string;
     }
-  ): Promise<{output: string}>
+  ): Promise<string>
   output(): Promise<{ [key: string]: TerraformOutput }>;
   abort: () => Promise<void>;
   


### PR DESCRIPTION
Closes: #2116

Currently a WIP

The basic idea here is to only deploy stacks that have no changes. This could potentially speed up multi-stack deployments using `*` as well as removing clutter from the terminal.

My current approach is to create a plan file, read the plan file using `terraform show`, check if there are any changes with in that plan file, and then selectively deploy based on that condition.  Open to feedback on whether this is the simplest approach 😁.