### PR TITLE
fix(hcl2cdk): Heredocs expression parsing

### DIFF
--- a/packages/@cdktf/hcl2cdk/lib/expressions.ts
+++ b/packages/@cdktf/hcl2cdk/lib/expressions.ts
@@ -33,6 +33,16 @@ function wrapTerraformExpression(input: string): string {
     return input;
   }
 
+  if (input.startsWith("<<")) {
+    // For Heredocs, we need to ensure that the string ends with an empty newline as
+    // the HCL parser doesn't find the ending token otherwise
+    if (!input.endsWith("\n")) {
+      return input + "\n";
+    }
+
+    return input;
+  }
+
   return `"${input}"`;
 }
 

--- a/packages/@cdktf/hcl2cdk/test/expressionToTs.test.ts
+++ b/packages/@cdktf/hcl2cdk/test/expressionToTs.test.ts
@@ -538,4 +538,41 @@ describe("expressionToTs", () => {
       `"cdktf.Fn.concat(\\"\${\\" + privateSubnets.value + \\"}.*.id\\", \\"\${\\" + publicSubnets.value + \\"}.*.id\\")"`
     );
   });
+
+  test("convert heredocs", async () => {
+    const expression = `<<EOF
+[{
+    "Condition": {
+        "KeyPrefixEquals": "docs/"
+    },
+    "Redirect": {
+        "ReplaceKeyPrefixWith": "documents/"
+    }
+}]
+EOF
+`;
+    const scope = getScope();
+    const result = await convertTerraformExpressionToTs(expression, scope, []);
+    expect(code(result)).toMatchInlineSnapshot(
+      `"\\"[{\\\\n    \\\\\\"Condition\\\\\\": {\\\\n        \\\\\\"KeyPrefixEquals\\\\\\": \\\\\\"docs/\\\\\\"\\\\n    },\\\\n    \\\\\\"Redirect\\\\\\": {\\\\n        \\\\\\"ReplaceKeyPrefixWith\\\\\\": \\\\\\"documents/\\\\\\"\\\\n    }\\\\n}]\\\\n\\""`
+    );
+  });
+
+  test("convert heredocs without a trailing newline", async () => {
+    const expression = `<<EOF
+hello world
+EOF`;
+    const scope = getScope();
+    const result = await convertTerraformExpressionToTs(expression, scope, []);
+    expect(code(result)).toMatchInlineSnapshot(`"\\"hello world\\\\n\\""`);
+  });
+
+  test("convert indented heredocs", async () => {
+    const expression = `<<-EOF
+              hello world
+          EOF`;
+    const scope = getScope();
+    const result = await convertTerraformExpressionToTs(expression, scope, []);
+    expect(code(result)).toMatchInlineSnapshot(`"\\"hello world\\\\n\\""`);
+  });
 });


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes https://github.com/hashicorp/terraform-cdk/issues/2753

### Description
For string based expressions, we were wrapping them in quotes, and not checking if the expression was a [here document](https://en.wikipedia.org/wiki/Here_document). This PR fixes that oversight. Additionally, HCL expects a newline at the end of the HEREDOC trailing marker, so the code also force-adds a new line if it doesn't exist.

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
