### PR TITLE
chore: Automate go package copyright/license inculsion

### DIFF
--- a/packages/cdktf/go-copyright-header.sh
+++ b/packages/cdktf/go-copyright-header.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+DIRECTORY="$PWD/dist/go/cdktf"
+COPYRIGHT="Copyright (c) HashiCorp, Inc."
+LICENSE="SPDX-License-Identifier: MPL-2.0"
+
+# search for all files in the dist/go/cdktf directory and its subdirectories
+find "$DIRECTORY" -type f -print0 | while IFS= read -r -d '' FILE; do
+    # avoid appending to tarball file
+    if [[ "$FILE" != *cdktf-0.0.0.tgz* ]]; then
+        # only add copyright to LICENSE, move to outer directory so its at root of Github Repo
+        if [[ "$FILE" == *LICENSE* ]]; then
+            awk -v s="$COPYRIGHT\n" 'BEGIN{print s}{print}' "$FILE" > temp && mv temp "$FILE" 2>/dev/null
+            mv "$FILE" "$DIRECTORY/../LICENSE" 2>/dev/null
+        else
+            awk -v s="// $COPYRIGHT\n// $LICENSE\n" 'BEGIN{print s}{print}' "$FILE" > temp && mv temp "$FILE" 2>/dev/null
+        fi
+    fi
+done

--- a/packages/cdktf/package.json
+++ b/packages/cdktf/package.json
@@ -7,7 +7,7 @@
     "docs": "node ./scripts/generate-documentation.js",
     "watch": "jsii -w --silence-warnings reserved-word",
     "watch-preserve-output": "tsc -w --preserveWatchOutput",
-    "package": "jsii-pacmak",
+    "package": "jsii-pacmak && bash ./go-copyright-header.sh",
     "package:python": "jsii-pacmak --targets python",
     "package:java": "jsii-pacmak --targets java",
     "package:dotnet": "jsii-pacmak --targets dotnet",
@@ -23,6 +23,11 @@
   "jsii": {
     "outdir": "dist",
     "versionFormat": "short",
+    "license": "MPL-2.0",
+    "author": {
+      "name": "HashiCorp, Inc.",       
+      "organization": true 
+    },
     "targets": {
       "python": {
         "distName": "cdktf",


### PR DESCRIPTION
Added script that appends copyright headings to files in `cdktf` go package for compliance.

Unsure if there's a better way of including the script in the packaging process. 