### PR TITLE
fix(provider-generator): Use registry.terraform.io links instead of old terraform.io

### DIFF
--- a/packages/@cdktf/hcl2cdk/lib/index.ts
+++ b/packages/@cdktf/hcl2cdk/lib/index.ts
@@ -40,6 +40,7 @@ import {
 } from "./iteration";
 import { getProviderRequirements } from "./provider";
 import { logger } from "./utils";
+import { FQPN } from "@cdktf/provider-generator/lib/get/generator/provider-schema";
 
 export const CODE_MARKER = "// define resources here";
 
@@ -95,7 +96,7 @@ export async function convertToTypescript(
         new CodeMaker(),
         providerSchema
       );
-      providerGenerator.buildResourceModels(fqpn);
+      providerGenerator.buildResourceModels(fqpn as FQPN); // can't use that type on the keys yet, since we are not on TS >=4.4 yet :sadcat:
       return { ...carry, [fqpn]: providerGenerator };
     }, {}),
     constructs: new Set<string>(),

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/complex-computed-types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/complex-computed-types.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`generate an acm certifacte resource with complex computed types: acm-certificate 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/acm_certificate
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -11,48 +11,48 @@ import * as cdktf from 'cdktf';
 
 export interface AcmCertificateConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/acm_certificate#certificate_authority_arn AcmCertificate#certificate_authority_arn}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate#certificate_authority_arn AcmCertificate#certificate_authority_arn}
   */
   readonly certificateAuthorityArn?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/acm_certificate#certificate_body AcmCertificate#certificate_body}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate#certificate_body AcmCertificate#certificate_body}
   */
   readonly certificateBody?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/acm_certificate#certificate_chain AcmCertificate#certificate_chain}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate#certificate_chain AcmCertificate#certificate_chain}
   */
   readonly certificateChain?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/acm_certificate#domain_name AcmCertificate#domain_name}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate#domain_name AcmCertificate#domain_name}
   */
   readonly domainName?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/acm_certificate#id AcmCertificate#id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate#id AcmCertificate#id}
   *
   * Please be aware that the id field is automatically added to all resources in Terraform providers using a Terraform provider SDK version below 2.
   * If you experience problems setting this value it might not be settable. Please take a look at the provider documentation to ensure it should be settable.
   */
   readonly id?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/acm_certificate#private_key AcmCertificate#private_key}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate#private_key AcmCertificate#private_key}
   */
   readonly privateKey?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/acm_certificate#subject_alternative_names AcmCertificate#subject_alternative_names}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate#subject_alternative_names AcmCertificate#subject_alternative_names}
   */
   readonly subjectAlternativeNames?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/acm_certificate#tags AcmCertificate#tags}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate#tags AcmCertificate#tags}
   */
   readonly tags?: { [key: string]: string };
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/acm_certificate#validation_method AcmCertificate#validation_method}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate#validation_method AcmCertificate#validation_method}
   */
   readonly validationMethod?: string;
   /**
   * options block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/acm_certificate#options AcmCertificate#options}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate#options AcmCertificate#options}
   */
   readonly options?: AcmCertificateOptions;
 }
@@ -137,7 +137,7 @@ export class AcmCertificateDomainValidationOptionsList extends cdktf.ComplexList
 }
 export interface AcmCertificateOptions {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/acm_certificate#certificate_transparency_logging_preference AcmCertificate#certificate_transparency_logging_preference}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate#certificate_transparency_logging_preference AcmCertificate#certificate_transparency_logging_preference}
   */
   readonly certificateTransparencyLoggingPreference?: string;
 }
@@ -202,7 +202,7 @@ export class AcmCertificateOptionsOutputReference extends cdktf.ComplexObject {
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/acm_certificate aws_acm_certificate}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate aws_acm_certificate}
 */
 export class AcmCertificate extends cdktf.TerraformResource {
 
@@ -216,7 +216,7 @@ export class AcmCertificate extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/acm_certificate aws_acm_certificate} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate aws_acm_certificate} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/description-escaping.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/description-escaping.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`broken attribute description comments 1`] = `
-"// https://www.terraform.io/docs/providers/google/r/description_escaping
+"// https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/description_escaping
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -17,13 +17,13 @@ export interface DescriptionEscapingConfig extends cdktf.TerraformMetaArguments 
  'roles/cloudkms.cryptoKeyEncrypterDecrypter' to use this feature. 
  The expected format is 'projects/*\\\\/locations/*\\\\/keyRings/*\\\\/cryptoKeys/*'
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/google/r/description_escaping#broken_comments DescriptionEscaping#broken_comments}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/description_escaping#broken_comments DescriptionEscaping#broken_comments}
   */
   readonly brokenComments: boolean | cdktf.IResolvable;
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/google/r/description_escaping description_escaping}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/description_escaping description_escaping}
 */
 export class DescriptionEscaping extends cdktf.TerraformResource {
 
@@ -37,7 +37,7 @@ export class DescriptionEscaping extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/google/r/description_escaping description_escaping} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/description_escaping description_escaping} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -91,7 +91,7 @@ export class DescriptionEscaping extends cdktf.TerraformResource {
 `;
 
 exports[`malformed code blocks which break in python rst 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/code_blocks
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/code_blocks
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -103,13 +103,13 @@ export interface CodeBlocksConfig extends cdktf.TerraformMetaArguments {
   /**
   * Here comes a code block \`\`\`foo.bar\`\`\` and here is more text.
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/code_blocks#with_code_block CodeBlocks#with_code_block}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/code_blocks#with_code_block CodeBlocks#with_code_block}
   */
   readonly withCodeBlock: boolean | cdktf.IResolvable;
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/code_blocks code_blocks}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/code_blocks code_blocks}
 */
 export class CodeBlocks extends cdktf.TerraformResource {
 
@@ -123,7 +123,7 @@ export class CodeBlocks extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/code_blocks code_blocks} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/code_blocks code_blocks} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/nested-types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/nested-types.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`generate a resource with nested types 1`] = `
-"// https://www.terraform.io/docs/providers/test/r/nested_types_resource
+"// https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/nested_types_resource
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -13,25 +13,25 @@ export interface NestedTypesResourceConfig extends cdktf.TerraformMetaArguments 
   /**
   * name of the resource
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/test/r/nested_types_resource#name NestedTypesResource#name}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/nested_types_resource#name NestedTypesResource#name}
   */
   readonly name?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/test/r/nested_types_resource#archive_rules NestedTypesResource#archive_rules}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/nested_types_resource#archive_rules NestedTypesResource#archive_rules}
   */
   readonly archiveRules?: NestedTypesResourceArchiveRules[] | cdktf.IResolvable;
 }
 export interface NestedTypesResourceArchiveRulesFilter {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/test/r/nested_types_resource#eq NestedTypesResource#eq}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/nested_types_resource#eq NestedTypesResource#eq}
   */
   readonly eq?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/test/r/nested_types_resource#exists NestedTypesResource#exists}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/nested_types_resource#exists NestedTypesResource#exists}
   */
   readonly exists?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/test/r/nested_types_resource#property NestedTypesResource#property}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/nested_types_resource#property NestedTypesResource#property}
   */
   readonly property: string;
 }
@@ -171,13 +171,13 @@ export class NestedTypesResourceArchiveRulesFilterList extends cdktf.ComplexList
 }
 export interface NestedTypesResourceArchiveRules {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/test/r/nested_types_resource#filter NestedTypesResource#filter}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/nested_types_resource#filter NestedTypesResource#filter}
   */
   readonly filter: NestedTypesResourceArchiveRulesFilter[] | cdktf.IResolvable;
   /**
   * The archive rule name
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/test/r/nested_types_resource#rule_name NestedTypesResource#rule_name}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/nested_types_resource#rule_name NestedTypesResource#rule_name}
   */
   readonly ruleName: string;
 }
@@ -291,7 +291,7 @@ export class NestedTypesResourceArchiveRulesList extends cdktf.ComplexList {
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/test/r/nested_types_resource nested_types_resource}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/nested_types_resource nested_types_resource}
 */
 export class NestedTypesResource extends cdktf.TerraformResource {
 
@@ -305,7 +305,7 @@ export class NestedTypesResource extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/test/r/nested_types_resource nested_types_resource} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/nested_types_resource nested_types_resource} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/provider.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/provider.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`generate provider 1`] = `
-"// https://www.terraform.io/docs/providers/aws
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -14,21 +14,21 @@ export interface AwsProviderConfig {
   * The access key for API operations. You can retrieve this
 from the 'Security & Credentials' section of the AWS console.
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#access_key AwsProvider#access_key}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#access_key AwsProvider#access_key}
   */
   readonly accessKey?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#allowed_account_ids AwsProvider#allowed_account_ids}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#allowed_account_ids AwsProvider#allowed_account_ids}
   */
   readonly allowedAccountIds?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#forbidden_account_ids AwsProvider#forbidden_account_ids}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#forbidden_account_ids AwsProvider#forbidden_account_ids}
   */
   readonly forbiddenAccountIds?: string[];
   /**
   * Explicitly allow the provider to perform \\"insecure\\" SSL requests. If omitted,default value is \`false\`
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#insecure AwsProvider#insecure}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#insecure AwsProvider#insecure}
   */
   readonly insecure?: boolean | cdktf.IResolvable;
   /**
@@ -36,21 +36,21 @@ from the 'Security & Credentials' section of the AWS console.
 being executed. If the API request still fails, an error is
 thrown.
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#max_retries AwsProvider#max_retries}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#max_retries AwsProvider#max_retries}
   */
   readonly maxRetries?: number;
   /**
   * The profile for API operations. If not set, the default profile
 created with \`aws configure\` will be used.
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#profile AwsProvider#profile}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#profile AwsProvider#profile}
   */
   readonly profile?: string;
   /**
   * The region where AWS operations will take place. Examples
 are us-east-1, us-west-2, etc.
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#region AwsProvider#region}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#region AwsProvider#region}
   */
   readonly region: string;
   /**
@@ -59,80 +59,80 @@ i.e., http://s3.amazonaws.com/BUCKET/KEY. By default, the S3 client will
 use virtual hosted bucket addressing when possible
 (http://BUCKET.s3.amazonaws.com/KEY). Specific to the Amazon S3 service.
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#s3_force_path_style AwsProvider#s3_force_path_style}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#s3_force_path_style AwsProvider#s3_force_path_style}
   */
   readonly s3ForcePathStyle?: boolean | cdktf.IResolvable;
   /**
   * The secret key for API operations. You can retrieve this
 from the 'Security & Credentials' section of the AWS console.
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#secret_key AwsProvider#secret_key}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#secret_key AwsProvider#secret_key}
   */
   readonly secretKey?: string;
   /**
   * The path to the shared credentials file. If not set
 this defaults to ~/.aws/credentials.
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#shared_credentials_file AwsProvider#shared_credentials_file}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#shared_credentials_file AwsProvider#shared_credentials_file}
   */
   readonly sharedCredentialsFile?: string;
   /**
   * Skip the credentials validation via STS API. Used for AWS API implementations that do not have STS available/implemented.
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#skip_credentials_validation AwsProvider#skip_credentials_validation}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#skip_credentials_validation AwsProvider#skip_credentials_validation}
   */
   readonly skipCredentialsValidation?: boolean | cdktf.IResolvable;
   /**
   * Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions.
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#skip_get_ec2_platforms AwsProvider#skip_get_ec2_platforms}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#skip_get_ec2_platforms AwsProvider#skip_get_ec2_platforms}
   */
   readonly skipGetEc2Platforms?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#skip_metadata_api_check AwsProvider#skip_metadata_api_check}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#skip_metadata_api_check AwsProvider#skip_metadata_api_check}
   */
   readonly skipMetadataApiCheck?: boolean | cdktf.IResolvable;
   /**
   * Skip static validation of region name. Used by users of alternative AWS-like APIs or users w/ access to regions that are not public (yet).
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#skip_region_validation AwsProvider#skip_region_validation}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#skip_region_validation AwsProvider#skip_region_validation}
   */
   readonly skipRegionValidation?: boolean | cdktf.IResolvable;
   /**
   * Skip requesting the account ID. Used for AWS API implementations that do not have IAM/STS API and/or metadata API.
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#skip_requesting_account_id AwsProvider#skip_requesting_account_id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#skip_requesting_account_id AwsProvider#skip_requesting_account_id}
   */
   readonly skipRequestingAccountId?: boolean | cdktf.IResolvable;
   /**
   * session token. A session token is only required if you are
 using temporary security credentials.
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#token AwsProvider#token}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#token AwsProvider#token}
   */
   readonly token?: string;
   /**
   * Alias name
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#alias AwsProvider#alias}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#alias AwsProvider#alias}
   */
   readonly alias?: string;
   /**
   * assume_role block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#assume_role AwsProvider#assume_role}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#assume_role AwsProvider#assume_role}
   */
   readonly assumeRole?: AwsProviderAssumeRole;
   /**
   * endpoints block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#endpoints AwsProvider#endpoints}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#endpoints AwsProvider#endpoints}
   */
   readonly endpoints?: AwsProviderEndpoints[] | cdktf.IResolvable;
   /**
   * ignore_tags block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#ignore_tags AwsProvider#ignore_tags}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#ignore_tags AwsProvider#ignore_tags}
   */
   readonly ignoreTags?: AwsProviderIgnoreTags;
 }
@@ -140,25 +140,25 @@ export interface AwsProviderAssumeRole {
   /**
   * The external ID to use when assuming the role. If omitted, no external ID is passed to the AssumeRole call.
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#external_id AwsProvider#external_id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#external_id AwsProvider#external_id}
   */
   readonly externalId?: string;
   /**
   * The permissions applied when assuming a role. You cannot use, this policy to grant further permissions that are in excess to those of the,  role that is being assumed.
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#policy AwsProvider#policy}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#policy AwsProvider#policy}
   */
   readonly policy?: string;
   /**
   * The ARN of an IAM role to assume prior to making API calls.
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#role_arn AwsProvider#role_arn}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#role_arn AwsProvider#role_arn}
   */
   readonly roleArn?: string;
   /**
   * The session name to use when assuming the role. If omitted, no session name is passed to the AssumeRole call.
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#session_name AwsProvider#session_name}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#session_name AwsProvider#session_name}
   */
   readonly sessionName?: string;
 }
