### PR TITLE
fix: don't post about large PRs since this currently happens repeatedly and spams the timeline of PRs

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -31,9 +31,5 @@ jobs:
           l_max_size: "1000"
           xl_label: "size/xl"
           fail_if_xl: "false"
-          message_if_xl: >
-            This PR exceeds the recommended size of 1000 lines.
-            Please make sure you are NOT addressing multiple issues with one PR.
-            Note this PR might be rejected due to its size.
           # Ignoring generate files
           files_to_ignore: "website/docs/cdktf/api-reference/csharp.mdx website/docs/cdktf/api-reference/go.mdx website/docs/cdktf/api-reference/java.mdx website/docs/cdktf/api-reference/python.mdx website/docs/cdktf/api-reference/typescript.mdx"


### PR DESCRIPTION
We already ignore that comment anyway :sweat_smile:

<img src="https://media0.giphy.com/media/t0iSe43jX8JH0Hb95a/giphy.gif"/>