### PR TITLE
fix(lib): support objects with keys that need escaping like e.g. colons

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -7,6 +7,10 @@ on:
       - synchronize
       - labeled
       - reopened
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   update-snapshots-setup:
     if: contains(github.event.pull_request.labels.*.name, 'ci/update-snapshots')
@@ -21,9 +25,11 @@ jobs:
       - uses: actions-ecosystem/action-add-labels@v1.1.0
         with:
           labels: ci/updating-snapshots
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions-ecosystem/action-remove-labels@v1.3.0
         with:
           labels: ci/update-snapshots
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - id: tf-version
         run: |
           DEFAULT_TERRAFORM_VERSION=$(cat .terraform.versions.json | jq -r '.default')
@@ -67,6 +73,7 @@ jobs:
       - uses: actions-ecosystem/action-remove-labels@v1.3.0
         with:
           labels: ci/updating-snapshots
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   update-snapshots-linux:
     needs: update-snapshots-setup
@@ -76,10 +83,18 @@ jobs:
     env:
       CHECKPOINT_DISABLE: "1"
     steps:
-      - uses: actions/checkout@v3.1.0
+      - name: Checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: "Add Git safe.directory" # Go 1.18+ started embedding repo info in the build and e.g. building @cdktf/hcl2json fails without this
+        run: git config --global --add safe.directory /__w/terraform-cdk/terraform-cdk
+      
+      - name: Set git identity
+        run: |-
+          git config user.name github-team-tf-cdk
+          git config user.email github-team-tf-cdk@hashicorp.com
 
       - name: Get yarn cache directory path
         id: global-cache-dir-path
@@ -92,11 +107,6 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-
-      - name: Set git identity
-        run: |-
-          git config user.name github-team-tf-cdk
-          git config user.email github-team-tf-cdk@hashicorp.com
 
       - name: installing dependencies and build
         run: |

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -90,7 +90,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: "Add Git safe.directory" # Go 1.18+ started embedding repo info in the build and e.g. building @cdktf/hcl2json fails without this
         run: git config --global --add safe.directory /__w/terraform-cdk/terraform-cdk
-      
+
       - name: Set git identity
         run: |-
           git config user.name github-team-tf-cdk

