### PR TITLE
chore: correct constructs docs "Through Validations" example

### DIFF
--- a/website/docs/cdktf/concepts/constructs.mdx
+++ b/website/docs/cdktf/concepts/constructs.mdx
@@ -260,7 +260,7 @@ class Ec2Instance extends Construct {
 #### Through Validations
 
 ```ts
-import { Construct } from "constructs";
+import { Annotations, Construct } from "constructs";
 
 class S3Bucket extends Construct {
   constructor(scope: Construct, name: string, config: S3BucketConfig) {
@@ -270,7 +270,7 @@ class S3Bucket extends Construct {
       this.isOpenToThePublic(config) &&
       !config.tags["reason-why-this-is-public"]
     ) {
-      Annotation.of(this).addWarning(
+      Annotations.of(this).addWarning(
         `This S3Bucket is open to the public and no reason why is stated in the tags, please add a "reason-why-this-is-public" tag`
       );
     }


### PR DESCRIPTION
### Related issue

None (simple doc change)

### Description

The `construct` example "Through Validations" had an error. Added the import

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
