### PR TITLE
fix(cli): send terraform output before approval

### DIFF
--- a/packages/@cdktf/cli-core/src/lib/models/deploy-machine.ts
+++ b/packages/@cdktf/cli-core/src/lib/models/deploy-machine.ts
@@ -116,6 +116,8 @@ export function handleLineReceived(send: (event: DeployEvent) => void) {
         "Do you really want to destroy all resources in workspace"
       )
     ) {
+      hideOutput = true;
+      send({ type: "OUTPUT_RECEIVED", output });
       send({ type: "REQUEST_APPROVAL" });
     } else if (
       noColorLine.includes("var.") &&


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes #2749

### Description

Currently, the terraform output is send after the approval dialog. This hides the diff until an option was selected. Sending the output first makes the diff visible before the dialog.

It's  a very small change, so no new tests or documentation.

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes
