### PR TITLE
chore: translate rest of the docs to C#

### DIFF
--- a/examples/csharp/documentation/FunctionsRawStack.cs
+++ b/examples/csharp/documentation/FunctionsRawStack.cs
@@ -1,0 +1,33 @@
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using Constructs;
+using HashiCorp.Cdktf;
+using aws.Provider;
+using aws.DataAwsAvailabilityZones;
+
+namespace Examples
+{
+    class FunctionsRawStack : TerraformStack
+    {
+        public FunctionsRawStack(Construct scope, string name) : base(scope, name)
+        {
+            new AwsProvider(this, "aws", new AwsProviderConfig {
+                Region = "eu-central-1"
+            });
+
+
+            // DOCS_BLOCK_START:functions-raw
+            DataAwsAvailabilityZones zones = new DataAwsAvailabilityZones(this, "zones", new DataAwsAvailabilityZonesConfig {
+                State = "available"
+            });
+
+            new TerraformOutput(this, "half-of-the-zone", new TerraformOutputConfig {
+                Value = $"${{length({zones.Fqn}.names) / 2}}"
+            });
+            // DOCS_BLOCK_END:functions-raw
+        }
+    }
+}

--- a/examples/csharp/documentation/Main.cs
+++ b/examples/csharp/documentation/Main.cs
@@ -58,6 +58,8 @@ namespace MyCompany.MyApp
             new Examples.VariablesStack(app, "variables");
             new Examples.OutputVariableStack(app, "outputs", new Examples.OutputVariableStackConfig("example.com"));
             new Examples.OutputsUsageStack(app, "outputs-define");
+            new Examples.Producer(app, "cdktf-producer");
+            new Examples.Consumer(app, "cdktf-consumer");
 
             TerraformStack stack = new TerraformStack(app, "stack-escape-hatches");
             // DOCS_BLOCK_START:stack-escape-hatches

--- a/examples/csharp/documentation/Main.cs
+++ b/examples/csharp/documentation/Main.cs
@@ -56,6 +56,7 @@ namespace MyCompany.MyApp
                 Region = "eu-central-1",
             });
             new Examples.VariablesStack(app, "variables");
+            new Examples.OutputVariableStack(app, "outputs", new Examples.OutputVariableStackConfig("example.com"));
 
             TerraformStack stack = new TerraformStack(app, "stack-escape-hatches");
             // DOCS_BLOCK_START:stack-escape-hatches

--- a/examples/csharp/documentation/Main.cs
+++ b/examples/csharp/documentation/Main.cs
@@ -61,6 +61,7 @@ namespace MyCompany.MyApp
             new Examples.Producer(app, "cdktf-producer");
             new Examples.Consumer(app, "cdktf-consumer");
             new Examples.OperatorsStack(app, "operators");
+            new Examples.FunctionsRawStack(app, "functions-raw");
 
             TerraformStack stack = new TerraformStack(app, "stack-escape-hatches");
             // DOCS_BLOCK_START:stack-escape-hatches

--- a/examples/csharp/documentation/Main.cs
+++ b/examples/csharp/documentation/Main.cs
@@ -55,6 +55,21 @@ namespace MyCompany.MyApp
                 Environment = "production",
                 Region = "eu-central-1",
             });
+            new Examples.VariablesStack(app, "variables");
+
+            TerraformStack stack = new TerraformStack(app, "stack-escape-hatches");
+            // DOCS_BLOCK_START:stack-escape-hatches
+            stack.AddOverride("terraform.backend", new Dictionary<string, object> {
+                {"local", null}, // delete the default local backend
+                {"remote", new Dictionary<string, object> {
+                    {"organization", "terraform.tfstate"},
+                    {"workspaces", new Dictionary<string, string> {
+                        {"name", "test"}
+                    }}
+                }}
+            });
+            // DOCS_BLOCK_END:stack-escape-hatches
+
             app.Synth();
             Console.WriteLine("App synth complete");
         }

