### PR TITLE
feat(lib): Enable declarationMap feature in TS compiler

### DIFF
--- a/packages/@cdktf/cli-core/templates/typescript/tsconfig.json
+++ b/packages/@cdktf/cli-core/templates/typescript/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "alwaysStrict": true,
     "declaration": true,
+    "declarationMap": true,
     "experimentalDecorators": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/@cdktf/cli-core/tsconfig.json
+++ b/packages/@cdktf/cli-core/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "alwaysStrict": true,
     "declaration": true,
+    "declarationMap": true,
     "experimentalDecorators": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/@cdktf/commons/tsconfig.json
+++ b/packages/@cdktf/commons/tsconfig.json
@@ -3,6 +3,7 @@
     "alwaysStrict": true,
     "baseUrl": ".",
     "declaration": true,
+    "declarationMap": true,
     "experimentalDecorators": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/@cdktf/hcl2cdk/tsconfig.json
+++ b/packages/@cdktf/hcl2cdk/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "alwaysStrict": true,
     "declaration": true,
+    "declarationMap": true,
     "experimentalDecorators": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/@cdktf/hcl2json/tsconfig.json
+++ b/packages/@cdktf/hcl2json/tsconfig.json
@@ -3,6 +3,7 @@
     "alwaysStrict": true,
     "baseUrl": ".",
     "declaration": true,
+    "declarationMap": true,
     "experimentalDecorators": true,
     "inlineSourceMap": true,
     "inlineSources": true,


### PR DESCRIPTION
### Related issue

Implements #2881

### Description

Enable the TS compiler feature `declarationMap`. This enables you to quickly navigate to the original sources, when you currently have a corresponding .d.ts file open and want to see its implementation.

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
