### PR TITLE
chore: fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,4 @@
 # We use this for automatic PR review assignment within Github.
-# We don't intent to gatekeep certain parts of the codebase and
-# won't use it in branch protection rules.
 # If individual users are specified in this file, this is mainly to
 # inform them of certain PRs and we don't require a review from them
 # to be able to merge PRs.
@@ -14,10 +12,10 @@
 # Education likes to get notifications if changes happen to docs.
 # We need to include the CDKTF team as well to ensure Education
 # members are not the only ones notified.
-website/docs/ @hashicorp/cdktf @mgarrell777 @robin-norwood
+website/docs/ @hashicorp/cdktf @hashicorp/team-docs-packer-and-terraform
 
 # No codeowners for these files, as they are generated.
-# This way, Laura does not get notified if only these files changed.
+# This way, Education does not get notified if only these files changed.
 website/docs/cdktf/api-reference/typescript.mdx
 website/docs/cdktf/api-reference/python.mdx
 website/docs/cdktf/api-reference/java.mdx


### PR DESCRIPTION
Heimdall has already been helpful to me in flagging there was an error with our CODEOWNERS file; someone had departed the company and no longer has write access to the repo. We should avoid naming individuals and try to use teams instead for that reason.

Also removed the line about branch protection rules because that may stop being true in the future as per new security policy that will be rolling out.