### PR TITLE
chore: fix copyright headers automation

### DIFF
--- a/.github/workflows/pr-copyright.yml
+++ b/.github/workflows/pr-copyright.yml
@@ -1,7 +1,7 @@
 name: "Add Copyright Headers"
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened


### PR DESCRIPTION
Use `pull_request_target` so that this can run successfully for outside contributors as well.

