### PR TITLE
fix(hcl2cdk): Handle multi-line strings better

### DIFF
--- a/packages/@cdktf/hcl2cdk/lib/expressions.ts
+++ b/packages/@cdktf/hcl2cdk/lib/expressions.ts
@@ -7,7 +7,10 @@ import { camelCase, logger, pascalCase } from "./utils";
 import { TerraformResourceBlock, ProgramScope, ResourceScope } from "./types";
 import { getReferencesInExpression, getExpressionAst } from "@cdktf/hcl2json";
 import { getFullProviderName } from "./provider";
-import { TFExpressionSyntaxTree as tex } from "@cdktf/hcl2json";
+import {
+  TFExpressionSyntaxTree as tex,
+  wrapTerraformExpression,
+} from "@cdktf/hcl2json";
 import { functionsMap, tsFunctionsMap } from "./function-bindings/functions";
 import { coerceType } from "./coerceType";
 import {
@@ -26,35 +29,6 @@ export type Reference = {
 };
 
 const leaveCommentText = `Please leave a comment at https://cdk.tf/bugs/convert-expressions if you run into this issue.`;
-
-function wrapTerraformExpression(input: string): string {
-  if (!isNaN(parseInt(input, 10))) {
-    return input;
-  }
-  if (input === "true" || input === "false") {
-    return input;
-  }
-  if (
-    input.startsWith("[") ||
-    input.startsWith("{") ||
-    input.startsWith(`"`) ||
-    input.startsWith("'")
-  ) {
-    return input;
-  }
-
-  if (input.startsWith("<<")) {
-    // For Heredocs, we need to ensure that the string ends with an empty newline as
-    // the HCL parser doesn't find the ending token otherwise
-    if (!input.endsWith("\n")) {
-      return input + "\n";
-    }
-
-    return input;
-  }
-
-  return `"${input}"`;
-}
 
 const tfBinaryOperatorsToCdktf = {
   logicalOr: "or",
@@ -873,17 +847,17 @@ export function findExpressionType(
 export async function expressionAst(
   input: string
 ): Promise<tex.ExpressionType> {
-  const sanitizedInput = wrapTerraformExpression(input);
-  const isWrapped = sanitizedInput.length !== input.length;
-  const ast = await getExpressionAst("main.tf", sanitizedInput);
+  const { wrap, wrapOffset } = wrapTerraformExpression(input);
+  const ast = await getExpressionAst("main.tf", wrap);
 
   if (!ast) {
     throw new Error(`Unable to parse terraform expression: ${input}`);
   }
 
-  if (isWrapped) {
+  if (wrapOffset != 0 && tex.isTemplateWrapExpression(ast)) {
     return ast.children[0];
   }
+
   return ast;
 }
 

--- a/packages/@cdktf/hcl2cdk/lib/expressions.ts
+++ b/packages/@cdktf/hcl2cdk/lib/expressions.ts
@@ -423,6 +423,14 @@ async function convertTFExpressionAstToTs(
       }))
     );
 
+    const lastPart = parts[parts.length - 1];
+    if (t.isStringLiteral(lastPart.expr) && lastPart.expr.value === "\n") {
+      // This is a bit of a hack, but the trailing newline we add due to
+      // heredocs looks ugly and unnecessary in the generated code, so we
+      // try to remove it
+      parts.pop();
+    }
+
     if (parts.length === 0) {
       return t.stringLiteral(node.meta.value);
     }

--- a/packages/@cdktf/hcl2cdk/test/__snapshots__/tfExpressions.test.ts.snap
+++ b/packages/@cdktf/hcl2cdk/test/__snapshots__/tfExpressions.test.ts.snap
@@ -81,13 +81,11 @@ class MyConvertedCode extends cdktf.TerraformStack {
     const adminUsers =
       "\${{ for name, user in \${" +
       users.value +
-      "} : name => user if user.is_admin}}" +
-      "\\n";
+      "} : name => user if user.is_admin}}";
     const regularUsers =
       "\${{ for name, user in \${" +
       users.value +
-      "} : name => user if !user.is_admin}}" +
-      "\\n";
+      "} : name => user if !user.is_admin}}";
     new cdktf.TerraformOutput(this, "combined-so-it-does-not-get-removed", {
       value: "\${" + adminUsers + "},\${" + regularUsers + "}",
     });
@@ -112,10 +110,7 @@ class MyConvertedCode extends cdktf.TerraformStack {
       ),
     });
     const usersByRole =
