### PR TITLE
feat(lib): fix using variables and locals directly in template strings

### DIFF
--- a/packages/cdktf/lib/terraform-local.ts
+++ b/packages/cdktf/lib/terraform-local.ts
@@ -82,4 +82,11 @@ export class TerraformLocal
       },
     };
   }
+
+  /**
+   * @returns a string token referencing the value of this local
+   */
+  toString(): string {
+    return this.asString;
+  }
 }

--- a/packages/cdktf/lib/terraform-variable.ts
+++ b/packages/cdktf/lib/terraform-variable.ts
@@ -180,4 +180,11 @@ export class TerraformVariable
       },
     };
   }
+
+  /**
+   * @returns a string token referencing the value of this variable
+   */
+  toString(): string {
+    return this.stringValue;
+  }
 }

--- a/packages/cdktf/test/__snapshots__/local.test.ts.snap
+++ b/packages/cdktf/test/__snapshots__/local.test.ts.snap
@@ -36,6 +36,21 @@ exports[`local reference 1`] = `
 }"
 `;
 
+exports[`local used in template string 1`] = `
+"{
+  "locals": {
+    "test-local": {
+      "type": "string"
+    }
+  },
+  "output": {
+    "test-output": {
+      "value": "The value is \${local.test-local}"
+    }
+  }
+}"
+`;
+
 exports[`multiple locals 1`] = `
 "{
   "locals": {

--- a/packages/cdktf/test/__snapshots__/variable.test.ts.snap
+++ b/packages/cdktf/test/__snapshots__/variable.test.ts.snap
@@ -198,6 +198,21 @@ exports[`validation block variable self reference 1`] = `
 }"
 `;
 
+exports[`variable used in template string 1`] = `
+"{
+  "output": {
+    "test-output": {
+      "value": "The value is \${var.test-variable}"
+    }
+  },
+  "variable": {
+    "test-variable": {
+      "type": "string"
+    }
+  }
+}"
+`;
+
 exports[`variable with variable default 1`] = `
 "{
   "variable": {

--- a/packages/cdktf/test/local.test.ts
+++ b/packages/cdktf/test/local.test.ts
@@ -1,6 +1,11 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import { Testing, TerraformStack, TerraformLocal } from "../lib";
+import {
+  Testing,
+  TerraformStack,
+  TerraformLocal,
+  TerraformOutput,
+} from "../lib";
 import { TestResource } from "./helper";
 import { TestProvider } from "./helper/provider";
 
@@ -63,6 +68,20 @@ test("multiple locals", () => {
   new TerraformLocal(stack, "local1", "1");
 
   new TerraformLocal(stack, "local2", "2");
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test("local used in template string", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+
+  const l = new TerraformLocal(stack, "test-local", {
+    type: "string",
+  });
+  new TerraformOutput(stack, "test-output", {
+    value: `The value is ${l}`,
+  });
 
   expect(Testing.synth(stack)).toMatchSnapshot();
 });

--- a/packages/cdktf/test/variable.test.ts
+++ b/packages/cdktf/test/variable.test.ts
@@ -6,6 +6,7 @@ import {
   TerraformVariable,
   VariableType,
   Fn,
+  TerraformOutput,
 } from "../lib";
 import { TestResource } from "./helper";
 import { TestProvider } from "./helper/provider";
@@ -169,6 +170,20 @@ test("nullable variable", () => {
     type: "string",
     nullable: true,
   });
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test("variable used in template string", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+
+  const v = new TerraformVariable(stack, "test-variable", {
+    type: "string",
+  });
+  new TerraformOutput(stack, "test-output", {
+    value: `The value is ${v}`,
+  });
+
   expect(Testing.synth(stack)).toMatchSnapshot();
 });
 


### PR DESCRIPTION
Usage in template strings will implicitly call .toString() on these which previously returned the address of the construct (as implemented in Construct#toString). With this change converting a variable or local instance to a string will just work
