### PR TITLE
feat: add cache flag for prettier to speed up subsequent runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "lerna run --scope 'cdktf*' --scope @cdktf/* build",
-    "format": "prettier --write .",
+    "format": "prettier --cache --write .",
     "package": "lerna run package && tools/collect-dist.sh",
     "package:python": "lerna run package:python && tools/collect-dist.sh",
     "package:java": "lerna run package:java && tools/collect-dist.sh",


### PR DESCRIPTION
Uses `--cache` options to speed up prettier runs through `yarn run format`

## Before this PR
> yarn format
> ✨  Done in 43.27s.

## After this PR (on subsequent runs; depends on how many files were changed afterwards)
> yarn format
> ✨  Done in 6.24s.
