### PR TITLE
chore: nitpick GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-prebuilt-providers.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report-prebuilt-providers.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Providers
       description: |
-        Please run `cdktf provider list` on the command line and paste the output in here. Alternatively, manually list the versions of all providers you are using.
+        Please run `cdktf provider list` on the command line and paste the output in here. Or, manually list the versions of all providers you are using.
         If you are not running the latest versions, please upgrade because your issue may have already been fixed.
       placeholder: |
         ┌────────────────────┬──────────────────┬─────────┬────────────┬────────────────────────┬─────────────────┐
@@ -86,7 +86,7 @@ body:
     attributes:
       label: Gist
       description: |
-        Please provide a link to a [GitHub Gist](https://gist.github.com/) containing a reproducible code sample and/or your complete debug output.
+        If possible, please provide a link to a [GitHub Gist](https://gist.github.com/) containing a reproducible code sample and/or your complete debug output.
       placeholder: |
         https://gist.github.com/gdb/b6365e79be6052e7531e7ba6ea8caf23
     validations:
@@ -116,9 +116,11 @@ body:
       label: References
       description: |
         Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Or links to documentation pages?
-        Information about referencing Github issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
-      value: |
-        - #0000
+        Guide to referencing Github issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
+      placeholder: |
+        - #123
+        - #456
+        - https://developer.hashicorp.com/terraform/cdktf/concepts/aspects
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Providers
       description: |
-        Please run `cdktf provider list` on the command line and paste the output in here. Alternatively, manually list the versions of all providers you are using.
+        Please run `cdktf provider list` on the command line and paste the output in here. Or, manually list the versions of all providers you are using.
         If you are not running the latest versions, please upgrade because your issue may have already been fixed.
       placeholder: |
         ┌────────────────────┬──────────────────┬─────────┬────────────┬────────────────────────┬─────────────────┐
@@ -86,7 +86,7 @@ body:
     attributes:
       label: Gist
       description: |
-        Please provide a link to a [GitHub Gist](https://gist.github.com/) containing a reproducible code sample and/or your complete debug output.
+        If possible, please provide a link to a [GitHub Gist](https://gist.github.com/) containing a reproducible code sample and/or your complete debug output.
       placeholder: |
         https://gist.github.com/gdb/b6365e79be6052e7531e7ba6ea8caf23
     validations:
@@ -116,9 +116,11 @@ body:
       label: References
       description: |
         Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Or links to documentation pages?
-        Information about referencing Github issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
-      value: |
-        - #0000
+        Guide to referencing Github issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
+      placeholder: |
+        - #123
+        - #456
+        - https://developer.hashicorp.com/terraform/cdktf/concepts/aspects
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -4,6 +4,11 @@ title: "COMPONENT: short issue description"
 labels: [documentation, new]
 assignees: []
 body:
+  - type: markdown
+    attributes:
+      value: |
+        We use GitHub issues for tracking bugs and enhancements. For questions, please use [the community forum](https://discuss.hashicorp.com/c/terraform-core/cdk-for-terraform/47) where there are more people ready to help.
+
   - type: textarea
     id: description
     attributes:
@@ -17,7 +22,12 @@ body:
     attributes:
       label: Links
       description: |
-        Include links to affected or related documentation page(s).
+        Include links to affected or related documentation page(s) or issues.
+        Guide to referencing Github issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
+      placeholder: |
+        - https://developer.hashicorp.com/terraform/cdktf/concepts/aspects
+        - #123
+        - #456
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -23,9 +23,11 @@ body:
       label: References
       description: |
         Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Or links to documentation pages?
-        Information about referencing Github issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
-      value: |
-        - #0000
+        Guide to referencing Github issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
+      placeholder: |
+        - #123
+        - #456
+        - https://developer.hashicorp.com/terraform/cdktf/concepts/aspects
     validations:
       required: false
 


### PR DESCRIPTION
Annoying that there's no way to preview these before merging...