### PR TITLE
fix(cli): Give hint when cdktf synth failed to create config

### DIFF
--- a/packages/@cdktf/cli-core/src/lib/synth-stack.ts
+++ b/packages/@cdktf/cli-core/src/lib/synth-stack.ts
@@ -154,7 +154,7 @@ Command output on stdout:
     }
 
     if (!(await fs.pathExists(path.join(outdir, Manifest.fileName)))) {
-      const errorMessage = `ERROR: synthesis failed, app expected to create "${outdir}/${Manifest.fileName}". Make sure your CDKTF App is synthesized.`;
+      const errorMessage = `ERROR: synthesis failed, because app was expected to call 'synth()`, but didn't. Thus "${outdir}/${Manifest.fileName}"  was not created.`;
       if (graceful) {
         throw new Error(errorMessage);
       }

--- a/packages/@cdktf/cli-core/src/lib/synth-stack.ts
+++ b/packages/@cdktf/cli-core/src/lib/synth-stack.ts
@@ -154,7 +154,7 @@ Command output on stdout:
     }
 
     if (!(await fs.pathExists(path.join(outdir, Manifest.fileName)))) {
-      const errorMessage = `ERROR: synthesis failed, app expected to create "${outdir}/${Manifest.fileName}"`;
+      const errorMessage = `ERROR: synthesis failed, app expected to create "${outdir}/${Manifest.fileName}". Did you forget to call app.synth()?`;
       if (graceful) {
         throw new Error(errorMessage);
       }

--- a/packages/@cdktf/cli-core/src/lib/synth-stack.ts
+++ b/packages/@cdktf/cli-core/src/lib/synth-stack.ts
@@ -154,7 +154,7 @@ Command output on stdout:
     }
 
     if (!(await fs.pathExists(path.join(outdir, Manifest.fileName)))) {
-      const errorMessage = `ERROR: synthesis failed, because app was expected to call 'synth()`, but didn't. Thus "${outdir}/${Manifest.fileName}"  was not created.`;
+      const errorMessage = `ERROR: synthesis failed, because app was expected to call 'synth()', but didn't. Thus "${outdir}/${Manifest.fileName}"  was not created.`;
       if (graceful) {
         throw new Error(errorMessage);
       }

--- a/packages/@cdktf/cli-core/src/lib/synth-stack.ts
+++ b/packages/@cdktf/cli-core/src/lib/synth-stack.ts
@@ -154,7 +154,7 @@ Command output on stdout:
     }
 
     if (!(await fs.pathExists(path.join(outdir, Manifest.fileName)))) {
-      const errorMessage = `ERROR: synthesis failed, app expected to create "${outdir}/${Manifest.fileName}". Did you forget to call app.synth()?`;
+      const errorMessage = `ERROR: synthesis failed, app expected to create "${outdir}/${Manifest.fileName}". Make sure your CDKTF App is synthesized.`;
       if (graceful) {
         throw new Error(errorMessage);
       }


### PR DESCRIPTION
There was a recent case where someone on the CDK Dev Slack got this error and it took them a while to figure out that they were missing the `app.synth()` call which is probably the most common mistake leading to this error.

The current error message is not really helpful in that regard:
<img width="905" alt="image" src="https://user-images.githubusercontent.com/1112056/224295391-1ebd35dd-8731-49d0-ade3-49e60615c404.png">

So this PR adds a hint.