### PR TITLE
fix: change trigger for adding PR labels to pull_request_target

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,5 +1,5 @@
 name: "Pull Request Labeler"
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   pr_ci_trigger:


### PR DESCRIPTION
This will enable that workflow to run on forks (aka PRs by contributors), too