@@ -180,811 +180,811 @@ export interface AwsProviderEndpoints {
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#accessanalyzer AwsProvider#accessanalyzer}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#accessanalyzer AwsProvider#accessanalyzer}
   */
   readonly accessanalyzer?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#acm AwsProvider#acm}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#acm AwsProvider#acm}
   */
   readonly acm?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#acmpca AwsProvider#acmpca}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#acmpca AwsProvider#acmpca}
   */
   readonly acmpca?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#amplify AwsProvider#amplify}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#amplify AwsProvider#amplify}
   */
   readonly amplify?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#apigateway AwsProvider#apigateway}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#apigateway AwsProvider#apigateway}
   */
   readonly apigateway?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#applicationautoscaling AwsProvider#applicationautoscaling}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#applicationautoscaling AwsProvider#applicationautoscaling}
   */
   readonly applicationautoscaling?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#applicationinsights AwsProvider#applicationinsights}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#applicationinsights AwsProvider#applicationinsights}
   */
   readonly applicationinsights?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#appmesh AwsProvider#appmesh}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#appmesh AwsProvider#appmesh}
   */
   readonly appmesh?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#appstream AwsProvider#appstream}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#appstream AwsProvider#appstream}
   */
   readonly appstream?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#appsync AwsProvider#appsync}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#appsync AwsProvider#appsync}
   */
   readonly appsync?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#athena AwsProvider#athena}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#athena AwsProvider#athena}
   */
   readonly athena?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#autoscaling AwsProvider#autoscaling}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#autoscaling AwsProvider#autoscaling}
   */
   readonly autoscaling?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#autoscalingplans AwsProvider#autoscalingplans}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#autoscalingplans AwsProvider#autoscalingplans}
   */
   readonly autoscalingplans?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#backup AwsProvider#backup}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#backup AwsProvider#backup}
   */
   readonly backup?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#batch AwsProvider#batch}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#batch AwsProvider#batch}
   */
   readonly batch?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#budgets AwsProvider#budgets}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#budgets AwsProvider#budgets}
   */
   readonly budgets?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#cloud9 AwsProvider#cloud9}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#cloud9 AwsProvider#cloud9}
   */
   readonly cloud9?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#cloudformation AwsProvider#cloudformation}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#cloudformation AwsProvider#cloudformation}
   */
   readonly cloudformation?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#cloudfront AwsProvider#cloudfront}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#cloudfront AwsProvider#cloudfront}
   */
   readonly cloudfront?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#cloudhsm AwsProvider#cloudhsm}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#cloudhsm AwsProvider#cloudhsm}
   */
   readonly cloudhsm?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#cloudsearch AwsProvider#cloudsearch}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#cloudsearch AwsProvider#cloudsearch}
   */
   readonly cloudsearch?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#cloudtrail AwsProvider#cloudtrail}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#cloudtrail AwsProvider#cloudtrail}
   */
   readonly cloudtrail?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#cloudwatch AwsProvider#cloudwatch}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#cloudwatch AwsProvider#cloudwatch}
   */
   readonly cloudwatch?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#cloudwatchevents AwsProvider#cloudwatchevents}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#cloudwatchevents AwsProvider#cloudwatchevents}
   */
   readonly cloudwatchevents?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#cloudwatchlogs AwsProvider#cloudwatchlogs}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#cloudwatchlogs AwsProvider#cloudwatchlogs}
   */
   readonly cloudwatchlogs?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#codebuild AwsProvider#codebuild}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#codebuild AwsProvider#codebuild}
   */
   readonly codebuild?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#codecommit AwsProvider#codecommit}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#codecommit AwsProvider#codecommit}
   */
   readonly codecommit?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#codedeploy AwsProvider#codedeploy}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#codedeploy AwsProvider#codedeploy}
   */
   readonly codedeploy?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#codepipeline AwsProvider#codepipeline}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#codepipeline AwsProvider#codepipeline}
   */
   readonly codepipeline?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#cognitoidentity AwsProvider#cognitoidentity}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#cognitoidentity AwsProvider#cognitoidentity}
   */
   readonly cognitoidentity?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#cognitoidp AwsProvider#cognitoidp}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#cognitoidp AwsProvider#cognitoidp}
   */
   readonly cognitoidp?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#configservice AwsProvider#configservice}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#configservice AwsProvider#configservice}
   */
   readonly configservice?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#cur AwsProvider#cur}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#cur AwsProvider#cur}
   */
   readonly cur?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#dataexchange AwsProvider#dataexchange}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#dataexchange AwsProvider#dataexchange}
   */
   readonly dataexchange?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#datapipeline AwsProvider#datapipeline}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#datapipeline AwsProvider#datapipeline}
   */
   readonly datapipeline?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#datasync AwsProvider#datasync}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#datasync AwsProvider#datasync}
   */
   readonly datasync?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#dax AwsProvider#dax}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#dax AwsProvider#dax}
   */
   readonly dax?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#devicefarm AwsProvider#devicefarm}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#devicefarm AwsProvider#devicefarm}
   */
   readonly devicefarm?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#directconnect AwsProvider#directconnect}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#directconnect AwsProvider#directconnect}
   */
   readonly directconnect?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#dlm AwsProvider#dlm}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#dlm AwsProvider#dlm}
   */
   readonly dlm?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#dms AwsProvider#dms}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#dms AwsProvider#dms}
   */
   readonly dms?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#docdb AwsProvider#docdb}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#docdb AwsProvider#docdb}
   */
   readonly docdb?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#ds AwsProvider#ds}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#ds AwsProvider#ds}
   */
   readonly ds?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#dynamodb AwsProvider#dynamodb}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#dynamodb AwsProvider#dynamodb}
   */
   readonly dynamodb?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#ec2 AwsProvider#ec2}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#ec2 AwsProvider#ec2}
   */
   readonly ec2?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#ecr AwsProvider#ecr}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#ecr AwsProvider#ecr}
   */
   readonly ecr?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#ecs AwsProvider#ecs}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#ecs AwsProvider#ecs}
   */
   readonly ecs?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#efs AwsProvider#efs}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#efs AwsProvider#efs}
   */
   readonly efs?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#eks AwsProvider#eks}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#eks AwsProvider#eks}
   */
   readonly eks?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#elasticache AwsProvider#elasticache}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#elasticache AwsProvider#elasticache}
   */
   readonly elasticache?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#elasticbeanstalk AwsProvider#elasticbeanstalk}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#elasticbeanstalk AwsProvider#elasticbeanstalk}
   */
   readonly elasticbeanstalk?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#elastictranscoder AwsProvider#elastictranscoder}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#elastictranscoder AwsProvider#elastictranscoder}
   */
   readonly elastictranscoder?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#elb AwsProvider#elb}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#elb AwsProvider#elb}
   */
   readonly elb?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#emr AwsProvider#emr}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#emr AwsProvider#emr}
   */
   readonly emr?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#es AwsProvider#es}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#es AwsProvider#es}
   */
   readonly es?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#firehose AwsProvider#firehose}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#firehose AwsProvider#firehose}
   */
   readonly firehose?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#fms AwsProvider#fms}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#fms AwsProvider#fms}
   */
   readonly fms?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#forecast AwsProvider#forecast}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#forecast AwsProvider#forecast}
   */
   readonly forecast?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#fsx AwsProvider#fsx}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#fsx AwsProvider#fsx}
   */
   readonly fsx?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#gamelift AwsProvider#gamelift}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#gamelift AwsProvider#gamelift}
   */
   readonly gamelift?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#glacier AwsProvider#glacier}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#glacier AwsProvider#glacier}
   */
   readonly glacier?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#globalaccelerator AwsProvider#globalaccelerator}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#globalaccelerator AwsProvider#globalaccelerator}
   */
   readonly globalaccelerator?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#glue AwsProvider#glue}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#glue AwsProvider#glue}
   */
   readonly glue?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#greengrass AwsProvider#greengrass}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#greengrass AwsProvider#greengrass}
   */
   readonly greengrass?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#guardduty AwsProvider#guardduty}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#guardduty AwsProvider#guardduty}
   */
   readonly guardduty?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#iam AwsProvider#iam}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#iam AwsProvider#iam}
   */
   readonly iam?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#imagebuilder AwsProvider#imagebuilder}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#imagebuilder AwsProvider#imagebuilder}
   */
   readonly imagebuilder?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#inspector AwsProvider#inspector}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#inspector AwsProvider#inspector}
   */
   readonly inspector?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#iot AwsProvider#iot}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#iot AwsProvider#iot}
   */
   readonly iot?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#iotanalytics AwsProvider#iotanalytics}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#iotanalytics AwsProvider#iotanalytics}
   */
   readonly iotanalytics?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#iotevents AwsProvider#iotevents}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#iotevents AwsProvider#iotevents}
   */
   readonly iotevents?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#kafka AwsProvider#kafka}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#kafka AwsProvider#kafka}
   */
   readonly kafka?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#kinesis AwsProvider#kinesis}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#kinesis AwsProvider#kinesis}
   */
   readonly kinesis?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#kinesis_analytics AwsProvider#kinesis_analytics}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#kinesis_analytics AwsProvider#kinesis_analytics}
   */
   readonly kinesisAnalytics?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#kinesisanalytics AwsProvider#kinesisanalytics}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#kinesisanalytics AwsProvider#kinesisanalytics}
   */
   readonly kinesisanalytics?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#kinesisvideo AwsProvider#kinesisvideo}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#kinesisvideo AwsProvider#kinesisvideo}
   */
   readonly kinesisvideo?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#kms AwsProvider#kms}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#kms AwsProvider#kms}
   */
   readonly kms?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#lakeformation AwsProvider#lakeformation}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#lakeformation AwsProvider#lakeformation}
   */
   readonly lakeformation?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#lambda AwsProvider#lambda}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#lambda AwsProvider#lambda}
   */
   readonly lambda?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#lexmodels AwsProvider#lexmodels}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#lexmodels AwsProvider#lexmodels}
   */
   readonly lexmodels?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#licensemanager AwsProvider#licensemanager}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#licensemanager AwsProvider#licensemanager}
   */
   readonly licensemanager?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#lightsail AwsProvider#lightsail}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#lightsail AwsProvider#lightsail}
   */
   readonly lightsail?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#macie AwsProvider#macie}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#macie AwsProvider#macie}
   */
   readonly macie?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#managedblockchain AwsProvider#managedblockchain}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#managedblockchain AwsProvider#managedblockchain}
   */
   readonly managedblockchain?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#marketplacecatalog AwsProvider#marketplacecatalog}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#marketplacecatalog AwsProvider#marketplacecatalog}
   */
   readonly marketplacecatalog?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#mediaconnect AwsProvider#mediaconnect}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#mediaconnect AwsProvider#mediaconnect}
   */
   readonly mediaconnect?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#mediaconvert AwsProvider#mediaconvert}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#mediaconvert AwsProvider#mediaconvert}
   */
   readonly mediaconvert?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#medialive AwsProvider#medialive}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#medialive AwsProvider#medialive}
   */
   readonly medialive?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#mediapackage AwsProvider#mediapackage}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#mediapackage AwsProvider#mediapackage}
   */
   readonly mediapackage?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#mediastore AwsProvider#mediastore}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#mediastore AwsProvider#mediastore}
   */
   readonly mediastore?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#mediastoredata AwsProvider#mediastoredata}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#mediastoredata AwsProvider#mediastoredata}
   */
   readonly mediastoredata?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#mq AwsProvider#mq}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#mq AwsProvider#mq}
   */
   readonly mq?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#neptune AwsProvider#neptune}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#neptune AwsProvider#neptune}
   */
   readonly neptune?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#opsworks AwsProvider#opsworks}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#opsworks AwsProvider#opsworks}
   */
   readonly opsworks?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#organizations AwsProvider#organizations}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#organizations AwsProvider#organizations}
   */
   readonly organizations?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#personalize AwsProvider#personalize}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#personalize AwsProvider#personalize}
   */
   readonly personalize?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#pinpoint AwsProvider#pinpoint}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#pinpoint AwsProvider#pinpoint}
   */
   readonly pinpoint?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#pricing AwsProvider#pricing}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#pricing AwsProvider#pricing}
   */
   readonly pricing?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#qldb AwsProvider#qldb}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#qldb AwsProvider#qldb}
   */
   readonly qldb?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#quicksight AwsProvider#quicksight}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#quicksight AwsProvider#quicksight}
   */
   readonly quicksight?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#r53 AwsProvider#r53}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#r53 AwsProvider#r53}
   */
   readonly r53?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#ram AwsProvider#ram}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#ram AwsProvider#ram}
   */
   readonly ram?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#rds AwsProvider#rds}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#rds AwsProvider#rds}
   */
   readonly rds?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#redshift AwsProvider#redshift}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#redshift AwsProvider#redshift}
   */
   readonly redshift?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#resourcegroups AwsProvider#resourcegroups}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#resourcegroups AwsProvider#resourcegroups}
   */
   readonly resourcegroups?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#route53 AwsProvider#route53}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#route53 AwsProvider#route53}
   */
   readonly route53?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#route53domains AwsProvider#route53domains}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#route53domains AwsProvider#route53domains}
   */
   readonly route53Domains?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#route53resolver AwsProvider#route53resolver}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#route53resolver AwsProvider#route53resolver}
   */
   readonly route53Resolver?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#s3 AwsProvider#s3}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#s3 AwsProvider#s3}
   */
   readonly s3?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#s3control AwsProvider#s3control}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#s3control AwsProvider#s3control}
   */
   readonly s3Control?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#sagemaker AwsProvider#sagemaker}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#sagemaker AwsProvider#sagemaker}
   */
   readonly sagemaker?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#sdb AwsProvider#sdb}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#sdb AwsProvider#sdb}
   */
   readonly sdb?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#secretsmanager AwsProvider#secretsmanager}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#secretsmanager AwsProvider#secretsmanager}
   */
   readonly secretsmanager?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#securityhub AwsProvider#securityhub}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#securityhub AwsProvider#securityhub}
   */
   readonly securityhub?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#serverlessrepo AwsProvider#serverlessrepo}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#serverlessrepo AwsProvider#serverlessrepo}
   */
   readonly serverlessrepo?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#servicecatalog AwsProvider#servicecatalog}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#servicecatalog AwsProvider#servicecatalog}
   */
   readonly servicecatalog?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#servicediscovery AwsProvider#servicediscovery}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#servicediscovery AwsProvider#servicediscovery}
   */
   readonly servicediscovery?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#servicequotas AwsProvider#servicequotas}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#servicequotas AwsProvider#servicequotas}
   */
   readonly servicequotas?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#ses AwsProvider#ses}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#ses AwsProvider#ses}
   */
   readonly ses?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#shield AwsProvider#shield}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#shield AwsProvider#shield}
   */
   readonly shield?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#sns AwsProvider#sns}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#sns AwsProvider#sns}
   */
   readonly sns?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#sqs AwsProvider#sqs}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#sqs AwsProvider#sqs}
   */
   readonly sqs?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#ssm AwsProvider#ssm}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#ssm AwsProvider#ssm}
   */
   readonly ssm?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#stepfunctions AwsProvider#stepfunctions}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#stepfunctions AwsProvider#stepfunctions}
   */
   readonly stepfunctions?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#storagegateway AwsProvider#storagegateway}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#storagegateway AwsProvider#storagegateway}
   */
   readonly storagegateway?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#sts AwsProvider#sts}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#sts AwsProvider#sts}
   */
   readonly sts?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#swf AwsProvider#swf}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#swf AwsProvider#swf}
   */
   readonly swf?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#transfer AwsProvider#transfer}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#transfer AwsProvider#transfer}
   */
   readonly transfer?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#waf AwsProvider#waf}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#waf AwsProvider#waf}
   */
   readonly waf?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#wafregional AwsProvider#wafregional}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#wafregional AwsProvider#wafregional}
   */
   readonly wafregional?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#wafv2 AwsProvider#wafv2}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#wafv2 AwsProvider#wafv2}
   */
   readonly wafv2?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#worklink AwsProvider#worklink}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#worklink AwsProvider#worklink}
   */
   readonly worklink?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#workmail AwsProvider#workmail}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#workmail AwsProvider#workmail}
   */
   readonly workmail?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#workspaces AwsProvider#workspaces}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#workspaces AwsProvider#workspaces}
   */
   readonly workspaces?: string;
   /**
   * Use this to override the default service endpoint URL
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#xray AwsProvider#xray}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#xray AwsProvider#xray}
   */
   readonly xray?: string;
 }
@@ -1137,13 +1137,13 @@ export interface AwsProviderIgnoreTags {
   /**
   * Resource tag key prefixes to ignore across all resources.
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#key_prefixes AwsProvider#key_prefixes}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#key_prefixes AwsProvider#key_prefixes}
   */
   readonly keyPrefixes?: string[];
   /**
   * Resource tag keys to ignore across all resources.
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws#keys AwsProvider#keys}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs#keys AwsProvider#keys}
   */
   readonly keys?: string[];
 }
