### PR TITLE
fix(lib): add more excludes to .npmignore

### DIFF
--- a/packages/@cdktf/hcl2json/.npmignore
+++ b/packages/@cdktf/hcl2json/.npmignore
@@ -5,6 +5,7 @@
 !.jsii
 
 test
+jest.config.js
 
 # Exclude jsii outdir
 dist
@@ -19,5 +20,6 @@ go.sum
 go.mod
 package.sh
 build-go.sh
+prebuild.sh
 tsconfig.json
 Dockerfile


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

none

### Description

There can be some more files excluded from the npm package.

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
