### PR TITLE
chore: pin provider versions in documentation examples

### DIFF
--- a/examples/csharp/documentation/ProviderClassesStack.cs
+++ b/examples/csharp/documentation/ProviderClassesStack.cs
@@ -11,7 +11,7 @@ using HashiCorp.Cdktf;
 using aws.Provider;
 using aws.Instance;
 using dnsimple.Provider;
-using dnsimple.Record;
+using dnsimple.ZoneRecord;
 
 
 namespace Examples
@@ -59,9 +59,9 @@ namespace Examples
                 Account = dnsimpleAccount.StringValue
             });
 
-            new Record(this, "web-www", new RecordConfig
+            new ZoneRecord(this, "web-www", new ZoneRecordConfig
             {
-                Domain = "example.com",
+                ZoneName = "example.com",
                 Name = "web",
                 Value = instance.PublicIp,
                 Type = "A"

--- a/examples/csharp/documentation/cdktf.json
+++ b/examples/csharp/documentation/cdktf.json
@@ -5,7 +5,7 @@
     "aws@~> 3.0",
     "kubernetes@~> 2.0",
     "hashicorp/random@~> 3.1",
-    "dnsimple/dnsimple@~> 0.17",
+    "dnsimple/dnsimple@~> 1.0",
     "kreuzwerker/docker@~> 3.0",
     "integrations/github@~> 5.22"
   ],

--- a/examples/csharp/documentation/cdktf.json
+++ b/examples/csharp/documentation/cdktf.json
@@ -5,9 +5,9 @@
     "aws@~> 3.0",
     "kubernetes@~> 2.0",
     "hashicorp/random@~> 3.1",
-    "dnsimple/dnsimple",
-    "kreuzwerker/docker",
-    "integrations/github"
+    "dnsimple/dnsimple@~> 0.17",
+    "kreuzwerker/docker@~> 3.0",
+    "integrations/github@~> 5.22"
   ],
   "terraformModules": [
     {

--- a/examples/go/documentation/cdktf.json
+++ b/examples/go/documentation/cdktf.json
@@ -6,7 +6,7 @@
         "hashicorp/aws@~> 3.70.0",
         "hashicorp/kubernetes@~> 2.0",
         "hashicorp/random@~> 3.4",
-        "dnsimple/dnsimple@~> 0.15",
+        "dnsimple/dnsimple@~> 1.0",
         "integrations/github@~> 5.16"
     ],
     "terraformModules": [

--- a/examples/go/documentation/providers.go
+++ b/examples/go/documentation/providers.go
@@ -11,7 +11,7 @@ import (
 
 	// DOCS_BLOCK_END:providers-import-providers
 	dnsimple "github.com/hashicorp/terraform-cdk/examples/go/documentation/generated/dnsimple/dnsimple/provider"
-	"github.com/hashicorp/terraform-cdk/examples/go/documentation/generated/dnsimple/dnsimple/record"
+	"github.com/hashicorp/terraform-cdk/examples/go/documentation/generated/dnsimple/dnsimple/zonerecord"
 
 	// DOCS_BLOCK_START:providers-import-providers
 	"github.com/hashicorp/terraform-cdk/examples/go/documentation/generated/hashicorp/aws/instance"
@@ -48,8 +48,8 @@ func NewProvidersStack(scope constructs.Construct, name string) cdktf.TerraformS
 		Account: dnsimpleAccount.StringValue(),
 	})
 
-	record.NewRecord(stack, jsii.String("web-www"), &record.RecordConfig{
-		Domain: jsii.String("example.com"),
+	zonerecord.NewZoneRecord(stack, jsii.String("web-www"), &zonerecord.ZoneRecordConfig{
+		ZoneName: jsii.String("example.com"),
 		Name:   jsii.String("web"),
 		Value:  instance.PublicIp(),
 		Type:   jsii.String("A"),

--- a/examples/java/documentation/cdktf.json
+++ b/examples/java/documentation/cdktf.json
@@ -6,7 +6,7 @@
     "aws@~> 3.0",
     "kubernetes@~> 2.0",
     "hashicorp/random@~> 3.1",
-    "dnsimple/dnsimple@~> 0.17",
+    "dnsimple/dnsimple@~> 1.0",
     "kreuzwerker/docker@~> 3.0",
     "integrations/github@~> 5.22"
   ],

--- a/examples/java/documentation/cdktf.json
+++ b/examples/java/documentation/cdktf.json
@@ -6,9 +6,9 @@
     "aws@~> 3.0",
     "kubernetes@~> 2.0",
     "hashicorp/random@~> 3.1",
-    "dnsimple/dnsimple",
-    "kreuzwerker/docker",
-    "integrations/github"
+    "dnsimple/dnsimple@~> 0.17",
+    "kreuzwerker/docker@~> 3.0",
+    "integrations/github@~> 5.22"
   ],
   "terraformModules": [
     {

--- a/examples/java/documentation/src/main/java/com/mycompany/app/providers/MainImportClasses.java
+++ b/examples/java/documentation/src/main/java/com/mycompany/app/providers/MainImportClasses.java
@@ -16,8 +16,8 @@ import imports.aws.provider.AwsProvider;
 import imports.aws.provider.AwsProviderConfig;
 import imports.dnsimple.provider.DnsimpleProvider;
 import imports.dnsimple.provider.DnsimpleProviderConfig;
-import imports.dnsimple.record.Record;
-import imports.dnsimple.record.RecordConfig;
+import imports.dnsimple.zone_record.ZoneRecord;
+import imports.dnsimple.zone_record.ZoneRecordConfig;
 
 public class MainImportClasses extends TerraformStack {
 
@@ -55,8 +55,8 @@ public class MainImportClasses extends TerraformStack {
                 .build()
         );
 
-        new Record(this, "web-www", RecordConfig.builder()
-                .domain("example.com")
+        new ZoneRecord(this, "web-www", ZoneRecordConfig.builder()
+                .zoneName("example.com")
                 .name("web")
                 .value(instance.getPublicIp())
                 .type("A")

--- a/examples/python/documentation/cdktf.json
+++ b/examples/python/documentation/cdktf.json
@@ -5,7 +5,7 @@
     "aws@~> 3.0",
     "kubernetes@~> 2.0",
     "hashicorp/random@~> 3.1",
-    "dnsimple/dnsimple@~> 0.17",
+    "dnsimple/dnsimple@~> 1.0",
     "kreuzwerker/docker@~> 3.0",
     "integrations/github@~> 5.22"
   ],

--- a/examples/python/documentation/cdktf.json
+++ b/examples/python/documentation/cdktf.json
@@ -5,9 +5,9 @@
     "aws@~> 3.0",
     "kubernetes@~> 2.0",
     "hashicorp/random@~> 3.1",
-    "dnsimple/dnsimple",
-    "kreuzwerker/docker",
-    "integrations/github"
+    "dnsimple/dnsimple@~> 0.17",
+    "kreuzwerker/docker@~> 3.0",
+    "integrations/github@~> 5.22"
   ],
   "terraformModules": [
     {

--- a/examples/python/documentation/providers.py
+++ b/examples/python/documentation/providers.py
@@ -35,7 +35,7 @@ from constructs import Construct
 from cdktf import App, TerraformStack, TerraformVariable, Token
 from imports.aws.provider import AwsProvider
 from imports.dnsimple.provider import DnsimpleProvider
-from imports.dnsimple.record import Record
+from imports.dnsimple.zone_record import ZoneRecord
 
 class ProviderStack(TerraformStack):
     def __init__(self, scope: Construct, id: str):
@@ -67,8 +67,8 @@ class ProviderStack(TerraformStack):
             account = dnsimpleAccount.string_value
         )
 
-        Record(self, "web-www",
-            domain = "example.com",
+        ZoneRecord(self, "web-www",
+            zone_name = "example.com",
             name = "web",
             value = instance.public_ip,
             type = "A"

--- a/website/docs/cdktf/concepts/providers.mdx
+++ b/website/docs/cdktf/concepts/providers.mdx
@@ -299,8 +299,8 @@ import imports.aws.provider.AwsProvider;
 import imports.aws.provider.AwsProviderConfig;
 import imports.dnsimple.provider.DnsimpleProvider;
 import imports.dnsimple.provider.DnsimpleProviderConfig;
-import imports.dnsimple.record.Record;
-import imports.dnsimple.record.RecordConfig;
+import imports.dnsimple.zone_record.ZoneRecord;
+import imports.dnsimple.zone_record.ZoneRecordConfig;
 
 public class MainImportClasses extends TerraformStack {
 
@@ -338,8 +338,8 @@ public class MainImportClasses extends TerraformStack {
                 .build()
         );
 
-        new Record(this, "web-www", RecordConfig.builder()
-                .domain("example.com")
+        new ZoneRecord(this, "web-www", ZoneRecordConfig.builder()
+                .zoneName("example.com")
                 .name("web")
                 .value(instance.getPublicIp())
                 .type("A")
@@ -361,7 +361,7 @@ from constructs import Construct
 from cdktf import App, TerraformStack, TerraformVariable, Token
 from imports.aws.provider import AwsProvider
 from imports.dnsimple.provider import DnsimpleProvider
-from imports.dnsimple.record import Record
+from imports.dnsimple.zone_record import ZoneRecord
 
 class ProviderStack(TerraformStack):
     def __init__(self, scope: Construct, id: str):
@@ -393,8 +393,8 @@ class ProviderStack(TerraformStack):
             account = dnsimpleAccount.string_value
         )
 
-        Record(self, "web-www",
-            domain = "example.com",
+        ZoneRecord(self, "web-www",
+            zoneName = "example.com",
             name = "web",
             value = instance.public_ip,
             type = "A"
@@ -415,7 +415,7 @@ using HashiCorp.Cdktf;
 using aws.Provider;
 using aws.Instance;
 using dnsimple.Provider;
-using dnsimple.Record;
+using dnsimple.ZoneRecord;
 
 
 namespace Examples
@@ -463,9 +463,9 @@ namespace Examples
                 Account = dnsimpleAccount.StringValue
             });
 
-            new Record(this, "web-www", new RecordConfig
+            new ZoneRecord(this, "web-www", new ZoneRecordConfig
             {
-                Domain = "example.com",
+                ZoneName = "example.com",
                 Name = "web",
                 Value = instance.PublicIp,
                 Type = "A"
@@ -482,7 +482,7 @@ import (
 	"github.com/hashicorp/terraform-cdk-go/cdktf"
 
 	dnsimple "github.com/hashicorp/terraform-cdk/examples/go/documentation/generated/dnsimple/dnsimple/provider"
-	"github.com/hashicorp/terraform-cdk/examples/go/documentation/generated/dnsimple/dnsimple/record"
+	"github.com/hashicorp/terraform-cdk/examples/go/documentation/generated/dnsimple/dnsimple/zonerecord"
 
 	"github.com/hashicorp/terraform-cdk/examples/go/documentation/generated/hashicorp/aws/instance"
 	aws "github.com/hashicorp/terraform-cdk/examples/go/documentation/generated/hashicorp/aws/provider"
@@ -517,8 +517,8 @@ func NewProvidersStack(scope constructs.Construct, name string) cdktf.TerraformS
 		Account: dnsimpleAccount.StringValue(),
 	})
 
-	record.NewRecord(stack, jsii.String("web-www"), &record.RecordConfig{
-		Domain: jsii.String("example.com"),
+	zonerecord.NewZoneRecord(stack, jsii.String("web-www"), &zonerecord.ZoneRecordConfig{
+		ZoneName: jsii.String("example.com"),
 		Name:   jsii.String("web"),
 		Value:  instance.PublicIp(),
 		Type:   jsii.String("A"),

--- a/website/docs/cdktf/concepts/stacks.mdx
+++ b/website/docs/cdktf/concepts/stacks.mdx
@@ -868,7 +868,8 @@ this.allResources = new TerraformLocal(this, "merged_items", [
 ```
 
 ```java
-this.allResources = new TerraformLocal(this, "merge_items", Fn.mergeLists(Arrays.asList(resourceFromStackA.items, resourceFromStackB.items)));
+this.allResources = new TerraformLocal(this, "merge_items",
+        Fn.concat(Arrays.asList(resourceFromStackA.items, resourceFromStackB.items)));
 ```
 
 ```python
@@ -876,7 +877,7 @@ self.allResources =  TerraformLocal(self, "merge_items", Fn.concat(resourceFromS
 ```
 
 ```csharp
-this.allResources = new TerraformLocal(this, "merge_items", Fn.mergeLists(Arrays.asList(resourceFromStackA.items, resourceFromStackB.items)));
+this.allResources = new TerraformLocal(this, "merge_items", Fn.concat(Arrays.asList(resourceFromStackA.items, resourceFromStackB.items)));
 ```
 
 ```go
@@ -991,15 +992,21 @@ stack.addOverride("terraform.backend", {
 ```
 
 ```java
-stack.addOverride("terraform.backend", new HashMap<String, HashMap<String, Object>>(){{
-    put("local", null); // delete the default local backend
-    put("remote", new HashMap<String, Object>(){{
-        put("organization", "test");
-        put("workspaces", new HashMap<String, String>(){{
-            put("name", "test");
-        }});
-    }});
-}});
+stack.addOverride("terraform.backend", new HashMap<String, HashMap<String, Object>>() {
+    {
+        put("local", null); // delete the default local backend
+        put("remote", new HashMap<String, Object>() {
+            {
+                put("organization", "test");
+                put("workspaces", new HashMap<String, String>() {
+                    {
+                        put("name", "test");
+                    }
+                });
+            }
+        });
+    }
+});
 ```
 
 ```python


### PR DESCRIPTION
This should fix the documentation examples.
