### PR TITLE
chore(docs): remove inaccurate line about commercial support

### DIFF
--- a/website/docs/cdktf/index.mdx
+++ b/website/docs/cdktf/index.mdx
@@ -31,7 +31,7 @@ CDKTF offers many benefits, but it is not the right choice for every project. Yo
 
 - You have a strong preference or need to use a procedural language to define infrastructure.
 - You need to create abstractions to help manage complexity. For example, you want to create constructs to model a reusable infrastructure pattern composed of multiple resources and convenience methods.
-- You are comfortable doing your own troubleshooting and do not require commercial support.
+- You are comfortable living on the cutting edge; CDKTF may still have breaking changes before our 1.0 release.
 
 You can make this choice for each team and project because CDK for Terraform [interoperates with existing Terraform providers and modules](/cdktf/concepts/hcl-interoperability).
 


### PR DESCRIPTION
I was reading through some conversations by the Field team today and found one of them link to this section of our docs when I realized this line has been inaccurate since our GA release, since we do offer commercial support now. Oops!

Replaced it in a hurry with this other line -- @robin-norwood I'm open to suggestions re: how to phrase this better.