-      "\${{ for name, user in \${" +
-      users.value +
-      "} : user.role => name...}}" +
-      "\\n";
+      "\${{ for name, user in \${" + users.value + "} : user.role => name...}}";
     new cdktf.TerraformOutput(this, "so-it-does-not-get-removed", {
       value: usersByRole,
     });
@@ -200,7 +195,7 @@ class MyConvertedCode extends cdktf.TerraformStack {
     super(scope, name);
     new cdktf.TerraformOutput(this, "hash", {
       value:
-        '{\\n  "example_hash_key": {"S": "something"},\\n  "example_attribute": {"N": "11111"}\\n}\\n\\n',
+        '{\\n  "example_hash_key": {"S": "something"},\\n  "example_attribute": {"N": "11111"}\\n}\\n',
     });
   }
 }

--- a/packages/@cdktf/hcl2cdk/test/__snapshots__/tfExpressions.test.ts.snap
+++ b/packages/@cdktf/hcl2cdk/test/__snapshots__/tfExpressions.test.ts.snap
@@ -81,11 +81,13 @@ class MyConvertedCode extends cdktf.TerraformStack {
     const adminUsers =
       "\${{ for name, user in \${" +
       users.value +
-      "} : name => user if user.is_admin}}";
+      "} : name => user if user.is_admin}}" +
+      "\\n";
     const regularUsers =
       "\${{ for name, user in \${" +
       users.value +
-      "} : name => user if !user.is_admin}}";
+      "} : name => user if !user.is_admin}}" +
+      "\\n";
     new cdktf.TerraformOutput(this, "combined-so-it-does-not-get-removed", {
       value: "\${" + adminUsers + "},\${" + regularUsers + "}",
     });
@@ -110,7 +112,10 @@ class MyConvertedCode extends cdktf.TerraformStack {
       ),
     });
     const usersByRole =
-      "\${{ for name, user in \${" + users.value + "} : user.role => name...}}";
+      "\${{ for name, user in \${" +
+      users.value +
+      "} : user.role => name...}}" +
+      "\\n";
     new cdktf.TerraformOutput(this, "so-it-does-not-get-removed", {
       value: usersByRole,
     });
@@ -181,6 +186,21 @@ class MyConvertedCode extends cdktf.TerraformStack {
       bucket: cdktf.Token.asString(
         cdktf.propertyAccess(settings.value, ["0", '"bucket_name"'])
       ),
+    });
+  }
+}
+"
+`;
+
+exports[`tfExpressions multi-line strings are supported typescript snapshot 1`] = `
+"import * as constructs from "constructs";
+import * as cdktf from "cdktf";
+class MyConvertedCode extends cdktf.TerraformStack {
+  constructor(scope: constructs.Construct, name: string) {
+    super(scope, name);
+    new cdktf.TerraformOutput(this, "hash", {
+      value:
+        '{\\n  "example_hash_key": {"S": "something"},\\n  "example_attribute": {"N": "11111"}\\n}\\n\\n',
     });
   }
 }

