### PR TITLE
fix: switch back to offical image to fix issue with stale signature files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-# Use a previous version as there are problems with the latest Docker image, related to https://github.com/aws/jsii/issues/3903
-FROM docker.mirror.hashicorp.services/jsii/superchain@sha256:80ee12fd2b143ff58d93c72c43985281bb6923370f8df93fcbb23834f0bfb5a7
-# FROM docker.mirror.hashicorp.services/jsii/superchain:1-buster-slim-node14
+FROM docker.mirror.hashicorp.services/jsii/superchain:1-buster-slim-node14
 
 USER root
 


### PR DESCRIPTION
Closes #2586

Docker build worked locally after changing this:
```
➜  terraform-cdk git:(main) docker build .                                                                                    13:11:33
[+] Building 477.1s (9/9) FINISHED
 => [internal] load build definition from Dockerfile                                                                              0.1s
 => => transferring dockerfile: 1.19kB                                                                                            0.0s
 => [internal] load .dockerignore                                                                                                 0.0s
 => => transferring context: 35B                                                                                                  0.0s
 => [internal] load metadata for docker.mirror.hashicorp.services/jsii/superchain:1-buster-slim-node14                            4.2s
 => [1/5] FROM docker.mirror.hashicorp.services/jsii/superchain:1-buster-slim-node14@sha256:0a0fcf8bb960b5799dc5b99457483fabf7  444.8s
 => => resolve docker.mirror.hashicorp.services/jsii/superchain:1-buster-slim-node14@sha256:0a0fcf8bb960b5799dc5b99457483fabf79a  0.0s
 => => sha256:0a0fcf8bb960b5799dc5b99457483fabf79a0a4d11253d64a961b859805a1f98 1.61kB / 1.61kB                                    0.0s
 => => sha256:7c15c34d11f7906a78c9eb23b51a3a5755daea9adcdcc71541f920abe08054d9 484B / 484B                                        0.0s
 => => sha256:52b2a3a9a1adc186062b933d866da2550de2f195221544413ef4c5de83e33714 3.98kB / 3.98kB                                    0.0s
 => => sha256:8e5e473139b690e175520c0ec2a22f93d760b2c0d1a25b3104cf214e27e02f61 1.35GB / 1.35GB                                  405.6s
 => => extracting sha256:8e5e473139b690e175520c0ec2a22f93d760b2c0d1a25b3104cf214e27e02f61                                        38.4s
 => [2/5] RUN apt-get update -y && apt-get install -y unzip jq build-essential time                                               7.4s
 => [3/5] RUN curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python3                                  13.8s
 => [4/5] RUN npm install -g @sentry/cli --unsafe-perm                                                                            5.9s
 => [5/5] RUN for VERSION in ${AVAILABLE_TERRAFORM_VERSIONS}; do curl -LOk https://releases.hashicorp.com/terraform/${VERSION}/t  0.3s
 => exporting to image                                                                                                            0.5s
 => => exporting layers                                                                                                           0.5s
 => => writing image sha256:140b09d4e3183fade7a611ace68313091b28c68de3d40d1a9fc1920e5489b292                                      0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
```