### PR TITLE
chore: Don't run `terraform init` when not required

### DIFF
--- a/packages/@cdktf/cli-core/src/lib/cdktf-stack.ts
+++ b/packages/@cdktf/cli-core/src/lib/cdktf-stack.ts
@@ -268,7 +268,7 @@ export class CdktfStack {
     const requiredProviders = this.requiredProviders();
 
     for (const provider of Object.values(requiredProviders)) {
-      const hasProvider = await lock.hasProvider(provider);
+      const hasProvider = await lock.hasMatchingProvider(provider);
       if (!hasProvider) {
         // If we don't have a provider or version doesn't match, we need to init
         return true;

--- a/packages/@cdktf/cli-core/src/lib/terraform-provider-lock.ts
+++ b/packages/@cdktf/cli-core/src/lib/terraform-provider-lock.ts
@@ -23,13 +23,22 @@ export class TerraformProviderLock {
     this._providerLockData = null;
   }
 
+  private get lockFilePath() {
+    return path.join(this.stackWorkingDirectory, TerraformLockFileName);
+  }
+
+  public async hasProviderLockFile() {
+    try {
+      await fs.stat(this.lockFilePath);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
   private async readProviderLockFile() {
     try {
-      const lockFilePath = path.join(
-        this.stackWorkingDirectory,
-        TerraformLockFileName
-      );
-      const lockFile = (await fs.readFile(lockFilePath)).toString();
+      const lockFile = (await fs.readFile(this.lockFilePath)).toString();
 
       return lockFile;
     } catch (e) {


### PR DESCRIPTION
This PR will prevent us from running `terraform init` when there isn't a change between what's present within provider lock, and the generated required providers. This makes cdktf plan/apply/destroy during development much faster.

depends on #2570