### PR TITLE
chore: create pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+<!--
+
+Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.
+
+Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md
+
+-->
+
+### Related issue
+
+Fixes # <!-- INSERT ISSUE NUMBER -->
+
+### Description
+
+In plain English, describe your approach to addressing the issue linked above. For example, if you made a particular design decision, let us know why you chose this path instead of another solution.
+
+### Checklist
+
+- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
+- [ ] I have run the linter on my code locally
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation if applicable
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
+- [ ] New and existing unit tests pass locally with my changes
+
+<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->


### PR DESCRIPTION
As per team discussion yesterday, adding a PR template enforcing that folks link to an existing issue when submitting a new PR.