@@ -1161,7 +1161,7 @@ export function awsProviderIgnoreTagsToTerraform(struct?: AwsProviderIgnoreTags)
 
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws aws}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs aws}
 */
 export class AwsProvider extends cdktf.TerraformProvider {
 
@@ -1175,7 +1175,7 @@ export class AwsProvider extends cdktf.TerraformProvider {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws aws} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs aws} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -1187,7 +1187,7 @@ export class AwsProvider extends cdktf.TerraformProvider {
       terraformGeneratorMetadata: {
         providerName: 'aws'
       },
-      terraformProviderSource: 'aws'
+      terraformProviderSource: 'registry.terraform.io/hashicorp/aws'
     });
     this._accessKey = config.accessKey;
     this._allowedAccountIds = config.allowedAccountIds;

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/resource-types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/resource-types.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`generate a cloudfront distribution resource: cloudfront 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -11,118 +11,118 @@ import * as cdktf from 'cdktf';
 
 export interface CloudfrontDistributionConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#aliases CloudfrontDistribution#aliases}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#aliases CloudfrontDistribution#aliases}
   */
   readonly aliases?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#comment CloudfrontDistribution#comment}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#comment CloudfrontDistribution#comment}
   */
   readonly comment?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#default_root_object CloudfrontDistribution#default_root_object}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#default_root_object CloudfrontDistribution#default_root_object}
   */
   readonly defaultRootObject?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#enabled CloudfrontDistribution#enabled}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#enabled CloudfrontDistribution#enabled}
   */
   readonly enabled: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#http_version CloudfrontDistribution#http_version}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#http_version CloudfrontDistribution#http_version}
   */
   readonly httpVersion?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#id CloudfrontDistribution#id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#id CloudfrontDistribution#id}
   *
   * Please be aware that the id field is automatically added to all resources in Terraform providers using a Terraform provider SDK version below 2.
   * If you experience problems setting this value it might not be settable. Please take a look at the provider documentation to ensure it should be settable.
   */
   readonly id?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#is_ipv6_enabled CloudfrontDistribution#is_ipv6_enabled}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#is_ipv6_enabled CloudfrontDistribution#is_ipv6_enabled}
   */
   readonly isIpv6Enabled?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#price_class CloudfrontDistribution#price_class}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#price_class CloudfrontDistribution#price_class}
   */
   readonly priceClass?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#retain_on_delete CloudfrontDistribution#retain_on_delete}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#retain_on_delete CloudfrontDistribution#retain_on_delete}
   */
   readonly retainOnDelete?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#tags CloudfrontDistribution#tags}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#tags CloudfrontDistribution#tags}
   */
   readonly tags?: { [key: string]: string };
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#wait_for_deployment CloudfrontDistribution#wait_for_deployment}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#wait_for_deployment CloudfrontDistribution#wait_for_deployment}
   */
   readonly waitForDeployment?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#web_acl_id CloudfrontDistribution#web_acl_id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#web_acl_id CloudfrontDistribution#web_acl_id}
   */
   readonly webAclId?: string;
   /**
   * cache_behavior block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#cache_behavior CloudfrontDistribution#cache_behavior}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#cache_behavior CloudfrontDistribution#cache_behavior}
   */
   readonly cacheBehavior?: CloudfrontDistributionCacheBehavior[] | cdktf.IResolvable;
   /**
   * custom_error_response block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#custom_error_response CloudfrontDistribution#custom_error_response}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#custom_error_response CloudfrontDistribution#custom_error_response}
   */
   readonly customErrorResponse?: CloudfrontDistributionCustomErrorResponse[] | cdktf.IResolvable;
   /**
   * default_cache_behavior block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#default_cache_behavior CloudfrontDistribution#default_cache_behavior}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#default_cache_behavior CloudfrontDistribution#default_cache_behavior}
   */
   readonly defaultCacheBehavior: CloudfrontDistributionDefaultCacheBehavior;
   /**
   * logging_config block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#logging_config CloudfrontDistribution#logging_config}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#logging_config CloudfrontDistribution#logging_config}
   */
   readonly loggingConfig?: CloudfrontDistributionLoggingConfig;
   /**
   * ordered_cache_behavior block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#ordered_cache_behavior CloudfrontDistribution#ordered_cache_behavior}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#ordered_cache_behavior CloudfrontDistribution#ordered_cache_behavior}
   */
   readonly orderedCacheBehavior?: CloudfrontDistributionOrderedCacheBehavior[] | cdktf.IResolvable;
   /**
   * origin block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#origin CloudfrontDistribution#origin}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#origin CloudfrontDistribution#origin}
   */
   readonly origin: CloudfrontDistributionOrigin[] | cdktf.IResolvable;
   /**
   * origin_group block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#origin_group CloudfrontDistribution#origin_group}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#origin_group CloudfrontDistribution#origin_group}
   */
   readonly originGroup?: CloudfrontDistributionOriginGroup[] | cdktf.IResolvable;
   /**
   * restrictions block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#restrictions CloudfrontDistribution#restrictions}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#restrictions CloudfrontDistribution#restrictions}
   */
   readonly restrictions: CloudfrontDistributionRestrictions;
   /**
   * viewer_certificate block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#viewer_certificate CloudfrontDistribution#viewer_certificate}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#viewer_certificate CloudfrontDistribution#viewer_certificate}
   */
   readonly viewerCertificate: CloudfrontDistributionViewerCertificate;
 }
 export interface CloudfrontDistributionCacheBehaviorForwardedValuesCookies {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#forward CloudfrontDistribution#forward}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#forward CloudfrontDistribution#forward}
   */
   readonly forward: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#whitelisted_names CloudfrontDistribution#whitelisted_names}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#whitelisted_names CloudfrontDistribution#whitelisted_names}
   */
   readonly whitelistedNames?: string[];
 }
@@ -207,21 +207,21 @@ export class CloudfrontDistributionCacheBehaviorForwardedValuesCookiesOutputRefe
 }
 export interface CloudfrontDistributionCacheBehaviorForwardedValues {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#headers CloudfrontDistribution#headers}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#headers CloudfrontDistribution#headers}
   */
   readonly headers?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#query_string CloudfrontDistribution#query_string}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#query_string CloudfrontDistribution#query_string}
   */
   readonly queryString: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#query_string_cache_keys CloudfrontDistribution#query_string_cache_keys}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#query_string_cache_keys CloudfrontDistribution#query_string_cache_keys}
   */
   readonly queryStringCacheKeys?: string[];
   /**
   * cookies block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#cookies CloudfrontDistribution#cookies}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#cookies CloudfrontDistribution#cookies}
   */
   readonly cookies: CloudfrontDistributionCacheBehaviorForwardedValuesCookies;
 }
@@ -349,15 +349,15 @@ export class CloudfrontDistributionCacheBehaviorForwardedValuesOutputReference e
 }
 export interface CloudfrontDistributionCacheBehaviorLambdaFunctionAssociation {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#event_type CloudfrontDistribution#event_type}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#event_type CloudfrontDistribution#event_type}
   */
   readonly eventType: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#include_body CloudfrontDistribution#include_body}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#include_body CloudfrontDistribution#include_body}
   */
   readonly includeBody?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#lambda_arn CloudfrontDistribution#lambda_arn}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#lambda_arn CloudfrontDistribution#lambda_arn}
   */
   readonly lambdaArn: string;
 }
@@ -494,63 +494,63 @@ export class CloudfrontDistributionCacheBehaviorLambdaFunctionAssociationList ex
 }
 export interface CloudfrontDistributionCacheBehavior {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#allowed_methods CloudfrontDistribution#allowed_methods}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#allowed_methods CloudfrontDistribution#allowed_methods}
   */
   readonly allowedMethods: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#cached_methods CloudfrontDistribution#cached_methods}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#cached_methods CloudfrontDistribution#cached_methods}
   */
   readonly cachedMethods: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#compress CloudfrontDistribution#compress}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#compress CloudfrontDistribution#compress}
   */
   readonly compress?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#default_ttl CloudfrontDistribution#default_ttl}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#default_ttl CloudfrontDistribution#default_ttl}
   */
   readonly defaultTtl?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#field_level_encryption_id CloudfrontDistribution#field_level_encryption_id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#field_level_encryption_id CloudfrontDistribution#field_level_encryption_id}
   */
   readonly fieldLevelEncryptionId?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#max_ttl CloudfrontDistribution#max_ttl}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#max_ttl CloudfrontDistribution#max_ttl}
   */
   readonly maxTtl?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#min_ttl CloudfrontDistribution#min_ttl}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#min_ttl CloudfrontDistribution#min_ttl}
   */
   readonly minTtl?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#path_pattern CloudfrontDistribution#path_pattern}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#path_pattern CloudfrontDistribution#path_pattern}
   */
   readonly pathPattern: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#smooth_streaming CloudfrontDistribution#smooth_streaming}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#smooth_streaming CloudfrontDistribution#smooth_streaming}
   */
   readonly smoothStreaming?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#target_origin_id CloudfrontDistribution#target_origin_id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#target_origin_id CloudfrontDistribution#target_origin_id}
   */
   readonly targetOriginId: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#trusted_signers CloudfrontDistribution#trusted_signers}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#trusted_signers CloudfrontDistribution#trusted_signers}
   */
   readonly trustedSigners?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#viewer_protocol_policy CloudfrontDistribution#viewer_protocol_policy}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#viewer_protocol_policy CloudfrontDistribution#viewer_protocol_policy}
   */
   readonly viewerProtocolPolicy: string;
   /**
   * forwarded_values block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#forwarded_values CloudfrontDistribution#forwarded_values}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#forwarded_values CloudfrontDistribution#forwarded_values}
   */
   readonly forwardedValues: CloudfrontDistributionCacheBehaviorForwardedValues;
   /**
   * lambda_function_association block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#lambda_function_association CloudfrontDistribution#lambda_function_association}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#lambda_function_association CloudfrontDistribution#lambda_function_association}
   */
   readonly lambdaFunctionAssociation?: CloudfrontDistributionCacheBehaviorLambdaFunctionAssociation[] | cdktf.IResolvable;
 }
@@ -928,19 +928,19 @@ export class CloudfrontDistributionCacheBehaviorList extends cdktf.ComplexList {
 }
 export interface CloudfrontDistributionCustomErrorResponse {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#error_caching_min_ttl CloudfrontDistribution#error_caching_min_ttl}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#error_caching_min_ttl CloudfrontDistribution#error_caching_min_ttl}
   */
   readonly errorCachingMinTtl?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#error_code CloudfrontDistribution#error_code}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#error_code CloudfrontDistribution#error_code}
   */
   readonly errorCode: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#response_code CloudfrontDistribution#response_code}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#response_code CloudfrontDistribution#response_code}
   */
   readonly responseCode?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#response_page_path CloudfrontDistribution#response_page_path}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#response_page_path CloudfrontDistribution#response_page_path}
   */
   readonly responsePagePath?: string;
 }
@@ -1103,11 +1103,11 @@ export class CloudfrontDistributionCustomErrorResponseList extends cdktf.Complex
 }
 export interface CloudfrontDistributionDefaultCacheBehaviorForwardedValuesCookies {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#forward CloudfrontDistribution#forward}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#forward CloudfrontDistribution#forward}
   */
   readonly forward: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#whitelisted_names CloudfrontDistribution#whitelisted_names}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#whitelisted_names CloudfrontDistribution#whitelisted_names}
   */
   readonly whitelistedNames?: string[];
 }
@@ -1192,21 +1192,21 @@ export class CloudfrontDistributionDefaultCacheBehaviorForwardedValuesCookiesOut
 }
 export interface CloudfrontDistributionDefaultCacheBehaviorForwardedValues {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#headers CloudfrontDistribution#headers}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#headers CloudfrontDistribution#headers}
   */
   readonly headers?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#query_string CloudfrontDistribution#query_string}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#query_string CloudfrontDistribution#query_string}
   */
   readonly queryString: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#query_string_cache_keys CloudfrontDistribution#query_string_cache_keys}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#query_string_cache_keys CloudfrontDistribution#query_string_cache_keys}
   */
   readonly queryStringCacheKeys?: string[];
   /**
   * cookies block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#cookies CloudfrontDistribution#cookies}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#cookies CloudfrontDistribution#cookies}
   */
   readonly cookies: CloudfrontDistributionDefaultCacheBehaviorForwardedValuesCookies;
 }
@@ -1334,15 +1334,15 @@ export class CloudfrontDistributionDefaultCacheBehaviorForwardedValuesOutputRefe
 }
 export interface CloudfrontDistributionDefaultCacheBehaviorLambdaFunctionAssociation {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#event_type CloudfrontDistribution#event_type}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#event_type CloudfrontDistribution#event_type}
   */
   readonly eventType: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#include_body CloudfrontDistribution#include_body}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#include_body CloudfrontDistribution#include_body}
   */
   readonly includeBody?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#lambda_arn CloudfrontDistribution#lambda_arn}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#lambda_arn CloudfrontDistribution#lambda_arn}
   */
   readonly lambdaArn: string;
 }
@@ -1479,59 +1479,59 @@ export class CloudfrontDistributionDefaultCacheBehaviorLambdaFunctionAssociation
 }
 export interface CloudfrontDistributionDefaultCacheBehavior {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#allowed_methods CloudfrontDistribution#allowed_methods}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#allowed_methods CloudfrontDistribution#allowed_methods}
   */
   readonly allowedMethods: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#cached_methods CloudfrontDistribution#cached_methods}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#cached_methods CloudfrontDistribution#cached_methods}
   */
   readonly cachedMethods: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#compress CloudfrontDistribution#compress}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#compress CloudfrontDistribution#compress}
   */
   readonly compress?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#default_ttl CloudfrontDistribution#default_ttl}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#default_ttl CloudfrontDistribution#default_ttl}
   */
   readonly defaultTtl?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#field_level_encryption_id CloudfrontDistribution#field_level_encryption_id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#field_level_encryption_id CloudfrontDistribution#field_level_encryption_id}
   */
   readonly fieldLevelEncryptionId?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#max_ttl CloudfrontDistribution#max_ttl}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#max_ttl CloudfrontDistribution#max_ttl}
   */
   readonly maxTtl?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#min_ttl CloudfrontDistribution#min_ttl}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#min_ttl CloudfrontDistribution#min_ttl}
   */
   readonly minTtl?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#smooth_streaming CloudfrontDistribution#smooth_streaming}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#smooth_streaming CloudfrontDistribution#smooth_streaming}
   */
   readonly smoothStreaming?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#target_origin_id CloudfrontDistribution#target_origin_id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#target_origin_id CloudfrontDistribution#target_origin_id}
   */
   readonly targetOriginId: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#trusted_signers CloudfrontDistribution#trusted_signers}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#trusted_signers CloudfrontDistribution#trusted_signers}
   */
   readonly trustedSigners?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#viewer_protocol_policy CloudfrontDistribution#viewer_protocol_policy}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#viewer_protocol_policy CloudfrontDistribution#viewer_protocol_policy}
   */
   readonly viewerProtocolPolicy: string;
   /**
   * forwarded_values block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#forwarded_values CloudfrontDistribution#forwarded_values}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#forwarded_values CloudfrontDistribution#forwarded_values}
   */
   readonly forwardedValues: CloudfrontDistributionDefaultCacheBehaviorForwardedValues;
   /**
   * lambda_function_association block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#lambda_function_association CloudfrontDistribution#lambda_function_association}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#lambda_function_association CloudfrontDistribution#lambda_function_association}
   */
   readonly lambdaFunctionAssociation?: CloudfrontDistributionDefaultCacheBehaviorLambdaFunctionAssociation[] | cdktf.IResolvable;
 }
@@ -1857,15 +1857,15 @@ export class CloudfrontDistributionDefaultCacheBehaviorOutputReference extends c
 }
 export interface CloudfrontDistributionLoggingConfig {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#bucket CloudfrontDistribution#bucket}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#bucket CloudfrontDistribution#bucket}
   */
   readonly bucket: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#include_cookies CloudfrontDistribution#include_cookies}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#include_cookies CloudfrontDistribution#include_cookies}
   */
   readonly includeCookies?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#prefix CloudfrontDistribution#prefix}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#prefix CloudfrontDistribution#prefix}
   */
   readonly prefix?: string;
 }
@@ -1973,11 +1973,11 @@ export class CloudfrontDistributionLoggingConfigOutputReference extends cdktf.Co
 }
 export interface CloudfrontDistributionOrderedCacheBehaviorForwardedValuesCookies {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#forward CloudfrontDistribution#forward}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#forward CloudfrontDistribution#forward}
   */
   readonly forward: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#whitelisted_names CloudfrontDistribution#whitelisted_names}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#whitelisted_names CloudfrontDistribution#whitelisted_names}
   */
   readonly whitelistedNames?: string[];
 }
@@ -2062,21 +2062,21 @@ export class CloudfrontDistributionOrderedCacheBehaviorForwardedValuesCookiesOut
 }
 export interface CloudfrontDistributionOrderedCacheBehaviorForwardedValues {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#headers CloudfrontDistribution#headers}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#headers CloudfrontDistribution#headers}
   */
   readonly headers?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#query_string CloudfrontDistribution#query_string}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#query_string CloudfrontDistribution#query_string}
   */
   readonly queryString: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#query_string_cache_keys CloudfrontDistribution#query_string_cache_keys}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#query_string_cache_keys CloudfrontDistribution#query_string_cache_keys}
   */
   readonly queryStringCacheKeys?: string[];
   /**
   * cookies block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#cookies CloudfrontDistribution#cookies}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#cookies CloudfrontDistribution#cookies}
   */
   readonly cookies: CloudfrontDistributionOrderedCacheBehaviorForwardedValuesCookies;
 }
@@ -2204,15 +2204,15 @@ export class CloudfrontDistributionOrderedCacheBehaviorForwardedValuesOutputRefe
 }
 export interface CloudfrontDistributionOrderedCacheBehaviorLambdaFunctionAssociation {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#event_type CloudfrontDistribution#event_type}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#event_type CloudfrontDistribution#event_type}
   */
   readonly eventType: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#include_body CloudfrontDistribution#include_body}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#include_body CloudfrontDistribution#include_body}
   */
   readonly includeBody?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#lambda_arn CloudfrontDistribution#lambda_arn}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#lambda_arn CloudfrontDistribution#lambda_arn}
   */
   readonly lambdaArn: string;
 }
@@ -2349,63 +2349,63 @@ export class CloudfrontDistributionOrderedCacheBehaviorLambdaFunctionAssociation
 }
 export interface CloudfrontDistributionOrderedCacheBehavior {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#allowed_methods CloudfrontDistribution#allowed_methods}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#allowed_methods CloudfrontDistribution#allowed_methods}
   */
   readonly allowedMethods: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#cached_methods CloudfrontDistribution#cached_methods}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#cached_methods CloudfrontDistribution#cached_methods}
   */
   readonly cachedMethods: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#compress CloudfrontDistribution#compress}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#compress CloudfrontDistribution#compress}
   */
   readonly compress?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#default_ttl CloudfrontDistribution#default_ttl}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#default_ttl CloudfrontDistribution#default_ttl}
   */
   readonly defaultTtl?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#field_level_encryption_id CloudfrontDistribution#field_level_encryption_id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#field_level_encryption_id CloudfrontDistribution#field_level_encryption_id}
   */
   readonly fieldLevelEncryptionId?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#max_ttl CloudfrontDistribution#max_ttl}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#max_ttl CloudfrontDistribution#max_ttl}
   */
   readonly maxTtl?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#min_ttl CloudfrontDistribution#min_ttl}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#min_ttl CloudfrontDistribution#min_ttl}
   */
   readonly minTtl?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#path_pattern CloudfrontDistribution#path_pattern}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#path_pattern CloudfrontDistribution#path_pattern}
   */
   readonly pathPattern: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#smooth_streaming CloudfrontDistribution#smooth_streaming}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#smooth_streaming CloudfrontDistribution#smooth_streaming}
   */
   readonly smoothStreaming?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#target_origin_id CloudfrontDistribution#target_origin_id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#target_origin_id CloudfrontDistribution#target_origin_id}
   */
   readonly targetOriginId: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#trusted_signers CloudfrontDistribution#trusted_signers}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#trusted_signers CloudfrontDistribution#trusted_signers}
   */
   readonly trustedSigners?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#viewer_protocol_policy CloudfrontDistribution#viewer_protocol_policy}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#viewer_protocol_policy CloudfrontDistribution#viewer_protocol_policy}
   */
   readonly viewerProtocolPolicy: string;
   /**
   * forwarded_values block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#forwarded_values CloudfrontDistribution#forwarded_values}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#forwarded_values CloudfrontDistribution#forwarded_values}
   */
   readonly forwardedValues: CloudfrontDistributionOrderedCacheBehaviorForwardedValues;
   /**
   * lambda_function_association block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#lambda_function_association CloudfrontDistribution#lambda_function_association}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#lambda_function_association CloudfrontDistribution#lambda_function_association}
   */
   readonly lambdaFunctionAssociation?: CloudfrontDistributionOrderedCacheBehaviorLambdaFunctionAssociation[] | cdktf.IResolvable;
 }
@@ -2783,11 +2783,11 @@ export class CloudfrontDistributionOrderedCacheBehaviorList extends cdktf.Comple
 }
 export interface CloudfrontDistributionOriginCustomHeader {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#name CloudfrontDistribution#name}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#name CloudfrontDistribution#name}
   */
   readonly name: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#value CloudfrontDistribution#value}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#value CloudfrontDistribution#value}
   */
   readonly value: string;
 }
@@ -2901,27 +2901,27 @@ export class CloudfrontDistributionOriginCustomHeaderList extends cdktf.ComplexL
 }
 export interface CloudfrontDistributionOriginCustomOriginConfig {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#http_port CloudfrontDistribution#http_port}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#http_port CloudfrontDistribution#http_port}
   */
   readonly httpPort: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#https_port CloudfrontDistribution#https_port}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#https_port CloudfrontDistribution#https_port}
   */
   readonly httpsPort: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#origin_keepalive_timeout CloudfrontDistribution#origin_keepalive_timeout}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#origin_keepalive_timeout CloudfrontDistribution#origin_keepalive_timeout}
   */
   readonly originKeepaliveTimeout?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#origin_protocol_policy CloudfrontDistribution#origin_protocol_policy}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#origin_protocol_policy CloudfrontDistribution#origin_protocol_policy}
   */
   readonly originProtocolPolicy: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#origin_read_timeout CloudfrontDistribution#origin_read_timeout}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#origin_read_timeout CloudfrontDistribution#origin_read_timeout}
   */
   readonly originReadTimeout?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#origin_ssl_protocols CloudfrontDistribution#origin_ssl_protocols}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#origin_ssl_protocols CloudfrontDistribution#origin_ssl_protocols}
   */
   readonly originSslProtocols: string[];
 }
@@ -3089,7 +3089,7 @@ export class CloudfrontDistributionOriginCustomOriginConfigOutputReference exten
 }
 export interface CloudfrontDistributionOriginS3OriginConfig {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#origin_access_identity CloudfrontDistribution#origin_access_identity}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#origin_access_identity CloudfrontDistribution#origin_access_identity}
   */
   readonly originAccessIdentity: string;
 }
@@ -3151,33 +3151,33 @@ export class CloudfrontDistributionOriginS3OriginConfigOutputReference extends c
 }
 export interface CloudfrontDistributionOrigin {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#domain_name CloudfrontDistribution#domain_name}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#domain_name CloudfrontDistribution#domain_name}
   */
   readonly domainName: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#origin_id CloudfrontDistribution#origin_id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#origin_id CloudfrontDistribution#origin_id}
   */
   readonly originId: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#origin_path CloudfrontDistribution#origin_path}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#origin_path CloudfrontDistribution#origin_path}
   */
   readonly originPath?: string;
   /**
   * custom_header block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#custom_header CloudfrontDistribution#custom_header}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#custom_header CloudfrontDistribution#custom_header}
   */
   readonly customHeader?: CloudfrontDistributionOriginCustomHeader[] | cdktf.IResolvable;
   /**
   * custom_origin_config block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#custom_origin_config CloudfrontDistribution#custom_origin_config}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#custom_origin_config CloudfrontDistribution#custom_origin_config}
   */
   readonly customOriginConfig?: CloudfrontDistributionOriginCustomOriginConfig;
   /**
   * s3_origin_config block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#s3_origin_config CloudfrontDistribution#s3_origin_config}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#s3_origin_config CloudfrontDistribution#s3_origin_config}
   */
   readonly s3OriginConfig?: CloudfrontDistributionOriginS3OriginConfig;
 }
@@ -3383,7 +3383,7 @@ export class CloudfrontDistributionOriginList extends cdktf.ComplexList {
 }
 export interface CloudfrontDistributionOriginGroupFailoverCriteria {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#status_codes CloudfrontDistribution#status_codes}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#status_codes CloudfrontDistribution#status_codes}
   */
   readonly statusCodes: number[];
 }
@@ -3445,7 +3445,7 @@ export class CloudfrontDistributionOriginGroupFailoverCriteriaOutputReference ex
 }
 export interface CloudfrontDistributionOriginGroupMember {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#origin_id CloudfrontDistribution#origin_id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#origin_id CloudfrontDistribution#origin_id}
   */
   readonly originId: string;
 }
@@ -3539,19 +3539,19 @@ export class CloudfrontDistributionOriginGroupMemberList extends cdktf.ComplexLi
 }
 export interface CloudfrontDistributionOriginGroup {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#origin_id CloudfrontDistribution#origin_id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#origin_id CloudfrontDistribution#origin_id}
   */
   readonly originId: string;
   /**
   * failover_criteria block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#failover_criteria CloudfrontDistribution#failover_criteria}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#failover_criteria CloudfrontDistribution#failover_criteria}
   */
   readonly failoverCriteria: CloudfrontDistributionOriginGroupFailoverCriteria;
   /**
   * member block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#member CloudfrontDistribution#member}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#member CloudfrontDistribution#member}
   */
   readonly member: CloudfrontDistributionOriginGroupMember[] | cdktf.IResolvable;
 }
@@ -3685,11 +3685,11 @@ export class CloudfrontDistributionOriginGroupList extends cdktf.ComplexList {
 }
 export interface CloudfrontDistributionRestrictionsGeoRestriction {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#locations CloudfrontDistribution#locations}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#locations CloudfrontDistribution#locations}
   */
   readonly locations?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#restriction_type CloudfrontDistribution#restriction_type}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#restriction_type CloudfrontDistribution#restriction_type}
   */
   readonly restrictionType: string;
 }
@@ -3776,7 +3776,7 @@ export interface CloudfrontDistributionRestrictions {
   /**
   * geo_restriction block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#geo_restriction CloudfrontDistribution#geo_restriction}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#geo_restriction CloudfrontDistribution#geo_restriction}
   */
   readonly geoRestriction: CloudfrontDistributionRestrictionsGeoRestriction;
 }
@@ -3838,23 +3838,23 @@ export class CloudfrontDistributionRestrictionsOutputReference extends cdktf.Com
 }
 export interface CloudfrontDistributionViewerCertificate {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#acm_certificate_arn CloudfrontDistribution#acm_certificate_arn}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#acm_certificate_arn CloudfrontDistribution#acm_certificate_arn}
   */
   readonly acmCertificateArn?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#cloudfront_default_certificate CloudfrontDistribution#cloudfront_default_certificate}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#cloudfront_default_certificate CloudfrontDistribution#cloudfront_default_certificate}
   */
   readonly cloudfrontDefaultCertificate?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#iam_certificate_id CloudfrontDistribution#iam_certificate_id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#iam_certificate_id CloudfrontDistribution#iam_certificate_id}
   */
   readonly iamCertificateId?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#minimum_protocol_version CloudfrontDistribution#minimum_protocol_version}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#minimum_protocol_version CloudfrontDistribution#minimum_protocol_version}
   */
   readonly minimumProtocolVersion?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution#ssl_support_method CloudfrontDistribution#ssl_support_method}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#ssl_support_method CloudfrontDistribution#ssl_support_method}
   */
   readonly sslSupportMethod?: string;
 }
@@ -4011,7 +4011,7 @@ export class CloudfrontDistributionViewerCertificateOutputReference extends cdkt
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution aws_cloudfront_distribution}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution aws_cloudfront_distribution}
 */
 export class CloudfrontDistribution extends cdktf.TerraformResource {
 
@@ -4025,7 +4025,7 @@ export class CloudfrontDistribution extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution aws_cloudfront_distribution} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution aws_cloudfront_distribution} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -4473,7 +4473,7 @@ export class CloudfrontDistribution extends cdktf.TerraformResource {
 `;
 
 exports[`generate a fms admin account with an empty options interface 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/fms_admin_account
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fms_admin_account
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -4483,11 +4483,11 @@ import * as cdktf from 'cdktf';
 
 export interface FmsAdminAccountConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/fms_admin_account#account_id FmsAdminAccount#account_id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fms_admin_account#account_id FmsAdminAccount#account_id}
   */
   readonly accountId?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/fms_admin_account#id FmsAdminAccount#id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fms_admin_account#id FmsAdminAccount#id}
   *
   * Please be aware that the id field is automatically added to all resources in Terraform providers using a Terraform provider SDK version below 2.
   * If you experience problems setting this value it might not be settable. Please take a look at the provider documentation to ensure it should be settable.
@@ -4496,7 +4496,7 @@ export interface FmsAdminAccountConfig extends cdktf.TerraformMetaArguments {
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/fms_admin_account aws_fms_admin_account}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fms_admin_account aws_fms_admin_account}
 */
 export class FmsAdminAccount extends cdktf.TerraformResource {
 
@@ -4510,7 +4510,7 @@ export class FmsAdminAccount extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/fms_admin_account aws_fms_admin_account} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fms_admin_account aws_fms_admin_account} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -4585,7 +4585,7 @@ export class FmsAdminAccount extends cdktf.TerraformResource {
 `;
 
 exports[`generate a s3 bucket resource 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/s3_bucket
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -4595,138 +4595,138 @@ import * as cdktf from 'cdktf';
 
 export interface S3BucketConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#acceleration_status S3Bucket#acceleration_status}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#acceleration_status S3Bucket#acceleration_status}
   */
   readonly accelerationStatus?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#acl S3Bucket#acl}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#acl S3Bucket#acl}
   */
   readonly acl?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#arn S3Bucket#arn}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#arn S3Bucket#arn}
   */
   readonly arn?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#bucket S3Bucket#bucket}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#bucket S3Bucket#bucket}
   */
   readonly bucket?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#bucket_prefix S3Bucket#bucket_prefix}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#bucket_prefix S3Bucket#bucket_prefix}
   */
   readonly bucketPrefix?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#force_destroy S3Bucket#force_destroy}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#force_destroy S3Bucket#force_destroy}
   */
   readonly forceDestroy?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#hosted_zone_id S3Bucket#hosted_zone_id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#hosted_zone_id S3Bucket#hosted_zone_id}
   */
   readonly hostedZoneId?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#id S3Bucket#id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#id S3Bucket#id}
   *
   * Please be aware that the id field is automatically added to all resources in Terraform providers using a Terraform provider SDK version below 2.
   * If you experience problems setting this value it might not be settable. Please take a look at the provider documentation to ensure it should be settable.
   */
   readonly id?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#policy S3Bucket#policy}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#policy S3Bucket#policy}
   */
   readonly policy?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#region S3Bucket#region}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#region S3Bucket#region}
   */
   readonly region?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#request_payer S3Bucket#request_payer}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#request_payer S3Bucket#request_payer}
   */
   readonly requestPayer?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#tags S3Bucket#tags}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#tags S3Bucket#tags}
   */
   readonly tags?: { [key: string]: string };
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#website_domain S3Bucket#website_domain}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#website_domain S3Bucket#website_domain}
   */
   readonly websiteDomain?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#website_endpoint S3Bucket#website_endpoint}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#website_endpoint S3Bucket#website_endpoint}
   */
   readonly websiteEndpoint?: string;
   /**
   * cors_rule block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#cors_rule S3Bucket#cors_rule}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#cors_rule S3Bucket#cors_rule}
   */
   readonly corsRule?: S3BucketCorsRule[] | cdktf.IResolvable;
   /**
   * grant block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#grant S3Bucket#grant}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#grant S3Bucket#grant}
   */
   readonly grant?: S3BucketGrant[] | cdktf.IResolvable;
   /**
   * lifecycle_rule block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#lifecycle_rule S3Bucket#lifecycle_rule}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#lifecycle_rule S3Bucket#lifecycle_rule}
   */
   readonly lifecycleRule?: S3BucketLifecycleRule[] | cdktf.IResolvable;
   /**
   * logging block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#logging S3Bucket#logging}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#logging S3Bucket#logging}
   */
   readonly logging?: S3BucketLogging[] | cdktf.IResolvable;
   /**
   * object_lock_configuration block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#object_lock_configuration S3Bucket#object_lock_configuration}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#object_lock_configuration S3Bucket#object_lock_configuration}
   */
   readonly objectLockConfiguration?: S3BucketObjectLockConfiguration;
   /**
   * replication_configuration block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#replication_configuration S3Bucket#replication_configuration}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#replication_configuration S3Bucket#replication_configuration}
   */
   readonly replicationConfiguration?: S3BucketReplicationConfiguration;
   /**
   * server_side_encryption_configuration block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#server_side_encryption_configuration S3Bucket#server_side_encryption_configuration}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#server_side_encryption_configuration S3Bucket#server_side_encryption_configuration}
   */
   readonly serverSideEncryptionConfiguration?: S3BucketServerSideEncryptionConfiguration;
   /**
   * versioning block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#versioning S3Bucket#versioning}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#versioning S3Bucket#versioning}
   */
   readonly versioning?: S3BucketVersioning;
   /**
   * website block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#website S3Bucket#website}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#website S3Bucket#website}
   */
   readonly website?: S3BucketWebsite;
 }
 export interface S3BucketCorsRule {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#allowed_headers S3Bucket#allowed_headers}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#allowed_headers S3Bucket#allowed_headers}
   */
   readonly allowedHeaders?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#allowed_methods S3Bucket#allowed_methods}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#allowed_methods S3Bucket#allowed_methods}
   */
   readonly allowedMethods: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#allowed_origins S3Bucket#allowed_origins}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#allowed_origins S3Bucket#allowed_origins}
   */
   readonly allowedOrigins: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#expose_headers S3Bucket#expose_headers}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#expose_headers S3Bucket#expose_headers}
   */
   readonly exposeHeaders?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#max_age_seconds S3Bucket#max_age_seconds}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#max_age_seconds S3Bucket#max_age_seconds}
   */
   readonly maxAgeSeconds?: number;
 }
@@ -4909,22 +4909,22 @@ export class S3BucketCorsRuleList extends cdktf.ComplexList {
 }
 export interface S3BucketGrant {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#id S3Bucket#id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#id S3Bucket#id}
   *
   * Please be aware that the id field is automatically added to all resources in Terraform providers using a Terraform provider SDK version below 2.
   * If you experience problems setting this value it might not be settable. Please take a look at the provider documentation to ensure it should be settable.
   */
   readonly id?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#permissions S3Bucket#permissions}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#permissions S3Bucket#permissions}
   */
   readonly permissions: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#type S3Bucket#type}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#type S3Bucket#type}
   */
   readonly type: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#uri S3Bucket#uri}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#uri S3Bucket#uri}
   */
   readonly uri?: string;
 }
@@ -5084,15 +5084,15 @@ export class S3BucketGrantList extends cdktf.ComplexList {
 }
 export interface S3BucketLifecycleRuleExpiration {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#date S3Bucket#date}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#date S3Bucket#date}
   */
   readonly date?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#days S3Bucket#days}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#days S3Bucket#days}
   */
   readonly days?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#expired_object_delete_marker S3Bucket#expired_object_delete_marker}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#expired_object_delete_marker S3Bucket#expired_object_delete_marker}
   */
   readonly expiredObjectDeleteMarker?: boolean | cdktf.IResolvable;
 }
@@ -5203,7 +5203,7 @@ export class S3BucketLifecycleRuleExpirationOutputReference extends cdktf.Comple
 }
 export interface S3BucketLifecycleRuleNoncurrentVersionExpiration {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#days S3Bucket#days}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#days S3Bucket#days}
   */
   readonly days?: number;
 }
@@ -5268,11 +5268,11 @@ export class S3BucketLifecycleRuleNoncurrentVersionExpirationOutputReference ext
 }
 export interface S3BucketLifecycleRuleNoncurrentVersionTransition {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#days S3Bucket#days}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#days S3Bucket#days}
   */
   readonly days?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#storage_class S3Bucket#storage_class}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#storage_class S3Bucket#storage_class}
   */
   readonly storageClass: string;
 }
@@ -5389,15 +5389,15 @@ export class S3BucketLifecycleRuleNoncurrentVersionTransitionList extends cdktf.
 }
 export interface S3BucketLifecycleRuleTransition {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#date S3Bucket#date}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#date S3Bucket#date}
   */
   readonly date?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#days S3Bucket#days}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#days S3Bucket#days}
   */
   readonly days?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#storage_class S3Bucket#storage_class}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#storage_class S3Bucket#storage_class}
   */
   readonly storageClass: string;
 }
@@ -5537,50 +5537,50 @@ export class S3BucketLifecycleRuleTransitionList extends cdktf.ComplexList {
 }
 export interface S3BucketLifecycleRule {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#abort_incomplete_multipart_upload_days S3Bucket#abort_incomplete_multipart_upload_days}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#abort_incomplete_multipart_upload_days S3Bucket#abort_incomplete_multipart_upload_days}
   */
   readonly abortIncompleteMultipartUploadDays?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#enabled S3Bucket#enabled}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#enabled S3Bucket#enabled}
   */
   readonly enabled: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#id S3Bucket#id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#id S3Bucket#id}
   *
   * Please be aware that the id field is automatically added to all resources in Terraform providers using a Terraform provider SDK version below 2.
   * If you experience problems setting this value it might not be settable. Please take a look at the provider documentation to ensure it should be settable.
   */
   readonly id?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#prefix S3Bucket#prefix}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#prefix S3Bucket#prefix}
   */
   readonly prefix?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#tags S3Bucket#tags}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#tags S3Bucket#tags}
   */
   readonly tags?: { [key: string]: string };
   /**
   * expiration block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#expiration S3Bucket#expiration}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#expiration S3Bucket#expiration}
   */
   readonly expiration?: S3BucketLifecycleRuleExpiration;
   /**
   * noncurrent_version_expiration block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#noncurrent_version_expiration S3Bucket#noncurrent_version_expiration}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#noncurrent_version_expiration S3Bucket#noncurrent_version_expiration}
   */
   readonly noncurrentVersionExpiration?: S3BucketLifecycleRuleNoncurrentVersionExpiration;
   /**
   * noncurrent_version_transition block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#noncurrent_version_transition S3Bucket#noncurrent_version_transition}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#noncurrent_version_transition S3Bucket#noncurrent_version_transition}
   */
   readonly noncurrentVersionTransition?: S3BucketLifecycleRuleNoncurrentVersionTransition[] | cdktf.IResolvable;
   /**
   * transition block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#transition S3Bucket#transition}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#transition S3Bucket#transition}
   */
   readonly transition?: S3BucketLifecycleRuleTransition[] | cdktf.IResolvable;
 }
@@ -5858,11 +5858,11 @@ export class S3BucketLifecycleRuleList extends cdktf.ComplexList {
 }
 export interface S3BucketLogging {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#target_bucket S3Bucket#target_bucket}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#target_bucket S3Bucket#target_bucket}
   */
   readonly targetBucket: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#target_prefix S3Bucket#target_prefix}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#target_prefix S3Bucket#target_prefix}
   */
   readonly targetPrefix?: string;
 }
@@ -5979,15 +5979,15 @@ export class S3BucketLoggingList extends cdktf.ComplexList {
 }
 export interface S3BucketObjectLockConfigurationRuleDefaultRetention {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#days S3Bucket#days}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#days S3Bucket#days}
   */
   readonly days?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#mode S3Bucket#mode}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#mode S3Bucket#mode}
   */
   readonly mode: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#years S3Bucket#years}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#years S3Bucket#years}
   */
   readonly years?: number;
 }
@@ -6097,7 +6097,7 @@ export interface S3BucketObjectLockConfigurationRule {
   /**
   * default_retention block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#default_retention S3Bucket#default_retention}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#default_retention S3Bucket#default_retention}
   */
   readonly defaultRetention: S3BucketObjectLockConfigurationRuleDefaultRetention;
 }
@@ -6159,13 +6159,13 @@ export class S3BucketObjectLockConfigurationRuleOutputReference extends cdktf.Co
 }
 export interface S3BucketObjectLockConfiguration {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#object_lock_enabled S3Bucket#object_lock_enabled}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#object_lock_enabled S3Bucket#object_lock_enabled}
   */
   readonly objectLockEnabled: string;
   /**
   * rule block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#rule S3Bucket#rule}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#rule S3Bucket#rule}
   */
   readonly rule?: S3BucketObjectLockConfigurationRule;
 }
@@ -6250,7 +6250,7 @@ export class S3BucketObjectLockConfigurationOutputReference extends cdktf.Comple
 }
 export interface S3BucketReplicationConfigurationRulesDestinationAccessControlTranslation {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#owner S3Bucket#owner}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#owner S3Bucket#owner}
   */
   readonly owner: string;
 }
@@ -6312,25 +6312,25 @@ export class S3BucketReplicationConfigurationRulesDestinationAccessControlTransl
 }
 export interface S3BucketReplicationConfigurationRulesDestination {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#account_id S3Bucket#account_id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#account_id S3Bucket#account_id}
   */
   readonly accountId?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#bucket S3Bucket#bucket}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#bucket S3Bucket#bucket}
   */
   readonly bucket: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#replica_kms_key_id S3Bucket#replica_kms_key_id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#replica_kms_key_id S3Bucket#replica_kms_key_id}
   */
   readonly replicaKmsKeyId?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#storage_class S3Bucket#storage_class}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#storage_class S3Bucket#storage_class}
   */
   readonly storageClass?: string;
   /**
   * access_control_translation block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#access_control_translation S3Bucket#access_control_translation}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#access_control_translation S3Bucket#access_control_translation}
   */
   readonly accessControlTranslation?: S3BucketReplicationConfigurationRulesDestinationAccessControlTranslation;
 }
@@ -6484,11 +6484,11 @@ export class S3BucketReplicationConfigurationRulesDestinationOutputReference ext
 }
 export interface S3BucketReplicationConfigurationRulesFilter {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#prefix S3Bucket#prefix}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#prefix S3Bucket#prefix}
   */
   readonly prefix?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#tags S3Bucket#tags}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#tags S3Bucket#tags}
   */
   readonly tags?: { [key: string]: string };
 }
@@ -6576,7 +6576,7 @@ export class S3BucketReplicationConfigurationRulesFilterOutputReference extends 
 }
 export interface S3BucketReplicationConfigurationRulesSourceSelectionCriteriaSseKmsEncryptedObjects {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#enabled S3Bucket#enabled}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#enabled S3Bucket#enabled}
   */
   readonly enabled: boolean | cdktf.IResolvable;
 }
@@ -6640,7 +6640,7 @@ export interface S3BucketReplicationConfigurationRulesSourceSelectionCriteria {
   /**
   * sse_kms_encrypted_objects block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#sse_kms_encrypted_objects S3Bucket#sse_kms_encrypted_objects}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#sse_kms_encrypted_objects S3Bucket#sse_kms_encrypted_objects}
   */
   readonly sseKmsEncryptedObjects?: S3BucketReplicationConfigurationRulesSourceSelectionCriteriaSseKmsEncryptedObjects;
 }
@@ -6705,40 +6705,40 @@ export class S3BucketReplicationConfigurationRulesSourceSelectionCriteriaOutputR
 }
 export interface S3BucketReplicationConfigurationRules {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#id S3Bucket#id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#id S3Bucket#id}
   *
   * Please be aware that the id field is automatically added to all resources in Terraform providers using a Terraform provider SDK version below 2.
   * If you experience problems setting this value it might not be settable. Please take a look at the provider documentation to ensure it should be settable.
   */
   readonly id?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#prefix S3Bucket#prefix}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#prefix S3Bucket#prefix}
   */
   readonly prefix?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#priority S3Bucket#priority}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#priority S3Bucket#priority}
   */
   readonly priority?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#status S3Bucket#status}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#status S3Bucket#status}
   */
   readonly status: string;
   /**
   * destination block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#destination S3Bucket#destination}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#destination S3Bucket#destination}
   */
   readonly destination: S3BucketReplicationConfigurationRulesDestination;
   /**
   * filter block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#filter S3Bucket#filter}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#filter S3Bucket#filter}
   */
   readonly filter?: S3BucketReplicationConfigurationRulesFilter;
   /**
   * source_selection_criteria block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#source_selection_criteria S3Bucket#source_selection_criteria}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#source_selection_criteria S3Bucket#source_selection_criteria}
   */
   readonly sourceSelectionCriteria?: S3BucketReplicationConfigurationRulesSourceSelectionCriteria;
 }
@@ -6967,13 +6967,13 @@ export class S3BucketReplicationConfigurationRulesList extends cdktf.ComplexList
 }
 export interface S3BucketReplicationConfiguration {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#role S3Bucket#role}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#role S3Bucket#role}
   */
   readonly role: string;
   /**
   * rules block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#rules S3Bucket#rules}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#rules S3Bucket#rules}
   */
   readonly rules: S3BucketReplicationConfigurationRules[] | cdktf.IResolvable;
 }
@@ -7055,11 +7055,11 @@ export class S3BucketReplicationConfigurationOutputReference extends cdktf.Compl
 }
 export interface S3BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#kms_master_key_id S3Bucket#kms_master_key_id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#kms_master_key_id S3Bucket#kms_master_key_id}
   */
   readonly kmsMasterKeyId?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#sse_algorithm S3Bucket#sse_algorithm}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#sse_algorithm S3Bucket#sse_algorithm}
   */
   readonly sseAlgorithm: string;
 }
@@ -7146,7 +7146,7 @@ export interface S3BucketServerSideEncryptionConfigurationRule {
   /**
   * apply_server_side_encryption_by_default block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#apply_server_side_encryption_by_default S3Bucket#apply_server_side_encryption_by_default}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#apply_server_side_encryption_by_default S3Bucket#apply_server_side_encryption_by_default}
   */
   readonly applyServerSideEncryptionByDefault: S3BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefault;
 }
@@ -7210,7 +7210,7 @@ export interface S3BucketServerSideEncryptionConfiguration {
   /**
   * rule block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#rule S3Bucket#rule}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#rule S3Bucket#rule}
   */
   readonly rule: S3BucketServerSideEncryptionConfigurationRule;
 }
@@ -7272,11 +7272,11 @@ export class S3BucketServerSideEncryptionConfigurationOutputReference extends cd
 }
 export interface S3BucketVersioning {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#enabled S3Bucket#enabled}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#enabled S3Bucket#enabled}
   */
   readonly enabled?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#mfa_delete S3Bucket#mfa_delete}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#mfa_delete S3Bucket#mfa_delete}
   */
   readonly mfaDelete?: boolean | cdktf.IResolvable;
 }
@@ -7364,19 +7364,19 @@ export class S3BucketVersioningOutputReference extends cdktf.ComplexObject {
 }
 export interface S3BucketWebsite {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#error_document S3Bucket#error_document}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#error_document S3Bucket#error_document}
   */
   readonly errorDocument?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#index_document S3Bucket#index_document}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#index_document S3Bucket#index_document}
   */
   readonly indexDocument?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#redirect_all_requests_to S3Bucket#redirect_all_requests_to}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#redirect_all_requests_to S3Bucket#redirect_all_requests_to}
   */
   readonly redirectAllRequestsTo?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket#routing_rules S3Bucket#routing_rules}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#routing_rules S3Bucket#routing_rules}
   */
   readonly routingRules?: string;
 }
@@ -7510,7 +7510,7 @@ export class S3BucketWebsiteOutputReference extends cdktf.ComplexObject {
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket aws_s3_bucket}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket aws_s3_bucket}
 */
 export class S3Bucket extends cdktf.TerraformResource {
 
@@ -7524,7 +7524,7 @@ export class S3Bucket extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/s3_bucket aws_s3_bucket} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket aws_s3_bucket} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -7987,7 +7987,7 @@ export class S3Bucket extends cdktf.TerraformResource {
 `;
 
 exports[`generate a security group 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/security_group
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -7997,86 +7997,86 @@ import * as cdktf from 'cdktf';
 
 export interface SecurityGroupConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#description SecurityGroup#description}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#description SecurityGroup#description}
   */
   readonly description?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#egress SecurityGroup#egress}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#egress SecurityGroup#egress}
   */
   readonly egress?: SecurityGroupEgress[] | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#id SecurityGroup#id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#id SecurityGroup#id}
   *
   * Please be aware that the id field is automatically added to all resources in Terraform providers using a Terraform provider SDK version below 2.
   * If you experience problems setting this value it might not be settable. Please take a look at the provider documentation to ensure it should be settable.
   */
   readonly id?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#ingress SecurityGroup#ingress}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#ingress SecurityGroup#ingress}
   */
   readonly ingress?: SecurityGroupIngress[] | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#name SecurityGroup#name}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#name SecurityGroup#name}
   */
   readonly name?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#name_prefix SecurityGroup#name_prefix}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#name_prefix SecurityGroup#name_prefix}
   */
   readonly namePrefix?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#revoke_rules_on_delete SecurityGroup#revoke_rules_on_delete}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#revoke_rules_on_delete SecurityGroup#revoke_rules_on_delete}
   */
   readonly revokeRulesOnDelete?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#tags SecurityGroup#tags}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#tags SecurityGroup#tags}
   */
   readonly tags?: { [key: string]: string };
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#vpc_id SecurityGroup#vpc_id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#vpc_id SecurityGroup#vpc_id}
   */
   readonly vpcId?: string;
   /**
   * timeouts block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#timeouts SecurityGroup#timeouts}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#timeouts SecurityGroup#timeouts}
   */
   readonly timeouts?: SecurityGroupTimeouts;
 }
 export interface SecurityGroupEgress {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#cidr_blocks SecurityGroup#cidr_blocks}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#cidr_blocks SecurityGroup#cidr_blocks}
   */
   readonly cidrBlocks?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#description SecurityGroup#description}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#description SecurityGroup#description}
   */
   readonly description?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#from_port SecurityGroup#from_port}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#from_port SecurityGroup#from_port}
   */
   readonly fromPort?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#ipv6_cidr_blocks SecurityGroup#ipv6_cidr_blocks}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#ipv6_cidr_blocks SecurityGroup#ipv6_cidr_blocks}
   */
   readonly ipv6CidrBlocks?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#prefix_list_ids SecurityGroup#prefix_list_ids}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#prefix_list_ids SecurityGroup#prefix_list_ids}
   */
   readonly prefixListIds?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#protocol SecurityGroup#protocol}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#protocol SecurityGroup#protocol}
   */
   readonly protocol?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#security_groups SecurityGroup#security_groups}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#security_groups SecurityGroup#security_groups}
   */
   readonly securityGroups?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#self SecurityGroup#self}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#self SecurityGroup#self}
   */
   readonly selfAttribute?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#to_port SecurityGroup#to_port}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#to_port SecurityGroup#to_port}
   */
   readonly toPort?: number;
 }
@@ -8357,39 +8357,39 @@ export class SecurityGroupEgressList extends cdktf.ComplexList {
 }
 export interface SecurityGroupIngress {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#cidr_blocks SecurityGroup#cidr_blocks}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#cidr_blocks SecurityGroup#cidr_blocks}
   */
   readonly cidrBlocks?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#description SecurityGroup#description}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#description SecurityGroup#description}
   */
   readonly description?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#from_port SecurityGroup#from_port}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#from_port SecurityGroup#from_port}
   */
   readonly fromPort?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#ipv6_cidr_blocks SecurityGroup#ipv6_cidr_blocks}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#ipv6_cidr_blocks SecurityGroup#ipv6_cidr_blocks}
   */
   readonly ipv6CidrBlocks?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#prefix_list_ids SecurityGroup#prefix_list_ids}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#prefix_list_ids SecurityGroup#prefix_list_ids}
   */
   readonly prefixListIds?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#protocol SecurityGroup#protocol}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#protocol SecurityGroup#protocol}
   */
   readonly protocol?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#security_groups SecurityGroup#security_groups}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#security_groups SecurityGroup#security_groups}
   */
   readonly securityGroups?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#self SecurityGroup#self}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#self SecurityGroup#self}
   */
   readonly selfAttribute?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#to_port SecurityGroup#to_port}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#to_port SecurityGroup#to_port}
   */
   readonly toPort?: number;
 }
@@ -8670,11 +8670,11 @@ export class SecurityGroupIngressList extends cdktf.ComplexList {
 }
 export interface SecurityGroupTimeouts {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#create SecurityGroup#create}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#create SecurityGroup#create}
   */
   readonly create?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/security_group#delete SecurityGroup#delete}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#delete SecurityGroup#delete}
   */
   readonly delete?: string;
 }
@@ -8772,7 +8772,7 @@ export class SecurityGroupTimeoutsOutputReference extends cdktf.ComplexObject {
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/security_group aws_security_group}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group aws_security_group}
 */
 export class SecurityGroup extends cdktf.TerraformResource {
 
@@ -8786,7 +8786,7 @@ export class SecurityGroup extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/security_group aws_security_group} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group aws_security_group} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`boolean list attribute 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/boolean_list
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/boolean_list
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -11,17 +11,17 @@ import * as cdktf from 'cdktf';
 
 export interface BooleanListConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/boolean_list#foo_required BooleanList#foo_required}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/boolean_list#foo_required BooleanList#foo_required}
   */
   readonly fooRequired: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/boolean_list#foo_optional BooleanList#foo_optional}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/boolean_list#foo_optional BooleanList#foo_optional}
   */
   readonly fooOptional?: Array<boolean | cdktf.IResolvable> | cdktf.IResolvable;
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/boolean_list aws_boolean_list}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/boolean_list aws_boolean_list}
 */
 export class BooleanList extends cdktf.TerraformResource {
 
@@ -35,7 +35,7 @@ export class BooleanList extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/boolean_list aws_boolean_list} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/boolean_list aws_boolean_list} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -113,7 +113,7 @@ export class BooleanList extends cdktf.TerraformResource {
 `;
 
 exports[`boolean map attribute 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/boolean_map
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/boolean_map
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -123,17 +123,17 @@ import * as cdktf from 'cdktf';
 
 export interface BooleanMapConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/boolean_map#foo_computed_optional BooleanMap#foo_computed_optional}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/boolean_map#foo_computed_optional BooleanMap#foo_computed_optional}
   */
   readonly fooComputedOptional?: { [key: string]: (boolean | cdktf.IResolvable) };
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/boolean_map#foo_optional BooleanMap#foo_optional}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/boolean_map#foo_optional BooleanMap#foo_optional}
   */
   readonly fooOptional?: { [key: string]: (boolean | cdktf.IResolvable) };
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/boolean_map aws_boolean_map}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/boolean_map aws_boolean_map}
 */
 export class BooleanMap extends cdktf.TerraformResource {
 
@@ -147,7 +147,7 @@ export class BooleanMap extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/boolean_map aws_boolean_map} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/boolean_map aws_boolean_map} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -228,7 +228,7 @@ export class BooleanMap extends cdktf.TerraformResource {
 `;
 
 exports[`computed complex attribute 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/computed_complex
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/computed_complex
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -344,7 +344,7 @@ export class ComputedComplexEgressList extends cdktf.ComplexList {
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/computed_complex aws_computed_complex}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/computed_complex aws_computed_complex}
 */
 export class ComputedComplex extends cdktf.TerraformResource {
 
@@ -358,7 +358,7 @@ export class ComputedComplex extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/computed_complex aws_computed_complex} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/computed_complex aws_computed_complex} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -403,7 +403,7 @@ export class ComputedComplex extends cdktf.TerraformResource {
 `;
 
 exports[`computed complex nested attribute 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/computed_complex_nested
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/computed_complex_nested
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -549,7 +549,7 @@ export class ComputedComplexNestedResourcesList extends cdktf.ComplexList {
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/computed_complex_nested aws_computed_complex_nested}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/computed_complex_nested aws_computed_complex_nested}
 */
 export class ComputedComplexNested extends cdktf.TerraformResource {
 
@@ -563,7 +563,7 @@ export class ComputedComplexNested extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/computed_complex_nested aws_computed_complex_nested} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/computed_complex_nested aws_computed_complex_nested} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -608,7 +608,7 @@ export class ComputedComplexNested extends cdktf.TerraformResource {
 `;
 
 exports[`computed nested complex list block type 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/block_type_nested_computed_list
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/block_type_nested_computed_list
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -620,7 +620,7 @@ export interface BlockTypeNestedComputedListConfig extends cdktf.TerraformMetaAr
   /**
   * inputs block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/block_type_nested_computed_list#inputs BlockTypeNestedComputedList#inputs}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/block_type_nested_computed_list#inputs BlockTypeNestedComputedList#inputs}
   */
   readonly inputs?: BlockTypeNestedComputedListInputs[] | cdktf.IResolvable;
 }
