### PR TITLE
feat(cli): support migrating state between backends

### DIFF
--- a/packages/@cdktf/cli-core/src/lib/cdktf-project.ts
+++ b/packages/@cdktf/cli-core/src/lib/cdktf-project.ts
@@ -75,6 +75,7 @@ export type DiffOptions = SingleStackOptions & {
   vars?: string[];
   varFiles?: string[];
   noColor?: boolean;
+  migrateState?: boolean;
 };
 
 export type MutationOptions = MultipleStackOptions &
@@ -86,6 +87,7 @@ export type MutationOptions = MultipleStackOptions &
     vars?: string[];
     varFiles?: string[];
     noColor?: boolean;
+    migrateState?: boolean;
   };
 
 export type LogMessage = {

--- a/packages/@cdktf/cli-core/src/lib/models/pty-process.ts
+++ b/packages/@cdktf/cli-core/src/lib/models/pty-process.ts
@@ -1,0 +1,165 @@
+import * as os from "os";
+import * as path from "path";
+import * as fs from "fs";
+
+import * as pty from "@cdktf/node-pty-prebuilt-multiarch";
+import { logger } from "@cdktf/commons";
+
+interface PtySpawnConfig {
+  file: Parameters<typeof pty.spawn>[0];
+  args: Parameters<typeof pty.spawn>[1];
+  options: Parameters<typeof pty.spawn>[2] & { cwd: string };
+}
+
+export interface PtyProcessActions {
+  write: (response: string) => void;
+  writeLine: (response: string) => void;
+  stop: () => void;
+}
+
+export interface PtyProcess {
+  // Resolves or rejects depending on the exit code of the process
+  progress: Promise<void>;
+  // Always resolves, returns the exit code of the process
+  exitCode: Promise<number>;
+  actions: PtyProcessActions;
+}
+
+/**
+ * A wrapper around node-pty that handles the platform specific differences
+ * and provide an intuitive API for bidirectional communication with the
+ * spawned process.
+ */
+export function spawnPty(
+  config: PtySpawnConfig,
+  onData: (data: string) => void
+): PtyProcess {
+  const { args, options } = config;
+  const file =
+    os.platform() === "win32"
+      ? findExecutable(config.file, options.cwd, options)
+      : config.file;
+
+  logger.trace(
+    `Spawning pty with file=${file}, args=${
+      Array.isArray(args) ? `[${args.join(", ")}]` : `"${args}"`
+    }, options=${JSON.stringify(options)}`
+  );
+
+  const p = pty.spawn(file, args, options);
+
+  const actions: PtyProcessActions = {
+    write: (response: string) => {
+      logger.trace(
+        `Sending response to pty (file=${file}, args=${
+          Array.isArray(args) ? `[${args.join(", ")}]` : `"${args}"`
+        }): ${response}`
+      );
+      p.write(response);
+    },
+    writeLine: (response: string) => {
+      logger.trace(
+        `Sending response (with newline) to pty (file=${file}, args=${
+          Array.isArray(args) ? `[${args.join(", ")}]` : `"${args}"`
+        }): ${response}`
+      );
+      p.write(`${response}${os.EOL}`);
+    },
+    stop: () => {
+      logger.trace(
+        `Aborting pty (file=${file}, args=${
+          Array.isArray(args) ? `[${args.join(", ")}]` : `"${args}"`
+        })`
+      );
+      p.write("\x03"); // CTRL + C, pty.kill() does not work on windows
+    },
+  };
+
+  p.onData((data) => onData(data));
+
+  const progress = new Promise<void>((resolve, reject) => {
+    p.onExit(({ exitCode }) => {
+      if (exitCode === 0) {
+        resolve();
+      } else {
+        reject(
+          new Error(
+            `Pty (file=${file}, args=${
+              Array.isArray(args) ? `[${args.join(", ")}]` : `"${args}"`
+            }) exited with code ${exitCode}`
+          )
+        );
+      }
+    });
+  });
+
+  const exitCode = new Promise<number>((resolve) => {
+    p.onExit(({ exitCode }) => {
+      resolve(exitCode);
+    });
+  });
+
+  return { progress, exitCode, actions };
+}
+
+// src: https://github.com/Microsoft/vscode/blob/c0c9ea27d6e8d660d8716d7acee82cf3c00fa3e5/src/vs/workbench/parts/tasks/electron-browser/terminalTaskSystem.ts#L691
+// TODO: properly annotate source of this function
+function findExecutable(
+  command: string,
+  cwd: string,
+  options: { env?: { [key: string]: string } }
+): string {
+  // If we have an absolute path then we take it.
+  if (path.isAbsolute(command)) {
+    return command;
+  }
+  const dir = path.dirname(command);
+  if (dir !== ".") {
+    // We have a directory and the directory is relative (see above). Make the path absolute
+    // to the current working directory.
+    return path.join(cwd, command);
+  }
+  let paths: string[] | undefined = undefined;
+  // The options can override the PATH. So consider that PATH if present.
+  if (options && options.env) {
+    // Path can be named in many different ways and for the execution it doesn't matter
+    for (const key of Object.keys(options.env)) {
+      if (key.toLowerCase() === "path") {
+        if (typeof options.env[key] === "string") {
+          paths = options.env[key].split(path.delimiter);
+        }
+        break;
+      }
+    }
+  }
+  if (paths === void 0 && typeof process.env.PATH === "string") {
+    paths = process.env.PATH.split(path.delimiter);
+  }
+  // No PATH environment. Make path absolute to the cwd.
+  if (paths === void 0 || paths.length === 0) {
+    return path.join(cwd, command);
+  }
+  // We have a simple file name. We get the path variable from the env
+  // and try to find the executable on the path.
+  for (const pathEntry of paths) {
+    // The path entry is absolute.
+    let fullPath: string;
+    if (path.isAbsolute(pathEntry)) {
+      fullPath = path.join(pathEntry, command);
+    } else {
+      fullPath = path.join(cwd, pathEntry, command);
+    }
+    if (fs.existsSync(fullPath)) {
+      return fullPath;
+    }
+    let withExtension = fullPath + ".com";
+    if (fs.existsSync(withExtension)) {
+      return withExtension;
+    }
+    withExtension = fullPath + ".exe";
+    if (fs.existsSync(withExtension)) {
+      return withExtension;
+    }
+  }
+  return path.join(cwd, command);
+}

--- a/packages/@cdktf/cli-core/src/lib/models/terraform-cli.ts
+++ b/packages/@cdktf/cli-core/src/lib/models/terraform-cli.ts
@@ -129,7 +129,7 @@ export class TerraformCli implements Terraform {
     });
 
     const stdout = this.onStdout("init");