--- a/examples/csharp/documentation/Main.cs
+++ b/examples/csharp/documentation/Main.cs
@@ -57,6 +57,7 @@ namespace MyCompany.MyApp
             });
             new Examples.VariablesStack(app, "variables");
             new Examples.OutputVariableStack(app, "outputs", new Examples.OutputVariableStackConfig("example.com"));
+            new Examples.OutputsUsageStack(app, "outputs-define");
 
             TerraformStack stack = new TerraformStack(app, "stack-escape-hatches");
             // DOCS_BLOCK_START:stack-escape-hatches

--- a/examples/csharp/documentation/Main.cs
+++ b/examples/csharp/documentation/Main.cs
@@ -60,6 +60,7 @@ namespace MyCompany.MyApp
             new Examples.OutputsUsageStack(app, "outputs-define");
             new Examples.Producer(app, "cdktf-producer");
             new Examples.Consumer(app, "cdktf-consumer");
+            new Examples.OperatorsStack(app, "operators");
 
             TerraformStack stack = new TerraformStack(app, "stack-escape-hatches");
             // DOCS_BLOCK_START:stack-escape-hatches

--- a/examples/csharp/documentation/OperatorStack.cs
+++ b/examples/csharp/documentation/OperatorStack.cs
@@ -1,0 +1,36 @@
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using Constructs;
+using HashiCorp.Cdktf;
+using aws.Provider;
+using aws.DataAwsAvailabilityZones;
+
+namespace Examples
+{
+    class OperatorsStack : TerraformStack
+    {
+        public OperatorsStack(Construct scope, string name) : base(scope, name)
+        {
+            new AwsProvider(this, "aws", new AwsProviderConfig {
+                Region = "eu-central-1"
+            });
+
+            /*
+            // DOCS_BLOCK_START:operators
+            DataAwsAvailabilityZones zones = new DataAwsAvailabilityZones(this, "zones", new DataAwsAvailabilityZonesConfig {
+                State = "available"
+            });
+
+            // This does not work in CDKTF as of now, see
+            // https://github.com/hashicorp/terraform-cdk/issues/2557
+            new TerraformOutput(this, "half-of-the-zone", new TerraformOutputConfig {
+                Value = Op.Div(Fn.LengthOf(zones.Names), 2)
+            });
+            // DOCS_BLOCK_END:operators
+            */
+        }
+    }
+}

--- a/examples/csharp/documentation/OperatorStack.cs
+++ b/examples/csharp/documentation/OperatorStack.cs
@@ -24,7 +24,7 @@ namespace Examples
                 State = "available"
             });
 
-            // This does not work in CDKTF as of now, see
+            // This does not work in CDKTF as of now, refer to
             // https://github.com/hashicorp/terraform-cdk/issues/2557
             new TerraformOutput(this, "half-of-the-zone", new TerraformOutputConfig {
                 Value = Op.Div(Fn.LengthOf(zones.Names), 2)

--- a/examples/csharp/documentation/OutputVariableStack.cs
+++ b/examples/csharp/documentation/OutputVariableStack.cs
@@ -26,8 +26,6 @@ namespace Examples
                 Value = config.MyDomain,
             });
         }
-
-
 // DOCS_BLOCK_END:var-out-output-values
 /*
 // DOCS_BLOCK_START:var-out-output-values
@@ -43,6 +41,4 @@ namespace Examples
     }
     
 }
-
-
 // DOCS_BLOCK_END:var-out-output-values

--- a/examples/csharp/documentation/OutputVariableStack.cs
+++ b/examples/csharp/documentation/OutputVariableStack.cs
@@ -1,0 +1,48 @@
+// DOCS_BLOCK_START:var-out-output-values
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using Constructs;
+using HashiCorp.Cdktf;
+using aws.Provider;
+using aws.Instance;
+
+namespace Examples
+{
+    class OutputVariableStackConfig {
+        public OutputVariableStackConfig (string myDomain) {
+            this.MyDomain = myDomain;
+        }
+
+        public string MyDomain { get; set; }
+    }
+
+    class OutputVariableStack : TerraformStack
+    {
+        public OutputVariableStack(Construct scope, string name, OutputVariableStackConfig config) : base(scope, name)
+        {
+            new TerraformOutput(this, "my-domain", new TerraformOutputConfig {
+                Value = config.MyDomain,
+            });
+        }
+
+
+// DOCS_BLOCK_END:var-out-output-values
+/*
+// DOCS_BLOCK_START:var-out-output-values
+        public static void Main(string[] args)
+        {
+            App app = new App();
+            new OutputVariableStack(app, "cdktf-producer", new OutputVariableStackConfig("example.com"));
+            app.Synth();
+        }
+// DOCS_BLOCK_END:var-out-output-values
+*/
+// DOCS_BLOCK_START:var-out-output-values
+    }
+    
+}
+
+
+// DOCS_BLOCK_END:var-out-output-values

