### PR TITLE
fix: Revert "chore: upgrade our Docker image to be based on Node 0.16"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-FROM docker.mirror.hashicorp.services/jsii/superchain:1-buster-slim-node16
+FROM docker.mirror.hashicorp.services/jsii/superchain:1-buster-slim-node14
 
 USER root
 


### PR DESCRIPTION
Reverts hashicorp/terraform-cdk#2770

This caused a lot more trouble, which I'll have to investigate first 😅