### PR TITLE
fix(hcl2cdk): Improve conversion of data sources with numeric acessors

### DIFF
--- a/packages/@cdktf/hcl2cdk/lib/expressions.ts
+++ b/packages/@cdktf/hcl2cdk/lib/expressions.ts
@@ -249,17 +249,10 @@ function convertTFExpressionAstToTs(
       tex.isIndexTraversalPart(seg)
     );
 
-    const refSegments =
-      indexOfNumericAccessor > -1
-        ? subSegments.slice(0, indexOfNumericAccessor)
-        : subSegments;
+    const refSegments = indexOfNumericAccessor > -1 ? [] : subSegments;
+    const nonRefSegments = indexOfNumericAccessor > -1 ? subSegments : [];
 
-    const nonRefSegments =
-      indexOfNumericAccessor > -1
-        ? subSegments.slice(indexOfNumericAccessor)
-        : [];
-
-    const ref = refSegments.reduce(
+    let ref = refSegments.reduce(
       (acc: t.Expression, seg, index) =>
         t.memberExpression(
           acc,
@@ -278,7 +271,7 @@ function convertTFExpressionAstToTs(
 
     return expressionForSerialStringConcatenation([
       t.stringLiteral("${"),
-      ref,
+      t.memberExpression(ref, t.identifier("fqn")),
       t.stringLiteral("}" + traversalPartsToString(nonRefSegments, true)),
     ]);
   }

--- a/packages/@cdktf/hcl2cdk/test/expressionToTs.test.ts
+++ b/packages/@cdktf/hcl2cdk/test/expressionToTs.test.ts
@@ -243,7 +243,7 @@ describe("expressionToTs", () => {
       getType
     );
     expect(code(result)).toMatchInlineSnapshot(
-      `"\\"\${\\" + awsS3BucketExamplebucket.networkInterface + \\"}[0].access_config[0].assigned_nat_ip\\""`
+      `"\\"\${\\" + awsS3BucketExamplebucket.fqn + \\"}.network_interface[0].access_config[0].assigned_nat_ip\\""`
     );
   });
 
@@ -257,7 +257,7 @@ describe("expressionToTs", () => {
       getType
     );
     expect(code(result)).toMatchInlineSnapshot(
-      `"\\"\${\\" + awsS3BucketExamplebucket.networkInterface + \\"}[0].access_config[0].assigned_nat_ip\\""`
+      `"\\"\${\\" + awsS3BucketExamplebucket.fqn + \\"}.network_interface[0].access_config[0].assigned_nat_ip\\""`
     );
   });
 
@@ -379,7 +379,7 @@ describe("expressionToTs", () => {
       getType
     );
     expect(code(result)).toMatchInlineSnapshot(
-      `"\\"\${\\" + awsS3BucketExamplebucket + \\"}[0].id\\""`
+      `"\\"\${\\" + awsS3BucketExamplebucket.fqn + \\"}[0].id\\""`
     );
   });
 
@@ -687,6 +687,21 @@ describe("expressionToTs", () => {
     );
     expect(code(result)).toMatchInlineSnapshot(
       `"cdktf.Token.asString(cdktf.TerraformSelf.getAny(\\"subnet.id\\"))"`
+    );
+  });
+
+  test("convert a data source with numeric access", async () => {
+    const expression = `"\${data.aws_availability_zones.changeme_az_list_ebs_snapshot.names[0]}"`;
+    const scope = getScope({
+      data: ["aws_subnet_ids"],
+    });
+    const result = await convertTerraformExpressionToTs(
+      expression,
+      scope,
+      getType
+    );
+    expect(code(result)).toMatchInlineSnapshot(
+      `"\\"\${\\" + dataAwsAvailabilityZonesChangemeAzListEbsSnapshot.fqn + \\"}.names[0]\\""`
     );
   });
 });

--- a/packages/@cdktf/hcl2cdk/test/references.test.ts
+++ b/packages/@cdktf/hcl2cdk/test/references.test.ts
@@ -241,4 +241,31 @@ describe("references", () => {
     Synth.no_missing_map_access,
     { resources: ["aws_eip"] }
   );
+
+  testCase.test(
+    "access use fqn for data source",
+    `
+    provider "aws" {
+      region                      = "us-east-1"
+    }
+    data "aws_availability_zones" "changeme_az_list_ebs_snapshot" {
+      state = "available"
+    }
+    resource "aws_ebs_volume" "changeme_ebs_volume_snapshot" {
+      availability_zone = data.aws_availability_zones.changeme_az_list_ebs_snapshot.names[0]
+      size              = 10
+      type              = "standard"
+      encrypted         = false
+      tags = {
+        Name = "changeme_ebs_volume_tag"
+      }
+    }
+    `,
+    [binding.aws],
+    Synth.yes,
+    {
+      resources: ["aws_ebs_volume"],
+      dataSources: ["aws_availability_zones"],
+    }
+  );
 });


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes https://github.com/hashicorp/terraform-cdk/issues/2649

### Description

Previously, we were splitting up resources and data sources up to the numeric index, which would not work. Now, we bail early if we see a numeric access and get the resource/data source's FQN and send it over to Terraform to process.

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
