### PR TITLE
feat(lib): TerraformIterators allow chaining

### DIFF
--- a/packages/cdktf/lib/terraform-data-source.ts
+++ b/packages/cdktf/lib/terraform-data-source.ts
@@ -155,7 +155,9 @@ export class TerraformDataSource
 
   public interpolationForAttribute(terraformAttribute: string) {
     return ref(
-      `data.${this.terraformResourceType}.${this.friendlyUniqueId}.${terraformAttribute}`,
+      `data.${this.terraformResourceType}.${this.friendlyUniqueId}${
+        this.forEach ? ".*" : ""
+      }.${terraformAttribute}`,
       this.cdktfStack
     );
   }

--- a/packages/cdktf/lib/terraform-module.ts
+++ b/packages/cdktf/lib/terraform-module.ts
@@ -73,7 +73,9 @@ export abstract class TerraformModule
 
   public interpolationForOutput(moduleOutput: string) {
     return ref(
-      `module.${this.friendlyUniqueId}.${moduleOutput}`,
+      `module.${this.friendlyUniqueId}${
+        this.forEach ? ".*" : ""
+      }.${moduleOutput}`,
       this.cdktfStack
     );
   }

--- a/packages/cdktf/lib/terraform-resource.ts
+++ b/packages/cdktf/lib/terraform-resource.ts
@@ -237,7 +237,9 @@ export class TerraformResource
 
   public interpolationForAttribute(terraformAttribute: string) {
     return ref(
-      `${this.terraformResourceType}.${this.friendlyUniqueId}.${terraformAttribute}`,
+      `${this.terraformResourceType}.${this.friendlyUniqueId}${
+        this.forEach ? ".*" : ""
+      }.${terraformAttribute}`,
       this.cdktfStack
     );
   }

--- a/packages/cdktf/test/helper/data-source.ts
+++ b/packages/cdktf/test/helper/data-source.ts
@@ -62,6 +62,10 @@ export class TestDataSource extends TerraformDataSource {
     return new AnyMap(this, "any_map").lookup(key);
   }
 
+  public get listValue() {
+    return this.getListAttribute("list_value");
+  }
+
   protected synthesizeAttributes(): { [p: string]: any } {
     return {
       name: stringToTerraform(this.name),


### PR DESCRIPTION
This won't solve the mismatch between programming language types and internal type of the reference (e.g. accessing a string property on an object using for_each will be a string in from the type systems of the programming languages, but a list of strings for terraform). This is not worse than what we currently have (an invalid Terraform reference), therefore I think we can go forward with this.

Relates to #2024