### PR TITLE
fix(deps): make `jest` and `typescript` development dependencies

### DIFF
--- a/packages/@cdktf/commons/package.json
+++ b/packages/@cdktf/commons/package.json
@@ -42,15 +42,15 @@
     "fs-extra": "^8.1.0",
     "is-valid-domain": "^0.1.6",
     "log4js": "^6.7.0",
-    "typescript": "^5.0.2",
-    "uuid": "^8.3.2",
-    "jest": "^29.5.0",
-    "ts-jest": "^29.0.5"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/follow-redirects": "^1.14.1",
     "@types/fs-extra": "^8.1.2",
-    "@types/uuid": "^8.3.4"
+    "@types/uuid": "^8.3.4",
+    "jest": "^29.5.0",
+    "ts-jest": "^29.0.5",
+    "typescript": "^5.0.2"
   },
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes #2862

### Description

As mentioned in #2862 there are multiple non-required dependencies added to `@cdktf/commons`, this moves them to `devDependnecies` which makes it consistent with all other packages in the project.

- `typescript`
- `ts-jest`
- `jest`

No version changes or anything, just moved to be classified as development dependencies. With this these packages will not be required by others and should save on ~225 needless package installs, plus the disk space 🎉 

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