--- a/examples/csharp/documentation/OutputsUsageStack.cs
+++ b/examples/csharp/documentation/OutputsUsageStack.cs
@@ -1,0 +1,38 @@
+// DOCS_BLOCK_START:var-out-define-output-values
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using Constructs;
+using HashiCorp.Cdktf;
+using random.Provider;
+using random.Pet;
+
+namespace Examples
+{
+    class OutputsUsageStack : TerraformStack
+    {
+        public OutputsUsageStack(Construct scope, string name) : base(scope, name)
+        {
+            new RandomProvider(this, "random", new RandomProviderConfig());
+            var pet = new Pet(this, "pet", new PetConfig());
+            new TerraformOutput(this, "random-pet", new TerraformOutputConfig {
+                Value = pet.Id,
+            });
+        }
+// DOCS_BLOCK_END:var-out-define-output-values
+/*
+// DOCS_BLOCK_START:var-out-define-output-values
+        public static void Main(string[] args)
+        {
+            App app = new App();
+            new OutputsUsageStack(app, "outputs-usage");
+            app.Synth();
+        }
+// DOCS_BLOCK_END:var-out-define-output-values
+*/
+// DOCS_BLOCK_START:var-out-define-output-values
+    }
+    
+}
+// DOCS_BLOCK_END:var-out-define-output-values

--- a/examples/csharp/documentation/RemoteStateStack.cs
+++ b/examples/csharp/documentation/RemoteStateStack.cs
@@ -1,0 +1,68 @@
+// DOCS_BLOCK_START:var-out-define-reference-remote-state
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using Constructs;
+using HashiCorp.Cdktf;
+using random.Provider;
+using random.Pet;
+
+namespace Examples
+{
+    class Producer : TerraformStack
+    {
+        public Producer(Construct scope, string name) : base(scope, name)
+        {
+            new CloudBackend(this, new CloudBackendConfig {
+                Organization = "hashicorp",
+                Workspaces = new NamedCloudWorkspace("producer"),
+            });
+
+            new RandomProvider(this, "random", new RandomProviderConfig());
+            var pet = new Pet(this, "pet", new PetConfig());
+
+            new TerraformOutput(this, "random-pet", new TerraformOutputConfig {
+                Value = pet.Id,
+            });
+        }
+    }
+
+    class Consumer : TerraformStack
+    {
+        public Consumer(Construct scope, string name) : base(scope, name)
+        {
+            new CloudBackend(this, new CloudBackendConfig {
+                Organization = "hashicorp",
+                Workspaces = new NamedCloudWorkspace("consumer"),
+            });
+
+            DataTerraformRemoteState remoteState = new DataTerraformRemoteState(this, "remote-state", new DataTerraformRemoteStateRemoteConfig {
+                Organization = "hashicorp",
+                Workspaces = new NamedRemoteWorkspace("producer"),
+            });
+
+            new TerraformOutput(this, "random-remote-pet", new TerraformOutputConfig {
+                Value = remoteState.GetString("random-pet"),
+            });
+        }
+    }
+
+    class Main {
+// DOCS_BLOCK_END:var-out-define-reference-remote-state
+/*
+// DOCS_BLOCK_START:var-out-define-reference-remote-state
+        public static void Main(string[] args)
+        {
+            App app = new App();
+            new Producer(app, "cdktf-producer");
+            new Consumer(app, "cdktf-consumer");
+            app.Synth();
+        }
+// DOCS_BLOCK_END:var-out-define-reference-remote-state
+*/
+// DOCS_BLOCK_START:var-out-define-reference-remote-state
+    }
+    
+}
+// DOCS_BLOCK_END:var-out-define-reference-remote-state

