### PR TITLE
feat(lib): Support adding Validations on App

### DIFF
--- a/packages/cdktf/lib/app.ts
+++ b/packages/cdktf/lib/app.ts
@@ -128,6 +128,16 @@ export class App extends Construct {
     stacks.forEach((stack) => stack.prepareStack());
     stacks.forEach((stack) => stack.synthesizer.synthesize(session));
 
+    if (!this.skipValidation) {
+      const validations = this.node.validate();
+      if (validations.length) {
+        const errorList = validations.join("\n  ");
+        throw new Error(
+          `App level validation failed with the following errors:\n  ${errorList}`
+        );
+      }
+    }
+
     this.manifest.writeToFile();
   }
 

--- a/packages/cdktf/test/app.test.ts
+++ b/packages/cdktf/test/app.test.ts
@@ -93,6 +93,38 @@ test("app synth throws error when provider is missing", () => {
   `);
 });
 
+test("app synth supports app level validations", () => {
+  const outdir = fs.mkdtempSync(path.join(os.tmpdir(), "cdktf.outdir."));
+  const app = Testing.stubVersion(new App({ stackTraces: false, outdir }));
+
+  const mockValidation = {
+    validate: jest.fn().mockReturnValue(["error1", "error2"]),
+  };
+  app.node.addValidation(mockValidation);
+
+  expect(() => app.synth()).toThrowErrorMatchingInlineSnapshot(`
+    "App level validation failed with the following errors:
+      error1
+      error2"
+  `);
+  expect(mockValidation.validate).toHaveBeenCalledTimes(1);
+});
+
+test("app synth supports skipping app level validations", () => {
+  const outdir = fs.mkdtempSync(path.join(os.tmpdir(), "cdktf.outdir."));
+  const app = Testing.stubVersion(
+    new App({ stackTraces: false, outdir, skipValidation: true })
+  );
+
+  const mockValidation = {
+    validate: jest.fn().mockReturnValue(["error1"]),
+  };
+  app.node.addValidation(mockValidation);
+
+  expect(() => app.synth()).not.toThrow();
+  expect(mockValidation.validate).toHaveBeenCalledTimes(0);
+});
+
 test("app synth executes Aspects", () => {
   const outdir = fs.mkdtempSync(path.join(os.tmpdir(), "cdktf.outdir."));
   const app = Testing.stubVersion(


### PR DESCRIPTION
Validations are a feature of the constructs lib. Previously we only ran validations added to Stacks (and below). This change also runs them on the root App

This is in preparation for adding a validation that confirms that no stacks are reusing the same backend configuration