--- a/packages/cdktf/lib/tfExpression.ts
+++ b/packages/cdktf/lib/tfExpression.ts
@@ -27,7 +27,7 @@ class TFExpression extends Intrinsic implements IResolvable {
 
     if (typeof resolvedArg === "object" && resolvedArg !== null) {
       return `{${Object.keys(resolvedArg)
-        .map((key) => `${key} = ${this.resolveArg(context, arg[key])}`)
+        .map((key) => `"${key}" = ${this.resolveArg(context, arg[key])}`)
         .join(", ")}}`;
     }
 

--- a/packages/cdktf/test/functions.test.ts
+++ b/packages/cdktf/test/functions.test.ts
@@ -311,7 +311,7 @@ test("functions with object inputs", () => {
     "{
       \\"output\\": {
         \\"test-output\\": {
-          \\"value\\": \\"\${lookup({var = var.test-var, stat = 4, internal = true, yes = \\\\\\"no\\\\\\"}, \\\\\\"internal\\\\\\", \\\\\\"waaat\\\\\\")}\\"
+          \\"value\\": \\"\${lookup({\\\\\\"var\\\\\\" = var.test-var, \\\\\\"stat\\\\\\" = 4, \\\\\\"internal\\\\\\" = true, \\\\\\"yes\\\\\\" = \\\\\\"no\\\\\\"}, \\\\\\"internal\\\\\\", \\\\\\"waaat\\\\\\")}\\"
         }
       },
       \\"variable\\": {
@@ -382,7 +382,7 @@ test("nested objects and arrays as args", () => {
     "{
       \\"output\\": {
         \\"test-output\\": {
-          \\"value\\": \\"\${jsonencode({Statement = [{Action = \\\\\\"sts:AssumeRole\\\\\\", Effect = \\\\\\"Allow\\\\\\", Principal = {Service = \\\\\\"lambda.amazonaws.com\\\\\\"}}], Version = \\\\\\"2012-10-17\\\\\\"})}\\"
+          \\"value\\": \\"\${jsonencode({\\\\\\"Statement\\\\\\" = [{\\\\\\"Action\\\\\\" = \\\\\\"sts:AssumeRole\\\\\\", \\\\\\"Effect\\\\\\" = \\\\\\"Allow\\\\\\", \\\\\\"Principal\\\\\\" = {\\\\\\"Service\\\\\\" = \\\\\\"lambda.amazonaws.com\\\\\\"}}], \\\\\\"Version\\\\\\" = \\\\\\"2012-10-17\\\\\\"})}\\"
         }
       }
     }"
@@ -436,7 +436,7 @@ test("undefined and null", () => {
       },
       \\"output\\": {
         \\"json-object\\": {
-          \\"value\\": \\"\${jsonencode({a = \\\\\\"hello\\\\\\", b = 123, c = null})}\\"
+          \\"value\\": \\"\${jsonencode({\\\\\\"a\\\\\\" = \\\\\\"hello\\\\\\", \\\\\\"b\\\\\\" = 123, \\\\\\"c\\\\\\" = null})}\\"
         },
         \\"test-output\\": {
           \\"value\\": \\"\${coalesce(local.value, 42, false)}\\"

--- a/packages/cdktf/test/tfExpression.test.ts
+++ b/packages/cdktf/test/tfExpression.test.ts
@@ -101,10 +101,22 @@ test("functions escape string markers", () => {
   ).toMatchInlineSnapshot(`"\${length(\\"\\\\\\"\\")}"`);
 });
 
+test("functions escape object keys", () => {
+  expect(
+    resolveExpression(
+      call("keys", [{ "key:with:colons": "value", normal_key: "value" }])
+    )
+  ).toMatchInlineSnapshot(
+    `"\${keys({\\"key:with:colons\\" = \\"value\\", \\"normal_key\\" = \\"value\\"})}"`
+  );
+});
+
 test("string index expression argument renders correctly", () => {
   expect(
     resolveExpression(Op.or(true, { a: "foo", b: "bar " }))
-  ).toMatchInlineSnapshot(`"\${(true || {a = \\"foo\\", b = \\"bar \\"})}"`);
+  ).toMatchInlineSnapshot(
+    `"\${(true || {\\"a\\" = \\"foo\\", \\"b\\" = \\"bar \\"})}"`
+  );
 });
 
 test("null expression argument renders correctly", () => {

--- a/test/python/terraform-functions/__snapshots__/test.ts.snap
+++ b/test/python/terraform-functions/__snapshots__/test.ts.snap
@@ -24,7 +24,7 @@ exports[`python terraform functions test synth synth generates JSON 1`] = `
   },
   \\"output\\": {
     \\"computed\\": {
-      \\"value\\": \\"\${element(merge({id = null_resource.nullresource.id}, {value = \\\\\\"123\\\\\\"}), 1)}\\"
+      \\"value\\": \\"\${element(merge({\\\\\\"id\\\\\\" = null_resource.nullresource.id}, {\\\\\\"value\\\\\\" = \\\\\\"123\\\\\\"}), 1)}\\"
     }
   },
   \\"provider\\": {

--- a/test/typescript/iterators/test.ts
+++ b/test/typescript/iterators/test.ts
@@ -34,11 +34,11 @@ describe("iterators integration test", () => {
     );
 
     expect(stack.output("testlisttype")).toEqual(
-      '${[ for key, val in toset(var.pets): {name = val["name"], age = val["age"]}]}'
+      '${[ for key, val in toset(var.pets): {"name" = val["name"], "age" = val["age"]}]}'
     );
     expect(stack.output("testnestedlisttype")).toHaveProperty(
       "nested.in.an.object",
-      '${[ for key, val in toset(var.pets): {name = val["name"], age = val["age"]}]}'
+      '${[ for key, val in toset(var.pets): {"name" = val["name"], "age" = val["age"]}]}'
     );
 
     // tests that .dynamic() can also be passed to nested blocks


### PR DESCRIPTION
We will just always wrap all keys in quotes

Closes #1795