### PR TITLE
refactor(hcl2json): rename wasm method to match its implementation and expose it more direct aswell

### DIFF
--- a/packages/@cdktf/hcl2json/lib/index.ts
+++ b/packages/@cdktf/hcl2json/lib/index.ts
@@ -98,7 +98,7 @@ export async function parse(
 
 export async function convertFiles(
   workingDirectory: string
-): Promise<Record<string, any> | void> {
+): Promise<Record<string, any>> {
   let tfFileContents = "";
   const tfJSONFileContents: Record<string, any>[] = [];
 

--- a/packages/@cdktf/hcl2json/lib/index.ts
+++ b/packages/@cdktf/hcl2json/lib/index.ts
@@ -114,7 +114,7 @@ export async function convertFiles(
     }
   }
 
-  if (tfFileContents === "" && tfJSONFileContents === []) {
+  if (tfFileContents === "" && tfJSONFileContents.length === 0) {
     console.error(`No '.tf' or '.tf.json' files found in ${workingDirectory}`);
     return;
   }

--- a/packages/@cdktf/hcl2json/lib/index.ts
+++ b/packages/@cdktf/hcl2json/lib/index.ts
@@ -14,7 +14,7 @@ import { gunzipSync } from "zlib";
 
 interface GoBridge {
   parse: (filename: string, hcl: string) => Promise<string>;
-  getReferencesInExpression: (filename: string, hcl: string) => Promise<string>;
+  parseExpression: (filename: string, hcl: string) => Promise<string>;
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -199,7 +199,7 @@ type TerraformObject =
   | TerraformLiteral
   | TerraformTraversal;
 
-type GoExpressionParseResult = null | TerraformObject;
+export type GoExpressionParseResult = null | TerraformObject;
 
 type Reference = { value: string; startPosition: number; endPosition: number };
 
@@ -256,7 +256,7 @@ function traversalToReference(
 
 function findAllReferencesInAst(
   input: string,
-  entry: TerraformObject | undefined | null
+  entry: TerraformObject | null
 ): Reference[] {
   if (!entry) {
     return [];
@@ -331,19 +331,18 @@ function findAllReferencesInAst(
   return [];
 }
 
+export async function parseExpression(
+  filename: string,
+  expression: string
+): Promise<GoExpressionParseResult> {
+  const res = await wasm.parseExpression(filename, JSON.stringify(expression));
+  return JSON.parse(res) as GoExpressionParseResult;
+}
+
 export async function getReferencesInExpression(
   filename: string,
   expression: string
 ): Promise<Reference[]> {
-  const res = await wasm.getReferencesInExpression(
-    filename,
-    JSON.stringify(expression)
-  );
-  const ast = JSON.parse(res) as GoExpressionParseResult;
-
-  if (!ast) {
-    return [];
-  }
-
+  const ast = await parseExpression(filename, expression);
   return findAllReferencesInAst(expression, ast);
 }

--- a/packages/@cdktf/hcl2json/lib/index.ts
+++ b/packages/@cdktf/hcl2json/lib/index.ts
@@ -116,7 +116,7 @@ export async function convertFiles(
 
   if (tfFileContents === "" && tfJSONFileContents.length === 0) {
     console.error(`No '.tf' or '.tf.json' files found in ${workingDirectory}`);
-    return;
+    return {};
   }
 
   return deepMerge(

--- a/packages/@cdktf/hcl2json/main.go
+++ b/packages/@cdktf/hcl2json/main.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//+ build js,wasm
+// + build js,wasm
 package main
 
 import (
@@ -66,7 +66,7 @@ func main() {
 		return string(converted), err
 	})
 
-	registerFn("getReferencesInExpression", func(this js.Value, args []js.Value) (interface{}, error) {
+	registerFn("parseExpression", func(this js.Value, args []js.Value) (interface{}, error) {
 		if len(args) == 0 {
 			return nil, fmt.Errorf("No arguments provided")
 		}
@@ -75,7 +75,6 @@ func main() {
 		if err != nil {
 			return nil, err
 		}
-
 
 		if !hcljson.IsJSONExpression(expr) {
 			return nil, fmt.Errorf("Expected JSON expression")
@@ -100,7 +99,6 @@ func main() {
 	})
 	<-c
 }
-
 
 func expressionForValue(val cty.Value) (hclsyntax.Expression, hcl.Diagnostics) {
 	// NOTE: This intentionally only supports the subset of cty

--- a/packages/@cdktf/hcl2json/test/__snapshots__/hcl2json.test.ts.snap
+++ b/packages/@cdktf/hcl2json/test/__snapshots__/hcl2json.test.ts.snap
@@ -4294,8 +4294,6 @@ exports[`convertFiles a simple directory 1`] = `
 }"
 `;
 
-exports[`convertFiles no files 1`] = `"{}"`;
-
 exports[`parse converts VPC module 1`] = `
 "{
   \\"locals\\": [


### PR DESCRIPTION
This PR prepares the library for the convert work that's going to happen to support e.g. replacing functions and operations.

- fix(hcl2json): correctly check for empty array
- refactor(hcl2json): rename wasm method to match its implementation and expose it more direct aswell
