### PR TITLE
fix: Accept nested quotes within strings

### DIFF
--- a/packages/@cdktf/hcl2cdk/lib/expressions.ts
+++ b/packages/@cdktf/hcl2cdk/lib/expressions.ts
@@ -116,7 +116,7 @@ function traversalToVariableName(
   if (!tex.isScopeTraversalExpression(node)) {
     logger.error(
       `Unexpected expression type ${node.type} with value ${node.meta.value} passed to convert to a variable. 
-        Please leave a comment at https://cdk.tf/bugs/convert-expressions if you run into this issue`
+        ${leaveCommentText}`
     );
     return "";
   }

--- a/packages/@cdktf/hcl2cdk/test/expressionToTs.test.ts
+++ b/packages/@cdktf/hcl2cdk/test/expressionToTs.test.ts
@@ -1097,7 +1097,7 @@ EOF`;
       getType
     );
     expect(code(result)).toMatchInlineSnapshot(
-      `"cdktf.Token.asString(cdktf.propertyAccess(dataAwsAvailabilityZonesAvailable.names, ["\${count.index}"]))"`
+      `""welcome to \\\\\\"cdktf\\\\\\"""`
     );
   });
 });

--- a/packages/@cdktf/hcl2cdk/test/expressionToTs.test.ts
+++ b/packages/@cdktf/hcl2cdk/test/expressionToTs.test.ts
@@ -1087,4 +1087,17 @@ EOF`;
       `"cdktf.Token.asString(cdktf.propertyAccess(dataAwsAvailabilityZonesAvailable.names, ["\${count.index}"]))"`
     );
   });
+
+  test("accept escaped quotes within string", async () => {
+    const expression = `"welcome to \"cdktf\""`;
+    const scope = getScope();
+    const result = await convertTerraformExpressionToTs(
+      expression,
+      scope,
+      getType
+    );
+    expect(code(result)).toMatchInlineSnapshot(
+      `"cdktf.Token.asString(cdktf.propertyAccess(dataAwsAvailabilityZonesAvailable.names, ["\${count.index}"]))"`
+    );
+  });
 });

--- a/packages/@cdktf/hcl2json/lib/util.ts
+++ b/packages/@cdktf/hcl2json/lib/util.ts
@@ -3,10 +3,51 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+/**
+ * This function is used to escape quotes within a string.
+ *  Note: This is a really naive implmentation that will not be able to work with
+ *    nested templates. However, nested templates require parsing, so we will
+ *    only handle strings without nested templates for the moment
+ * @param input The string to escape
+ */
+export function replaceQuotes(input: string): string {
+  const fullyQuotedMatch = /^(\s*")(.*)("\s*)$/.exec(input);
+  const hasTemplate = /(?<!\$)\$\{/.test(input);
+
+  if (fullyQuotedMatch !== null && !hasTemplate) {
+    return `${fullyQuotedMatch[1]}${fullyQuotedMatch[2].replace(/"/g, `\\"`)}${
+      fullyQuotedMatch[3]
+    }`;
+  }
+
+  return input;
+}
+
+/**
+ * This function is used to wrap a string in quotes conditionally.
+ *  - If the string is already quoted, it will be returned as-is.
+ *  - If the string contains a newline, it will be wrapped in a heredoc.
+ *  - If the string is a number, it will be returned as-is.
+ *  - If the string is a boolean, it will be returned as-is.
+ *  - If the string is a list or map, it will be returned as-is.
+ *
+ * @param input The string to wrap
+ * @returns The wrapped string, and the offset of the cursor within the string
+ *
+ * @example
+ * wrapTerraformExpression("foo") // { wrap: '"foo"', wrapOffset: 1 }
+ * wrapTerraformExpression("foo\nbar") // { wrap: '<<EOE\nfoo\nbar\nEOE\n', wrapOffset: 5 }
+ * wrapTerraformExpression("22") // { wrap: '22', wrapOffset: 0 }
+ * wrapTerraformExpression("true") // { wrap: 'true', wrapOffset: 0 }
+ * wrapTerraformExpression("[22, 10]") // { wrap: '[22, 10]', wrapOffset: 0 }
+ * wrapTerraformExpression("{ foo = 22 }") // { wrap: '{ foo = 22 }', wrapOffset: 0 }
+ */
 export function wrapTerraformExpression(input: string): {
   wrap: string;
   wrapOffset: number;
 } {
+  input = replaceQuotes(input);
+
   if (!isNaN(Number(input))) {
     return { wrap: input, wrapOffset: 0 };
   }

--- a/packages/@cdktf/hcl2json/test/util.test.ts
+++ b/packages/@cdktf/hcl2json/test/util.test.ts
@@ -1,0 +1,13 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+//
+import { replaceQuotes } from "../lib/util";
+
+describe("replaceQuotes", () => {
+  test("replaces a simple quote", () => {
+    expect(replaceQuotes(`"foo\"bar"`)).toEqual(`"foo\\"bar"`);
+  });
+  test("replaces a simple quote twice", () => {
+    expect(replaceQuotes(`"foo\"bar\""`)).toEqual(`"foo\\"bar\\""`);
+  });
+});


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes https://github.com/orgs/hashicorp/projects/207/views/12?pane=issue&itemId=25824299

### Description

If strings to be converted have quotes nested within them, we throw an error here. I don't know where we should solve this problem, but it requires more than just a few regexs. I went for a really complex solution but it just doesn't work without parsing. Maybe I missed something, but I'd like to get the core fix out before we find a complete solution to strings with nested quotes and nested templates.

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
