### PR TITLE
chore: Mock synth to make parallelism test fail less

### DIFF
--- a/packages/@cdktf/cli-core/src/test/lib/terraform-parallelism.test.ts
+++ b/packages/@cdktf/cli-core/src/test/lib/terraform-parallelism.test.ts
@@ -197,6 +197,15 @@ describe("terraform parallelism", () => {
         },
       });
 
+      cdktfProject.synth = jest.fn().mockImplementation(async () => {
+        return [
+          stackWithName("first"),
+          stackWithName("second"),
+          stackWithName("third"),
+          stackWithName("fourth"),
+        ];
+      });
+
       await cdktfProject.deploy({
         stackNames: ["first"],
         autoApprove: true,
@@ -221,6 +230,15 @@ describe("terraform parallelism", () => {
         },
       });
 
+      cdktfProject.synth = jest.fn().mockImplementation(async () => {
+        return [
+          stackWithName("first"),
+          stackWithName("second"),
+          stackWithName("third"),
+          stackWithName("fourth"),
+        ];
+      });
+
       await cdktfProject.destroy({
         stackNames: ["second"],
         autoApprove: true,
@@ -241,6 +259,15 @@ describe("terraform parallelism", () => {
         onUpdate: (event) => {
           events.push(event);
         },
+      });
+
+      cdktfProject.synth = jest.fn().mockImplementation(async () => {
+        return [
+          stackWithName("first"),
+          stackWithName("second"),
+          stackWithName("third"),
+          stackWithName("fourth"),
+        ];
       });
 
       await cdktfProject.destroy({
@@ -270,6 +297,15 @@ describe("terraform parallelism", () => {
         },
       });
 
+      cdktfProject.synth = jest.fn().mockImplementation(async () => {
+        return [
+          stackWithName("first"),
+          stackWithName("second"),
+          stackWithName("third"),
+          stackWithName("fourth"),
+        ];
+      });
+
       await cdktfProject.diff({
         stackName: "first",
         terraformParallelism: 1,
@@ -291,6 +327,15 @@ describe("terraform parallelism", () => {
             event.approve();
           }
         },
+      });
+
+      cdktfProject.synth = jest.fn().mockImplementation(async () => {
+        return [
+          stackWithName("first"),
+          stackWithName("second"),
+          stackWithName("third"),
+          stackWithName("fourth"),
+        ];
       });
 
       await cdktfProject.diff({

--- a/packages/@cdktf/cli-core/src/test/lib/terraform-parallelism.test.ts
+++ b/packages/@cdktf/cli-core/src/test/lib/terraform-parallelism.test.ts
@@ -68,7 +68,7 @@ const stackWithName = (name: string) => {
           },
         },
       },
-      terraformVersion: "0.14.0",
+      terraformVersion: "1.2.8",
       variables: {},
       outputs: {},
       resources: [

--- a/packages/@cdktf/cli-core/src/test/lib/terraform-parallelism.test.ts
+++ b/packages/@cdktf/cli-core/src/test/lib/terraform-parallelism.test.ts
@@ -46,45 +46,43 @@ const projectName = `cdktf-api-test`;
 
 const stackWithName = (name: string) => {
   return {
-    [name]: {
+    name,
+    constructPath: name,
+    workingDirectory: `cdktf.out/stacks/${name}`,
+    synthesizedStackPath: `stacks/${name}/cdk.tf.json`,
+    annotations: [],
+    dependencies: [],
+    content: JSON.stringify({
       name,
-      constructPath: name,
-      workingDirectory: `cdktf.out/stacks/${name}`,
-      synthesizedStackPath: `stacks/${name}/cdk.tf.json`,
-      annotations: [],
-      dependencies: [],
-      content: JSON.stringify({
-        name,
-        backend: {
-          type: "local",
-          config: {
-            path: `${name}.tfstate`,
-          },
-        },
+      backend: {
+        type: "local",
         config: {
-          required_providers: {
-            null: {
-              source: "hashicorp/null",
-              version: "3.1.0",
+          path: `${name}.tfstate`,
+        },
+      },
+      config: {
+        required_providers: {
+          null: {
+            source: "hashicorp/null",
+            version: "3.1.0",
+          },
+        },
+      },
+      terraformVersion: "0.14.0",
+      variables: {},
+      outputs: {},
+      resources: [
+        {
+          name,
+          type: "null_resource",
+          config: {
+            triggers: {
+              foo: "bar",
             },
           },
         },
-        terraformVersion: "0.14.0",
-        variables: {},
-        outputs: {},
-        resources: [
-          {
-            name,
-            type: "null_resource",
-            config: {
-              triggers: {
-                foo: "bar",
-              },
-            },
-          },
-        ],
-      }),
-    },
+      ],
+    }),
   };
 };
 

--- a/packages/@cdktf/cli-core/src/test/lib/terraform-parallelism.test.ts
+++ b/packages/@cdktf/cli-core/src/test/lib/terraform-parallelism.test.ts
@@ -48,34 +48,42 @@ const stackWithName = (name: string) => {
   return {
     [name]: {
       name,
-      backend: {
-        type: "local",
-        config: {
-          path: `${name}.tfstate`,
-        },
-      },
-      config: {
-        required_providers: {
-          null: {
-            source: "hashicorp/null",
-            version: "3.1.0",
+      constructPath: name,
+      workingDirectory: `cdktf.out/stacks/${name}`,
+      synthesizedStackPath: `stacks/${name}/cdk.tf.json`,
+      annotations: [],
+      dependencies: [],
+      content: JSON.stringify({
+        name,
+        backend: {
+          type: "local",
+          config: {
+            path: `${name}.tfstate`,
           },
         },
-      },
-      terraformVersion: "0.14.0",
-      variables: {},
-      outputs: {},
-      resources: [
-        {
-          name,
-          type: "null_resource",
-          config: {
-            triggers: {
-              foo: "bar",
+        config: {
+          required_providers: {
+            null: {
+              source: "hashicorp/null",
+              version: "3.1.0",
             },
           },
         },
-      ],
+        terraformVersion: "0.14.0",
+        variables: {},
+        outputs: {},
+        resources: [
+          {
+            name,
+            type: "null_resource",
+            config: {
+              triggers: {
+                foo: "bar",
+              },
+            },
+          },
+        ],
+      }),
     },
   };
 };


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes issue with CI failures

### Description

The terraform parallelism test suite was the single most problematic test suite that blocked the 0.16 release and I had to retry a few times for that. It still causes a lot of problems on every release, so this is an attempt to try and resolve the issue. 

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
