### PR TITLE
fix(provider-generator): remove duplicates between wrapper classes and interfaces generated from provider schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ tsconfig.json
 **/.terraform
 **/*.tfstate
 **/*.tfstate.backup
+**/*.d.ts.map
 
 # https://github.com/github/gitignore/blob/master/Global/VisualStudioCode.gitignore
 .vscode/*

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -3901,7 +3901,7 @@ export interface BlockTypeSetListConfig extends cdktf.TerraformMetaArguments {
   * 
   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/block_type_set_list#timeouts_list BlockTypeSetList#timeouts_list}
   */
-  readonly timeoutsList?: BlockTypeSetListTimeoutsList[] | cdktf.IResolvable;
+  readonly timeoutsList?: BlockTypeSetListTimeoutsListStruct[] | cdktf.IResolvable;
 }
 export interface BlockTypeSetListTimeoutsSet {
   /**
@@ -4000,14 +4000,14 @@ export class BlockTypeSetListTimeoutsSetList extends cdktf.ComplexList {
     return new BlockTypeSetListTimeoutsSetOutputReference(this.terraformResource, this.terraformAttribute, index, this.wrapsSet);
   }
 }
-export interface BlockTypeSetListTimeoutsList {
+export interface BlockTypeSetListTimeoutsListStruct {
   /**
   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/block_type_set_list#create BlockTypeSetList#create}
   */
   readonly create?: string;
 }
 
-export function blockTypeSetListTimeoutsListToTerraform(struct?: BlockTypeSetListTimeoutsList | cdktf.IResolvable): any {
+export function blockTypeSetListTimeoutsListStructToTerraform(struct?: BlockTypeSetListTimeoutsListStruct | cdktf.IResolvable): any {
   if (!cdktf.canInspect(struct) || cdktf.Tokenization.isResolvable(struct)) { return struct; }
   if (cdktf.isComplexElement(struct)) {
     throw new Error("A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration");
@@ -4017,7 +4017,7 @@ export function blockTypeSetListTimeoutsListToTerraform(struct?: BlockTypeSetLis
   }
 }
 
-export class BlockTypeSetListTimeoutsListOutputReference extends cdktf.ComplexObject {
+export class BlockTypeSetListTimeoutsListStructOutputReference extends cdktf.ComplexObject {
   private isEmptyObject = false;
   private resolvableValue?: cdktf.IResolvable;
 
@@ -4031,7 +4031,7 @@ export class BlockTypeSetListTimeoutsListOutputReference extends cdktf.ComplexOb
     super(terraformResource, terraformAttribute, complexObjectIsFromSet, complexObjectIndex);
   }
 
-  public get internalValue(): BlockTypeSetListTimeoutsList | cdktf.IResolvable | undefined {
+  public get internalValue(): BlockTypeSetListTimeoutsListStruct | cdktf.IResolvable | undefined {
     if (this.resolvableValue) {
       return this.resolvableValue;
     }
@@ -4044,7 +4044,7 @@ export class BlockTypeSetListTimeoutsListOutputReference extends cdktf.ComplexOb
     return hasAnyValues ? internalValueResult : undefined;
   }
 
-  public set internalValue(value: BlockTypeSetListTimeoutsList | cdktf.IResolvable | undefined) {
+  public set internalValue(value: BlockTypeSetListTimeoutsListStruct | cdktf.IResolvable | undefined) {
     if (value === undefined) {
       this.isEmptyObject = false;
       this.resolvableValue = undefined;
@@ -4078,8 +4078,8 @@ export class BlockTypeSetListTimeoutsListOutputReference extends cdktf.ComplexOb
   }
 }
 
-export class BlockTypeSetListTimeoutsListList extends cdktf.ComplexList {
-  public internalValue? : BlockTypeSetListTimeoutsList[] | cdktf.IResolvable
+export class BlockTypeSetListTimeoutsListStructList extends cdktf.ComplexList {
+  public internalValue? : BlockTypeSetListTimeoutsListStruct[] | cdktf.IResolvable
 
   /**
   * @param terraformResource The parent resource
@@ -4093,8 +4093,8 @@ export class BlockTypeSetListTimeoutsListList extends cdktf.ComplexList {
   /**
   * @param index the index of the item to return
   */
-  public get(index: number): BlockTypeSetListTimeoutsListOutputReference {
-    return new BlockTypeSetListTimeoutsListOutputReference(this.terraformResource, this.terraformAttribute, index, this.wrapsSet);
+  public get(index: number): BlockTypeSetListTimeoutsListStructOutputReference {
+    return new BlockTypeSetListTimeoutsListStructOutputReference(this.terraformResource, this.terraformAttribute, index, this.wrapsSet);
   }
 }
 
@@ -4158,11 +4158,11 @@ export class BlockTypeSetList extends cdktf.TerraformResource {
   }
 
   // timeouts_list - computed: false, optional: true, required: false
-  private _timeoutsList = new BlockTypeSetListTimeoutsListList(this, "timeouts_list", false);
+  private _timeoutsList = new BlockTypeSetListTimeoutsListStructList(this, "timeouts_list", false);
   public get timeoutsList() {
     return this._timeoutsList;
   }
-  public putTimeoutsList(value: BlockTypeSetListTimeoutsList[] | cdktf.IResolvable) {
+  public putTimeoutsList(value: BlockTypeSetListTimeoutsListStruct[] | cdktf.IResolvable) {
     this._timeoutsList.internalValue = value;
   }
   public resetTimeoutsList() {
@@ -4180,7 +4180,7 @@ export class BlockTypeSetList extends cdktf.TerraformResource {
   protected synthesizeAttributes(): { [name: string]: any } {
     return {
       timeouts_set: cdktf.listMapper(blockTypeSetListTimeoutsSetToTerraform, true)(this._timeoutsSet.internalValue),
-      timeouts_list: cdktf.listMapper(blockTypeSetListTimeoutsListToTerraform, true)(this._timeoutsList.internalValue),
+      timeouts_list: cdktf.listMapper(blockTypeSetListTimeoutsListStructToTerraform, true)(this._timeoutsList.internalValue),
     };
   }
 }

--- a/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
@@ -58,6 +58,10 @@ const isReservedClassOrNamespaceName = (className: string): boolean => {
   ].includes(className.toLowerCase());
 };
 
+const isReservedStructClassName = (className: string): boolean => {
+  return className.toLowerCase().endsWith("list");
+};
+
 const getFileName = (provider: ProviderName, baseName: string): string => {
   if (baseName === "index") {
     return "index-resource/index.ts";
@@ -564,9 +568,15 @@ class Parser {
     nesting_mode: string,
     isSingleItem = false
   ) {
-    const name = this.uniqueClassName(
-      toPascalCase(scope.map((x) => toSnakeCase(x.name)).join("_"))
+    const possibleName = toPascalCase(
+      scope.map((x) => toSnakeCase(x.name)).join("_")
     );
+    const name = this.uniqueClassName(
+      isReservedStructClassName(possibleName)
+        ? `${possibleName}Struct`
+        : possibleName
+    );
+
     const parent = scope[scope.length - 1];
     // blockType.nesting_mode => list/set & blockType.max_items === 1,
     const isClass = (parent.isComputed && !parent.isOptional) || isSingleItem;


### PR DESCRIPTION

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes #2879 

### Description

If an attribute is called "list" and it's parent class is accessible via a list both the interface for the attribute and the class for the accessor on the parents parent have the same name. This clash causes JSII to fail

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