@@ -690,7 +690,7 @@ export class BlockTypeNestedComputedListInputsStartingPositionConfigurationList 
 }
 export interface BlockTypeNestedComputedListInputs {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/block_type_nested_computed_list#name_prefix BlockTypeNestedComputedList#name_prefix}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/block_type_nested_computed_list#name_prefix BlockTypeNestedComputedList#name_prefix}
   */
   readonly namePrefix: string;
 }
@@ -800,7 +800,7 @@ export class BlockTypeNestedComputedListInputsList extends cdktf.ComplexList {
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/block_type_nested_computed_list aws_block_type_nested_computed_list}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/block_type_nested_computed_list aws_block_type_nested_computed_list}
 */
 export class BlockTypeNestedComputedList extends cdktf.TerraformResource {
 
@@ -814,7 +814,7 @@ export class BlockTypeNestedComputedList extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/block_type_nested_computed_list aws_block_type_nested_computed_list} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/block_type_nested_computed_list aws_block_type_nested_computed_list} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -871,7 +871,7 @@ export class BlockTypeNestedComputedList extends cdktf.TerraformResource {
 `;
 
 exports[`computed optional complex attribute 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/computed_optional_complex
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/computed_optional_complex
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -881,45 +881,45 @@ import * as cdktf from 'cdktf';
 
 export interface ComputedOptionalComplexConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/computed_optional_complex#egress ComputedOptionalComplex#egress}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/computed_optional_complex#egress ComputedOptionalComplex#egress}
   */
   readonly egress?: ComputedOptionalComplexEgress[] | cdktf.IResolvable;
 }
 export interface ComputedOptionalComplexEgress {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/computed_optional_complex#cidr_blocks ComputedOptionalComplex#cidr_blocks}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/computed_optional_complex#cidr_blocks ComputedOptionalComplex#cidr_blocks}
   */
   readonly cidrBlocks?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/computed_optional_complex#description ComputedOptionalComplex#description}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/computed_optional_complex#description ComputedOptionalComplex#description}
   */
   readonly description?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/computed_optional_complex#from_port ComputedOptionalComplex#from_port}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/computed_optional_complex#from_port ComputedOptionalComplex#from_port}
   */
   readonly fromPort?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/computed_optional_complex#ipv6_cidr_blocks ComputedOptionalComplex#ipv6_cidr_blocks}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/computed_optional_complex#ipv6_cidr_blocks ComputedOptionalComplex#ipv6_cidr_blocks}
   */
   readonly ipv6CidrBlocks?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/computed_optional_complex#prefix_list_ids ComputedOptionalComplex#prefix_list_ids}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/computed_optional_complex#prefix_list_ids ComputedOptionalComplex#prefix_list_ids}
   */
   readonly prefixListIds?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/computed_optional_complex#protocol ComputedOptionalComplex#protocol}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/computed_optional_complex#protocol ComputedOptionalComplex#protocol}
   */
   readonly protocol?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/computed_optional_complex#security_groups ComputedOptionalComplex#security_groups}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/computed_optional_complex#security_groups ComputedOptionalComplex#security_groups}
   */
   readonly securityGroups?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/computed_optional_complex#self ComputedOptionalComplex#self}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/computed_optional_complex#self ComputedOptionalComplex#self}
   */
   readonly selfAttribute?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/computed_optional_complex#to_port ComputedOptionalComplex#to_port}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/computed_optional_complex#to_port ComputedOptionalComplex#to_port}
   */
   readonly toPort?: number;
 }
