### PR TITLE
fix(provider-generator): remove @types/node from JSII dependencies

### DIFF
--- a/packages/@cdktf/provider-generator/lib/get/constructs-maker.ts
+++ b/packages/@cdktf/provider-generator/lib/get/constructs-maker.ts
@@ -503,7 +503,7 @@ export class ConstructsMaker {
 
   private async generateJsiiLanguage(target: ConstructsMakerTarget) {
     // these are the module dependencies we compile against
-    const deps = ["@types/node", "constructs", "cdktf"];
+    const deps = ["constructs", "cdktf"];
     const opts: srcmak.Options = {
       entrypoint: target.fileName,
       deps: deps.map((dep) =>


### PR DESCRIPTION
We don't need node-specific types for our generated bindings, therefore
we can drop the dependency.
