### PR TITLE
chore: upgrade our Docker image to be based on Node 0.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-FROM docker.mirror.hashicorp.services/jsii/superchain:1-buster-slim-node14
+FROM docker.mirror.hashicorp.services/jsii/superchain:1-buster-slim-node16
 
 USER root
 


### PR DESCRIPTION
This has to be done separately from #2768 as our CI always uses the latest available Docker image