@@ -1200,7 +1200,7 @@ export class ComputedOptionalComplexEgressList extends cdktf.ComplexList {
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/computed_optional_complex aws_computed_optional_complex}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/computed_optional_complex aws_computed_optional_complex}
 */
 export class ComputedOptionalComplex extends cdktf.TerraformResource {
 
@@ -1214,7 +1214,7 @@ export class ComputedOptionalComplex extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/computed_optional_complex aws_computed_optional_complex} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/computed_optional_complex aws_computed_optional_complex} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -1271,7 +1271,7 @@ export class ComputedOptionalComplex extends cdktf.TerraformResource {
 `;
 
 exports[`deeply nested block types 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/deeply_nested_block_types
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/deeply_nested_block_types
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -1283,13 +1283,13 @@ export interface DeeplyNestedBlockTypesConfig extends cdktf.TerraformMetaArgumen
   /**
   * lifecycle_rule block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/deeply_nested_block_types#lifecycle_rule DeeplyNestedBlockTypes#lifecycle_rule}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/deeply_nested_block_types#lifecycle_rule DeeplyNestedBlockTypes#lifecycle_rule}
   */
   readonly lifecycleRule?: DeeplyNestedBlockTypesLifecycleRule[] | cdktf.IResolvable;
 }
 export interface DeeplyNestedBlockTypesLifecycleRuleExpiration {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/deeply_nested_block_types#date DeeplyNestedBlockTypes#date}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/deeply_nested_block_types#date DeeplyNestedBlockTypes#date}
   */
   readonly date?: string;
 }
