### PR TITLE
fix(provider-generator): fix resources named 'license' causing collisions with LICENSE file on case-insensitive filesystems for Go packages

### DIFF
--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -1908,7 +1908,7 @@ export * as licenseResource from './license-resource';
 `;
 
 exports[`incompatible resource names: license-resource 1`] = `
-"// https://www.terraform.io/docs/providers/test/r/license
+"// https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/license
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -1918,27 +1918,27 @@ import * as cdktf from 'cdktf';
 
 export interface LicenseResourceConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/test/r/license#dummy LicenseResource#dummy}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/license#dummy LicenseResource#dummy}
   */
   readonly dummy?: string;
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/test/r/license test_license}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/license test_license}
 */
 export class LicenseResource extends cdktf.TerraformResource {
 
   // =================
   // STATIC PROPERTIES
   // =================
-  public static readonly tfResourceType = \\"test_license\\";
+  public static readonly tfResourceType = "test_license";
 
   // ===========
   // INITIALIZER
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/test/r/license test_license} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/license test_license} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -1902,7 +1902,95 @@ export * as objectResource from './object-resource';
 export * as functionResource from './function-resource';
 export * as staticResource from './static-resource';
 export * as providerResource from './provider-resource';
+export * as licenseResource from './license-resource';
 
+"
+`;
+
+exports[`incompatible resource names: license-resource 1`] = `
+"// https://www.terraform.io/docs/providers/test/r/license
+// generated from terraform resource schema
+
+import { Construct } from 'constructs';
+import * as cdktf from 'cdktf';
+
+// Configuration
+
+export interface LicenseResourceConfig extends cdktf.TerraformMetaArguments {
+  /**
+  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/test/r/license#dummy LicenseResource#dummy}
+  */
+  readonly dummy?: string;
+}
+
+/**
+* Represents a {@link https://www.terraform.io/docs/providers/test/r/license test_license}
+*/
+export class LicenseResource extends cdktf.TerraformResource {
+
+  // =================
+  // STATIC PROPERTIES
+  // =================
+  public static readonly tfResourceType = \\"test_license\\";
+
+  // ===========
+  // INITIALIZER
+  // ===========
+
+  /**
+  * Create a new {@link https://www.terraform.io/docs/providers/test/r/license test_license} Resource
+  *
+  * @param scope The scope in which to define this construct
+  * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
+  * @param options LicenseResourceConfig = {}
+  */
+  public constructor(scope: Construct, id: string, config: LicenseResourceConfig = {}) {
+    super(scope, id, {
+      terraformResourceType: 'test_license',
+      terraformGeneratorMetadata: {
+        providerName: 'test'
+      },
+      provider: config.provider,
+      dependsOn: config.dependsOn,
+      count: config.count,
+      lifecycle: config.lifecycle,
+      provisioners: config.provisioners,
+      connection: config.connection,
+      forEach: config.forEach
+    });
+    this._dummy = config.dummy;
+  }
+
+  // ==========
+  // ATTRIBUTES
+  // ==========
+
+  // dummy - computed: false, optional: true, required: false
+  private _dummy?: string; 
+  public get dummy() {
+    return this.getStringAttribute('dummy');
+  }
+  public set dummy(value: string) {
+    this._dummy = value;
+  }
+  public resetDummy() {
+    this._dummy = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get dummyInput() {
+    return this._dummy;
+  }
+
+  // =========
+  // SYNTHESIS
+  // =========
+
+  protected synthesizeAttributes(): { [name: string]: any } {
+    return {
+      dummy: cdktf.stringToTerraform(this._dummy),
+    };
+  }
+}
 "
 `;
 

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/incompatible-resource-names.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/incompatible-resource-names.test.fixture.json
@@ -61,6 +61,18 @@
             }
           },
           "block_types": {}
+        },
+        "test_license": {
+          "version": 1,
+          "block": {
+            "attributes": {
+              "dummy": {
+                "type": "string",
+                "optional": true
+              }
+            }
+          },
+          "block_types": {}
         }
       }
     }

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/types.test.ts
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/types.test.ts
@@ -435,6 +435,7 @@ test("incompatible resource names", async () => {
     [
       "function-resource",
       "index.ts",
+      "license-resource",
       "object-resource",
       "provider-resource",
       "static-resource",

--- a/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
@@ -43,12 +43,18 @@ const RESERVED_KEYWORDS_FOR_NAMESPACES = [
   "await",
 ];
 
+const COLLIDING_NAMESPACE_NAMES = [
+  // e.g. hashicorp/consul – collides with the LICENSE file on case-insensitive filesystems in the Go package (#2627)
+  "license",
+];
+
 const isReservedClassOrNamespaceName = (className: string): boolean => {
   return [
     "string",
     "object",
     "function",
     ...RESERVED_KEYWORDS_FOR_NAMESPACES,
+    ...COLLIDING_NAMESPACE_NAMES,
   ].includes(className.toLowerCase());
 };
 


### PR DESCRIPTION
Resolves #2627

I'm unsure whether releasing this as part of a patch is okay – it changes the `License` resource to `LicenseResource` which is a breaking change for folks that currently generate bindings for `consul`, so I'd rather merge this after our last patch release for the current version is out – what do you think?