### PR TITLE
fix(docs): Fix typo in commands.mdx

### DIFF
--- a/packages/cdktf-cli/src/bin/cmds/convert.ts
+++ b/packages/cdktf-cli/src/bin/cmds/convert.ts
@@ -33,7 +33,7 @@ class Command extends BaseCommand {
       )
       .example(
         "cat main.tf | cdktf convert --provider 'hashicorp/aws@ ~>3.62.0' 'integrations/github@ ~>4.16.0' --language python > imported.py",
-        "Takes the HCL content of main.tf and converts it to CDK for Terraform content in imported.ts"
+        "Takes the HCL content of main.tf and converts it to CDK for Terraform content in imported.py"
       )
       .option("language", {
         choices: ["typescript", "python", "csharp", "java", "go"],

--- a/website/docs/cdktf/cli-reference/commands.mdx
+++ b/website/docs/cdktf/cli-reference/commands.mdx
@@ -107,7 +107,7 @@ Examples:
   cat main.tf | cdktf convert --provider hashicorp/aws > imported.ts                 Takes the HCL content of main.tf and converts it to CDK for Terraform content
                                                                                      in imported.ts
   cat main.tf | cdktf convert --provider 'hashicorp/aws@ ~>3.62.0'                   Takes the HCL content of main.tf and converts it to CDK for Terraform content
-  'integrations/github@ ~>4.16.0' --language python > imported.py                    in imported.ts
+  'integrations/github@ ~>4.16.0' --language python > imported.py                    in imported.py
 
 ```
 


### PR DESCRIPTION
Tiny typo in convert command documentation

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes # <!-- INSERT ISSUE NUMBER -->

### Description

In plain English, describe your approach to addressing the issue linked above. For example, if you made a particular design decision, let us know why you chose this path instead of another solution.

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
