### PR TITLE
chore: improve development performance by excluding synth

### DIFF
--- a/packages/@cdktf/hcl2cdk/README.md
+++ b/packages/@cdktf/hcl2cdk/README.md
@@ -77,21 +77,6 @@ This transforms your Terraform project into a CDK for Terraform project, besides
 
 ## Known Limitations
 
-### Terraform Expressions are of the wrong TS/Java/C# type
-
-When working with typed languages the converter can run into problems where the Terraform Expression evaluates to a certain type but it's encoded in a string. Therefore the type checker of the language detects a type mismatch, resulting in an compilation error. These problems need to be manually solved by adding a typecast. One example would be:
-
-```ts
-{
-  // Typescript expects a boolean here, but a string is passed
-  booleanProperty:
-    ( // This Terraform expression evaluates to a boolean as required by the property
-      `\${${shouldBeTrue.value} ? true : false}`
-      as boolean // We need to cast the type so that Typescript understand the right type is being passed
-    );
-}
-```
-
 ### Providers guessed can be not functional
 
 If your HCL includes providers that are not mentioned under `required_providers` we infer the name, e.g. if you use the `datadog_dashboard` resource we infer the provider `datadog` which is right, but the namespace is missing, for DataDog it would be `datadog/datadog`. Instead we will try to use `hashicorp/datadog` and fail because this provider is not known to the registry.
@@ -100,3 +85,11 @@ Please see the [required providers docs](https://www.terraform.io/docs/language/
 ### Local Modules and Files
 
 We don't move modules or files for you, if you reference local modules you have to move them so that the relative paths are correct. If you want to make use of files you need to wrap them in a [`TerraformAsset`](../../docs/working-with-cdk-for-terraform/terraform-assets.md) before using them.
+
+### Development
+
+We have two types of test cases, one within `lib` that are on the unit level and one within `test` that are testing the entire package at once by converting and then synthesizing the resulting code.
+
+In general, both test types can be run by `npx jest <pathToTestCase>`. You can add `-u` to update the snapshots and `--watch` to run the tests in watch mode.
+
+To make the tests inside `test` faster we disable synthesizing and multi-language snapshots by default. You can enable them by setting the envinronment variable `CI=true`. Another way of improving the performance significantly is setting the `TF_PLUGIN_CACHE_DIR` to a valid directory in order to cache the provider binaries used within the tests. E.g. by running `TF_PLUGIN_CACHE_DIR=(mktemp -d) npx jest <pathToTestCase> --watch`.

--- a/packages/@cdktf/hcl2cdk/test/helpers/convert.ts
+++ b/packages/@cdktf/hcl2cdk/test/helpers/convert.ts
@@ -334,7 +334,10 @@ app.synth();
               expect.stringContaining(`Generated Terraform code for the stacks`)
             );
           }, 500_000);
-        } else {
+        } else if (
+          shouldSynth === Synth.yes ||
+          shouldSynth === Synth.yes_all_languages
+        ) {
           it.skip("synth", () => {});
         }
       });
@@ -364,7 +367,7 @@ app.synth();
             expect(convertResult.all).toMatchSnapshot();
           }, 500_000);
         });
-      } else {
+      } else if (shouldSynth === Synth.yes_all_languages) {
         describe.skip.each(["python", "csharp", "java", "go"])("%s", () => {
           it.skip("snapshot", () => {});
         });

--- a/packages/@cdktf/hcl2cdk/test/helpers/convert.ts
+++ b/packages/@cdktf/hcl2cdk/test/helpers/convert.ts
@@ -305,41 +305,37 @@ const createTestCase =
           includeSynthTests &&
           (shouldSynth === Synth.yes || shouldSynth === Synth.yes_all_languages)
         ) {
-          it.concurrent(
-            "synth",
-            async () => {
-              const filename = name.replace(/\s/g, "-");
-              const projectDirPromise = getProjectDirectory(providers);
-              const { all } = convertResult;
-              const projectDir = await projectDirPromise;
+          it("synth", async () => {
+            const filename = name.replace(/\s/g, "-");
+            const projectDirPromise = getProjectDirectory(providers);
+            const { all } = convertResult;
+            const projectDir = await projectDirPromise;
 
-              // Have a before all somewhere above bootstrap a TS project
-              // __dirname should be replaceed by the bootstrapped directory
-              const pathToThisProjectsFile = path.join(
-                projectDir,
-                filename + ".ts"
-              );
-              const fileContent = `
+            // Have a before all somewhere above bootstrap a TS project
+            // __dirname should be replaceed by the bootstrapped directory
+            const pathToThisProjectsFile = path.join(
+              projectDir,
+              filename + ".ts"
+            );
+            const fileContent = `
 ${all}
 const app = new cdktf.App();
 new MyConvertedCode(app, "${filename}");
 app.synth();
 `;
 
-              fs.writeFileSync(pathToThisProjectsFile, fileContent, "utf8");
+            fs.writeFileSync(pathToThisProjectsFile, fileContent, "utf8");
 
-              const stdout = execSync(
-                `${cdktfBin} synth -a 'npx ts-node ${filename}.ts' -o ./${filename}-output`,
-                { cwd: projectDir }
-              );
-              expect(stdout.toString()).toEqual(
-                expect.stringContaining(
-                  `Generated Terraform code for the stacks`
-                )
-              );
-            },
-            500_000
-          );
+            const stdout = execSync(
+              `${cdktfBin} synth -a 'npx ts-node ${filename}.ts' -o ./${filename}-output`,
+              { cwd: projectDir }
+            );
+            expect(stdout.toString()).toEqual(
+              expect.stringContaining(`Generated Terraform code for the stacks`)
+            );
+          }, 500_000);
+        } else {
+          it.skip("synth", () => {});
         }
       });
 
@@ -367,6 +363,10 @@ app.synth();
             });
             expect(convertResult.all).toMatchSnapshot();
           }, 500_000);
+        });
+      } else {
+        describe.skip.each(["python", "csharp", "java", "go"])("%s", () => {
+          it.skip("snapshot", () => {});
         });
       }
     };


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

None

### Description

This removes the synths from the local test invocations by default, but not during CI

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
