### PR TITLE
chore: release 0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 0.15.2
+
+### fix
+
+- fix: cdktf login issues [\#2543](https://github.com/hashicorp/terraform-cdk/pull/2543)
+- fix(lib): don't use Fn.set on tagged cloud backend [\#2536](https://github.com/hashicorp/terraform-cdk/pull/2536)
+- fix(provider-generator): use class based map abstractions [\#2530](https://github.com/hashicorp/terraform-cdk/pull/2530)
+
+### chore
+
+- chore: actually autoclose older GHA updater PRs [\#2542](https://github.com/hashicorp/terraform-cdk/pull/2542)
+- chore: fill out homebrew pr body [\#2537](https://github.com/hashicorp/terraform-cdk/pull/2537)
+- chore: support soft sentinel overrides [\#2485](https://github.com/hashicorp/terraform-cdk/pull/2485)
+
+### feat
+
+- feat: create a plan file for non-TFC runs [\#2531](https://github.com/hashicorp/terraform-cdk/pull/2531)
+
 ## 0.15.1
 
 ### fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.15.2
 
+### feat
+
+- feat: create a plan file for non-TFC runs [\#2531](https://github.com/hashicorp/terraform-cdk/pull/2531)
+
 ### fix
 
 - fix: cdktf login issues [\#2543](https://github.com/hashicorp/terraform-cdk/pull/2543)
@@ -11,10 +15,6 @@
 - chore: actually autoclose older GHA updater PRs [\#2542](https://github.com/hashicorp/terraform-cdk/pull/2542)
 - chore: fill out homebrew pr body [\#2537](https://github.com/hashicorp/terraform-cdk/pull/2537)
 - chore: support soft sentinel overrides [\#2485](https://github.com/hashicorp/terraform-cdk/pull/2485)
-
-### feat
-
-- feat: create a plan file for non-TFC runs [\#2531](https://github.com/hashicorp/terraform-cdk/pull/2531)
 
 ## 0.15.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "private": true,
   "scripts": {
     "build": "lerna run --scope 'cdktf*' --scope @cdktf/* build",


### PR DESCRIPTION
## 0.15.2

### feat

- feat: create a plan file for non-TFC runs [\#2531](https://github.com/hashicorp/terraform-cdk/pull/2531)

### fix

- fix: cdktf login issues [\#2543](https://github.com/hashicorp/terraform-cdk/pull/2543)
- fix(lib): don't use Fn.set on tagged cloud backend [\#2536](https://github.com/hashicorp/terraform-cdk/pull/2536)
- fix(provider-generator): use class based map abstractions [\#2530](https://github.com/hashicorp/terraform-cdk/pull/2530)

### chore

- chore: actually autoclose older GHA updater PRs [\#2542](https://github.com/hashicorp/terraform-cdk/pull/2542)
- chore: fill out homebrew pr body [\#2537](https://github.com/hashicorp/terraform-cdk/pull/2537)
- chore: support soft sentinel overrides [\#2485](https://github.com/hashicorp/terraform-cdk/pull/2485)
