### PR TITLE
fix(lib): fix Symbol for Terraform dynamic expression causing crashes when using Iterator.dynamic() on blocks

### DIFF
--- a/packages/cdktf/lib/terraform-dynamic-expression.ts
+++ b/packages/cdktf/lib/terraform-dynamic-expression.ts
@@ -5,7 +5,9 @@ import { forExpression } from ".";
 import { IResolvable, Lazy, Token } from "./tokens";
 import { captureStackTrace } from "./tokens/private/stack-trace";
 
-const DYNAMIC_EXPRESSION_SYMBOL = Symbol.for("cdktf/TerraformDynamicBlock");
+const DYNAMIC_EXPRESSION_SYMBOL = Symbol.for(
+  "cdktf/TerraformDynamicExpression"
+);
 
 /**
  * A TerraformDynamicExpression is returned by TerraformIterator.dynamic

--- a/packages/cdktf/test/dynamic-expression.test.ts
+++ b/packages/cdktf/test/dynamic-expression.test.ts
@@ -1,0 +1,26 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { Testing, TerraformStack, TerraformIterator } from "../lib";
+import { TestProvider, TestResource } from "./helper";
+
+test("dynamic expressions are properly rendered for resources", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+  new TestProvider(stack, "provider", {});
+
+  const it = TerraformIterator.fromList(["a", "b", "c"]);
+
+  new TestResource(stack, "test", {
+    name: "foo",
+    listAttribute: it.dynamic({ name: it.value }),
+  });
+
+  const res = JSON.parse(Testing.synth(stack));
+
+  const expected = {
+    name: "foo",
+    list_attribute:
+      '${[ for key, val in toset(["a", "b", "c"]): {"name" = val}]}',
+  };
+  expect(res).toHaveProperty("resource.test_resource.test", expected);
+});

--- a/packages/cdktf/test/helper/resource.ts
+++ b/packages/cdktf/test/helper/resource.ts
@@ -17,6 +17,7 @@ export interface TestResourceConfig extends TerraformMetaArguments {
   tags?: { [key: string]: string };
   nestedType?: { [key: string]: string };
   listBlock?: IResolvable;
+  listAttribute?: IResolvable;
 }
 
 export class TestResource extends TerraformResource {
@@ -26,6 +27,7 @@ export class TestResource extends TerraformResource {
   public tags?: { [key: string]: string };
   public nestedType?: { [key: string]: string };
   public listBlock?: IResolvable; // real life bindings also allow an interface here, but we don't use that in our tests using this
+  public listAttribute?: IResolvable;
 
   constructor(scope: Construct, id: string, config: TestResourceConfig) {
     super(scope, id, {
@@ -47,6 +49,7 @@ export class TestResource extends TerraformResource {
     this.tags = config.tags;
     this.nestedType = config.nestedType;
     this.listBlock = config.listBlock;
+    this.listAttribute = config.listAttribute;
   }
 
   protected synthesizeAttributes(): { [name: string]: any } {
@@ -56,6 +59,7 @@ export class TestResource extends TerraformResource {
       tags: this.tags,
       nested_type: this.nestedType,
       list_block: listMapper((a) => a, true)(this.listBlock), // identity function to skip writing a toTerraform function
+      list_attribute: listMapper((a) => a, false)(this.listAttribute), // identity function to skip writing a toTerraform function
     };
   }
 


### PR DESCRIPTION
- fix(lib): fix Symbol for Terraform dynamic expression causing crashes when using Iterator.dynamic() on blocks
- test(lib): Add a test case that would've caught the error that the previous commit fixed
