### PR TITLE
chore: Remove links within headers of documentation pages

### DIFF
--- a/website/docs/cdktf/release/upgrade-guide-v0-10.mdx
+++ b/website/docs/cdktf/release/upgrade-guide-v0-10.mdx
@@ -9,11 +9,15 @@ description: >-
 0.10 includes improvements to the provider code bindings, to allow referencing lists of computed attributes as a whole list instead of just individual items of that list.
 We also shipped a lot of CLI improvements in 0.10, including support for multiple stacks in `cdktf deploy`, `cdktf output`, and `cdktf destroy`.
 
-### Remove `cdktf synth --json` Option [#1640](https://github.com/hashicorp/terraform-cdk/pull/1640)
+### Remove `cdktf synth --json` Option
+
+PR: [#1640](https://github.com/hashicorp/terraform-cdk/pull/1640)
 
 If you are using `cdktf synth --json <stack-name>` to get the synthesized JSON configuration for your Stack, you will now need to run `cdktf synth && cat ./cdktf.out/stacks/<stack-name>/cdk.tf.json` instead. The `./cdktf.out` part is your output directory (set by `cdktf.json` or via the `--output` flag).
 
-### Model ComplexComputedLists as ComplexLists and ComputedObjects [#1499](https://github.com/hashicorp/terraform-cdk/pull/1499)
+### Model ComplexComputedLists as ComplexLists and ComputedObjects
+
+PR: [#1499](https://github.com/hashicorp/terraform-cdk/pull/1499)
 
 In an effort to streamline the interfaces of resources, computed attributes of the type list and set are now modeled as a separate `ComplexList` type instead of being a method that directly takes an index and returns an item. This change also did change the type of the index from `string` to `number`.
 
@@ -72,7 +76,9 @@ firstItemId := resource.ListAttribute().Get(jsii.Number(0)).Id();
 firstItem := resource.ListAttribute().Get(jsii.Number(0)); // now possible
 ```
 
-### Referencing computed string map entries via function call [#1630](https://github.com/hashicorp/terraform-cdk/pull/1630)
+### Referencing computed string map entries via function call
+
+PR: [#1630](https://github.com/hashicorp/terraform-cdk/pull/1630)
 
 In preparation for a similar change as to the computed lists, string map entries can now be accessed via a function call instead of using `Fn.lookup`. Accessing the whole map at once now requires a different function call in the meantime.
 

--- a/website/docs/cdktf/release/upgrade-guide-v0-11.mdx
+++ b/website/docs/cdktf/release/upgrade-guide-v0-11.mdx
@@ -44,7 +44,9 @@ const firstRuleStage = bucket.lifecycleRule.get(0).tags.lookup("stage");
 const firstRuleTags = bucket.lifecycleRule.get(0).tags;
 ```
 
-### Use ComplexLists and ComplexMaps for complex assignable properties [#1725](https://github.com/hashicorp/terraform-cdk/pull/1725)
+### Use ComplexLists and ComplexMaps for complex assignable properties
+
+PR: [#1725](https://github.com/hashicorp/terraform-cdk/pull/1725)
 
 Assignable properties of the form `Object[]` or `{ [key: string]: Object }` no longer have setters; they instead have `putX` methods. The getter return type is also changed to be a derivative of either `ComplexList` or `ComplexMap`.
 

--- a/website/docs/cdktf/release/upgrade-guide-v0-9.mdx
+++ b/website/docs/cdktf/release/upgrade-guide-v0-9.mdx
@@ -8,7 +8,9 @@ description: >-
 
 0.9 includes improvements to some of our provider code bindings, to improve usage across all languages.
 
-### Standardize IResolvable Usage [#1299](https://github.com/hashicorp/terraform-cdk/pull/1299)
+### Standardize IResolvable Usage
+
+PR: [#1299](https://github.com/hashicorp/terraform-cdk/pull/1299)
 
 This is an effort to make sure attributes can be freely passed between resources for all different types.
 
@@ -16,7 +18,9 @@ There is a minor breaking change:
 
 - `count` on resources and data sources has gone from `number | cdktf.IResolvable` to `number`. If code was previously passing an `IResolvable`, it will now need to wrap the `IResolvable` using `Token.asNumber()` on Typescript and Java , `Token.AsNumer()` on C#, `cdktf.Token_AsNumber()` on Go, and `Token().as_string()` on Python.
 
-### Map Tokens [#1411](https://github.com/hashicorp/terraform-cdk/pull/1411)
+### Map Tokens
+
+PR: [#1411](https://github.com/hashicorp/terraform-cdk/pull/1411)
 
 As part of an effort to use more native types, there are now tokens for maps of primitive values.
 
@@ -25,7 +29,9 @@ As a result, there is a minor breaking change:
 - Map attributes have gone from `{ [key: string]: TYPE } | cdktf.IResolvable` to `{ [key: string]:TYPE }` when `TYPE` is `string, number, or boolean`.
   - The most common impact is maps created by using Terraform functions (`Fn.(...)`) will now need to be passed to `Token.as<String/Number/Boolean>Map()` before assigning to a resource attribute. The naming is a bit different per language, on C# it's `Token.As<String/Number/Boolean>Map()`, on Go it's `cdktf.Token_As<String/Number/Boolean>Map()`, and on Python it's `Token().as_<string/number/boolean>_map()`.
 
-### Number[] Tokens [#1471](https://github.com/hashicorp/terraform-cdk/pull/1471)
+### Number[] Tokens
+
+PR: [#1471](https://github.com/hashicorp/terraform-cdk/pull/1471)
 
 As part of an effort to use more native types, there are now tokens for `number[]`.
 This is mostly an internal change, but there is now `Token.asNumberList()` (on C# it's `Token.AsNumberList()`, on Go it's `cdktf.Token_AsNumberList`, on Python it's `Token().as_number_list()`) which can be used to convert other values into `number[]`.


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Requested on internal Slack

### Description

Removing nested links within headers from our documentation pages, as links in headings can cause issues with anchor link generation and accessibility.

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