--- a/packages/@cdktf/hcl2cdk/test/resources.test.ts
+++ b/packages/@cdktf/hcl2cdk/test/resources.test.ts
@@ -24,114 +24,114 @@ describe("resources", () => {
 
   testCase.test(
     "complex resource",
-    ` 
-    provider "aws" {
-      region                      = "us-east-1"
-    }
-    resource "aws_cloudfront_distribution" "s3_distribution" {
-      origin {
-        domain_name = "aws_s3_bucket.b.bucket_regional_domain_name"
-        origin_id   = "local_s3_origin_id"
-    
-        s3_origin_config {
-          origin_access_identity = "origin-access-identity/cloudfront/ABCDEFG1234567"
-        }
+    `
+      provider "aws" {
+        region                      = "us-east-1"
       }
-    
-      enabled             = true
-      is_ipv6_enabled     = true
-      comment             = "Some comment"
-      default_root_object = "index.html"
-    
-      logging_config {
-        include_cookies = false
-        bucket          = "mylogs.s3.amazonaws.com"
-        prefix          = "myprefix"
-      }
-    
-      aliases = ["mysite.example.com", "yoursite.example.com"]
-    
-      default_cache_behavior {
-        allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
-        cached_methods   = ["GET", "HEAD"]
-        target_origin_id = "local_s3_origin_id"
-    
-        forwarded_values {
-          query_string = false
-    
-          cookies {
-            forward = "none"
+      resource "aws_cloudfront_distribution" "s3_distribution" {
+        origin {
+          domain_name = "aws_s3_bucket.b.bucket_regional_domain_name"
+          origin_id   = "local_s3_origin_id"
+
+          s3_origin_config {
+            origin_access_identity = "origin-access-identity/cloudfront/ABCDEFG1234567"
           }
         }
-    
-        viewer_protocol_policy = "allow-all"
-        min_ttl                = 0
-        default_ttl            = 3600
-        max_ttl                = 86400
-      }
-    
-      # Cache behavior with precedence 0
-      ordered_cache_behavior {
-        path_pattern     = "/content/immutable/*"
-        allowed_methods  = ["GET", "HEAD", "OPTIONS"]
-        cached_methods   = ["GET", "HEAD", "OPTIONS"]
-        target_origin_id = "local_s3_origin_id"
-    
-        forwarded_values {
-          query_string = false
-          headers      = ["Origin"]
-    
-          cookies {
-            forward = "none"
+
+        enabled             = true
+        is_ipv6_enabled     = true
+        comment             = "Some comment"
+        default_root_object = "index.html"
+
+        logging_config {
+          include_cookies = false
+          bucket          = "mylogs.s3.amazonaws.com"
+          prefix          = "myprefix"
+        }
+
+        aliases = ["mysite.example.com", "yoursite.example.com"]
+
+        default_cache_behavior {
+          allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+          cached_methods   = ["GET", "HEAD"]
+          target_origin_id = "local_s3_origin_id"
+
+          forwarded_values {
+            query_string = false
+
+            cookies {
+              forward = "none"
+            }
+          }
+
+          viewer_protocol_policy = "allow-all"
+          min_ttl                = 0
+          default_ttl            = 3600
+          max_ttl                = 86400
+        }
+
+        # Cache behavior with precedence 0
+        ordered_cache_behavior {
+          path_pattern     = "/content/immutable/*"
+          allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+          cached_methods   = ["GET", "HEAD", "OPTIONS"]
+          target_origin_id = "local_s3_origin_id"
+
+          forwarded_values {
+            query_string = false
+            headers      = ["Origin"]
+
+            cookies {
+              forward = "none"
+            }
+          }
+
+          min_ttl                = 0
+          default_ttl            = 86400
+          max_ttl                = 31536000
+          compress               = true
+          viewer_protocol_policy = "redirect-to-https"
+        }
+
+        # Cache behavior with precedence 1
+        ordered_cache_behavior {
+          path_pattern     = "/content/*"
+          allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+          cached_methods   = ["GET", "HEAD"]
+          target_origin_id = "local_s3_origin_id"
+
+          forwarded_values {
+            query_string = false
+
+            cookies {
+              forward = "none"
+            }
+          }
+
+          min_ttl                = 0
+          default_ttl            = 3600
+          max_ttl                = 86400
+          compress               = true
+          viewer_protocol_policy = "redirect-to-https"
+        }
+
+        price_class = "PriceClass_200"
+
+        restrictions {
+          geo_restriction {
+            restriction_type = "whitelist"
+            locations        = ["US", "CA", "GB", "DE"]
           }
         }
-    
-        min_ttl                = 0
-        default_ttl            = 86400
-        max_ttl                = 31536000
-        compress               = true
-        viewer_protocol_policy = "redirect-to-https"
-      }
-    
-      # Cache behavior with precedence 1
-      ordered_cache_behavior {
-        path_pattern     = "/content/*"
-        allowed_methods  = ["GET", "HEAD", "OPTIONS"]
-        cached_methods   = ["GET", "HEAD"]
-        target_origin_id = "local_s3_origin_id"
-    
-        forwarded_values {
-          query_string = false
-    
-          cookies {
-            forward = "none"
-          }
+
+        tags = {
+          Environment = "production"
         }
-    
-        min_ttl                = 0
-        default_ttl            = 3600
-        max_ttl                = 86400
-        compress               = true
-        viewer_protocol_policy = "redirect-to-https"
-      }
-    
-      price_class = "PriceClass_200"
-    
-      restrictions {
-        geo_restriction {
-          restriction_type = "whitelist"
-          locations        = ["US", "CA", "GB", "DE"]
+
+        viewer_certificate {
+          cloudfront_default_certificate = true
         }
-      }
-    
-      tags = {
-        Environment = "production"
-      }
-    
-      viewer_certificate {
-        cloudfront_default_certificate = true
-      }
-    }`,
+      }`,
     [binding.aws],
     Synth.yes,
     {
@@ -142,12 +142,12 @@ describe("resources", () => {
   testCase.test(
     "simple data source",
     `
-    provider "aws" {
-      region                      = "us-east-1"
-    }
-    data "aws_subnet" "selected" {
-      vpc_id = "subnet_id"
-    }`,
+      provider "aws" {
+        region                      = "us-east-1"
+      }
+      data "aws_subnet" "selected" {
+        vpc_id = "subnet_id"
+      }`,
     [binding.aws],
     Synth.yes,
     {
@@ -158,45 +158,45 @@ describe("resources", () => {
   testCase.test(
     "multiple blocks",
     `
-  provider "aws" {
-    region                      = "us-east-1"
-  }
-  resource "aws_security_group" "allow_tls" {
-    name        = "allow_tls"
-    description = "Allow TLS inbound traffic"
-  
-    ingress {
-      description      = "TLS from VPC"
-      from_port        = 443
-      to_port          = 443
-      protocol         = "tcp"
+    provider "aws" {
+      region                      = "us-east-1"
     }
+    resource "aws_security_group" "allow_tls" {
+      name        = "allow_tls"
+      description = "Allow TLS inbound traffic"
 
-    ingress {
-      description      = "TLS from VPC"
-      from_port        = 80
-      to_port          = 80
-      protocol         = "tcp"
-    }
+      ingress {
+        description      = "TLS from VPC"
+        from_port        = 443
+        to_port          = 443
+        protocol         = "tcp"
+      }
 
-    ingress {
-      from_port        = 8080
-      to_port          = 8080
-      protocol         = "tcp"
-    }
-  
-    egress {
-      from_port        = 0
-      to_port          = 0
-      protocol         = "-1"
-      cidr_blocks      = ["0.0.0.0/0"]
-      ipv6_cidr_blocks = ["::/0"]
-    }
-  
-    tags = {
-      Name = "allow_tls"
-    }
-  }`,
+      ingress {
+        description      = "TLS from VPC"
+        from_port        = 80
+        to_port          = 80
+        protocol         = "tcp"
+      }
+
+      ingress {
+        from_port        = 8080
+        to_port          = 8080
+        protocol         = "tcp"
+      }
+
+      egress {
+        from_port        = 0
+        to_port          = 0
+        protocol         = "-1"
+        cidr_blocks      = ["0.0.0.0/0"]
+        ipv6_cidr_blocks = ["::/0"]
+      }
+
+      tags = {
+        Name = "allow_tls"
+      }
+    }`,
     [binding.aws],
     Synth.yes,
     {
@@ -207,26 +207,26 @@ describe("resources", () => {
   testCase.test(
     "blocks should be arrays",
     `
-  provider "google" {
-    project = "my-project"
-    region  = "us-central1"
-  }
-  resource "google_compute_autoscaler" "example" {
-    name   = "example-autoscaler"
-    zone   = "us-east1-b"
-    target = "target-for-example-autoscaler"
-  
-    autoscaling_policy = {
-      max_replicas    = 8
-      min_replicas    = 2
-      cooldown_period = 60
-  
-      cpu_utilization = {
-        target = 0.5
+    provider "google" {
+      project = "my-project"
+      region  = "us-central1"
+    }
+    resource "google_compute_autoscaler" "example" {
+      name   = "example-autoscaler"
+      zone   = "us-east1-b"
+      target = "target-for-example-autoscaler"
+
+      autoscaling_policy = {
+        max_replicas    = 8
+        min_replicas    = 2
+        cooldown_period = 60
+
+        cpu_utilization = {
+          target = 0.5
+        }
       }
     }
-  }
-  `,
+    `,
     [binding.google],
     Synth.yes,
     {
@@ -236,6 +236,30 @@ describe("resources", () => {
 
   testCase.test(
     "maps are not arrays",
+    `
+    provider "kubernetes" {
+      config_path    = "~/.kube/config"
+      config_context = "my-context"
+    }
+
+    resource "kubernetes_secret" "secrets-xxx" {
+      metadata {
+        name      = "secrets-xxx"
+      }
+      data = {
+        "xxx" : "yyy"
+      }
+    }
+    `,
+    [binding.kubernetes],
+    Synth.yes,
+    {
+      resources: ["kubernetes_secret"],
+    }
+  );
+
+  testCase.test(
+    "maps dont get camel case keys",
     `
   provider "kubernetes" {
     config_path    = "~/.kube/config"
@@ -247,34 +271,10 @@ describe("resources", () => {
       name      = "secrets-xxx"
     }
     data = {
-      "xxx" : "yyy"
+      "camel_cased_key": "yes"
     }
   }
   `,
-    [binding.kubernetes],
-    Synth.yes,
-    {
-      resources: ["kubernetes_secret"],
-    }
-  );
-
-  testCase.test(
-    "maps dont get camel case keys",
-    `
-provider "kubernetes" {
-  config_path    = "~/.kube/config"
-  config_context = "my-context"
-}
-
-resource "kubernetes_secret" "secrets-xxx" {
-  metadata {
-    name      = "secrets-xxx"
-  }
-  data = {
-    "camel_cased_key": "yes"
-  }
-}
-`,
     [binding.kubernetes],
     Synth.yes,
     {
@@ -285,16 +285,16 @@ resource "kubernetes_secret" "secrets-xxx" {
   testCase.test(
     "same name local, var, out",
     `
-  variable "test" {
-    type    = string
-  }
-  locals {
-    test = "\${var.test} + 1"
-  }
-  output "test" {
-    value = "\${local.test}"
-  }
-  `,
+    variable "test" {
+      type    = string
+    }
+    locals {
+      test = "\${var.test} + 1"
+    }
+    output "test" {
+      value = "\${local.test}"
+    }
+    `,
     [],
     Synth.yes
   );
@@ -302,39 +302,39 @@ resource "kubernetes_secret" "secrets-xxx" {
   testCase.test(
     "property level renamings",
     `
-    provider "aws" {
-      region                      = "us-east-1"
-    }
-    resource "aws_guardduty_filter" "MyFilter" {
-      name        = "MyFilter"
-      action      = "ARCHIVE"
-      detector_id = "id"
-      rank        = 1
-    
-      finding_criteria {
-        criterion {
-          field  = "region"
-          equals = ["eu-west-1"]
-        }
-    
-        criterion {
-          field      = "service.additionalInfo.threatListName"
-          not_equals = ["some-threat", "another-threat"]
-        }
-    
-        criterion {
-          field        = "updatedAt"
-          greater_than = "2020-01-01T00:00:00Z"
-          less_than    = "2020-02-01T00:00:00Z"
-        }
-    
-        criterion {
-          field                 = "severity"
-          greater_than_or_equal = "4"
+      provider "aws" {
+        region                      = "us-east-1"
+      }
+      resource "aws_guardduty_filter" "MyFilter" {
+        name        = "MyFilter"
+        action      = "ARCHIVE"
+        detector_id = "id"
+        rank        = 1
+
+        finding_criteria {
+          criterion {
+            field  = "region"
+            equals = ["eu-west-1"]
+          }
+
+          criterion {
+            field      = "service.additionalInfo.threatListName"
+            not_equals = ["some-threat", "another-threat"]
+          }
+
+          criterion {
+            field        = "updatedAt"
+            greater_than = "2020-01-01T00:00:00Z"
+            less_than    = "2020-02-01T00:00:00Z"
+          }
+
+          criterion {
+            field                 = "severity"
+            greater_than_or_equal = "4"
+          }
         }
       }
-    }
-      `,
+        `,
     [binding.aws],
     Synth.yes,
     {
@@ -345,30 +345,30 @@ resource "kubernetes_secret" "secrets-xxx" {
   testCase.test(
     "tricky to parse items",
     `
-    provider "aws" {
-      region                      = "us-east-1"
-    }
-    variable "tags" {
-      type    = map
-    }
-
-
-    resource "aws_instance" "play" {
-      ami                         = join("-", [var.tags.app, var.tags.env])
-      instance_type               = "t3.small"
-      key_name                    = aws_key_pair.master_key.id
-      vpc_security_group_ids      = [aws_security_group.ssh.id]
-      subnet_id                   = aws_subnet.main.id
-      associate_public_ip_address = true
-    
-      connection {
-        type        = "ssh"
-        user        = "ubuntu"
-        private_key = file("./terraform_key")
-        host        = self.public_ip
+      provider "aws" {
+        region                      = "us-east-1"
       }
-    }
-      `,
+      variable "tags" {
+        type    = map
+      }
+
+
+      resource "aws_instance" "play" {
+        ami                         = join("-", [var.tags.app, var.tags.env])
+        instance_type               = "t3.small"
+        key_name                    = aws_key_pair.master_key.id
+        vpc_security_group_ids      = [aws_security_group.ssh.id]
+        subnet_id                   = aws_subnet.main.id
+        associate_public_ip_address = true
+
+        connection {
+          type        = "ssh"
+          user        = "ubuntu"
+          private_key = file("./terraform_key")
+          host        = self.public_ip
+        }
+      }
+        `,
     [binding.aws],
     Synth.never,
     {
@@ -390,23 +390,23 @@ resource "kubernetes_secret" "secrets-xxx" {
   testCase.test(
     "handle special resource names",
     `
-    provider "scaleway" {
-      zone   = "fr-par-1"
-      region = "fr-par"
-    }
+      provider "scaleway" {
+        zone   = "fr-par-1"
+        region = "fr-par"
+      }
 
-    resource "scaleway_object_bucket" "some_bucket" {
-      name = "some-unique-name"
-    }
-    
-    resource scaleway_object "some_file" {
-      bucket = scaleway_object_bucket.some_bucket.name
-      key = "object_path"
-    
-      file = "myfile"
-      hash = filemd5("myfile")
-    }
-      `,
+      resource "scaleway_object_bucket" "some_bucket" {
+        name = "some-unique-name"
+      }
+
+      resource scaleway_object "some_file" {
+        bucket = scaleway_object_bucket.some_bucket.name
+        key = "object_path"
+
+        file = "myfile"
+        hash = filemd5("myfile")
+      }
+        `,
     [binding.scaleway],
     Synth.yes,
     {
@@ -417,23 +417,23 @@ resource "kubernetes_secret" "secrets-xxx" {
   testCase.test(
     "handles special resource names without schema",
     `
-    provider "scaleway" {
-      zone   = "fr-par-1"
-      region = "fr-par"
-    }
+      provider "scaleway" {
+        zone   = "fr-par-1"
+        region = "fr-par"
+      }
 
-    resource "scaleway_object_bucket" "some_bucket" {
-      name = "some-unique-name"
-    }
-    
-    resource scaleway_object "some_file" {
-      bucket = scaleway_object_bucket.some_bucket.name
-      key = "object_path"
-    
-      file = "myfile"
-      hash = filemd5("myfile")
-    }
-      `,
+      resource "scaleway_object_bucket" "some_bucket" {
+        name = "some-unique-name"
+      }
+
+      resource scaleway_object "some_file" {
+        bucket = scaleway_object_bucket.some_bucket.name
+        key = "object_path"
+
+        file = "myfile"
+        hash = filemd5("myfile")
+      }
+        `,
     [],
     Synth.never
   );
@@ -441,22 +441,22 @@ resource "kubernetes_secret" "secrets-xxx" {
   testCase.test(
     "access use fqn for data source",
     `
-    provider "aws" {
-      region                      = "us-east-1"
-    }
-    data "aws_availability_zones" "changeme_az_list_ebs_snapshot" {
-      state = "available"
-    }
-    resource "aws_ebs_volume" "changeme_ebs_volume_snapshot" {
-      availability_zone = data.aws_availability_zones.changeme_az_list_ebs_snapshot.names[0]
-      size              = 10
-      type              = "standard"
-      encrypted         = false
-      tags = {
-        Name = "changeme_ebs_volume_tag"
+      provider "aws" {
+        region                      = "us-east-1"
       }
-    }
-    `,
+      data "aws_availability_zones" "changeme_az_list_ebs_snapshot" {
+        state = "available"
+      }
+      resource "aws_ebs_volume" "changeme_ebs_volume_snapshot" {
+        availability_zone = data.aws_availability_zones.changeme_az_list_ebs_snapshot.names[0]
+        size              = 10
+        type              = "standard"
+        encrypted         = false
+        tags = {
+          Name = "changeme_ebs_volume_tag"
+        }
+      }
+      `,
     [binding.aws],
     Synth.yes,
     {
@@ -468,47 +468,47 @@ resource "kubernetes_secret" "secrets-xxx" {
   testCase.test(
     "handles JSON encoded blocks",
     `
-    provider "aws" {
-      region                      = "us-east-1"
-    }
-    resource "aws_ecs_task_definition" "client" {
-      family                   = "client"
-      requires_compatibilities = ["FARGATE"]
-      # required for Fargate launch type
-      memory       = 512
-      cpu          = 256
-      network_mode = "awsvpc"
-    
-      container_definitions = jsonencode([
-        {
-          name      = "client"
-          image     = "crccheck/hello-world"
-          cpu       = 0 # take up proportional cpu
-          essential = true
-    
-          portMappings = [
-            {
-              containerPort = 8000
-              hostPort      = 8000 # though, access to the ephemeral port range is needed to connect on EC2, the exact port is required on Fargate from a security group standpoint.
-              protocol      = "tcp"
-            }
-          ]
-    
-          # Fake Service settings are set via Environment variables
-          environment = [
-            {
-              name  = "NAME"
-              value = "client"
-            },
-            {
-              name  = "MESSAGE"
-              value = "Hello from the client!"
-            }
-          ]
-        }
-      ])
-    }
-    `,
+      provider "aws" {
+        region                      = "us-east-1"
+      }
+      resource "aws_ecs_task_definition" "client" {
+        family                   = "client"
+        requires_compatibilities = ["FARGATE"]
+        # required for Fargate launch type
+        memory       = 512
+        cpu          = 256
+        network_mode = "awsvpc"
+
+        container_definitions = jsonencode([
+          {
+            name      = "client"
+            image     = "crccheck/hello-world"
+            cpu       = 0 # take up proportional cpu
+            essential = true
+
+            portMappings = [
+              {
+                containerPort = 8000
+                hostPort      = 8000 # though, access to the ephemeral port range is needed to connect on EC2, the exact port is required on Fargate from a security group standpoint.
+                protocol      = "tcp"
+              }
+            ]
+
+            # Fake Service settings are set via Environment variables
+            environment = [
+              {
+                name  = "NAME"
+                value = "client"
+              },
+              {
+                name  = "MESSAGE"
+                value = "Hello from the client!"
+              }
+            ]
+          }
+        ])
+      }
+      `,
     [binding.aws],
     Synth.no_missing_type_coercion,
     {

--- a/packages/@cdktf/hcl2cdk/test/tfExpressions.test.ts
+++ b/packages/@cdktf/hcl2cdk/test/tfExpressions.test.ts
@@ -15,7 +15,7 @@ describe("tfExpressions", () => {
           variable "admins" {
             type = number
           }
-          
+
           output "arithmetics" {
             value = var.members + var.admins
           }`,
@@ -33,12 +33,12 @@ describe("tfExpressions", () => {
         description             = "KMS key 1"
         deletion_window_in_days = 7
       }
-      
+
       resource "aws_s3_bucket" "examplebucket" {
         bucket = "examplebuckettftest"
         acl    = "private"
       }
-      
+
       resource "aws_s3_bucket_object" "examplebucket_object" {
         key        = "someobject"
         bucket     = aws_kms_key.examplekms.deletion_window_in_days > 3 ? aws_s3_bucket.examplebucket.id : []
@@ -60,7 +60,7 @@ describe("tfExpressions", () => {
                 is_admin = boolean
               }))
             }
-            
+
             locals {
               admin_users = {
                 for name, user in var.users : name => user
@@ -71,7 +71,7 @@ describe("tfExpressions", () => {
                 if !user.is_admin
               }
             }
-            
+
             output "combined-so-it-does-not-get-removed" {
               value = "\${local.admin_users},\${local.regular_users}"
             }
@@ -88,13 +88,13 @@ describe("tfExpressions", () => {
               role = string
             }))
           }
-          
+
           locals {
             users_by_role = {
               for name, user in var.users : user.role => name...
             }
           }
-          
+
           output "so-it-does-not-get-removed" {
             value = local.users_by_role
           }`,
@@ -109,13 +109,13 @@ describe("tfExpressions", () => {
               api_key = "api_key"
               app_key = "app_key"
             }
-    
+
             variable "users" {
               type = list(object({
                 id = string
               }))
             }
-            
+
             resource "datadog_monitor" "hard_query" {
               name    = "queries are hard"
               message = "here we go"
@@ -208,6 +208,25 @@ describe("tfExpressions", () => {
     Synth.yes,
     {
       resources: ["google_compute_instance"],
+    }
+  );
+
+  testCase.test(
+    "multi-line strings are supported",
+    `
+      output "hash" {
+        value = <<ITEM
+{
+  "example_hash_key": {"S": "something"},
+  "example_attribute": {"N": "11111"}
+}
+ITEM
+      }
+      `,
+    [],
+    Synth.yes,
+    {
+      resources: [],
     }
   );
 });

--- a/packages/@cdktf/hcl2json/lib/index.ts
+++ b/packages/@cdktf/hcl2json/lib/index.ts
@@ -8,4 +8,6 @@ export {
   getExpressionAst,
 } from "./bridge";
 
+export { wrapTerraformExpression } from "./util";
+
 export * as TFExpressionSyntaxTree from "./syntax-tree";

--- a/packages/@cdktf/hcl2json/lib/util.ts
+++ b/packages/@cdktf/hcl2json/lib/util.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 export function wrapTerraformExpression(input: string): {
   wrap: string;
   wrapOffset: number;

--- a/packages/@cdktf/hcl2json/lib/util.ts
+++ b/packages/@cdktf/hcl2json/lib/util.ts
@@ -1,0 +1,38 @@
+export function wrapTerraformExpression(input: string): {
+  wrap: string;
+  wrapOffset: number;
+} {
+  if (!isNaN(Number(input))) {
+    return { wrap: input, wrapOffset: 0 };
+  }
+  if (input === "true" || input === "false") {
+    return { wrap: input, wrapOffset: 0 };
+  }
+
+  if (input.startsWith(`"`) || input.startsWith("'")) {
+    if (input.indexOf("\n") >= 0) {
+      const trimWrapped = input.substring(1, input.length - 1);
+      return {
+        wrap: `<<EOE\n${trimWrapped}\nEOE\n`,
+        wrapOffset: 5,
+      };
+    }
+    return { wrap: input, wrapOffset: 0 };
+  }
+
+  if (input.startsWith("[") || input.startsWith("{")) {
+    return { wrap: input, wrapOffset: 0 };
+  }
+
+  if (input.startsWith("<<")) {
+    // For Heredocs, we need to ensure that the string ends with an empty newline as
+    // the HCL parser doesn't find the ending token otherwise
+    if (!input.endsWith("\n")) {
+      return { wrap: input + "\n", wrapOffset: 0 };
+    }
+
+    return { wrap: input, wrapOffset: 0 };
+  }
+
+  return { wrap: `"${input}"`, wrapOffset: 1 };
+}


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes https://github.com/orgs/hashicorp/projects/207/views/12?pane=issue&itemId=25824022

### Description

This is a pretty hacky PR, and I'm not really comfortable with the solution. That being said, I think this does resolve our immediate woes around heredocs. 

The problem is as such: By the time the heredoc string comes in for parsing by the expression parser, (I suspect) the hcl2json parser has already converted it into a quote containing newlines. Quote with newlines are not accepted within HCL and thus breaks our expression. 

This PR tries to detect newlines within string literals and wraps them back into a heredoc literal, making the expression parseable. As you can see from the PRs, this requires a lot of tweaks to existing logic to ensure it works ok, and even then, I'm not 100% sure this will not be caught off guard on other situations.

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
