### PR TITLE
fix(cli): Always run init, but selectively skip locking providers

### DIFF
--- a/packages/@cdktf/cli-core/src/lib/cdktf-stack.ts
+++ b/packages/@cdktf/cli-core/src/lib/cdktf-stack.ts
@@ -238,7 +238,12 @@ export class CdktfStack {
     const terraform = await this.terraformClient();
     const needsLockfileUpdate = await this.checkNeedsLockfileUpdate();
     const needsUpgrade = await this.checkNeedsUpgrade();
-    await terraform.init({ needsUpgrade, noColor ?? false, needsLockfileUpdate, this.options.migrateState ?? false });
+    await terraform.init({
+      needsUpgrade,
+      noColor: noColor ?? false,
+      needsLockfileUpdate,
+      migrateState: this.options.migrateState ?? false,
+    });
     return terraform;
   }
 

--- a/packages/@cdktf/cli-core/src/lib/models/terraform.ts
+++ b/packages/@cdktf/cli-core/src/lib/models/terraform.ts
@@ -129,11 +129,13 @@ export type TerraformDeployState =
   | { type: "external sentinel override reply"; overridden: boolean };
 
 export interface Terraform {
-  init: (
-    upgrade: boolean,
-    noColor: boolean,
-    migrateState: boolean
-  ) => Promise<void>;
+  init: (opts: {
+    needsUpgrade: boolean;
+    noColor?: boolean;
+    needsLockfileUpdate: boolean;
+    migrateState: boolean;
+  }) => Promise<void>;
+
   plan: (opts: {
     destroy: boolean;
     refreshOnly?: boolean;

--- a/test/typescript/init-repeatedly/cdktf.json
+++ b/test/typescript/init-repeatedly/cdktf.json
@@ -1,8 +1,12 @@
 {
   "language": "typescript",
   "app": "npm run --silent compile && node main.js",
-  "terraformProviders": [
-    "null"
+  "terraformProviders": ["null"],
+  "terraformModules": [
+    {
+      "name": "our-local-module",
+      "source": "./local-module"
+    }
   ],
   "context": {
     "excludeStackIdFromLogicalIds": "true"

--- a/test/typescript/init-repeatedly/cdktf.json
+++ b/test/typescript/init-repeatedly/cdktf.json
@@ -1,0 +1,10 @@
+{
+  "language": "typescript",
+  "app": "npm run --silent compile && node main.js",
+  "terraformProviders": [
+    "null"
+  ],
+  "context": {
+    "excludeStackIdFromLogicalIds": "true"
+  }
+}

--- a/test/typescript/init-repeatedly/local-module/main.tf
+++ b/test/typescript/init-repeatedly/local-module/main.tf
@@ -1,0 +1,18 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "enabled" {
+  description = "Flag to optionally disable usage of this module."
+  type        = bool
+  default     = true
+}
+
+variable "set" {
+  description = "Making sure bindings can be created for modules using the set type"
+  type = set(string)
+}
+
+output "create_cmd_bin" {
+  description = "The full bin path & command used on create"
+  value       = "foo"
+}

--- a/test/typescript/init-repeatedly/main.ts
+++ b/test/typescript/init-repeatedly/main.ts
@@ -1,0 +1,22 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { Construct } from "constructs";
+import { App, TerraformStack, Testing, LocalBackend } from "cdktf";
+import { OurLocalModule } from "./.gen/modules/our-local-module";
+
+export class StackWithModule extends TerraformStack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+    new LocalBackend(this, {
+      path: "terraform.tfstate",
+    });
+
+    new OurLocalModule(this, "local-module", {
+      set: ["test", "sets"],
+    });
+  }
+}
+
+const app = Testing.stubVersion(new App({ stackTraces: false }));
+new StackWithModule(app, "repeated-init-stack");
+app.synth();

--- a/test/typescript/init-repeatedly/test.ts
+++ b/test/typescript/init-repeatedly/test.ts
@@ -1,8 +1,8 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
 import { TestDriver, onPosix } from "../../test-helper";
-import path from "node:path";
-import fs from "fs-extra";
+import * as path from "path";
+import * as fs from "fs-extra";
 
 // Since chalk auto-detects the capabilities, colored output is
 // deactivated by default in non-tty environments. We had an issue
@@ -24,8 +24,13 @@ describe("test with colors", () => {
     await driver.get();
   });
 
-  it("doesn't repeat init on subsequent diff", async () => {
-    const output = await driver.synth();
-    console.log(output);
+  it("repeats init on subsequent diff, but not provider lock", async () => {
+    const output = await driver.diff();
+    expect(output).toContain("Initializing provider plugins");
+    expect(output).toContain("validated the lock file");
+
+    const secondDiffOutput = await driver.diff();
+    expect(secondDiffOutput).toContain("Initializing provider plugins");
+    expect(secondDiffOutput).not.toContain("validated the lock file");
   });
 });

--- a/test/typescript/init-repeatedly/test.ts
+++ b/test/typescript/init-repeatedly/test.ts
@@ -1,0 +1,31 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { TestDriver, onPosix } from "../../test-helper";
+import path from "node:path";
+import fs from "fs-extra";
+
+// Since chalk auto-detects the capabilities, colored output is
+// deactivated by default in non-tty environments. We had an issue
+// in the past, where this turned out to be a problem
+// see https://github.com/hashicorp/terraform-cdk/issues/139
+
+describe("test with colors", () => {
+  let driver: TestDriver;
+
+  beforeAll(async () => {
+    driver = new TestDriver(__dirname);
+    driver.switchToTempDir();
+    await driver.init("typescript");
+    driver.copyFiles("main.ts", "cdktf.json");
+    fs.copySync(
+      path.join(__dirname, "local-module"),
+      path.join(driver.workingDirectory, "local-module")
+    );
+    await driver.get();
+  });
+
+  it("doesn't repeat init on subsequent diff", async () => {
+    const output = await driver.synth();
+    console.log(output);
+  });
+});


### PR DESCRIPTION
Resolves #2616

### Open tasks
- [ ] Write a test that tests the reproduction case described in #2612 (probably also can be reproduced with a local module, can be converted into a follow-up issue)