--- a/examples/csharp/documentation/VariablesStack.cs
+++ b/examples/csharp/documentation/VariablesStack.cs
@@ -33,6 +33,27 @@ namespace Examples
             // DOCS_BLOCK_END:var-out-input-variables
 
         
+        // const commonTags = new TerraformLocal(this, "common_tags", {
+        // Service: "service_name",
+        // Owner: "owner",
+        // });
+
+        // new Instance(this, "example", {
+        // ami: "ami-abcde123",
+        // instanceType: "t2.micro",
+        // tags: commonTags.expression,
+        // });
+        // DOCS_BLOCK_START:var-out-define-local
+        TerraformLocal commonTags = new TerraformLocal(this, "common_tags", new Dictionary<string, string> {
+            { "Service", "service_name" },
+            { "Owner", "owner" },
+        });
+        new Instance(this, "example", new InstanceConfig {
+            Ami = "ami-abcde123",
+            InstanceType = "t2.micro",
+            Tags = Token.AsStringMap(commonTags.Expression),
+        });
+        // DOCS_BLOCK_END:var-out-define-local
         }
     }
 }

--- a/examples/csharp/documentation/VariablesStack.cs
+++ b/examples/csharp/documentation/VariablesStack.cs
@@ -1,0 +1,38 @@
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using Constructs;
+using HashiCorp.Cdktf;
+using aws.Provider;
+using aws.Instance;
+
+namespace Examples
+{
+    class VariablesStack : TerraformStack
+    {
+        public VariablesStack(Construct scope, string name) : base(scope, name)
+        {
+
+            new AwsProvider(this, "aws", new AwsProviderConfig {
+                Region = "eu-central-1"
+            });
+
+            // DOCS_BLOCK_START:var-out-input-variables
+            TerraformVariable imageId = new TerraformVariable(this, "imageId", new TerraformVariableConfig {
+                Type = "string",
+                Default = "ami-abcde123",
+                Description = "What AMI to use to create an instance",
+            });
+
+            new Instance(this, "hello", new InstanceConfig {
+                Ami = imageId.StringValue,
+                InstanceType = "t2.micro",
+            });
+            // DOCS_BLOCK_END:var-out-input-variables
+
+        
+        }
+    }
+}

--- a/examples/csharp/documentation/VariablesStack.cs
+++ b/examples/csharp/documentation/VariablesStack.cs
@@ -32,28 +32,17 @@ namespace Examples
             });
             // DOCS_BLOCK_END:var-out-input-variables
 
-        
-        // const commonTags = new TerraformLocal(this, "common_tags", {
-        // Service: "service_name",
-        // Owner: "owner",
-        // });
-
-        // new Instance(this, "example", {
-        // ami: "ami-abcde123",
-        // instanceType: "t2.micro",
-        // tags: commonTags.expression,
-        // });
-        // DOCS_BLOCK_START:var-out-define-local
-        TerraformLocal commonTags = new TerraformLocal(this, "common_tags", new Dictionary<string, string> {
-            { "Service", "service_name" },
-            { "Owner", "owner" },
-        });
-        new Instance(this, "example", new InstanceConfig {
-            Ami = "ami-abcde123",
-            InstanceType = "t2.micro",
-            Tags = Token.AsStringMap(commonTags.Expression),
-        });
-        // DOCS_BLOCK_END:var-out-define-local
+            // DOCS_BLOCK_START:var-out-define-local
+            TerraformLocal commonTags = new TerraformLocal(this, "common_tags", new Dictionary<string, string> {
+                { "Service", "service_name" },
+                { "Owner", "owner" },
+            });
+            new Instance(this, "example", new InstanceConfig {
+                Ami = "ami-abcde123",
+                InstanceType = "t2.micro",
+                Tags = Token.AsStringMap(commonTags.Expression),
+            });
+            // DOCS_BLOCK_END:var-out-define-local
         }
     }
 }

