### PR TITLE
chore: remove unused input from copywrite

### DIFF
--- a/.github/workflows/pr-copyright.yml
+++ b/.github/workflows/pr-copyright.yml
@@ -27,9 +27,7 @@ jobs:
           git config user.name "hashicorp-copywrite[bot]"
           git config user.email "110428419+hashicorp-copywrite[bot]@users.noreply.github.com"
       - name: Setup Copywrite tool
-        uses: hashicorp/setup-copywrite@867a1a2a064a0626db322392806428f7dc59cb3e # v1.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        uses: hashicorp/setup-copywrite@867a1a2a064a0626db322392806428f7dc59cb3e # v1.1.2
       - name: Add headers using Copywrite tool
         run: copywrite headers
       - name: Check if there are any changes


### PR DESCRIPTION
Minor nitpick but we don't need to pass the token anymore with the newer version.