### PR TITLE
fix: github action shouldn't use untrusted input

### DIFF
--- a/.github/workflows/pr-copyright.yml
+++ b/.github/workflows/pr-copyright.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   add-copyright-headers:
     runs-on: ubuntu-latest
+    env:
+      HEAD_REF: ${{ github.event.pull_request.head.ref }}
     permissions:
       contents: write
     steps:
@@ -38,4 +40,4 @@ jobs:
         run: |-
           git add .
           git commit -s -m "chore: add required copyright headers"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          git push origin HEAD:$HEAD_REF


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Description
Fix according to security advisory