--- a/website/docs/cdktf/concepts/functions.mdx
+++ b/website/docs/cdktf/concepts/functions.mdx
@@ -161,6 +161,8 @@ new TerraformOutput(this, "half-of-the-zone", {
 
 It is also possible to use all built-in Terraform functions without using CDKTF's `Fn.*` functions described above. To write Terraform built-in functions the same as you would in HCL, simply wrap the desired string within the HCL `${` and `}` syntax. **Note:** CDKTF doesn't do any further processing within the escaped syntax (`${` and `}`), and thus is unable to handle nested escape syntaxes yet.
 
+<!-- #NEXT_CODE_BLOCK_SOURCE:csharp examples/csharp/documentation#functions-raw -->
+
 <CodeTabs>
 
 ```typescript
@@ -169,13 +171,23 @@ import { DataAwsAvailabilityZones } from "@cdktf/provider-aws/lib/data-aws-avail
 
 // ...
 
-const const zones = new DataAwsAvailabilityZones(this, "zones", {
+const zones = new DataAwsAvailabilityZones(this, "zones", {
   state: "available",
 });
 
 new TerraformOutput(this, "half-of-the-zone", {
-  value: `\${length(${zones.fqn}.names) / 2}`
+  value: `\${length(${zones.fqn}.names) / 2}`,
 });
+```
+
+```csharp
+            DataAwsAvailabilityZones zones = new DataAwsAvailabilityZones(this, "zones", new DataAwsAvailabilityZonesConfig {
+                State = "available"
+            });
+
+            new TerraformOutput(this, "half-of-the-zone", new TerraformOutputConfig {
+                Value = $"${{length({zones.Fqn}.names) / 2}}"
+            });
 ```
 
 </CodeTabs>

--- a/website/docs/cdktf/concepts/functions.mdx
+++ b/website/docs/cdktf/concepts/functions.mdx
@@ -125,6 +125,8 @@ namespace Examples
 
 Use the `Op` object to include operators like `!`, `+`, and `-`.
 
+<!-- #NEXT_CODE_BLOCK_SOURCE:csharp examples/csharp/documentation#operators -->
+
 <CodeTabs>
 
 ```typescript
@@ -132,13 +134,25 @@ import { Fn, Op, TerraformOutput } from "cdktf";
 
 // ...
 
-const const zones = new DataAwsAvailabilityZones(this, "zones", {
+const zones = new DataAwsAvailabilityZones(this, "zones", {
   state: "available",
 });
 
 new TerraformOutput(this, "half-of-the-zone", {
-  value: Op.div(Fn.length(zones.names), 2),
+  value: Op.div(Fn.lengthOf(zones.names), 2),
 });
+```
+
+```csharp
+            DataAwsAvailabilityZones zones = new DataAwsAvailabilityZones(this, "zones", new DataAwsAvailabilityZonesConfig {
+                State = "available"
+            });
+
+            // This does not work in CDKTF as of now, see
+            // https://github.com/hashicorp/terraform-cdk/issues/2557
+            new TerraformOutput(this, "half-of-the-zone", new TerraformOutputConfig {
+                Value = Op.Div(Fn.LengthOf(zones.Names), 2)
+            });
 ```
 
 </CodeTabs>

--- a/website/docs/cdktf/concepts/functions.mdx
+++ b/website/docs/cdktf/concepts/functions.mdx
@@ -148,7 +148,7 @@ new TerraformOutput(this, "half-of-the-zone", {
                 State = "available"
             });
 
-            // This does not work in CDKTF as of now, see
+            // This does not work in CDKTF as of now, refer to
             // https://github.com/hashicorp/terraform-cdk/issues/2557
             new TerraformOutput(this, "half-of-the-zone", new TerraformOutputConfig {
                 Value = Op.Div(Fn.LengthOf(zones.Names), 2)

--- a/website/docs/cdktf/concepts/functions.mdx
+++ b/website/docs/cdktf/concepts/functions.mdx
@@ -125,6 +125,8 @@ namespace Examples
 
 Use the `Op` object to include operators like `!`, `+`, and `-`.
 
+<CodeTabs>
+
 ```typescript
 import { Fn, Op, TerraformOutput } from "cdktf";
 
@@ -139,9 +141,13 @@ new TerraformOutput(this, "half-of-the-zone", {
 });
 ```
 
+</CodeTabs>
+
 # Using Terraform built-in functions directly within strings
 
 It is also possible to use all built-in Terraform functions without using CDKTF's `Fn.*` functions described above. To write Terraform built-in functions the same as you would in HCL, simply wrap the desired string within the HCL `${` and `}` syntax. **Note:** CDKTF doesn't do any further processing within the escaped syntax (`${` and `}`), and thus is unable to handle nested escape syntaxes yet.
+
+<CodeTabs>
 
 ```typescript
 import { Fn, Op, TerraformOutput } from "cdktf";
@@ -157,3 +163,5 @@ new TerraformOutput(this, "half-of-the-zone", {
   value: `\${length(${zones.fqn}.names) / 2}`
 });
 ```
+
+</CodeTabs>

--- a/website/docs/cdktf/concepts/stacks.mdx
+++ b/website/docs/cdktf/concepts/stacks.mdx
@@ -774,6 +774,7 @@ The following example synthesizes a Terraform configuration with the `remote` ba
 <!-- #NEXT_CODE_BLOCK_SOURCE:ts examples/typescript/documentation#stack-escape-hatches -->
 <!-- #NEXT_CODE_BLOCK_SOURCE:java examples/java/documentation#stack-escape-hatches -->
 <!-- #NEXT_CODE_BLOCK_SOURCE:python examples/python/documentation#stack-escape-hatches -->
+<!-- #NEXT_CODE_BLOCK_SOURCE:csharp examples/csharp/documentation#stack-escape-hatches -->
 
 <CodeTabs>
 
@@ -808,6 +809,18 @@ stack.add_override("terraform.backend",{
         }
     }
 })
+```
+
+```csharp
+stack.AddOverride("terraform.backend", new Dictionary<string, object> {
+    {"local", null}, // delete the default local backend
+    {"remote", new Dictionary<string, object> {
+        {"organization", "terraform.tfstate"},
+        {"workspaces", new Dictionary<string, string> {
+            {"name", "test"}
+        }}
+    }}
+});
 ```
 
 </CodeTabs>

--- a/website/docs/cdktf/concepts/variables-and-outputs.mdx
+++ b/website/docs/cdktf/concepts/variables-and-outputs.mdx
@@ -228,6 +228,7 @@ The following example uses a `TerraformOutput` to create an output.
 <!-- #NEXT_CODE_BLOCK_SOURCE:ts examples/typescript/documentation#outputs -->
 <!-- #NEXT_CODE_BLOCK_SOURCE:python examples/python/documentation#var-out-output-values -->
 <!-- #NEXT_CODE_BLOCK_SOURCE:java examples/java/documentation#var-out-output-values -->
+<!-- #NEXT_CODE_BLOCK_SOURCE:csharp examples/csharp/documentation#var-out-output-values -->
 
 <CodeTabs>
 
@@ -315,6 +316,49 @@ class OutputValuesStack(TerraformStack):
 app = App()
 OutputValuesStack(app, "cdktf-producer", OutputValuesProps(myDomain = "example.com"))
 app.synth()
+```
+
+```csharp
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using Constructs;
+using HashiCorp.Cdktf;
+using aws.Provider;
+using aws.Instance;
+
+namespace Examples
+{
+    class OutputVariableStackConfig {
+        public OutputVariableStackConfig (string myDomain) {
+            this.MyDomain = myDomain;
+        }
+
+        public string MyDomain { get; set; }
+    }
+
+    class OutputVariableStack : TerraformStack
+    {
+        public OutputVariableStack(Construct scope, string name, OutputVariableStackConfig config) : base(scope, name)
+        {
+            new TerraformOutput(this, "my-domain", new TerraformOutputConfig {
+                Value = config.MyDomain,
+            });
+        }
+
+
+        public static void Main(string[] args)
+        {
+            App app = new App();
+            new OutputVariableStack(app, "cdktf-producer", new OutputVariableStackConfig("example.com"));
+            app.Synth();
+        }
+    }
+
+}
+
+
 ```
 
 </CodeTabs>

--- a/website/docs/cdktf/concepts/variables-and-outputs.mdx
+++ b/website/docs/cdktf/concepts/variables-and-outputs.mdx
@@ -514,6 +514,7 @@ The following example uses outputs to share data between stacks, each of which h
 <!-- #NEXT_CODE_BLOCK_SOURCE:ts examples/typescript/documentation#remote-state -->
 <!-- #NEXT_CODE_BLOCK_SOURCE:python examples/python/documentation#var-out-define-reference-remote-state -->
 <!-- #NEXT_CODE_BLOCK_SOURCE:java examples/java/documentation#var-out-define-reference-remote-state -->
+<!-- #NEXT_CODE_BLOCK_SOURCE:csharp examples/csharp/documentation#var-out-define-reference-remote-state -->
 
 <CodeTabs>
 
@@ -684,6 +685,69 @@ app = App()
 Producer(app, "cdktf-producer")
 Consumer(app, "cdktf-consumer")
 app.synth()
+```
+
+```csharp
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using Constructs;
+using HashiCorp.Cdktf;
+using random.Provider;
+using random.Pet;
+
+namespace Examples
+{
+    class Producer : TerraformStack
+    {
+        public Producer(Construct scope, string name) : base(scope, name)
+        {
+            new CloudBackend(this, new CloudBackendConfig {
+                Organization = "hashicorp",
+                Workspaces = new NamedCloudWorkspace("producer"),
+            });
+
+            new RandomProvider(this, "random", new RandomProviderConfig());
+            var pet = new Pet(this, "pet", new PetConfig());
+
+            new TerraformOutput(this, "random-pet", new TerraformOutputConfig {
+                Value = pet.Id,
+            });
+        }
+    }
+
+    class Consumer : TerraformStack
+    {
+        public Consumer(Construct scope, string name) : base(scope, name)
+        {
+            new CloudBackend(this, new CloudBackendConfig {
+                Organization = "hashicorp",
+                Workspaces = new NamedCloudWorkspace("consumer"),
+            });
+
+            DataTerraformRemoteState remoteState = new DataTerraformRemoteState(this, "remote-state", new DataTerraformRemoteStateRemoteConfig {
+                Organization = "hashicorp",
+                Workspaces = new NamedRemoteWorkspace("producer"),
+            });
+
+            new TerraformOutput(this, "random-remote-pet", new TerraformOutputConfig {
+                Value = remoteState.GetString("random-pet"),
+            });
+        }
+    }
+
+    class Main {
+        public static void Main(string[] args)
+        {
+            App app = new App();
+            new Producer(app, "cdktf-producer");
+            new Consumer(app, "cdktf-consumer");
+            app.Synth();
+        }
+    }
+
+}
 ```
 
 </CodeTabs>

--- a/website/docs/cdktf/concepts/variables-and-outputs.mdx
+++ b/website/docs/cdktf/concepts/variables-and-outputs.mdx
@@ -140,6 +140,7 @@ The following example uses `TerraformLocal` to create a local value.
 <!-- #NEXT_CODE_BLOCK_SOURCE:ts examples/typescript/documentation#locals -->
 <!-- #NEXT_CODE_BLOCK_SOURCE:python examples/python/documentation#var-out-define-local -->
 <!-- #NEXT_CODE_BLOCK_SOURCE:java examples/java/documentation#var-out-define-local -->
+<!-- #NEXT_CODE_BLOCK_SOURCE:csharp examples/csharp/documentation#var-out-define-local -->
 
 <CodeTabs>
 
@@ -177,6 +178,18 @@ new Instance(this, "example", {
         Instance(self, "example",
             tags = commonTags.as_string_map
         )
+```
+
+```csharp
+TerraformLocal commonTags = new TerraformLocal(this, "common_tags", new Dictionary<string, string> {
+    { "Service", "service_name" },
+    { "Owner", "owner" },
+});
+new Instance(this, "example", new InstanceConfig {
+    Ami = "ami-abcde123",
+    InstanceType = "t2.micro",
+    Tags = Token.AsStringMap(commonTags.Expression),
+});
 ```
 
 </CodeTabs>

--- a/website/docs/cdktf/concepts/variables-and-outputs.mdx
+++ b/website/docs/cdktf/concepts/variables-and-outputs.mdx
@@ -346,8 +346,6 @@ namespace Examples
                 Value = config.MyDomain,
             });
         }
