### PR TITLE
fix(cli): Remove @types/node-fetch from dependencies as those take precedence over direct devDependencies on @node/types

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,5 +115,8 @@
       "*.d.ts",
       "*.js"
     ]
+  },
+  "resolutions": {
+    "@types/node": "14.18.33"
   }
 }

--- a/packages/@cdktf/hcl2json/package.json
+++ b/packages/@cdktf/hcl2json/package.json
@@ -29,7 +29,6 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "@types/node-fetch": "^2.6.2",
     "fs-extra": "^8.1.0",
     "node-fetch": "^2.6.7"
   },
@@ -37,6 +36,7 @@
     "@types/fs-extra": "^8.1.2",
     "@types/jest": "^26.0.24",
     "@types/node": "^14.18.33",
+    "@types/node-fetch": "^2.6.2",
     "jest": "^26.6.3",
     "ts-jest": "^26.5.6",
     "typescript": "^3.9.10"

--- a/packages/@cdktf/provider-generator/package.json
+++ b/packages/@cdktf/provider-generator/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@cdktf/commons": "0.0.0",
     "@cdktf/hcl2json": "0.0.0",
+    "@types/node": "14.18.33",
     "codemaker": "^1.73.0",
     "deepmerge": "^4.2.2",
     "fs-extra": "^8.1.0",
@@ -41,7 +42,6 @@
     "@types/fs-extra": "^8.1.2",
     "@types/glob": "^7.2.0",
     "@types/jest": "^26.0.24",
-    "@types/node": "^14.18.33",
     "@types/reserved-words": "^0.1.0",
     "jest": "^26.6.3",
     "ts-jest": "^26.5.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2066,20 +2066,10 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*":
-  version "18.11.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
-  integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
-
-"@types/node@^14.18.33":
+"@types/node@*", "@types/node@14.18.33", "@types/node@^14.18.33", "@types/node@^16.18.3":
   version "14.18.33"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.33.tgz#8c29a0036771569662e4635790ffa9e057db379b"
   integrity sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==
-
-"@types/node@^16.18.3":
-  version "16.18.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.3.tgz#d7f7ba828ad9e540270f01ce00d391c54e6e0abc"
-  integrity sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
- fix(cli): Remove @types/node-fetch from dependencies as those take precence over direct devDependencies on @node/types
- fix: use override for @types/node in yarn monorepo

If this one works, prefer it over #2621