### PR TITLE
chore: Clean up github actions containing deprecated parts

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -135,15 +135,13 @@ jobs:
       TERRAFORM_VERSION: ${{ matrix.terraform }}
       GITHUB_API_TOKEN_CDKTF: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 60
-    defaults:
-      run:
-        shell: bash
 
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       - name: Get yarn cache directory path
         id: global-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+        shell: bash
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         id: global-cache # use this to check for `cache-hit` (`steps.global-cache.outputs.cache-hit != 'true'`)
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       - name: Get yarn cache directory path
         id: global-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: ensure correct user
         run: chown -R root /__w/terraform-cdk
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
@@ -140,7 +140,7 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       - name: Get yarn cache directory path
         id: global-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         id: global-cache # use this to check for `cache-hit` (`steps.global-cache.outputs.cache-hit != 'true'`)
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -135,6 +135,7 @@ jobs:
       TERRAFORM_VERSION: ${{ matrix.terraform }}
       GITHUB_API_TOKEN_CDKTF: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 60
+    shell: bash
 
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -135,7 +135,9 @@ jobs:
       TERRAFORM_VERSION: ${{ matrix.terraform }}
       GITHUB_API_TOKEN_CDKTF: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 60
-    shell: bash
+    defaults:
+      run:
+        shell: bash
 
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -158,6 +158,7 @@ jobs:
         uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753
         with:
           go-version: 1.18.x
+          cache: false # This is disabled because we don't have a go.sum file and setup-go expects it to use caching. Thus, caching is always broken anyways
       - name: Download dist
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Description

Follow up on our github actions pinning PR. This removes the one instance that we're using the deprecated `set-output` mechanism.

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
