### PR TITLE
chore: add docs issue template

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -6,7 +6,7 @@ project {
 
   header_ignore = [
     "**node_modules**",
-    ".github/ISSUE_TEMPLATE/config.yml",
+    ".github/ISSUE_TEMPLATE/*.yml",
     "packages/cdktf-cli/templates/**"
   ]
 }

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -4,10 +4,10 @@ title: "(page name): (short issue description)"
 labels: [documentation, new]
 assignees: []
 body:
-  - type: markdown
+  - type: textarea
     id: description
     attributes:
-      label: Describe the issue
+      label: Description
       description: A clear and concise description of the issue in plain English.
     validations:
       required: true
@@ -29,3 +29,15 @@ body:
       options:
         - label: I'm interested in contributing a fix myself
           required: false
+
+  - type: textarea
+    id: community
+    attributes:
+      label: Community Note
+      description: Please do not remove, edit, or change the following note for our community. Just leave everything in this textbox as-is.
+      value: |
+        - Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
+        - Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
+        - If you are interested in working on this issue or have submitted a pull request, please leave a comment
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,31 @@
+name: "📕 Documentation Issue"
+description: 👀 Report an issue with the CDKTF docs and tutorials on developer.hashicorp.com
+title: "(page name): (short issue description)"
+labels: [documentation, new]
+assignees: []
+body:
+  - type: markdown
+    id: description
+    attributes:
+      label: Describe the issue
+      description: A clear and concise description of the issue in plain English.
+    validations:
+      required: true
+
+  - type: textarea
+    id: links
+    attributes:
+      label: Links
+      description: |
+        Include links to affected documentation page(s).
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Help Wanted
+      description: Is this something you're able to or interested in helping out with? This is not required but a helpful way to signal to us that you're planning to open a PR with a fix.
+      options:
+        - label: I'm interested in contributing a fix myself
+          required: false


### PR DESCRIPTION
As we're starting to get more bug reports about our docs, I figured it might be helpful to have a separate issue template. I used the template that JSII uses as inspiration, as it is simple but effective.