### PR TITLE
feat: also go through files not yet added to git

### DIFF
--- a/tools/documentation-code-snippets/update-documentation-code-snippets.ts
+++ b/tools/documentation-code-snippets/update-documentation-code-snippets.ts
@@ -269,8 +269,16 @@ ${requestedSnippets
     const files = (await execa("git", ["ls-files"], { cwd: sourcePath })).stdout
       .split("\n")
       .map((f) => `${sourcePath}/${f}`);
+    // files that haven't been git add'ed yet
+    const notYetAddedFiles = (
+      await execa("git", ["ls-files", "--exclude-standard", "--others"], {
+        cwd: sourcePath,
+      })
+    ).stdout
+      .split("\n")
+      .map((f) => `${sourcePath}/${f}`);
 
-    for (const filename of files) {
+    for (const filename of [...files, ...notYetAddedFiles]) {
       const containsSources = await fileContainsCodeBlockSources(filename);
       if (containsSources) {
         sourceFilesWithCodeBlock.push({


### PR DESCRIPTION
previously the script would only use git ls-files in a way that listed all files known to git (to skip going through e.g. node_modules). However, this had the quirk, that files that hadn't been added to git yet, would not be detected which was annoying when writing documentation examples. This change fixes that.