@@ -1354,13 +1354,13 @@ export class DeeplyNestedBlockTypesLifecycleRuleExpirationOutputReference extend
 }
 export interface DeeplyNestedBlockTypesLifecycleRule {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/deeply_nested_block_types#abort_incomplete_multipart_upload_days DeeplyNestedBlockTypes#abort_incomplete_multipart_upload_days}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/deeply_nested_block_types#abort_incomplete_multipart_upload_days DeeplyNestedBlockTypes#abort_incomplete_multipart_upload_days}
   */
   readonly abortIncompleteMultipartUploadDays?: number;
   /**
   * expiration block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/deeply_nested_block_types#expiration DeeplyNestedBlockTypes#expiration}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/deeply_nested_block_types#expiration DeeplyNestedBlockTypes#expiration}
   */
   readonly expiration?: DeeplyNestedBlockTypesLifecycleRuleExpiration;
 }
@@ -1480,7 +1480,7 @@ export class DeeplyNestedBlockTypesLifecycleRuleList extends cdktf.ComplexList {
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/deeply_nested_block_types aws_deeply_nested_block_types}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/deeply_nested_block_types aws_deeply_nested_block_types}
 */
 export class DeeplyNestedBlockTypes extends cdktf.TerraformResource {
 
@@ -1494,7 +1494,7 @@ export class DeeplyNestedBlockTypes extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/deeply_nested_block_types aws_deeply_nested_block_types} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/deeply_nested_block_types aws_deeply_nested_block_types} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -1551,7 +1551,7 @@ export class DeeplyNestedBlockTypes extends cdktf.TerraformResource {
 `;
 
 exports[`ignored attributes 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/ignored_attributes
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ignored_attributes
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -1561,7 +1561,7 @@ import * as cdktf from 'cdktf';
 
 export interface IgnoredAttributesConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/ignored_attributes#id IgnoredAttributes#id}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ignored_attributes#id IgnoredAttributes#id}
   *
   * Please be aware that the id field is automatically added to all resources in Terraform providers using a Terraform provider SDK version below 2.
   * If you experience problems setting this value it might not be settable. Please take a look at the provider documentation to ensure it should be settable.
@@ -1570,7 +1570,7 @@ export interface IgnoredAttributesConfig extends cdktf.TerraformMetaArguments {
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/ignored_attributes aws_ignored_attributes}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ignored_attributes aws_ignored_attributes}
 */
 export class IgnoredAttributes extends cdktf.TerraformResource {
 
@@ -1584,7 +1584,7 @@ export class IgnoredAttributes extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/ignored_attributes aws_ignored_attributes} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ignored_attributes aws_ignored_attributes} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -1646,7 +1646,7 @@ export class IgnoredAttributes extends cdktf.TerraformResource {
 `;
 
 exports[`incompatible attribute names 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/incompatible_attribute_names
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/incompatible_attribute_names
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -1656,29 +1656,29 @@ import * as cdktf from 'cdktf';
 
 export interface IncompatibleAttributeNamesConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/incompatible_attribute_names#get_password_data IncompatibleAttributeNames#get_password_data}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/incompatible_attribute_names#get_password_data IncompatibleAttributeNames#get_password_data}
   */
   readonly fetchPasswordData?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/incompatible_attribute_names#self IncompatibleAttributeNames#self}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/incompatible_attribute_names#self IncompatibleAttributeNames#self}
   */
   readonly selfAttribute: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/incompatible_attribute_names#equals IncompatibleAttributeNames#equals}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/incompatible_attribute_names#equals IncompatibleAttributeNames#equals}
   */
   readonly equalTo: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/incompatible_attribute_names#node IncompatibleAttributeNames#node}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/incompatible_attribute_names#node IncompatibleAttributeNames#node}
   */
   readonly nodeAttribute: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/incompatible_attribute_names#system IncompatibleAttributeNames#system}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/incompatible_attribute_names#system IncompatibleAttributeNames#system}
   */
   readonly systemAttribute: string;
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/incompatible_attribute_names aws_incompatible_attribute_names}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/incompatible_attribute_names aws_incompatible_attribute_names}
 */
 export class IncompatibleAttributeNames extends cdktf.TerraformResource {
 
@@ -1692,7 +1692,7 @@ export class IncompatibleAttributeNames extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/incompatible_attribute_names aws_incompatible_attribute_names} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/incompatible_attribute_names aws_incompatible_attribute_names} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -1809,7 +1809,7 @@ export class IncompatibleAttributeNames extends cdktf.TerraformResource {
 `;
 
 exports[`incompatible resource names: function-resource 1`] = `
-"// https://www.terraform.io/docs/providers/test/r/function
+"// https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/function
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -1819,13 +1819,13 @@ import * as cdktf from 'cdktf';
 
 export interface FunctionResourceConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/test/r/function#dummy FunctionResource#dummy}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/function#dummy FunctionResource#dummy}
   */
   readonly dummy?: string;
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/test/r/function test_function}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/function test_function}
 */
 export class FunctionResource extends cdktf.TerraformResource {
 
@@ -1839,7 +1839,7 @@ export class FunctionResource extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/test/r/function test_function} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/function test_function} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -1907,7 +1907,7 @@ export * as providerResource from './provider-resource';
 `;
 
 exports[`incompatible resource names: object-resource 1`] = `
