### PR TITLE
chore: additionally lock providers for linux only

### DIFF
--- a/packages/@cdktf/cli-core/src/lib/models/terraform-cli.ts
+++ b/packages/@cdktf/cli-core/src/lib/models/terraform-cli.ts
@@ -137,8 +137,6 @@ export class TerraformCli implements Terraform {
       [
         "providers",
         "lock",
-        "-platform=windows_amd64",
-        "-platform=darwin_amd64",
         "-platform=linux_amd64",
         ...(noColor ? ["-no-color"] : []),
       ],


### PR DESCRIPTION
This PR reduces the OS platforms we update the terraform provider lock on to make cdktf plan/apply/destroy operations faster.

### Context
We're currently being too careful with provider locking, but after some basic testing, the following seems to be true:

- `terraform init` generates the provider lock for the current platform `cdktf` is running on
![image](https://user-images.githubusercontent.com/573531/216582139-19ee2ce4-214d-4007-9183-c86104f17e75.png)


- Workflows will fail on TFC/E if we don't do an additional `terraform providers lock` command for linux
![image](https://user-images.githubusercontent.com/573531/216584821-d35929cd-b441-4b66-a1ed-68d45037ab84.png)


- Terraform `providers lock` command appends hashes, and doesn't override older hashes, so it's additive.
![image](https://user-images.githubusercontent.com/573531/216582596-c0a630f8-8fee-4652-8bd0-703d122462c2.png)


- We don't have insight into whether we're running locally or remotely at this level, so we need to assume that all workflows are remote execution.