### PR TITLE
fix(provider-generator): Fix generating bindings for providers that have only block types in their schema

### DIFF
--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/provider.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/provider.test.ts.snap
@@ -1563,3 +1563,199 @@ export class AwsProvider extends cdktf.TerraformProvider {
 }
 "
 `;
+
+exports[`generate provider with only block_types 1`] = `
+"// https://registry.terraform.io/providers/elastic/elasticstack/latest/docs
+// generated from terraform resource schema
+
+import { Construct } from 'constructs';
+import * as cdktf from 'cdktf';
+
+// Configuration
+
+export interface ElasticstackProviderConfig {
+  /**
+  * Alias name
+  * 
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/elastic/elasticstack/latest/docs#alias ElasticstackProvider#alias}
+  */
+  readonly alias?: string;
+  /**
+  * elasticsearch block
+  * 
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/elastic/elasticstack/latest/docs#elasticsearch ElasticstackProvider#elasticsearch}
+  */
+  readonly elasticsearch?: ElasticstackProviderElasticsearch;
+}
+export interface ElasticstackProviderElasticsearch {
+  /**
+  * API Key to use for authentication to Elasticsearch
+  * 
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/elastic/elasticstack/latest/docs#api_key ElasticstackProvider#api_key}
+  */
+  readonly apiKey?: string;
+  /**
+  * PEM-encoded custom Certificate Authority certificate
+  * 
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/elastic/elasticstack/latest/docs#ca_data ElasticstackProvider#ca_data}
+  */
+  readonly caData?: string;
+  /**
+  * Path to a custom Certificate Authority certificate
+  * 
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/elastic/elasticstack/latest/docs#ca_file ElasticstackProvider#ca_file}
+  */
+  readonly caFile?: string;
+  /**
+  * PEM encoded certificate for client auth
+  * 
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/elastic/elasticstack/latest/docs#cert_data ElasticstackProvider#cert_data}
+  */
+  readonly certData?: string;
+  /**
+  * Path to a file containing the PEM encoded certificate for client auth
+  * 
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/elastic/elasticstack/latest/docs#cert_file ElasticstackProvider#cert_file}
+  */
+  readonly certFile?: string;
+  /**
+  * A comma-separated list of endpoints where the terraform provider will point to, this must include the http(s) schema and port number.
+  * 
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/elastic/elasticstack/latest/docs#endpoints ElasticstackProvider#endpoints}
+  */
+  readonly endpoints?: string[];
+  /**
+  * Disable TLS certificate validation
+  * 
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/elastic/elasticstack/latest/docs#insecure ElasticstackProvider#insecure}
+  */
+  readonly insecure?: boolean | cdktf.IResolvable;
+  /**
+  * PEM encoded private key for client auth
+  * 
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/elastic/elasticstack/latest/docs#key_data ElasticstackProvider#key_data}
+  */
+  readonly keyData?: string;
+  /**
+  * Path to a file containing the PEM encoded private key for client auth
+  * 
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/elastic/elasticstack/latest/docs#key_file ElasticstackProvider#key_file}
+  */
+  readonly keyFile?: string;
+  /**
+  * Password to use for API authentication to Elasticsearch.
+  * 
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/elastic/elasticstack/latest/docs#password ElasticstackProvider#password}
+  */
+  readonly password?: string;
+  /**
+  * Username to use for API authentication to Elasticsearch.
+  * 
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/elastic/elasticstack/latest/docs#username ElasticstackProvider#username}
+  */
+  readonly username?: string;
+}
+
+export function elasticstackProviderElasticsearchToTerraform(struct?: ElasticstackProviderElasticsearch): any {
+  if (!cdktf.canInspect(struct) || cdktf.Tokenization.isResolvable(struct)) { return struct; }
+  if (cdktf.isComplexElement(struct)) {
+    throw new Error(\\"A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration\\");
+  }
+  return {
+    api_key: cdktf.stringToTerraform(struct!.apiKey),
+    ca_data: cdktf.stringToTerraform(struct!.caData),
+    ca_file: cdktf.stringToTerraform(struct!.caFile),
+    cert_data: cdktf.stringToTerraform(struct!.certData),
+    cert_file: cdktf.stringToTerraform(struct!.certFile),
+    endpoints: cdktf.listMapper(cdktf.stringToTerraform, false)(struct!.endpoints),
+    insecure: cdktf.booleanToTerraform(struct!.insecure),
+    key_data: cdktf.stringToTerraform(struct!.keyData),
+    key_file: cdktf.stringToTerraform(struct!.keyFile),
+    password: cdktf.stringToTerraform(struct!.password),
+    username: cdktf.stringToTerraform(struct!.username),
+  }
+}
+
+
+/**
+* Represents a {@link https://registry.terraform.io/providers/elastic/elasticstack/latest/docs elasticstack}
+*/
+export class ElasticstackProvider extends cdktf.TerraformProvider {
+
+  // =================
+  // STATIC PROPERTIES
+  // =================
+  public static readonly tfResourceType = \\"elasticstack\\";
+
+  // ===========
+  // INITIALIZER
+  // ===========
+
+  /**
+  * Create a new {@link https://registry.terraform.io/providers/elastic/elasticstack/latest/docs elasticstack} Resource
+  *
+  * @param scope The scope in which to define this construct
+  * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
+  * @param options ElasticstackProviderConfig = {}
+  */
+  public constructor(scope: Construct, id: string, config: ElasticstackProviderConfig = {}) {
+    super(scope, id, {
+      terraformResourceType: 'elasticstack',
+      terraformGeneratorMetadata: {
+        providerName: 'elasticstack'
+      },
+      terraformProviderSource: 'registry.terraform.io/elastic/elasticstack'
+    });
+    this._alias = config.alias;
+    this._elasticsearch = config.elasticsearch;
+  }
+
+  // ==========
+  // ATTRIBUTES
+  // ==========
+
+  // alias - computed: false, optional: true, required: false
+  private _alias?: string; 
+  public get alias() {
+    return this._alias;
+  }
+  public set alias(value: string | undefined) {
+    this._alias = value;
+  }
+  public resetAlias() {
+    this._alias = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get aliasInput() {
+    return this._alias;
+  }
+
+  // elasticsearch - computed: false, optional: true, required: false
+  private _elasticsearch?: ElasticstackProviderElasticsearch; 
+  public get elasticsearch() {
+    return this._elasticsearch;
+  }
+  public set elasticsearch(value: ElasticstackProviderElasticsearch | undefined) {
+    this._elasticsearch = value;
+  }
+  public resetElasticsearch() {
+    this._elasticsearch = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get elasticsearchInput() {
+    return this._elasticsearch;
+  }
+
+  // =========
+  // SYNTHESIS
+  // =========
+
+  protected synthesizeAttributes(): { [name: string]: any } {
+    return {
+      alias: cdktf.stringToTerraform(this._alias),
+      elasticsearch: elasticstackProviderElasticsearchToTerraform(this._elasticsearch),
+    };
+  }
+}
+"
+`;

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/elasticstack-provider.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/elasticstack-provider.test.fixture.json
@@ -1,0 +1,99 @@
+{
+  "format_version": "1.0",
+  "provider_schemas": {
+    "registry.terraform.io/elastic/elasticstack": {
+      "provider": {
+        "version": 0,
+        "block": {
+          "block_types": {
+            "elasticsearch": {
+              "nesting_mode": "list",
+              "block": {
+                "attributes": {
+                  "api_key": {
+                    "type": "string",
+                    "description": "API Key to use for authentication to Elasticsearch",
+                    "description_kind": "markdown",
+                    "optional": true,
+                    "sensitive": true
+                  },
+                  "ca_data": {
+                    "type": "string",
+                    "description": "PEM-encoded custom Certificate Authority certificate",
+                    "description_kind": "markdown",
+                    "optional": true
+                  },
+                  "ca_file": {
+                    "type": "string",
+                    "description": "Path to a custom Certificate Authority certificate",
+                    "description_kind": "markdown",
+                    "optional": true
+                  },
+                  "cert_data": {
+                    "type": "string",
+                    "description": "PEM encoded certificate for client auth",
+                    "description_kind": "markdown",
+                    "optional": true
+                  },
+                  "cert_file": {
+                    "type": "string",
+                    "description": "Path to a file containing the PEM encoded certificate for client auth",
+                    "description_kind": "markdown",
+                    "optional": true
+                  },
+                  "endpoints": {
+                    "type": [
+                      "list",
+                      "string"
+                    ],
+                    "description": "A comma-separated list of endpoints where the terraform provider will point to, this must include the http(s) schema and port number.",
+                    "description_kind": "markdown",
+                    "optional": true,
+                    "sensitive": true
+                  },
+                  "insecure": {
+                    "type": "bool",
+                    "description": "Disable TLS certificate validation",
+                    "description_kind": "markdown",
+                    "optional": true
+                  },
+                  "key_data": {
+                    "type": "string",
+                    "description": "PEM encoded private key for client auth",
+                    "description_kind": "markdown",
+                    "optional": true,
+                    "sensitive": true
+                  },
+                  "key_file": {
+                    "type": "string",
+                    "description": "Path to a file containing the PEM encoded private key for client auth",
+                    "description_kind": "markdown",
+                    "optional": true
+                  },
+                  "password": {
+                    "type": "string",
+                    "description": "Password to use for API authentication to Elasticsearch.",
+                    "description_kind": "markdown",
+                    "optional": true,
+                    "sensitive": true
+                  },
+                  "username": {
+                    "type": "string",
+                    "description": "Username to use for API authentication to Elasticsearch.",
+                    "description_kind": "markdown",
+                    "optional": true
+                  }
+                },
+                "description": "Elasticsearch connection configuration block.",
+                "description_kind": "markdown"
+              },
+              "max_items": 1
+            }
+          },
+          "description_kind": "plain"
+        }
+      },
+      "resource_schemas": []
+    }
+  }
+}

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/provider.test.ts
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/provider.test.ts
@@ -24,3 +24,26 @@ test("generate provider", async () => {
   );
   expect(output).toMatchSnapshot();
 });
+
+test("generate provider with only block_types", async () => {
+  const code = new CodeMaker();
+  const workdir = fs.mkdtempSync(path.join(os.tmpdir(), "provider.test"));
+  const spec = JSON.parse(
+    fs.readFileSync(
+      path.join(
+        __dirname,
+        "fixtures",
+        "elasticstack-provider.test.fixture.json"
+      ),
+      "utf-8"
+    )
+  );
+  new TerraformProviderGenerator(code, spec).generateAll();
+  await code.save(workdir);
+
+  const output = fs.readFileSync(
+    path.join(workdir, "providers/elasticstack/provider/index.ts"),
+    "utf-8"
+  );
+  expect(output).toMatchSnapshot();
+});

--- a/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
@@ -93,7 +93,10 @@ class Parser {
     if (isProvider) {
       baseName = `${provider}_${baseName}`;
       if (!("attributes" in schema.block)) {
-        schema.block = { attributes: {}, block_types: {} };
+        schema.block = {
+          attributes: {},
+          block_types: (schema.block as Block).block_types || {},
+        };
       }
       // somehow missing from provider schema
       schema.block.attributes["alias"] = {


### PR DESCRIPTION
Resolves #2735