-"// https://www.terraform.io/docs/providers/test/r/object
+"// https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/object
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -1917,13 +1917,13 @@ import * as cdktf from 'cdktf';
 
 export interface ObjectResourceConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/test/r/object#dummy ObjectResource#dummy}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/object#dummy ObjectResource#dummy}
   */
   readonly dummy?: string;
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/test/r/object test_object}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/object test_object}
 */
 export class ObjectResource extends cdktf.TerraformResource {
 
@@ -1937,7 +1937,7 @@ export class ObjectResource extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/test/r/object test_object} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/object test_object} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -1994,7 +1994,7 @@ export class ObjectResource extends cdktf.TerraformResource {
 `;
 
 exports[`incompatible resource names: provider-resource 1`] = `
-"// https://www.terraform.io/docs/providers/test/r/provider
+"// https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/provider
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -2004,13 +2004,13 @@ import * as cdktf from 'cdktf';
 
 export interface ProviderResourceConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/test/r/provider#dummy ProviderResource#dummy}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/provider#dummy ProviderResource#dummy}
   */
   readonly dummy?: string;
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/test/r/provider test_provider}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/provider test_provider}
 */
 export class ProviderResource extends cdktf.TerraformResource {
 
@@ -2024,7 +2024,7 @@ export class ProviderResource extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/test/r/provider test_provider} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/provider test_provider} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -2081,7 +2081,7 @@ export class ProviderResource extends cdktf.TerraformResource {
 `;
 
 exports[`incompatible resource names: static-resource 1`] = `
-"// https://www.terraform.io/docs/providers/test/r/static
+"// https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/static
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -2091,13 +2091,13 @@ import * as cdktf from 'cdktf';
 
 export interface StaticResourceConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/test/r/static#dummy StaticResource#dummy}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/static#dummy StaticResource#dummy}
   */
   readonly dummy?: string;
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/test/r/static test_static}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/static test_static}
 */
 export class StaticResource extends cdktf.TerraformResource {
 
@@ -2111,7 +2111,7 @@ export class StaticResource extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/test/r/static test_static} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/static test_static} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -2168,7 +2168,7 @@ export class StaticResource extends cdktf.TerraformResource {
 `;
 
 exports[`incompatible resource names: string-resource 1`] = `
-"// https://www.terraform.io/docs/providers/test/r/string
+"// https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/string
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -2178,13 +2178,13 @@ import * as cdktf from 'cdktf';
 
 export interface StringResourceConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/test/r/string#dummy StringResource#dummy}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/string#dummy StringResource#dummy}
   */
   readonly dummy?: string;
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/test/r/string test_string}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/string test_string}
 */
 export class StringResource extends cdktf.TerraformResource {
 
@@ -2198,7 +2198,7 @@ export class StringResource extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/test/r/string test_string} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/string test_string} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -2255,7 +2255,7 @@ export class StringResource extends cdktf.TerraformResource {
 `;
 
 exports[`list of list attributes 1`] = `
-"// https://www.terraform.io/docs/providers/test/r/complex
+"// https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/complex
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -2619,7 +2619,7 @@ export class ComplexSsList extends cdktf.ComplexList {
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/test/r/complex test_complex}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/complex test_complex}
 */
 export class Complex extends cdktf.TerraformResource {
 
@@ -2633,7 +2633,7 @@ export class Complex extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/test/r/complex test_complex} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/resources/complex test_complex} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -2696,7 +2696,7 @@ export class Complex extends cdktf.TerraformResource {
 `;
 
 exports[`list of string map attribute 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/list_of_string_map
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/list_of_string_map
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -2708,13 +2708,13 @@ export interface ListOfStringMapConfig extends cdktf.TerraformMetaArguments {
   /**
   * List of key versions in the keyring.
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/list_of_string_map#settable_keys ListOfStringMap#settable_keys}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/list_of_string_map#settable_keys ListOfStringMap#settable_keys}
   */
   readonly settableKeys?: { [key: string]: string }[] | cdktf.IResolvable;
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/list_of_string_map aws_list_of_string_map}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/list_of_string_map aws_list_of_string_map}
 */
 export class ListOfStringMap extends cdktf.TerraformResource {
 
@@ -2728,7 +2728,7 @@ export class ListOfStringMap extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/list_of_string_map aws_list_of_string_map} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/list_of_string_map aws_list_of_string_map} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -2791,7 +2791,7 @@ export class ListOfStringMap extends cdktf.TerraformResource {
 `;
 
 exports[`map of string list attribute 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/map_of_string_list
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/map_of_string_list
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -2803,13 +2803,13 @@ export interface MapOfStringListConfig extends cdktf.TerraformMetaArguments {
   /**
   * Map of String List.
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/map_of_string_list#settable_keys MapOfStringList#settable_keys}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/map_of_string_list#settable_keys MapOfStringList#settable_keys}
   */
   readonly settableKeys?: { [key: string]: string[] } | cdktf.IResolvable;
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/map_of_string_list aws_map_of_string_list}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/map_of_string_list aws_map_of_string_list}
 */
 export class MapOfStringList extends cdktf.TerraformResource {
 
@@ -2823,7 +2823,7 @@ export class MapOfStringList extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/map_of_string_list aws_map_of_string_list} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/map_of_string_list aws_map_of_string_list} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -2886,7 +2886,7 @@ export class MapOfStringList extends cdktf.TerraformResource {
 `;
 
 exports[`number list attribute 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/number_list
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/number_list
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -2896,17 +2896,17 @@ import * as cdktf from 'cdktf';
 
 export interface NumberListConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/number_list#foo_required NumberList#foo_required}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/number_list#foo_required NumberList#foo_required}
   */
   readonly fooRequired: number[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/number_list#foo_optional NumberList#foo_optional}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/number_list#foo_optional NumberList#foo_optional}
   */
   readonly fooOptional?: number[];
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/number_list aws_number_list}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/number_list aws_number_list}
 */
 export class NumberList extends cdktf.TerraformResource {
 
@@ -2920,7 +2920,7 @@ export class NumberList extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/number_list aws_number_list} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/number_list aws_number_list} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -2992,7 +2992,7 @@ export class NumberList extends cdktf.TerraformResource {
 `;
 
 exports[`number map attribute 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/number_map
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/number_map
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -3002,17 +3002,17 @@ import * as cdktf from 'cdktf';
 
 export interface NumberMapConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/number_map#foo_computed_optional NumberMap#foo_computed_optional}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/number_map#foo_computed_optional NumberMap#foo_computed_optional}
   */
   readonly fooComputedOptional?: { [key: string]: number };
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/number_map#foo_optional NumberMap#foo_optional}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/number_map#foo_optional NumberMap#foo_optional}
   */
   readonly fooOptional?: { [key: string]: number };
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/number_map aws_number_map}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/number_map aws_number_map}
 */
 export class NumberMap extends cdktf.TerraformResource {
 
@@ -3026,7 +3026,7 @@ export class NumberMap extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/number_map aws_number_map} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/number_map aws_number_map} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -3107,7 +3107,7 @@ export class NumberMap extends cdktf.TerraformResource {
 `;
 
 exports[`primitive boolean 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/primitive_boolean
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_boolean
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -3117,21 +3117,21 @@ import * as cdktf from 'cdktf';
 
 export interface PrimitiveBooleanConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/primitive_boolean#foo_computed_optional PrimitiveBoolean#foo_computed_optional}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_boolean#foo_computed_optional PrimitiveBoolean#foo_computed_optional}
   */
   readonly fooComputedOptional?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/primitive_boolean#foo_optional PrimitiveBoolean#foo_optional}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_boolean#foo_optional PrimitiveBoolean#foo_optional}
   */
   readonly fooOptional?: boolean | cdktf.IResolvable;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/primitive_boolean#foo_required PrimitiveBoolean#foo_required}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_boolean#foo_required PrimitiveBoolean#foo_required}
   */
   readonly fooRequired: boolean | cdktf.IResolvable;
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/primitive_boolean aws_primitive_boolean}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_boolean aws_primitive_boolean}
 */
 export class PrimitiveBoolean extends cdktf.TerraformResource {
 
@@ -3145,7 +3145,7 @@ export class PrimitiveBoolean extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/primitive_boolean aws_primitive_boolean} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_boolean aws_primitive_boolean} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -3240,7 +3240,7 @@ export class PrimitiveBoolean extends cdktf.TerraformResource {
 `;
 
 exports[`primitive dynamic 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/primitive_dynamic
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_dynamic
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -3250,21 +3250,21 @@ import * as cdktf from 'cdktf';
 
 export interface PrimitiveDynamicConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/primitive_dynamic#foo_computed_optional PrimitiveDynamic#foo_computed_optional}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_dynamic#foo_computed_optional PrimitiveDynamic#foo_computed_optional}
   */
   readonly fooComputedOptional?: { [key: string]: any };
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/primitive_dynamic#foo_optional PrimitiveDynamic#foo_optional}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_dynamic#foo_optional PrimitiveDynamic#foo_optional}
   */
   readonly fooOptional?: { [key: string]: any };
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/primitive_dynamic#foo_required PrimitiveDynamic#foo_required}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_dynamic#foo_required PrimitiveDynamic#foo_required}
   */
   readonly fooRequired: { [key: string]: any };
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/primitive_dynamic aws_primitive_dynamic}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_dynamic aws_primitive_dynamic}
 */
 export class PrimitiveDynamic extends cdktf.TerraformResource {
 
@@ -3278,7 +3278,7 @@ export class PrimitiveDynamic extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/primitive_dynamic aws_primitive_dynamic} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_dynamic aws_primitive_dynamic} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -3374,7 +3374,7 @@ export class PrimitiveDynamic extends cdktf.TerraformResource {
 `;
 
 exports[`primitive number 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/primitive_number
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_number
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -3384,21 +3384,21 @@ import * as cdktf from 'cdktf';
 
 export interface PrimitiveNumberConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/primitive_number#foo_computed_optional PrimitiveNumber#foo_computed_optional}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_number#foo_computed_optional PrimitiveNumber#foo_computed_optional}
   */
   readonly fooComputedOptional?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/primitive_number#foo_optional PrimitiveNumber#foo_optional}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_number#foo_optional PrimitiveNumber#foo_optional}
   */
   readonly fooOptional?: number;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/primitive_number#foo_required PrimitiveNumber#foo_required}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_number#foo_required PrimitiveNumber#foo_required}
   */
   readonly fooRequired: number;
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/primitive_number aws_primitive_number}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_number aws_primitive_number}
 */
 export class PrimitiveNumber extends cdktf.TerraformResource {
 
@@ -3412,7 +3412,7 @@ export class PrimitiveNumber extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/primitive_number aws_primitive_number} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_number aws_primitive_number} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -3507,7 +3507,7 @@ export class PrimitiveNumber extends cdktf.TerraformResource {
 `;
 
 exports[`primitive string 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/primitive_string
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_string
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -3517,21 +3517,21 @@ import * as cdktf from 'cdktf';
 
 export interface PrimitiveStringConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/primitive_string#foo_computed_optional PrimitiveString#foo_computed_optional}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_string#foo_computed_optional PrimitiveString#foo_computed_optional}
   */
   readonly fooComputedOptional?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/primitive_string#foo_optional PrimitiveString#foo_optional}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_string#foo_optional PrimitiveString#foo_optional}
   */
   readonly fooOptional?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/primitive_string#foo_required PrimitiveString#foo_required}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_string#foo_required PrimitiveString#foo_required}
   */
   readonly fooRequired: string;
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/primitive_string aws_primitive_string}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_string aws_primitive_string}
 */
 export class PrimitiveString extends cdktf.TerraformResource {
 
@@ -3545,7 +3545,7 @@ export class PrimitiveString extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/primitive_string aws_primitive_string} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/primitive_string aws_primitive_string} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -3640,7 +3640,7 @@ export class PrimitiveString extends cdktf.TerraformResource {
 `;
 
 exports[`reset and input name conflicts 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/name_conflict
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/name_conflict
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -3650,25 +3650,25 @@ import * as cdktf from 'cdktf';
 
 export interface NameConflictConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/name_conflict#values NameConflict#values}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/name_conflict#values NameConflict#values}
   */
   readonly values?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/name_conflict#reset_values NameConflict#reset_values}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/name_conflict#reset_values NameConflict#reset_values}
   */
   readonly resetValues?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/name_conflict#template NameConflict#template}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/name_conflict#template NameConflict#template}
   */
   readonly template?: string;
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/name_conflict#template_input NameConflict#template_input}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/name_conflict#template_input NameConflict#template_input}
   */
   readonly templateInput?: string;
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/name_conflict aws_name_conflict}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/name_conflict aws_name_conflict}
 */
 export class NameConflict extends cdktf.TerraformResource {
 
@@ -3682,7 +3682,7 @@ export class NameConflict extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/name_conflict aws_name_conflict} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/name_conflict aws_name_conflict} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -3793,7 +3793,7 @@ export class NameConflict extends cdktf.TerraformResource {
 `;
 
 exports[`set / list block type 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/block_type_set_list
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/block_type_set_list
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -3805,19 +3805,19 @@ export interface BlockTypeSetListConfig extends cdktf.TerraformMetaArguments {
   /**
   * timeouts_set block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/block_type_set_list#timeouts_set BlockTypeSetList#timeouts_set}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/block_type_set_list#timeouts_set BlockTypeSetList#timeouts_set}
   */
   readonly timeoutsSet?: BlockTypeSetListTimeoutsSet[] | cdktf.IResolvable;
   /**
   * timeouts_list block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/block_type_set_list#timeouts_list BlockTypeSetList#timeouts_list}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/block_type_set_list#timeouts_list BlockTypeSetList#timeouts_list}
   */
   readonly timeoutsList?: BlockTypeSetListTimeoutsList[] | cdktf.IResolvable;
 }
 export interface BlockTypeSetListTimeoutsSet {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/block_type_set_list#create BlockTypeSetList#create}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/block_type_set_list#create BlockTypeSetList#create}
   */
   readonly create?: string;
 }
@@ -3914,7 +3914,7 @@ export class BlockTypeSetListTimeoutsSetList extends cdktf.ComplexList {
 }
 export interface BlockTypeSetListTimeoutsList {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/block_type_set_list#create BlockTypeSetList#create}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/block_type_set_list#create BlockTypeSetList#create}
   */
   readonly create?: string;
 }
@@ -4011,7 +4011,7 @@ export class BlockTypeSetListTimeoutsListList extends cdktf.ComplexList {
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/block_type_set_list aws_block_type_set_list}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/block_type_set_list aws_block_type_set_list}
 */
 export class BlockTypeSetList extends cdktf.TerraformResource {
 
@@ -4025,7 +4025,7 @@ export class BlockTypeSetList extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/block_type_set_list aws_block_type_set_list} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/block_type_set_list aws_block_type_set_list} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -4100,7 +4100,7 @@ export class BlockTypeSetList extends cdktf.TerraformResource {
 `;
 
 exports[`single block type 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/single_block_type
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/single_block_type
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -4112,13 +4112,13 @@ export interface SingleBlockTypeConfig extends cdktf.TerraformMetaArguments {
   /**
   * timeouts block
   * 
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/single_block_type#timeouts SingleBlockType#timeouts}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/single_block_type#timeouts SingleBlockType#timeouts}
   */
   readonly timeouts?: SingleBlockTypeTimeouts;
 }
 export interface SingleBlockTypeTimeouts {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/single_block_type#create SingleBlockType#create}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/single_block_type#create SingleBlockType#create}
   */
   readonly create?: string;
 }
@@ -4193,7 +4193,7 @@ export class SingleBlockTypeTimeoutsOutputReference extends cdktf.ComplexObject 
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/single_block_type aws_single_block_type}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/single_block_type aws_single_block_type}
 */
 export class SingleBlockType extends cdktf.TerraformResource {
 
@@ -4207,7 +4207,7 @@ export class SingleBlockType extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/single_block_type aws_single_block_type} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/single_block_type aws_single_block_type} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -4264,7 +4264,7 @@ export class SingleBlockType extends cdktf.TerraformResource {
 `;
 
 exports[`string list attribute 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/string_list
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/string_list
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -4274,21 +4274,21 @@ import * as cdktf from 'cdktf';
 
 export interface StringListConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/string_list#subject_alternative_names_optional_computed StringList#subject_alternative_names_optional_computed}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/string_list#subject_alternative_names_optional_computed StringList#subject_alternative_names_optional_computed}
   */
   readonly subjectAlternativeNamesOptionalComputed?: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/string_list#subject_alternative_names_required StringList#subject_alternative_names_required}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/string_list#subject_alternative_names_required StringList#subject_alternative_names_required}
   */
   readonly subjectAlternativeNamesRequired: string[];
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/string_list#subject_alternative_names_optional StringList#subject_alternative_names_optional}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/string_list#subject_alternative_names_optional StringList#subject_alternative_names_optional}
   */
   readonly subjectAlternativeNamesOptional?: string[];
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/string_list aws_string_list}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/string_list aws_string_list}
 */
 export class StringList extends cdktf.TerraformResource {
 
@@ -4302,7 +4302,7 @@ export class StringList extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/string_list aws_string_list} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/string_list aws_string_list} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
@@ -4397,7 +4397,7 @@ export class StringList extends cdktf.TerraformResource {
 `;
 
 exports[`string map attribute 1`] = `
-"// https://www.terraform.io/docs/providers/aws/r/string_map
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/string_map
 // generated from terraform resource schema
 
 import { Construct } from 'constructs';
@@ -4407,21 +4407,21 @@ import * as cdktf from 'cdktf';
 
 export interface StringMapConfig extends cdktf.TerraformMetaArguments {
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/string_map#subject_alternative_names_computed_optional StringMap#subject_alternative_names_computed_optional}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/string_map#subject_alternative_names_computed_optional StringMap#subject_alternative_names_computed_optional}
   */
   readonly subjectAlternativeNamesComputedOptional?: { [key: string]: string };
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/string_map#subject_alternative_names_optional StringMap#subject_alternative_names_optional}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/string_map#subject_alternative_names_optional StringMap#subject_alternative_names_optional}
   */
   readonly subjectAlternativeNamesOptional?: { [key: string]: string };
   /**
-  * Docs at Terraform Registry: {@link https://www.terraform.io/docs/providers/aws/r/string_map#subject_alternative_names_required StringMap#subject_alternative_names_required}
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/string_map#subject_alternative_names_required StringMap#subject_alternative_names_required}
   */
   readonly subjectAlternativeNamesRequired: { [key: string]: string };
 }
 
 /**
-* Represents a {@link https://www.terraform.io/docs/providers/aws/r/string_map aws_string_map}
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/string_map aws_string_map}
 */
 export class StringMap extends cdktf.TerraformResource {
 
@@ -4435,7 +4435,7 @@ export class StringMap extends cdktf.TerraformResource {
   // ===========
 
   /**
-  * Create a new {@link https://www.terraform.io/docs/providers/aws/r/string_map aws_string_map} Resource
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/string_map aws_string_map} Resource
   *
   * @param scope The scope in which to define this construct
   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/aws-provider.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/aws-provider.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "provider": {
         "version": 0,
         "block": {

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/aws_acm_certificate.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/aws_acm_certificate.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_acm_certificate": {
           "version": 0,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/aws_cloudfront_distribution.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/aws_cloudfront_distribution.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_cloudfront_distribution": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/aws_fms_admin_account.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/aws_fms_admin_account.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_fms_admin_account": {
           "version": 0,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/aws_s3_bucket.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/aws_s3_bucket.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_s3_bucket": {
           "version": 0,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/aws_security_group.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/aws_security_group.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_security_group": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/aws_wafv2_web_acl.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/aws_wafv2_web_acl.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_wafv2_web_acl": {
           "version": 0,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/block-type-nested-computed-list.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/block-type-nested-computed-list.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_block_type_nested_computed_list": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/block-type-set-list.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/block-type-set-list.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_block_type_set_list": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/boolean-list.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/boolean-list.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_boolean_list": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/boolean-map.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/boolean-map.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_boolean_map": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/computed-complex-nested.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/computed-complex-nested.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_computed_complex_nested": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/computed-complex.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/computed-complex.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_computed_complex": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/computed-optional-complex.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/computed-optional-complex.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_computed_optional_complex": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/datadog_dashboard.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/datadog_dashboard.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "datadog": {
+    "registry.terraform.io/hashicorp/datadog": {
       "resource_schemas": {
         "datadog_dashboard": {
           "version": 0,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/deep-attributes.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/deep-attributes.test.fixture.json
@@ -1,7 +1,7 @@
 {
   "format_version": "1.0",
   "provider_schemas": {
-    "stripe": {
+    "registry.terraform.io/hashicorp/stripe": {
       "resource_schemas": {
         "stripe_invoiceitems": {
           "version": 0,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/deeply-nested-block-types.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/deeply-nested-block-types.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_deeply_nested_block_types": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/description-escaping.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/description-escaping.test.fixture.json
@@ -1,7 +1,7 @@
 
 {
   "provider_schemas": {
-    "google": {
+    "registry.terraform.io/hashicorp/google": {
       "resource_schemas": {
         "description_escaping": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/empty-provider-resources.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/empty-provider-resources.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": null
     }
   }

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/ignored-attributes.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/ignored-attributes.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_ignored_attributes": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/incompatible-attribute-names.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/incompatible-attribute-names.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_incompatible_attribute_names": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/incompatible-resource-names.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/incompatible-resource-names.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "test": {
+    "registry.terraform.io/hashicorp/test": {
       "resource_schemas": {
         "test_string": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/list-list-object.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/list-list-object.test.fixture.json
@@ -1,7 +1,7 @@
 {
     "format_version": "1.0",
     "provider_schemas": {
-      "test": {
+      "registry.terraform.io/hashicorp/test": {
         "resource_schemas": {
           "test_complex": {
             "version": 0,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/list-of-string-map.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/list-of-string-map.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_list_of_string_map": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/map-of-string-list.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/map-of-string-list.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_map_of_string_list": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/markdown-description-with-code-blocks.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/markdown-description-with-code-blocks.test.fixture.json
@@ -1,6 +1,6 @@
 {
 	"provider_schemas": {
-		"aws": {
+		"registry.terraform.io/hashicorp/aws": {
 			"resource_schemas": {
 				"code_blocks": {
 					"version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/name-conflict.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/name-conflict.test.fixture.json
@@ -1,6 +1,6 @@
 {
     "provider_schemas": {
-      "aws": {
+      "registry.terraform.io/hashicorp/aws": {
         "resource_schemas": {
           "aws_name_conflict": {
             "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/nested-types.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/nested-types.test.fixture.json
@@ -1,7 +1,7 @@
 {
   "format_version": "0.2",
   "provider_schemas": {
-    "test": {
+    "registry.terraform.io/hashicorp/test": {
       "resource_schemas": {
         "nested_types_resource": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/number-list.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/number-list.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_number_list": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/number-map.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/number-map.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_number_map": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/primitive-boolean.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/primitive-boolean.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_primitive_boolean": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/primitive-dynamic.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/primitive-dynamic.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_primitive_dynamic": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/primitive-number.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/primitive-number.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_primitive_number": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/primitive-string.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/primitive-string.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_primitive_string": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/single-block-type.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/single-block-type.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_single_block_type": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/string-list.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/string-list.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_string_list": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/string-map.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/string-map.test.fixture.json
@@ -1,6 +1,6 @@
 {
   "provider_schemas": {
-    "aws": {
+    "registry.terraform.io/hashicorp/aws": {
       "resource_schemas": {
         "aws_string_map": {
           "version": 1,

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/stripe-schema.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/stripe-schema.test.fixture.json
@@ -1,7 +1,7 @@
 {
   "format_version": "1.0",
   "provider_schemas": {
-    "stripe": {
+    "registry.terraform.io/andrewbaxter/stripe": {
       "resource_schemas": {
         "stripe_invoiceitems": {
           "version": 0,

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/resource-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/resource-model.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 import { toSnakeCase } from "codemaker";
 import path from "path";
-import { ProviderName, Schema } from "../provider-schema";
+import { FQPN, parseFQPN, ProviderName, Schema } from "../provider-schema";
 import { AttributeModel } from "./attribute-model";
 import { Struct, ConfigStruct } from "./struct";
 
@@ -19,7 +19,7 @@ interface ResourceModelOptions {
   filePath: string;
   attributes: AttributeModel[];
   structs: Struct[];
-  provider: ProviderName;
+  fqpn: FQPN;
   schema: Schema;
   terraformSchemaType: string;
   configStructName: string;
@@ -32,6 +32,7 @@ export class ResourceModel {
   public terraformType: string;
   public baseName: string;
   public provider: ProviderName;
+  public fqpn: FQPN;
   public providerVersionConstraint?: string;
   public providerVersion?: string;
   public terraformProviderSource?: string;
@@ -52,7 +53,8 @@ export class ResourceModel {
     this.baseName = options.baseName;
     this.attributes = options.attributes;
     this.schema = options.schema;
-    this.provider = options.provider;
+    this.fqpn = options.fqpn;
+    this.provider = parseFQPN(options.fqpn).name;
     this.fileName = options.fileName;
     this._structs = options.structs;
     this.terraformSchemaType = options.terraformSchemaType;
@@ -89,7 +91,6 @@ export class ResourceModel {
 
   public get linkToDocs(): string {
     if (this.isProvider)
-      // https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs
       return `https://www.terraform.io/docs/providers/${this.provider}`;
     return `https://www.terraform.io/docs/providers/${this.provider}/${
       this.isDataSource ? "d" : "r"

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/resource-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/resource-model.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 import { toSnakeCase } from "codemaker";
 import path from "path";
-import { Schema } from "../provider-schema";
+import { ProviderName, Schema } from "../provider-schema";
 import { AttributeModel } from "./attribute-model";
 import { Struct, ConfigStruct } from "./struct";
 
@@ -19,7 +19,7 @@ interface ResourceModelOptions {
   filePath: string;
   attributes: AttributeModel[];
   structs: Struct[];
-  provider: string;
+  provider: ProviderName;
   schema: Schema;
   terraformSchemaType: string;
   configStructName: string;
@@ -31,7 +31,7 @@ export class ResourceModel {
   public filePath: string;
   public terraformType: string;
   public baseName: string;
-  public provider: string;
+  public provider: ProviderName;
   public providerVersionConstraint?: string;
   public providerVersion?: string;
   public terraformProviderSource?: string;
@@ -89,6 +89,7 @@ export class ResourceModel {
 
   public get linkToDocs(): string {
     if (this.isProvider)
+      // https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs
       return `https://www.terraform.io/docs/providers/${this.provider}`;
     return `https://www.terraform.io/docs/providers/${this.provider}/${
       this.isDataSource ? "d" : "r"

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/resource-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/resource-model.ts
@@ -90,11 +90,13 @@ export class ResourceModel {
   }
 
   public get linkToDocs(): string {
-    if (this.isProvider)
-      return `https://www.terraform.io/docs/providers/${this.provider}`;
-    return `https://www.terraform.io/docs/providers/${this.provider}/${
-      this.isDataSource ? "d" : "r"
-    }/${this.terraformDocName}`;
+    const { hostname, namespace, name } = parseFQPN(this.fqpn);
+    const version = this.providerVersion || "latest";
+    const base = `https://${hostname}/providers/${namespace}/${name}/${version}/docs`;
+    if (this.isProvider) return base;
+    if (this.isDataSource)
+      return `${base}/data-sources/${this.terraformDocName}`;
+    return `${base}/resources/${this.terraformDocName}`;
   }
 
   public get isProvider(): boolean {

--- a/packages/@cdktf/provider-generator/lib/get/generator/provider-generator.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/provider-generator.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 import { CodeMaker, toCamelCase } from "codemaker";
 import { LANGUAGES, logger, TerraformProviderConstraint } from "@cdktf/commons";
-import { ProviderSchema } from "./provider-schema";
+import { FQPN, parseFQPN, ProviderSchema } from "./provider-schema";
 import { ResourceModel } from "./models";
 import { ResourceParser } from "./resource-parser";
 import { ResourceEmitter, StructEmitter } from "./emitter";
@@ -57,10 +57,12 @@ export class TerraformProviderGenerator {
     this.structEmitter = new StructEmitter(this.code);
   }
 
-  private getProviderByConstraint(providerConstraint: ConstructsMakerTarget) {
+  private getProviderByConstraint(
+    providerConstraint: ConstructsMakerTarget
+  ): FQPN | undefined {
     return Object.keys(this.schema.provider_schemas || {}).find((fqpn) =>
       isMatching(providerConstraint, fqpn)
-    );
+    ) as FQPN | undefined;
   }
 
   public generate(providerConstraint: ConstructsMakerTarget) {
@@ -98,8 +100,8 @@ export class TerraformProviderGenerator {
     await this.code.save(outdir);
   }
 
-  public buildResourceModels(fqpn: string): ResourceModel[] {
-    const name = fqpn.split("/").pop();
+  public buildResourceModels(fqpn: FQPN): ResourceModel[] {
+    const { name } = parseFQPN(fqpn);
     if (!name) {
       throw new Error(`can't handle ${fqpn}`);
     }
@@ -127,11 +129,11 @@ export class TerraformProviderGenerator {
   }
 
   private emitProvider(
-    fqpn: string,
+    fqpn: FQPN,
     providerVersion?: string,
     constraint?: ConstructsMakerTarget
   ) {
-    const name = fqpn.split("/").pop();
+    const { name } = parseFQPN(fqpn);
     if (!name) {
       throw new Error(`can't handle ${fqpn}`);
     }

--- a/packages/@cdktf/provider-generator/lib/get/generator/provider-schema.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/provider-schema.ts
@@ -21,6 +21,9 @@ export type ProviderName = string & { __type: "ProviderName" };
 
 export const parseFQPN = (f: FQPN) => {
   const [hostname, namespace, name] = f.split("/");
+  if (!name) {
+    throw new Error(`can't handle ${f}`);
+  }
   return { hostname, namespace, name } as {
     hostname: ProviderHostname;
     namespace: ProviderNamespace;

--- a/packages/@cdktf/provider-generator/lib/get/generator/provider-schema.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/provider-schema.ts
@@ -10,14 +10,32 @@ import { ConstructsMakerProviderTarget } from "../constructs-maker";
 
 const terraformBinaryName = process.env.TERRAFORM_BINARY_NAME || "terraform";
 
+/**
+ * Fully Qualified provider name in the format:
+ * like e.g. registry.terraform.io/hashicorp/aws
+ */
+export type FQPN = string & { __type: "FullyQualifiedProviderName" };
+export type ProviderHostname = string & { __type: "ProviderHostname" };
+export type ProviderNamespace = string & { __type: "ProviderNamespace" };
+export type ProviderName = string & { __type: "ProviderName" };
+
+export const parseFQPN = (f: FQPN) => {
+  const [hostname, namespace, name] = f.split("/");
+  return { hostname, namespace, name } as {
+    hostname: ProviderHostname;
+    namespace: ProviderNamespace;
+    name: ProviderName;
+  };
+};
+
 export interface ProviderSchema {
   /*
   0.1 is e.g. returned by Terraform 0.14
   0.2 is e.g. returned by Terraform 1.0 (0.2 added support for nested_type / plugin protocol v6)
   */
   format_version?: "0.1" | "0.2";
-  provider_schemas?: { [type: string]: Provider };
-  provider_versions?: { [fqn: string]: string };
+  provider_schemas?: { [fqpn: string]: Provider };
+  provider_versions?: { [fqpn: string]: string };
 }
 
 export interface Provider {

--- a/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
@@ -11,6 +11,8 @@ import {
   isNestedTypeAttribute,
   Schema,
   ProviderName,
+  FQPN,
+  parseFQPN,
 } from "./provider-schema";
 import {
   ResourceModel,
@@ -76,11 +78,12 @@ class Parser {
   }
 
   public resourceFrom(
-    provider: ProviderName,
+    fqpn: FQPN,
     type: string,
     schema: Schema,
     terraformSchemaType: string
   ): ResourceModel {
+    const provider = parseFQPN(fqpn).name;
     let baseName = type;
     if (baseName.startsWith(`${provider}_`)) {
       baseName = baseName.substr(provider.length + 1);
@@ -192,7 +195,7 @@ class Parser {
       filePath,
       className,
       schema,
-      provider,
+      fqpn,
       attributes,
       terraformSchemaType,
       structs: this.structs,
@@ -568,7 +571,7 @@ export class ResourceParser {
   private resources: Record<string, ResourceModel> = {};
 
   public parse(
-    provider: ProviderName,
+    fqpn: FQPN,
     type: string,
     schema: Schema,
     terraformType: string
@@ -578,7 +581,7 @@ export class ResourceParser {
     }
 
     const parser = new Parser(this.uniqueClassnames);
-    const resource = parser.resourceFrom(provider, type, schema, terraformType);
+    const resource = parser.resourceFrom(fqpn, type, schema, terraformType);
     this.resources[type] = resource;
     return resource;
   }

--- a/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
@@ -10,6 +10,7 @@ import {
   isAttributeNestedType,
   isNestedTypeAttribute,
   Schema,
+  ProviderName,
 } from "./provider-schema";
 import {
   ResourceModel,
@@ -49,7 +50,7 @@ const isReservedClassOrNamespaceName = (className: string): boolean => {
   ].includes(className.toLowerCase());
 };
 
-const getFileName = (provider: string, baseName: string): string => {
+const getFileName = (provider: ProviderName, baseName: string): string => {
   if (baseName === "index") {
     return "index-resource/index.ts";
   }
@@ -75,7 +76,7 @@ class Parser {
   }
 
   public resourceFrom(
-    provider: string,
+    provider: ProviderName,
     type: string,
     schema: Schema,
     terraformSchemaType: string
@@ -567,7 +568,7 @@ export class ResourceParser {
   private resources: Record<string, ResourceModel> = {};
 
   public parse(
-    provider: string,
+    provider: ProviderName,
     type: string,
     schema: Schema,
     terraformType: string


### PR DESCRIPTION
- chore(provider-generator): introduce branded types for fully qualified provider name
- chore(provider-generator): make fqpn available in resource model
- fix(provider-generator): Use registry.terraform.io links instead of old terraform.io
- chore(provider-generator): update tests and snapshots