-
-
         public static void Main(string[] args)
         {
             App app = new App();
@@ -357,8 +355,6 @@ namespace Examples
     }
 
 }
-
-
 ```
 
 </CodeTabs>
@@ -374,6 +370,7 @@ The following Typescript example uses `TerraformOutput` to create an output for 
 <!-- #NEXT_CODE_BLOCK_SOURCE:ts examples/typescript/documentation#outputs-usage -->
 <!-- #NEXT_CODE_BLOCK_SOURCE:java examples/java/documentation#var-out-define-output-values -->
 <!-- #NEXT_CODE_BLOCK_SOURCE:python examples/python/documentation#var-out-define-output-values -->
+<!-- #NEXT_CODE_BLOCK_SOURCE:csharp examples/csharp/documentation#var-out-define-output-values -->
 
 <CodeTabs>
 
@@ -451,6 +448,39 @@ class DefineOutputStack(TerraformStack):
 app = App()
 DefineOutputStack(app, "cdktf-demo")
 app.synth()
+```
+
+```csharp
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using Constructs;
+using HashiCorp.Cdktf;
+using random.Provider;
+using random.Pet;
+
+namespace Examples
+{
+    class OutputsUsageStack : TerraformStack
+    {
+        public OutputsUsageStack(Construct scope, string name) : base(scope, name)
+        {
+            new RandomProvider(this, "random", new RandomProviderConfig());
+            var pet = new Pet(this, "pet", new PetConfig());
+            new TerraformOutput(this, "random-pet", new TerraformOutputConfig {
+                Value = pet.Id,
+            });
+        }
+        public static void Main(string[] args)
+        {
+            App app = new App();
+            new OutputsUsageStack(app, "outputs-usage");
+            app.Synth();
+        }
+    }
+
+}
 ```
 
 </CodeTabs>

