### PR TITLE
fix(hcl2cdk): flaky tests on hcl2cdk expressions

### DIFF
--- a/packages/@cdktf/hcl2cdk/lib/__tests__/expressions.test.ts
+++ b/packages/@cdktf/hcl2cdk/lib/__tests__/expressions.test.ts
@@ -25,19 +25,19 @@ const nodeIds = [
 describe("expressions", () => {
   describe("#extractReferencesFromExpression", () => {
     it("finds no references in literals", () => {
-      expect(
+      return expect(
         extractReferencesFromExpression("nothingtobeseen", nodeIds)
       ).resolves.toEqual([]);
     });
 
     it("finds no references in literals with functions", () => {
-      expect(
+      return expect(
         extractReferencesFromExpression("${foo(nothingtobeseen)}", nodeIds)
       ).resolves.toEqual([]);
     });
 
     it("finds no references in literals with functions and artihmetics", () => {
-      expect(
+      return expect(
         extractReferencesFromExpression(
           "${foo(nothingtobeseen - 2) + 3}",
           nodeIds
@@ -46,7 +46,7 @@ describe("expressions", () => {
     });
 
     it("finds plain var reference", () => {
-      expect(
+      return expect(
         extractReferencesFromExpression("${var.input}", nodeIds)
       ).resolves.toEqual([
         {
@@ -60,7 +60,7 @@ describe("expressions", () => {
     });
 
     it("finds plain module reference", () => {
-      expect(
+      return expect(
         extractReferencesFromExpression("${module.vpc.public_subnets}", nodeIds)
       ).resolves.toEqual([
         {
@@ -77,7 +77,7 @@ describe("expressions", () => {
     });
 
     it("finds plain data reference", () => {
-      expect(
+      return expect(
         extractReferencesFromExpression(
           "${data.aws_s3_bucket.examplebucket.arn}",
           nodeIds
@@ -97,7 +97,7 @@ describe("expressions", () => {
     });
 
     it("finds plain local reference", () => {
-      expect(
+      return expect(
         extractReferencesFromExpression("${local.service_name}", nodeIds)
       ).resolves.toEqual([
         {
@@ -114,7 +114,7 @@ describe("expressions", () => {
     });
 
     it("finds plain resource reference", () => {
-      expect(
+      return expect(
         extractReferencesFromExpression(
           "${aws_s3_bucket.examplebucket.id}",
           nodeIds
@@ -134,7 +134,7 @@ describe("expressions", () => {
     });
 
     it("finds plain resource references in artihmetics", () => {
-      expect(
+      return expect(
         extractReferencesFromExpression(
           "${aws_s3_bucket.examplebucket.count + aws_s3_bucket.otherbucket.count }",
           nodeIds
@@ -164,7 +164,7 @@ describe("expressions", () => {
     });
 
     it("use fqn for splat reference", () => {
-      expect(
+      return expect(
         extractReferencesFromExpression(
           "${aws_s3_bucket.examplebucket.*.id}",
           nodeIds
@@ -184,7 +184,7 @@ describe("expressions", () => {
     });
 
     it("use no fqn if property is present on numeric access", () => {
-      expect(
+      return expect(
         extractReferencesFromExpression(
           "${aws_s3_bucket.examplebucket.network_interface.0.access_config.0.assigned_nat_ip}",
           nodeIds
@@ -193,18 +193,18 @@ describe("expressions", () => {
         {
           referencee: {
             id: "aws_s3_bucket.examplebucket",
-            full: "aws_s3_bucket.examplebucket.network_interface",
+            full: "aws_s3_bucket.examplebucket",
           },
-          useFqn: false,
+          useFqn: true,
           isVariable: false,
           start: 2,
-          end: 47,
+          end: 81,
         },
       ]);
     });
 
     it("detect splat reference within function", () => {
-      expect(
+      return expect(
         extractReferencesFromExpression(
           "${toset(aws_s3_bucket.examplebucket.*)}",
           nodeIds
@@ -224,7 +224,7 @@ describe("expressions", () => {
     });
 
     it("finds all resources in conditional", () => {
-      expect(
+      return expect(
         extractReferencesFromExpression(
           "${aws_kms_key.key.deletion_window_in_days > 3 ? aws_s3_bucket.examplebucket.id : []}",
           nodeIds
@@ -254,7 +254,7 @@ describe("expressions", () => {
     });
 
     it("finds all resources in functions", () => {
-      expect(
+      return expect(
         extractReferencesFromExpression(
           "${element(aws_s3_bucket.examplebucket, 0).id}",
           nodeIds
@@ -265,7 +265,7 @@ describe("expressions", () => {
             id: "aws_s3_bucket.examplebucket",
             full: "aws_s3_bucket.examplebucket",
           },
-          useFqn: true,
+          useFqn: false,
           isVariable: false,
           start: 10,
           end: 37,
@@ -274,7 +274,7 @@ describe("expressions", () => {
     });
 
     it("finds all resources in functions with splat", () => {
-      expect(
+      return expect(
         extractReferencesFromExpression(
           "${element(aws_s3_bucket.examplebucket.*.id, 0)}",
           nodeIds
@@ -294,7 +294,7 @@ describe("expressions", () => {
     });
 
     it("finds all resources in for loops", () => {
-      expect(
+      return expect(
         extractReferencesFromExpression(
           "${{ for name, user in var.users : user.role => name...}}",
           nodeIds
@@ -311,7 +311,7 @@ describe("expressions", () => {
     });
 
     it("finds resources with property access", () => {
-      expect(
+      return expect(
         extractReferencesFromExpression(
           "${aws_s3_bucket.examplebucket[0].id}",
           nodeIds
@@ -331,7 +331,7 @@ describe("expressions", () => {
     });
 
     it("finds references within functions that use arrays and comments", () => {
-      expect(
+      return expect(
         extractReferencesFromExpression(
           `\${compact([
             # The example "bucket"
@@ -348,7 +348,7 @@ describe("expressions", () => {
             id: "aws_s3_bucket.examplebucket",
             full: "aws_s3_bucket.examplebucket",
           },
-          useFqn: true,
+          useFqn: false,
           isVariable: false,
           start: 59,
           end: 86,
@@ -367,7 +367,7 @@ describe("expressions", () => {
     });
 
     it("finds references for same referencees", () => {
-      expect(
+      return expect(
         extractReferencesFromExpression(
           `\${var.input == "test" ? "azure-ad-int" : "azure-ad-\${var.input}"}`,
           nodeIds

--- a/packages/@cdktf/hcl2cdk/test/expressionToTs.test.ts
+++ b/packages/@cdktf/hcl2cdk/test/expressionToTs.test.ts
@@ -239,9 +239,23 @@ describe("expressionToTs", () => {
     );
   });
 
-  test("use no fqn if property is present on numeric access", async () => {
+  test("use no fqn if property is present on numeric access using dot notation", async () => {
     const expression =
       "${aws_s3_bucket.examplebucket.network_interface.0.access_config.0.assigned_nat_ip}";
+    const scope = getScope({ resources: ["aws_s3_bucket.examplebucket"] });
+    const result = await convertTerraformExpressionToTs(
+      expression,
+      scope,
+      getType
+    );
+    expect(code(result)).toMatchInlineSnapshot(
+      `"\\"\${\\" + awsS3BucketExamplebucket.networkInterface + \\"}[0].access_config[0].assigned_nat_ip\\""`
+    );
+  });
+
+  test("use no fqn if property is present on numeric access using []", async () => {
+    const expression =
+      "${aws_s3_bucket.examplebucket.network_interface[0].access_config[0].assigned_nat_ip}";
     const scope = getScope({ resources: ["aws_s3_bucket.examplebucket"] });
     const result = await convertTerraformExpressionToTs(
       expression,

--- a/packages/@cdktf/hcl2cdk/test/expressionToTs.test.ts
+++ b/packages/@cdktf/hcl2cdk/test/expressionToTs.test.ts
@@ -253,20 +253,6 @@ describe("expressionToTs", () => {
     );
   });
 
-  test("use no fqn if property is present on numeric access", async () => {
-    const expression =
-      "${aws_s3_bucket.examplebucket.network_interface[0].access_config[0].assigned_nat_ip}";
-    const scope = getScope({ resources: ["aws_s3_bucket.examplebucket"] });
-    const result = await convertTerraformExpressionToTs(
-      expression,
-      scope,
-      getType
-    );
-    expect(code(result)).toMatchInlineSnapshot(
-      `"\\"\${\\" + awsS3BucketExamplebucket.networkInterface + \\"}[0].access_config[0].assigned_nat_ip\\""`
-    );
-  });
-
   test("detects splat reference within function", async () => {
     const expression = "${toset(aws_s3_bucket.examplebucket.*)}";
     const scope = getScope({ resources: ["aws_s3_bucket.examplebucket"] });

--- a/packages/@cdktf/hcl2json/test/expressions.test.ts
+++ b/packages/@cdktf/hcl2json/test/expressions.test.ts
@@ -81,7 +81,7 @@ describe("getReferencesInExpression", () => {
   });
 
   test("fails on malformed expressions", () => {
-    expect(
+    return expect(
       getReferencesInExpression("main.tf", '"${module.foo.output"')
     ).rejects.toMatchSnapshot();
   });
@@ -137,11 +137,13 @@ describe("getExpressionAst", () => {
     ],
     ["list expressions", `"\${ [var.tags.app, var.tags.env] }"`],
   ])("%s", async (_, input) => {
-    expect(getExpressionAst("main.tf", input)).resolves.toMatchSnapshot();
+    return expect(
+      getExpressionAst("main.tf", input)
+    ).resolves.toMatchSnapshot();
   });
 
   test("fails on malformed expressions", async () => {
-    expect(
+    return expect(
       getExpressionAst("main.tf", '"${module.foo.output"')
     ).rejects.toMatchSnapshot();
   });


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes CI issues on release

### Description

As per the following article on jest, we need to return all `resolves` or `rejects` expects, and that's what caused the test to be flaky. The test itself was failing, which was correct, but only failed when it accidentally ran the full thing:
![image](https://user-images.githubusercontent.com/573531/230067088-ba450021-81dd-418d-b9bc-27c339c66af7.png)


### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
