### PR TITLE
fix: do not always overwrite global.performance

### DIFF
--- a/packages/@cdktf/hcl2json/wasm/bridge_wasm_exec.js
+++ b/packages/@cdktf/hcl2json/wasm/bridge_wasm_exec.js
@@ -11,15 +11,10 @@ globalThis.fs = require("fs");
 globalThis.TextEncoder = require("util").TextEncoder;
 globalThis.TextDecoder = require("util").TextDecoder;
 
-globalThis.performance = {
-	now() {
-		const [sec, nsec] = process.hrtime();
-		return sec * 1000 + nsec / 1000000;
-	},
-};
+globalThis.performance ??= require("performance");
 
 // Node >= 19 has a crypto function object, lower node versions need this polyfill
-if (!globalThis.crypto) { 
+if (!globalThis.crypto) {
 	const crypto = require("crypto");
 	globalThis.crypto = {
 		getRandomValues(b) {


### PR DESCRIPTION
new node version already have a performance global, see https://nodejs.org/api/globals.html#performance

it contains many methods, see https://nodejs.org/api/perf_hooks.html

when always overwriting it, other modules like `undici` which use the performance object won't work any more. in genera using the performance object become unusable as soon as the `@cdktf/hcl2json` package is required.

discussion/bug: https://github.com/renovatebot/renovate/discussions/22615

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes # <!-- INSERT ISSUE NUMBER -->

### Description

In plain English, describe your approach to addressing the issue linked above. For example, if you made a particular design decision, let us know why you chose this path instead of another solution.

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
