### PR TITLE
fix: set GITHUB_TOKEN for retrieving copywrite tool

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -61,6 +61,8 @@ jobs:
       - uses: actions/checkout@v3.1.0
       - name: Setup Copywrite
         uses: hashicorp/setup-copywrite@3ace06ad72e6ec679ea8572457b17dbc3960b8ce # v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # See https://github.com/hashicorp/copywrite for more details
       - name: Check Header Compliance


### PR DESCRIPTION
We might (and did) run into rate limits when doing unauthenticated requests in multiple workflows at the same time