--- a/website/docs/cdktf/concepts/variables-and-outputs.mdx
+++ b/website/docs/cdktf/concepts/variables-and-outputs.mdx
@@ -36,6 +36,7 @@ The following example uses `TerraformVariable` to provide inputs to resources.
 <!-- #NEXT_CODE_BLOCK_SOURCE:ts examples/typescript/documentation#variables -->
 <!-- #NEXT_CODE_BLOCK_SOURCE:python examples/python/documentation#var-out-input-variables -->
 <!-- #NEXT_CODE_BLOCK_SOURCE:java examples/java/documentation#var-out-input-variables -->
+<!-- #NEXT_CODE_BLOCK_SOURCE:csharp examples/csharp/documentation#var-out-input-variables -->
 
 <CodeTabs>
 
@@ -76,6 +77,19 @@ Instance(self, "hello",
     ami = imageId.string_value,
     instance_type = "t2.micro"
 )
+```
+
+```csharp
+            TerraformVariable imageId = new TerraformVariable(this, "imageId", new TerraformVariableConfig {
+                Type = "string",
+                Default = "ami-abcde123",
+                Description = "What AMI to use to create an instance",
+            });
+
+            new Instance(this, "hello", new InstanceConfig {
+                Ami = imageId.StringValue,
+                InstanceType = "t2.micro",
+            });
 ```
 
 </CodeTabs>


### PR DESCRIPTION
The Operators example does not work in C# I added a bug into our issues and linked it, so we are transparent to users. Right below is a workaround using plain strings so I don't feel like this is a big problem in this case
