### PR TITLE
chore(docs): change to `synth` from `synthScope` for #2755

### DIFF
--- a/website/docs/cdktf/test/unit-tests.mdx
+++ b/website/docs/cdktf/test/unit-tests.mdx
@@ -62,7 +62,9 @@ describe("Unit testing using assertions", () => {
     const stack = new MyApplicationsAbstraction(app, "my-app", {});
     const synthesized = Testing.synth(stack);
 
-    expect(synthesized).toHaveResourceWithProperties(Image, { name: "ubuntu:latest" });
+    expect(synthesized).toHaveResourceWithProperties(Image, {
+      name: "ubuntu:latest",
+    });
   });
 });
 ```

--- a/website/docs/cdktf/test/unit-tests.mdx
+++ b/website/docs/cdktf/test/unit-tests.mdx
@@ -27,9 +27,9 @@ If you would like to add testing to an existing project, refer the following res
 
 ### Write Assertions
 
-The following Typescript example uses `Testing.synthScope` to test a part of the application. This creates a scope to test a subset of the application and returns a JSON string representing the synthesized HCL-JSON. Then it uses custom matchers to verify the code acts as intended.
+The following Typescript example uses `Testing.synth` to test a part of the application. Given the desired scope to test, a JSON string representing the synthesized HCL-JSON is returned. Then the custom assertions under `Testing` in the cdktf package can be used to verify the code acts as intended. `Testing.synth` can test the `Stack` that extends the `TerraformStack`.
 
-The other examples use `Testing.synth` to test a part of the application. Given the desired scope to test, a JSON string representing the synthesized HCL-JSON is returned. Then the custom assertions under `Testing` in the cdktf package can be used to verify the code acts as intended.
+The other examples use `Testing.synthScope` to test a part of the application. This creates a scope to test a subset of the application and returns a JSON string representing the synthesized HCL-JSON. Then it uses custom matchers to verify the code acts as intended. `Testing.synthScope` can test the `Constructs` that extends the `IConstruct`.
 
 Examples in
 
@@ -50,19 +50,19 @@ import MyApplicationsAbstraction from "../app"; // Could be a class extending fr
 
 describe("Unit testing using assertions", () => {
   it("should contain a container", () => {
-    expect(
-      Testing.synthScope((scope) => {
-        new MyApplicationsAbstraction(scope, "my-app", {});
-      })
-    ).toHaveResource(Container);
+    const app = Testing.app();
+    const stack = new MyApplicationsAbstraction(app, "my-app", {});
+    const synthesized = Testing.synth(stack);
+
+    expect(synthesized).toHaveResource(Container);
   });
 
   it("should use an ubuntu image", () => {
-    expect(
-      Testing.synthScope((scope) => {
-        new MyApplicationsAbstraction(scope, "my-app", {});
-      })
-    ).toHaveResourceWithProperties(Image, { name: "ubuntu:latest" });
+    const app = Testing.app();
+    const stack = new MyApplicationsAbstraction(app, "my-app", {});
+    const synthesized = Testing.synth(stack);
+
+    expect(synthesized).toHaveResourceWithProperties(Image, { name: "ubuntu:latest" });
   });
 });
 ```


### PR DESCRIPTION


### Related issue

Fixes #2755

### Description

The document shows an example using `synthScope` that can test the `Construct` type. But this document is for most beginners, so we want to test the `Stack`, because followed docs were showing examples of `Stack`.

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