-    const { actions, progress } = spawnPty(
+    const { actions, exitCode } = spawnPty(
       {
         file: terraformBinaryName,
         args,
@@ -156,6 +156,11 @@ export class TerraformCli implements Terraform {
       actions.stop();
     });
 
+    const progress = exitCode.then((code) => {
+      if (code !== 0) {
+        throw new Error(`terraform init failed with exit code ${code}`);
+      }
+    });
     await Promise.race([progress, rejectsIfInitCanNotContinue]);
 
     // TODO: this might have performance implications because we don't know if we're

--- a/packages/@cdktf/cli-core/src/lib/models/terraform-cli.ts
+++ b/packages/@cdktf/cli-core/src/lib/models/terraform-cli.ts
@@ -291,8 +291,8 @@ export class TerraformCli implements Terraform {
       logger.trace(
         `Terraform CLI state machine event: ${JSON.stringify(event)}`
       );
-      if (isDeployEvent(event, "LINE_RECEIVED"))
-        this.onStdout(type)(event.line);
+      if (isDeployEvent(event, "OUTPUT_RECEIVED"))
+        this.onStdout(type)(event.output);
       else if (isDeployEvent(event, "APPROVED_EXTERNALLY"))
         callback({ type: "external approval reply", approved: true });
       else if (isDeployEvent(event, "REJECTED_EXTERNALLY"))

--- a/packages/@cdktf/cli-core/src/lib/models/terraform.ts
+++ b/packages/@cdktf/cli-core/src/lib/models/terraform.ts
@@ -129,7 +129,11 @@ export type TerraformDeployState =
   | { type: "external sentinel override reply"; overridden: boolean };
 
 export interface Terraform {
-  init: (upgrade: boolean, noColor?: boolean) => Promise<void>;
+  init: (
+    upgrade: boolean,
+    noColor: boolean,
+    migrateState: boolean
+  ) => Promise<void>;
   plan: (opts: {
     destroy: boolean;
     refreshOnly?: boolean;

--- a/packages/@cdktf/cli-core/src/test/lib/cdktf-project.test.ts
+++ b/packages/@cdktf/cli-core/src/test/lib/cdktf-project.test.ts
@@ -403,11 +403,17 @@ describe("CdktfProject", () => {
       });
 
       try {
-        await cdktfProject.deploy({
-          stackNames: ["stack1", "stack2", "stack3"],
-          parallelism: 100,
-          autoApprove: true,
-        });
+        await cdktfProject
+          .deploy({
+            stackNames: ["stack1", "stack2", "stack3"],
+            parallelism: 100,
+            autoApprove: true,
+          })
+          .catch((e) => {
+            console.log("deploy throws", e);
+            throw e;
+          });
+
         throw new Error("This error should not be thrown");
       } catch (e) {
         expect(e).toMatchInlineSnapshot(

--- a/packages/@cdktf/cli-core/src/test/models/deploy-machine.test.ts
+++ b/packages/@cdktf/cli-core/src/test/models/deploy-machine.test.ts
@@ -233,7 +233,7 @@ describe("handleLineReceived", () => {
     handleLineReceived(send)("foo");
     expect(send).toHaveBeenCalledWith({
       type: "OUTPUT_RECEIVED",
-      Line: "foo",
+      output: "foo",
     });
   });
 
@@ -246,7 +246,7 @@ describe("handleLineReceived", () => {
     handleLineReceived(send)(input);
     expect(send).not.toHaveBeenCalledWith({
       type: "OUTPUT_RECEIVED",
-      Line: input,
+      output: input,
     });
     expect(send).toHaveBeenCalledWith({
       type: "VARIABLE_MISSING",

--- a/packages/cdktf-cli/src/bin/cmds/deploy.ts
+++ b/packages/cdktf-cli/src/bin/cmds/deploy.ts
@@ -84,6 +84,12 @@ class Command extends BaseCommand {
         required: false,
         desc: "Disables terminal formatting sequences in the output.",
       })
+      .option("migrate-state", {
+        type: "boolean",
+        default: false,
+        required: false,
+        desc: "Reconfigure a backend, and attempt to migrate any existing state for all selected stacks.",
+      })
       .option("var", {
         type: "array",
         default: [],

--- a/packages/cdktf-cli/src/bin/cmds/deploy.ts
+++ b/packages/cdktf-cli/src/bin/cmds/deploy.ts
@@ -88,7 +88,7 @@ class Command extends BaseCommand {
         type: "boolean",
         default: false,
         required: false,
-        desc: "Reconfigure a backend, and attempt to migrate any existing state for all selected stacks.",
+        desc: "Pass this flag after switching state backends to approve a state migration for all targeted stacks",
       })
       .option("var", {
         type: "array",

--- a/packages/cdktf-cli/src/bin/cmds/destroy.ts
+++ b/packages/cdktf-cli/src/bin/cmds/destroy.ts
@@ -77,7 +77,7 @@ class Command extends BaseCommand {
         type: "boolean",
         default: false,
         required: false,
-        desc: "Reconfigure a backend, and attempt to migrate any existing state for all selected stacks.",
+        desc: "Pass this flag after switching state backends to approve a state migration for all targeted stacks",
       })
       .showHelpOnFail(true);
 

--- a/packages/cdktf-cli/src/bin/cmds/destroy.ts
+++ b/packages/cdktf-cli/src/bin/cmds/destroy.ts
@@ -73,6 +73,12 @@ class Command extends BaseCommand {
         required: false,
         desc: "Disables terminal formatting sequences in the output.",
       })
+      .option("migrate-state", {
+        type: "boolean",
+        default: false,
+        required: false,
+        desc: "Reconfigure a backend, and attempt to migrate any existing state for all selected stacks.",
+      })
       .showHelpOnFail(true);
 
   public async handleCommand(argv: any) {

--- a/packages/cdktf-cli/src/bin/cmds/diff.ts
+++ b/packages/cdktf-cli/src/bin/cmds/diff.ts
@@ -69,7 +69,7 @@ class Command extends BaseCommand {
         type: "boolean",
         default: false,
         required: false,
-        desc: "Reconfigure a backend, and attempt to migrate any existing state for the selected stack.",
+        desc: "Pass this flag after switching state backends to approve a state migration for the targeted stack",
       })
       .showHelpOnFail(true);
 

--- a/packages/cdktf-cli/src/bin/cmds/diff.ts
+++ b/packages/cdktf-cli/src/bin/cmds/diff.ts
@@ -65,6 +65,12 @@ class Command extends BaseCommand {
         required: false,
         desc: "Disables terminal formatting sequences in the output.",
       })
+      .option("migrate-state", {
+        type: "boolean",
+        default: false,
+        required: false,
+        desc: "Reconfigure a backend, and attempt to migrate any existing state for the selected stack.",
+      })
       .showHelpOnFail(true);
 
   public async handleCommand(argv: any) {

--- a/packages/cdktf-cli/src/bin/cmds/handlers.ts
+++ b/packages/cdktf-cli/src/bin/cmds/handlers.ts
@@ -138,6 +138,7 @@ export async function deploy(argv: any) {
   const vars = argv.var;
   const varFiles = sanitizeVarFiles(argv.varFile);
   const noColor = argv.noColor;
+  const migrateState = argv.migrateState;
 
   let outputsPath: string | undefined = undefined;
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -163,6 +164,7 @@ export async function deploy(argv: any) {
       vars,
       varFiles,
       noColor,
+      migrateState,
     })
   );
 }
@@ -183,6 +185,7 @@ export async function destroy(argv: any) {
   const vars = argv.var;
   const varFiles = sanitizeVarFiles(argv.varFile);
   const noColor = argv.noColor;
+  const migrateState = argv.migrateState;
 
   await renderInk(
     React.createElement(Destroy, {
@@ -196,6 +199,7 @@ export async function destroy(argv: any) {
       vars,
       varFiles,
       noColor,
+      migrateState,
     })
   );
 }
@@ -213,6 +217,7 @@ export async function diff(argv: any) {
   const vars = argv.var;
   const varFiles = sanitizeVarFiles(argv.varFile);
   const noColor = argv.noColor;
+  const migrateState = argv.migrateState;
 
   await renderInk(
     React.createElement(Diff, {
@@ -224,6 +229,7 @@ export async function diff(argv: any) {
       vars,
       varFiles,
       noColor,
+      migrateState,
     })
   );
 }

--- a/packages/cdktf-cli/src/bin/cmds/ui/deploy.tsx
+++ b/packages/cdktf-cli/src/bin/cmds/ui/deploy.tsx
@@ -60,6 +60,7 @@ interface DeployConfig {
   vars?: string[];
   varFiles?: string[];
   noColor?: boolean;
+  migrateState?: boolean;
 }
 
 export const Deploy = ({
@@ -76,6 +77,7 @@ export const Deploy = ({
   vars,
   varFiles,
   noColor,
+  migrateState,
 }: DeployConfig): React.ReactElement => {
   const [outputs, setOutputs] = useState<NestedTerraformOutputs>();
   const { status, logEntries } = useCdktfProject(
@@ -91,6 +93,7 @@ export const Deploy = ({
         vars,
         varFiles,
         noColor,
+        migrateState,
       });
 
       if (onOutputsRetrieved) {

--- a/packages/cdktf-cli/src/bin/cmds/ui/destroy.tsx
+++ b/packages/cdktf-cli/src/bin/cmds/ui/destroy.tsx
@@ -18,6 +18,7 @@ interface DestroyConfig {
   parallelism?: number;
   terraformParallelism?: number;
   noColor?: boolean;
+  migrateState?: boolean;
   vars?: string[];
   varFiles?: string[];
 }
@@ -31,6 +32,7 @@ export const Destroy = ({
   parallelism,
   terraformParallelism,
   noColor,
+  migrateState,
   vars,
   varFiles,
 }: DestroyConfig): React.ReactElement => {
@@ -44,6 +46,7 @@ export const Destroy = ({
         parallelism,
         terraformParallelism,
         noColor,
+        migrateState,
         vars,
         varFiles,
       })

--- a/packages/cdktf-cli/src/bin/cmds/ui/diff.tsx
+++ b/packages/cdktf-cli/src/bin/cmds/ui/diff.tsx
@@ -12,6 +12,7 @@ interface DiffConfig {
   vars?: string[];
   varFiles?: string[];
   noColor?: boolean;
+  migrateState?: boolean;
 }
 
 export const Diff = ({
@@ -23,6 +24,7 @@ export const Diff = ({
   vars,
   varFiles,
   noColor,
+  migrateState,
 }: DiffConfig): React.ReactElement => {
   const { status, logEntries } = useCdktfProject(
     { outDir, synthCommand },
@@ -34,6 +36,7 @@ export const Diff = ({
         vars,
         varFiles,
         noColor,
+        migrateState,
       })
   );
 

--- a/test/typescript/terraform-cloud/test.ts
+++ b/test/typescript/terraform-cloud/test.ts
@@ -77,9 +77,15 @@ describe("full integration test", () => {
     });
 
     process.env.TF_EXECUTE_LOCAL = "true";
-    await driver.deploy(["source-stack"]);
+    await driver.deploy(["source-stack"], "before-migration.json");
     process.env.TF_EXECUTE_LOCAL = undefined;
-    await driver.deploy(["source-stack"]);
+    await driver.deploy(["source-stack"], "after-migration.json", [
+      "--migrate-state",
+    ]);
+
+    expect(readFileSync("before-migration.json")).toEqual(
+      readFileSync("after-migration.json")
+    );
 
     await client.Workspaces.deleteByName(orgName, workspaceName);
   });

--- a/website/docs/cdktf/cli-reference/commands.mdx
+++ b/website/docs/cdktf/cli-reference/commands.mdx
@@ -147,7 +147,7 @@ Options:
       --version                                 Show version number  [boolean]
       --disable-plugin-cache-env                Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env CDKTF_DISABLE_PLUGIN_CACHE_ENV.  [boolean] [default: false]
       --log-level                               Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL  [string]
-  -a, --app                                     Command to use in order to execute cdktf app  [required]
+  -a, --app                                     Command to use in order to execute cdktf app  [required] [default: "npx ts-node main.ts"]
   -o, --output                                  Output directory for the synthesized Terraform config  [required] [default: "cdktf.out"]
       --auto-approve                            Auto approve  [boolean] [default: false]
       --outputs-file                            Path to file where stack outputs will be written as JSON  [string]
@@ -156,6 +156,10 @@ Options:
       --parallelism                             Number of concurrent CDKTF stacks to run. Defaults to infinity, denoted by -1  [number] [default: -1]
       --refresh-only                            Select the "refresh only" planning mode, which checks whether remote objects still match the outcome of the most recent Terraform apply but does not propose any actions to undo any changes made outside of Terraform.  [boolean] [default: false]
       --terraform-parallelism                   Forwards value as the `-parallelism` flag to Terraform. By default, the this flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend  [number] [default: -1]
+      --no-color                                Disables terminal formatting sequences in the output.  [boolean] [default: false]
+      --migrate-state                           Reconfigure a backend, and attempt to migrate any existing state for all selected stacks.  [boolean] [default: false]
+      --var                                     Set a value for one of the input variables in the stack or stacks to apply. Use this option more than once to set more than one variable.  [array] [default: []]
+      --var-file                                Load variable values from the given file, in addition to the default files terraform.tfvars and *.auto.tfvars. Use this option more than once to include more than one variables file.  [array] [default: []]
   -h, --help                                    Show help  [boolean]
 ```
 
@@ -213,24 +217,23 @@ cdktf destroy [stacks..]
 Destroy the given stacks
 
 Positionals:
-  stacks  Destroy stacks matching the given ids. Required when more than one stack is present in the app                                                                                     [array] [default: []]
+  stacks  Destroy stacks matching the given ids. Required when more than one stack is present in the app  [array] [default: []]
 
 Options:
-      --version                            Show version number                                                                                                                                           [boolean]
-      --disable-plugin-cache-env           Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env CDKTF_DISABLE_PLUGIN_CACHE_ENV.
-                                                                                                                                                                                        [boolean] [default: false]
-      --log-level                          Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL                                                                          [string]
-  -a, --app                                Command to use in order to execute cdktf app                                                                                                                 [required]
-  -o, --output                             Output directory for the synthesized Terraform config                                                                                 [required] [default: "cdktf.out"]
-      --auto-approve                       Auto approve                                                                                                                                 [boolean] [default: false]
-      --ignore-missing-stack-dependencies  Don't check if all stacks specified in the command have their dependencies included as well                                                  [boolean] [default: false]
-      --parallelism                        Number of concurrent CDKTF stacks to run. Defaults to infinity, denoted by -1                                                                    [number] [default: -1]
-      --terraform-parallelism              Forwards value as the `-parallelism` flag to Terraform. By default, the this flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud
-                                           backend                                                                                                                                          [number] [default: -1]
-      --var                                Set a value for one of the input variables in the stack or stacks to apply. Use this option more than once to set more than one variable.         [array] [default: []]
-      --var-file                           Load variable values from the given file, in addition to the default files terraform.tfvars and *.auto.tfvars. Use this option more than once to include more than one
-                                           variables file.                                                                                                                                   [array] [default: []]
-  -h, --help                               Show help                                                                                                                                                     [boolean]
+      --version                            Show version number  [boolean]
+      --disable-plugin-cache-env           Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env CDKTF_DISABLE_PLUGIN_CACHE_ENV.  [boolean] [default: false]
+      --log-level                          Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL  [string]
+  -a, --app                                Command to use in order to execute cdktf app  [required] [default: "npx ts-node main.ts"]
+  -o, --output                             Output directory for the synthesized Terraform config  [required] [default: "cdktf.out"]
+      --auto-approve                       Auto approve  [boolean] [default: false]
+      --ignore-missing-stack-dependencies  Don't check if all stacks specified in the command have their dependencies included as well  [boolean] [default: false]
+      --parallelism                        Number of concurrent CDKTF stacks to run. Defaults to infinity, denoted by -1  [number] [default: -1]
+      --terraform-parallelism              Forwards value as the `-parallelism` flag to Terraform. By default, the this flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend  [number] [default: -1]
+      --var                                Set a value for one of the input variables in the stack or stacks to apply. Use this option more than once to set more than one variable.  [array] [default: []]
+      --var-file                           Load variable values from the given file, in addition to the default files terraform.tfvars and *.auto.tfvars. Use this option more than once to include more than one variables file.  [array] [default: []]
+      --no-color                           Disables terminal formatting sequences in the output.  [boolean] [default: false]
+      --migrate-state                      Reconfigure a backend, and attempt to migrate any existing state for all selected stacks.  [boolean] [default: false]
+  -h, --help                               Show help  [boolean]
 ```
 
 ~> **Note:** The `parallelism` flag has a different behavior than the [terraform parallelism flag](/cli/commands/apply#parallelism-n). To set the custom terraform parallelism flag, please use the `--terraform-parallelism` flag instead.
@@ -285,23 +288,21 @@ cdktf diff [stack]
 Perform a diff (terraform plan) for the given stack
 
 Positionals:
-  stack  Diff stack which matches the given id only. Required when more than one stack is present in the app                                                                                              [string]
+  stack  Diff stack which matches the given id only. Required when more than one stack is present in the app  [string]
 
 Options:
-      --version                   Show version number                                                                                                                                                    [boolean]
-      --disable-plugin-cache-env  Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env CDKTF_DISABLE_PLUGIN_CACHE_ENV.
-                                                                                                                                                                                        [boolean] [default: false]
-      --log-level                 Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL                                                                                   [string]
-  -a, --app                       Command to use in order to execute cdktf app                                                                                                                          [required]
-  -o, --output                    Output directory for the synthesized Terraform config                                                                                          [required] [default: "cdktf.out"]
-      --refresh-only              Select the "refresh only" planning mode, which checks whether remote objects still match the outcome of the most recent Terraform apply but does not propose any actions to undo
-                                  any changes made outside of Terraform.                                                                                                                [boolean] [default: false]
-      --terraform-parallelism     Forwards value as the `-parallelism` flag to Terraform. By default, the this flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend
-                                                                                                                                                                                            [number] [default: -1]
-      --var                       Set a value for one of the input variables in the stack. Use this option more than once to set more than one variable.                                     [array] [default: []]
-      --var-file                  Load variable values from the given file, in addition to the default files terraform.tfvars and *.auto.tfvars. Use this option more than once to include more than one variables
-                                  file.                                                                                                                                                      [array] [default: []]
-  -h, --help                      Show help                                                                                                                                                              [boolean]
+      --version                   Show version number  [boolean]
+      --disable-plugin-cache-env  Dont set TF_PLUGIN_CACHE_DIR automatically. This is useful when the plugin cache is configured differently. Supported using the env CDKTF_DISABLE_PLUGIN_CACHE_ENV.  [boolean] [default: false]
+      --log-level                 Which log level should be written. Only supported via setting the env CDKTF_LOG_LEVEL  [string]
+  -a, --app                       Command to use in order to execute cdktf app  [required] [default: "npx ts-node main.ts"]
+  -o, --output                    Output directory for the synthesized Terraform config  [required] [default: "cdktf.out"]
+      --refresh-only              Select the "refresh only" planning mode, which checks whether remote objects still match the outcome of the most recent Terraform apply but does not propose any actions to undo any changes made outside of Terraform.  [boolean] [default: false]
+      --terraform-parallelism     Forwards value as the `-parallelism` flag to Terraform. By default, the this flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend  [number] [default: -1]
+      --var                       Set a value for one of the input variables in the stack. Use this option more than once to set more than one variable.  [array] [default: []]
+      --var-file                  Load variable values from the given file, in addition to the default files terraform.tfvars and *.auto.tfvars. Use this option more than once to include more than one variables file.  [array] [default: []]
+      --no-color                  Disables terminal formatting sequences in the output.  [boolean] [default: false]
+      --migrate-state             Reconfigure a backend, and attempt to migrate any existing state for the selected stack.  [boolean] [default: false]
+  -h, --help                      Show help  [boolean]
 ```
 
 ~> **Note:** The `parallelism` flag has a different behavior than the [terraform parallelism flag](/cli/commands/plan#parallelism-n). To set the custom terraform parallelism flag, please use the `--terraform-parallelism` flag instead.

--- a/website/docs/cdktf/cli-reference/commands.mdx
+++ b/website/docs/cdktf/cli-reference/commands.mdx
@@ -157,7 +157,7 @@ Options:
       --refresh-only                            Select the "refresh only" planning mode, which checks whether remote objects still match the outcome of the most recent Terraform apply but does not propose any actions to undo any changes made outside of Terraform.  [boolean] [default: false]
       --terraform-parallelism                   Forwards value as the `-parallelism` flag to Terraform. By default, the this flag is not forwarded to Terraform. Note: This flag is not supported by remote / cloud backend  [number] [default: -1]
       --no-color                                Disables terminal formatting sequences in the output.  [boolean] [default: false]
-      --migrate-state                           Reconfigure a backend, and attempt to migrate any existing state for all selected stacks.  [boolean] [default: false]
+      --migrate-state                           Pass this flag after switching state backends to approve a state migration for all targeted stacks  [boolean] [default: false]
       --var                                     Set a value for one of the input variables in the stack or stacks to apply. Use this option more than once to set more than one variable.  [array] [default: []]
       --var-file                                Load variable values from the given file, in addition to the default files terraform.tfvars and *.auto.tfvars. Use this option more than once to include more than one variables file.  [array] [default: []]
   -h, --help                                    Show help  [boolean]
@@ -232,7 +232,7 @@ Options:
       --var                                Set a value for one of the input variables in the stack or stacks to apply. Use this option more than once to set more than one variable.  [array] [default: []]
       --var-file                           Load variable values from the given file, in addition to the default files terraform.tfvars and *.auto.tfvars. Use this option more than once to include more than one variables file.  [array] [default: []]
       --no-color                           Disables terminal formatting sequences in the output.  [boolean] [default: false]
-      --migrate-state                      Reconfigure a backend, and attempt to migrate any existing state for all selected stacks.  [boolean] [default: false]
+      --migrate-state                      Pass this flag after switching state backends to approve a state migration for all targeted stacks  [boolean] [default: false]
   -h, --help                               Show help  [boolean]
 ```
 
@@ -301,7 +301,7 @@ Options:
       --var                       Set a value for one of the input variables in the stack. Use this option more than once to set more than one variable.  [array] [default: []]
       --var-file                  Load variable values from the given file, in addition to the default files terraform.tfvars and *.auto.tfvars. Use this option more than once to include more than one variables file.  [array] [default: []]
       --no-color                  Disables terminal formatting sequences in the output.  [boolean] [default: false]
-      --migrate-state             Reconfigure a backend, and attempt to migrate any existing state for the selected stack.  [boolean] [default: false]
+      --migrate-state             Pass this flag after switching state backends to approve a state migration for the targeted stack  [boolean] [default: false]
   -h, --help                      Show help  [boolean]
 ```
 

--- a/website/docs/cdktf/concepts/remote-backends.mdx
+++ b/website/docs/cdktf/concepts/remote-backends.mdx
@@ -345,53 +345,30 @@ func main() {
 
 </CodeTabs>
 
-3. Run `cdktf synth` to generate the Terraform configuration file.
-
-4. Move the Terraform state file into the output directory.
+3. Run `cdktf diff <stack name> --migrate-state` to migrate the state into Terraform Cloud / Terraform Enterprise.
 
    ```bash
-   mv terraform.hello-terraform.tfstate cdktf.out/stacks/hello-terraform
+   Initializing Terraform Cloud...
+   Migrating from backend "local" to Terraform Cloud.
+   Do you wish to proceed?
+                 As part of migrating to Terraform Cloud, Terraform can optionally copy your
+                 current workspace state to the configured Terraform Cloud workspace.
+
+                 Answer "yes" to copy the latest state snapshot to the configured
+                 Terraform Cloud workspace.
+
+                 Answer "no" to ignore the existing state and just activate the configured
+                 Terraform Cloud workspace with its existing state, if any.
+
+                 Should Terraform migrate your existing state?
+
+                 Enter a value:
+   yes
+   Initializing provider plugins...
+               - Reusing previous version of hashicorp/random from the dependency lock file
+   - Using previously-installed hashicorp/random v3.4.3
+   Terraform Cloud has been successfully initialized!
    ```
-
-5. Navigate to `cdktf.out/stacks/hello-terraform` and run `terraform init`. CDKTF prints the following output:
-
-   ```
-   Initializing the backend...
-   Do you want to copy existing state to the new backend?
-     Pre-existing state was found while migrating the previous "local" backend to the
-     newly configured "remote" backend. No existing state was found in the newly
-     configured "remote" backend. Do you want to copy this state to the new "remote"
-     backend? Enter "yes" to copy and "no" to start with an empty state.
-
-     Enter a value: yes
-
-     Successfully configured the backend "remote"! Terraform will automatically
-     use this backend unless the backend configuration changes.
-
-     Initializing provider plugins...
-
-     .....
-     Terraform has been successfully initialized!
-
-     You may now begin working with Terraform. Try running "terraform plan" to see
-     any changes that are required for your infrastructure. All Terraform commands
-     should now work.
-
-     If you ever set or change modules or backend configuration for Terraform,
-     other cdktf cli commands will detect the change and prompt you to rerun this command if necessary.
-
-   ```
-
-6. Run`cdktf diff` in the root `hello-terraform` directory to validate state migration. CDKTF prints the following output:
-
-   ```bash
-   Stack: hello-terraform
-
-   Diff: 0 to create, 0 to update, 0 to delete.
-
-   ```
-
-   With the remote backend type in this example, a diff would indicate that the state was not migrated properly. There are no changes to the stack, which means the migration was successful. Consult the documentation for the remote backend you are using to understand how to validate state migration.
 
 # Supported Backends
 


### PR DESCRIPTION
After this change a --migrate-state flag can be passed to diff, deploy, destroy
that will migrate the state from the previous backend to the current one.

Please not that Terraform CLI does not support migrating from the cloud configuration
to other backends, as a result this is not supported in cdktf either.

Closes #490
Closes #489