### PR TITLE
fix(lib): zipmap arg validators

### DIFF
--- a/packages/cdktf/lib/terraform-functions.ts
+++ b/packages/cdktf/lib/terraform-functions.ts
@@ -496,7 +496,12 @@ export class Fn {
     keyslist: any[] | IResolvable,
     valueslist: any[] | IResolvable
   ) {
-    return asAny(terraformFunction("zipmap", [mapValue])(keyslist, valueslist));
+    return asAny(
+      terraformFunction("zipmap", [listOf(stringValue), listOf(anyValue)])(
+        keyslist,
+        valueslist
+      )
+    );
   }
 
   /**


### PR DESCRIPTION
when trying to use `Fn.zipmap` getting `Error: zipmap takes 1 arguments, but 2 were provided`
after this fix it works