### PR TITLE
feat(provider-generator): allow removing big, cost intensive structures

### DIFF
--- a/examples/typescript/aws-kubernetes/cdktf.json
+++ b/examples/typescript/aws-kubernetes/cdktf.json
@@ -3,7 +3,7 @@
   "app": "npx ts-node main.ts",
   "terraformProviders": [
     "kubernetes@~> 2.7.1",
-    "aws@~> 3.70.0"
+    "aws@~> 5.0.0"
   ],
   "terraformModules": [
     "terraform-aws-modules/vpc/aws@ ~> 3.2.0",

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/skipped-attributes.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/skipped-attributes.test.ts.snap
@@ -1,23 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`skips attributes in the disallow list: quicksight-template 1`] = `
-"// generated from terraform resource schema
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template
+// generated from terraform resource schema
 
-import { QuicksightTemplateDefinition, 
-quicksightTemplateDefinitionToTerraform, 
-QuicksightTemplateDefinitionOutputReference, 
-QuicksightTemplatePermissions, 
-quicksightTemplatePermissionsToTerraform, 
-QuicksightTemplatePermissionsList, 
-QuicksightTemplateSourceEntity, 
-quicksightTemplateSourceEntityToTerraform, 
-QuicksightTemplateSourceEntityOutputReference, 
-QuicksightTemplateTimeouts, 
-quicksightTemplateTimeoutsToTerraform, 
-QuicksightTemplateTimeoutsOutputReference} from './index-structs'
-export * from './index-structs'
 import { Construct } from 'constructs';
 import * as cdktf from 'cdktf';
+
+// Configuration
+
 export interface QuicksightTemplateConfig extends cdktf.TerraformMetaArguments {
   /**
   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#aws_account_id QuicksightTemplate#aws_account_id}
@@ -55,7 +46,7 @@ export interface QuicksightTemplateConfig extends cdktf.TerraformMetaArguments {
   * 
   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#definition QuicksightTemplate#definition}
   */
-  readonly definition?: QuicksightTemplateDefinition;
+  readonly definition?: any;
   /**
   * permissions block
   * 
@@ -74,6 +65,617 @@ export interface QuicksightTemplateConfig extends cdktf.TerraformMetaArguments {
   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#timeouts QuicksightTemplate#timeouts}
   */
   readonly timeouts?: QuicksightTemplateTimeouts;
+}
+export interface QuicksightTemplatePermissions {
+  /**
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#actions QuicksightTemplate#actions}
+  */
+  readonly actions: string[];
+  /**
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#principal QuicksightTemplate#principal}
+  */
+  readonly principal: string;
+}
+
+export function quicksightTemplatePermissionsToTerraform(struct?: QuicksightTemplatePermissions | cdktf.IResolvable): any {
+  if (!cdktf.canInspect(struct) || cdktf.Tokenization.isResolvable(struct)) { return struct; }
+  if (cdktf.isComplexElement(struct)) {
+    throw new Error("A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration");
+  }
+  return {
+    actions: cdktf.listMapper(cdktf.stringToTerraform, false)(struct!.actions),
+    principal: cdktf.stringToTerraform(struct!.principal),
+  }
+}
+
+export class QuicksightTemplatePermissionsOutputReference extends cdktf.ComplexObject {
+  private isEmptyObject = false;
+  private resolvableValue?: cdktf.IResolvable;
+
+  /**
+  * @param terraformResource The parent resource
+  * @param terraformAttribute The attribute on the parent resource this class is referencing
+  * @param complexObjectIndex the index of this item in the list
+  * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+  */
+  public constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean) {
+    super(terraformResource, terraformAttribute, complexObjectIsFromSet, complexObjectIndex);
+  }
+
+  public get internalValue(): QuicksightTemplatePermissions | cdktf.IResolvable | undefined {
+    if (this.resolvableValue) {
+      return this.resolvableValue;
+    }
+    let hasAnyValues = this.isEmptyObject;
+    const internalValueResult: any = {};
+    if (this._actions !== undefined) {
+      hasAnyValues = true;
+      internalValueResult.actions = this._actions;
+    }
+    if (this._principal !== undefined) {
+      hasAnyValues = true;
+      internalValueResult.principal = this._principal;
+    }
+    return hasAnyValues ? internalValueResult : undefined;
+  }
+
+  public set internalValue(value: QuicksightTemplatePermissions | cdktf.IResolvable | undefined) {
+    if (value === undefined) {
+      this.isEmptyObject = false;
+      this.resolvableValue = undefined;
+      this._actions = undefined;
+      this._principal = undefined;
+    }
+    else if (cdktf.Tokenization.isResolvable(value)) {
+      this.isEmptyObject = false;
+      this.resolvableValue = value;
+    }
+    else {
+      this.isEmptyObject = Object.keys(value).length === 0;
+      this.resolvableValue = undefined;
+      this._actions = value.actions;
+      this._principal = value.principal;
+    }
+  }
+
+  // actions - computed: false, optional: false, required: true
+  private _actions?: string[]; 
+  public get actions() {
+    return cdktf.Fn.tolist(this.getListAttribute('actions'));
+  }
+  public set actions(value: string[]) {
+    this._actions = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get actionsInput() {
+    return this._actions;
+  }
+
+  // principal - computed: false, optional: false, required: true
+  private _principal?: string; 
+  public get principal() {
+    return this.getStringAttribute('principal');
+  }
+  public set principal(value: string) {
+    this._principal = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get principalInput() {
+    return this._principal;
+  }
+}
+
+export class QuicksightTemplatePermissionsList extends cdktf.ComplexList {
+  public internalValue? : QuicksightTemplatePermissions[] | cdktf.IResolvable
+
+  /**
+  * @param terraformResource The parent resource
+  * @param terraformAttribute The attribute on the parent resource this class is referencing
+  * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+  */
+  constructor(protected terraformResource: cdktf.IInterpolatingParent, protected terraformAttribute: string, protected wrapsSet: boolean) {
+    super(terraformResource, terraformAttribute, wrapsSet)
+  }
+
+  /**
+  * @param index the index of the item to return
+  */
+  public get(index: number): QuicksightTemplatePermissionsOutputReference {
+    return new QuicksightTemplatePermissionsOutputReference(this.terraformResource, this.terraformAttribute, index, this.wrapsSet);
+  }
+}
+export interface QuicksightTemplateSourceEntitySourceAnalysisDataSetReferences {
+  /**
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#data_set_arn QuicksightTemplate#data_set_arn}
+  */
+  readonly dataSetArn: string;
+  /**
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#data_set_placeholder QuicksightTemplate#data_set_placeholder}
+  */
+  readonly dataSetPlaceholder: string;
+}
+
+export function quicksightTemplateSourceEntitySourceAnalysisDataSetReferencesToTerraform(struct?: QuicksightTemplateSourceEntitySourceAnalysisDataSetReferences | cdktf.IResolvable): any {
+  if (!cdktf.canInspect(struct) || cdktf.Tokenization.isResolvable(struct)) { return struct; }
+  if (cdktf.isComplexElement(struct)) {
+    throw new Error("A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration");
+  }
+  return {
+    data_set_arn: cdktf.stringToTerraform(struct!.dataSetArn),
+    data_set_placeholder: cdktf.stringToTerraform(struct!.dataSetPlaceholder),
+  }
+}
+
+export class QuicksightTemplateSourceEntitySourceAnalysisDataSetReferencesOutputReference extends cdktf.ComplexObject {
+  private isEmptyObject = false;
+  private resolvableValue?: cdktf.IResolvable;
+
+  /**
+  * @param terraformResource The parent resource
+  * @param terraformAttribute The attribute on the parent resource this class is referencing
+  * @param complexObjectIndex the index of this item in the list
+  * @param complexObjectIsFromSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+  */
+  public constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string, complexObjectIndex: number, complexObjectIsFromSet: boolean) {
+    super(terraformResource, terraformAttribute, complexObjectIsFromSet, complexObjectIndex);
+  }
+
+  public get internalValue(): QuicksightTemplateSourceEntitySourceAnalysisDataSetReferences | cdktf.IResolvable | undefined {
+    if (this.resolvableValue) {
+      return this.resolvableValue;
+    }
+    let hasAnyValues = this.isEmptyObject;
+    const internalValueResult: any = {};
+    if (this._dataSetArn !== undefined) {
+      hasAnyValues = true;
+      internalValueResult.dataSetArn = this._dataSetArn;
+    }
+    if (this._dataSetPlaceholder !== undefined) {
+      hasAnyValues = true;
+      internalValueResult.dataSetPlaceholder = this._dataSetPlaceholder;
+    }
+    return hasAnyValues ? internalValueResult : undefined;
+  }
+
+  public set internalValue(value: QuicksightTemplateSourceEntitySourceAnalysisDataSetReferences | cdktf.IResolvable | undefined) {
+    if (value === undefined) {
+      this.isEmptyObject = false;
+      this.resolvableValue = undefined;
+      this._dataSetArn = undefined;
+      this._dataSetPlaceholder = undefined;
+    }
+    else if (cdktf.Tokenization.isResolvable(value)) {
+      this.isEmptyObject = false;
+      this.resolvableValue = value;
+    }
+    else {
+      this.isEmptyObject = Object.keys(value).length === 0;
+      this.resolvableValue = undefined;
+      this._dataSetArn = value.dataSetArn;
+      this._dataSetPlaceholder = value.dataSetPlaceholder;
+    }
+  }
+
+  // data_set_arn - computed: false, optional: false, required: true
+  private _dataSetArn?: string; 
+  public get dataSetArn() {
+    return this.getStringAttribute('data_set_arn');
+  }
+  public set dataSetArn(value: string) {
+    this._dataSetArn = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get dataSetArnInput() {
+    return this._dataSetArn;
+  }
+
+  // data_set_placeholder - computed: false, optional: false, required: true
+  private _dataSetPlaceholder?: string; 
+  public get dataSetPlaceholder() {
+    return this.getStringAttribute('data_set_placeholder');
+  }
+  public set dataSetPlaceholder(value: string) {
+    this._dataSetPlaceholder = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get dataSetPlaceholderInput() {
+    return this._dataSetPlaceholder;
+  }
+}
+
+export class QuicksightTemplateSourceEntitySourceAnalysisDataSetReferencesList extends cdktf.ComplexList {
+  public internalValue? : QuicksightTemplateSourceEntitySourceAnalysisDataSetReferences[] | cdktf.IResolvable
+
+  /**
+  * @param terraformResource The parent resource
+  * @param terraformAttribute The attribute on the parent resource this class is referencing
+  * @param wrapsSet whether the list is wrapping a set (will add tolist() to be able to access an item via an index)
+  */
+  constructor(protected terraformResource: cdktf.IInterpolatingParent, protected terraformAttribute: string, protected wrapsSet: boolean) {
+    super(terraformResource, terraformAttribute, wrapsSet)
+  }
+
+  /**
+  * @param index the index of the item to return
+  */
+  public get(index: number): QuicksightTemplateSourceEntitySourceAnalysisDataSetReferencesOutputReference {
+    return new QuicksightTemplateSourceEntitySourceAnalysisDataSetReferencesOutputReference(this.terraformResource, this.terraformAttribute, index, this.wrapsSet);
+  }
+}
+export interface QuicksightTemplateSourceEntitySourceAnalysis {
+  /**
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#arn QuicksightTemplate#arn}
+  */
+  readonly arn: string;
+  /**
+  * data_set_references block
+  * 
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#data_set_references QuicksightTemplate#data_set_references}
+  */
+  readonly dataSetReferences: QuicksightTemplateSourceEntitySourceAnalysisDataSetReferences[] | cdktf.IResolvable;
+}
+
+export function quicksightTemplateSourceEntitySourceAnalysisToTerraform(struct?: QuicksightTemplateSourceEntitySourceAnalysisOutputReference | QuicksightTemplateSourceEntitySourceAnalysis): any {
+  if (!cdktf.canInspect(struct) || cdktf.Tokenization.isResolvable(struct)) { return struct; }
+  if (cdktf.isComplexElement(struct)) {
+    throw new Error("A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration");
+  }
+  return {
+    arn: cdktf.stringToTerraform(struct!.arn),
+    data_set_references: cdktf.listMapper(quicksightTemplateSourceEntitySourceAnalysisDataSetReferencesToTerraform, true)(struct!.dataSetReferences),
+  }
+}
+
+export class QuicksightTemplateSourceEntitySourceAnalysisOutputReference extends cdktf.ComplexObject {
+  private isEmptyObject = false;
+
+  /**
+  * @param terraformResource The parent resource
+  * @param terraformAttribute The attribute on the parent resource this class is referencing
+  */
+  public constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string) {
+    super(terraformResource, terraformAttribute, false, 0);
+  }
+
+  public get internalValue(): QuicksightTemplateSourceEntitySourceAnalysis | undefined {
+    let hasAnyValues = this.isEmptyObject;
+    const internalValueResult: any = {};
+    if (this._arn !== undefined) {
+      hasAnyValues = true;
+      internalValueResult.arn = this._arn;
+    }
+    if (this._dataSetReferences?.internalValue !== undefined) {
+      hasAnyValues = true;
+      internalValueResult.dataSetReferences = this._dataSetReferences?.internalValue;
+    }
+    return hasAnyValues ? internalValueResult : undefined;
+  }
+
+  public set internalValue(value: QuicksightTemplateSourceEntitySourceAnalysis | undefined) {
+    if (value === undefined) {
+      this.isEmptyObject = false;
+      this._arn = undefined;
+      this._dataSetReferences.internalValue = undefined;
+    }
+    else {
+      this.isEmptyObject = Object.keys(value).length === 0;
+      this._arn = value.arn;
+      this._dataSetReferences.internalValue = value.dataSetReferences;
+    }
+  }
+
+  // arn - computed: false, optional: false, required: true
+  private _arn?: string; 
+  public get arn() {
+    return this.getStringAttribute('arn');
+  }
+  public set arn(value: string) {
+    this._arn = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get arnInput() {
+    return this._arn;
+  }
+
+  // data_set_references - computed: false, optional: false, required: true
+  private _dataSetReferences = new QuicksightTemplateSourceEntitySourceAnalysisDataSetReferencesList(this, "data_set_references", false);
+  public get dataSetReferences() {
+    return this._dataSetReferences;
+  }
+  public putDataSetReferences(value: QuicksightTemplateSourceEntitySourceAnalysisDataSetReferences[] | cdktf.IResolvable) {
+    this._dataSetReferences.internalValue = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get dataSetReferencesInput() {
+    return this._dataSetReferences.internalValue;
+  }
+}
+export interface QuicksightTemplateSourceEntitySourceTemplate {
+  /**
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#arn QuicksightTemplate#arn}
+  */
+  readonly arn: string;
+}
+
+export function quicksightTemplateSourceEntitySourceTemplateToTerraform(struct?: QuicksightTemplateSourceEntitySourceTemplateOutputReference | QuicksightTemplateSourceEntitySourceTemplate): any {
+  if (!cdktf.canInspect(struct) || cdktf.Tokenization.isResolvable(struct)) { return struct; }
+  if (cdktf.isComplexElement(struct)) {
+    throw new Error("A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration");
+  }
+  return {
+    arn: cdktf.stringToTerraform(struct!.arn),
+  }
+}
+
+export class QuicksightTemplateSourceEntitySourceTemplateOutputReference extends cdktf.ComplexObject {
+  private isEmptyObject = false;
+
+  /**
+  * @param terraformResource The parent resource
+  * @param terraformAttribute The attribute on the parent resource this class is referencing
+  */
+  public constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string) {
+    super(terraformResource, terraformAttribute, false, 0);
+  }
+
+  public get internalValue(): QuicksightTemplateSourceEntitySourceTemplate | undefined {
+    let hasAnyValues = this.isEmptyObject;
+    const internalValueResult: any = {};
+    if (this._arn !== undefined) {
+      hasAnyValues = true;
+      internalValueResult.arn = this._arn;
+    }
+    return hasAnyValues ? internalValueResult : undefined;
+  }
+
+  public set internalValue(value: QuicksightTemplateSourceEntitySourceTemplate | undefined) {
+    if (value === undefined) {
+      this.isEmptyObject = false;
+      this._arn = undefined;
+    }
+    else {
+      this.isEmptyObject = Object.keys(value).length === 0;
+      this._arn = value.arn;
+    }
+  }
+
+  // arn - computed: false, optional: false, required: true
+  private _arn?: string; 
+  public get arn() {
+    return this.getStringAttribute('arn');
+  }
+  public set arn(value: string) {
+    this._arn = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get arnInput() {
+    return this._arn;
+  }
+}
+export interface QuicksightTemplateSourceEntity {
+  /**
+  * source_analysis block
+  * 
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#source_analysis QuicksightTemplate#source_analysis}
+  */
+  readonly sourceAnalysis?: QuicksightTemplateSourceEntitySourceAnalysis;
+  /**
+  * source_template block
+  * 
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#source_template QuicksightTemplate#source_template}
+  */
+  readonly sourceTemplate?: QuicksightTemplateSourceEntitySourceTemplate;
+}
+
+export function quicksightTemplateSourceEntityToTerraform(struct?: QuicksightTemplateSourceEntityOutputReference | QuicksightTemplateSourceEntity): any {
+  if (!cdktf.canInspect(struct) || cdktf.Tokenization.isResolvable(struct)) { return struct; }
+  if (cdktf.isComplexElement(struct)) {
+    throw new Error("A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration");
+  }
+  return {
+    source_analysis: quicksightTemplateSourceEntitySourceAnalysisToTerraform(struct!.sourceAnalysis),
+    source_template: quicksightTemplateSourceEntitySourceTemplateToTerraform(struct!.sourceTemplate),
+  }
+}
+
+export class QuicksightTemplateSourceEntityOutputReference extends cdktf.ComplexObject {
+  private isEmptyObject = false;
+
+  /**
+  * @param terraformResource The parent resource
+  * @param terraformAttribute The attribute on the parent resource this class is referencing
+  */
+  public constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string) {
+    super(terraformResource, terraformAttribute, false, 0);
+  }
+
+  public get internalValue(): QuicksightTemplateSourceEntity | undefined {
+    let hasAnyValues = this.isEmptyObject;
+    const internalValueResult: any = {};
+    if (this._sourceAnalysis?.internalValue !== undefined) {
+      hasAnyValues = true;
+      internalValueResult.sourceAnalysis = this._sourceAnalysis?.internalValue;
+    }
+    if (this._sourceTemplate?.internalValue !== undefined) {
+      hasAnyValues = true;
+      internalValueResult.sourceTemplate = this._sourceTemplate?.internalValue;
+    }
+    return hasAnyValues ? internalValueResult : undefined;
+  }
+
+  public set internalValue(value: QuicksightTemplateSourceEntity | undefined) {
+    if (value === undefined) {
+      this.isEmptyObject = false;
+      this._sourceAnalysis.internalValue = undefined;
+      this._sourceTemplate.internalValue = undefined;
+    }
+    else {
+      this.isEmptyObject = Object.keys(value).length === 0;
+      this._sourceAnalysis.internalValue = value.sourceAnalysis;
+      this._sourceTemplate.internalValue = value.sourceTemplate;
+    }
+  }
+
+  // source_analysis - computed: false, optional: true, required: false
+  private _sourceAnalysis = new QuicksightTemplateSourceEntitySourceAnalysisOutputReference(this, "source_analysis");
+  public get sourceAnalysis() {
+    return this._sourceAnalysis;
+  }
+  public putSourceAnalysis(value: QuicksightTemplateSourceEntitySourceAnalysis) {
+    this._sourceAnalysis.internalValue = value;
+  }
+  public resetSourceAnalysis() {
+    this._sourceAnalysis.internalValue = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get sourceAnalysisInput() {
+    return this._sourceAnalysis.internalValue;
+  }
+
+  // source_template - computed: false, optional: true, required: false
+  private _sourceTemplate = new QuicksightTemplateSourceEntitySourceTemplateOutputReference(this, "source_template");
+  public get sourceTemplate() {
+    return this._sourceTemplate;
+  }
+  public putSourceTemplate(value: QuicksightTemplateSourceEntitySourceTemplate) {
+    this._sourceTemplate.internalValue = value;
+  }
+  public resetSourceTemplate() {
+    this._sourceTemplate.internalValue = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get sourceTemplateInput() {
+    return this._sourceTemplate.internalValue;
+  }
+}
+export interface QuicksightTemplateTimeouts {
+  /**
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#create QuicksightTemplate#create}
+  */
+  readonly create?: string;
+  /**
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#delete QuicksightTemplate#delete}
+  */
+  readonly delete?: string;
+  /**
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#update QuicksightTemplate#update}
+  */
+  readonly update?: string;
+}
+
+export function quicksightTemplateTimeoutsToTerraform(struct?: QuicksightTemplateTimeouts | cdktf.IResolvable): any {
+  if (!cdktf.canInspect(struct) || cdktf.Tokenization.isResolvable(struct)) { return struct; }
+  if (cdktf.isComplexElement(struct)) {
+    throw new Error("A complex element was used as configuration, this is not supported: https://cdk.tf/complex-object-as-configuration");
+  }
+  return {
+    create: cdktf.stringToTerraform(struct!.create),
+    delete: cdktf.stringToTerraform(struct!.delete),
+    update: cdktf.stringToTerraform(struct!.update),
+  }
+}
+
+export class QuicksightTemplateTimeoutsOutputReference extends cdktf.ComplexObject {
+  private isEmptyObject = false;
+  private resolvableValue?: cdktf.IResolvable;
+
+  /**
+  * @param terraformResource The parent resource
+  * @param terraformAttribute The attribute on the parent resource this class is referencing
+  */
+  public constructor(terraformResource: cdktf.IInterpolatingParent, terraformAttribute: string) {
+    super(terraformResource, terraformAttribute, false);
+  }
+
+  public get internalValue(): QuicksightTemplateTimeouts | cdktf.IResolvable | undefined {
+    if (this.resolvableValue) {
+      return this.resolvableValue;
+    }
+    let hasAnyValues = this.isEmptyObject;
+    const internalValueResult: any = {};
+    if (this._create !== undefined) {
+      hasAnyValues = true;
+      internalValueResult.create = this._create;
+    }
+    if (this._delete !== undefined) {
+      hasAnyValues = true;
+      internalValueResult.delete = this._delete;
+    }
+    if (this._update !== undefined) {
+      hasAnyValues = true;
+      internalValueResult.update = this._update;
+    }
+    return hasAnyValues ? internalValueResult : undefined;
+  }
+
+  public set internalValue(value: QuicksightTemplateTimeouts | cdktf.IResolvable | undefined) {
+    if (value === undefined) {
+      this.isEmptyObject = false;
+      this.resolvableValue = undefined;
+      this._create = undefined;
+      this._delete = undefined;
+      this._update = undefined;
+    }
+    else if (cdktf.Tokenization.isResolvable(value)) {
+      this.isEmptyObject = false;
+      this.resolvableValue = value;
+    }
+    else {
+      this.isEmptyObject = Object.keys(value).length === 0;
+      this.resolvableValue = undefined;
+      this._create = value.create;
+      this._delete = value.delete;
+      this._update = value.update;
+    }
+  }
+
+  // create - computed: false, optional: true, required: false
+  private _create?: string; 
+  public get create() {
+    return this.getStringAttribute('create');
+  }
+  public set create(value: string) {
+    this._create = value;
+  }
+  public resetCreate() {
+    this._create = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get createInput() {
+    return this._create;
+  }
+
+  // delete - computed: false, optional: true, required: false
+  private _delete?: string; 
+  public get delete() {
+    return this.getStringAttribute('delete');
+  }
+  public set delete(value: string) {
+    this._delete = value;
+  }
+  public resetDelete() {
+    this._delete = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get deleteInput() {
+    return this._delete;
+  }
+
+  // update - computed: false, optional: true, required: false
+  private _update?: string; 
+  public get update() {
+    return this.getStringAttribute('update');
+  }
+  public set update(value: string) {
+    this._update = value;
+  }
+  public resetUpdate() {
+    this._update = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get updateInput() {
+    return this._update;
+  }
 }
 
 /**
@@ -118,7 +720,7 @@ export class QuicksightTemplate extends cdktf.TerraformResource {
     this._tagsAll = config.tagsAll;
     this._templateId = config.templateId;
     this._versionDescription = config.versionDescription;
-    this._definition.internalValue = config.definition;
+    this._definition = config.definition;
     this._permissions.internalValue = config.permissions;
     this._sourceEntity.internalValue = config.sourceEntity;
     this._timeouts.internalValue = config.timeouts;
@@ -262,19 +864,19 @@ export class QuicksightTemplate extends cdktf.TerraformResource {
   }
 
   // definition - computed: false, optional: true, required: false
-  private _definition = new QuicksightTemplateDefinitionOutputReference(this, "definition");
+  private _definition?: any; 
   public get definition() {
-    return this._definition;
+    return this.interpolationForAttribute('definition');
   }
-  public putDefinition(value: QuicksightTemplateDefinition) {
-    this._definition.internalValue = value;
+  public set definition(value: any) {
+    this._definition = value;
   }
   public resetDefinition() {
-    this._definition.internalValue = undefined;
+    this._definition = undefined;
   }
   // Temporarily expose input value. Use with caution.
   public get definitionInput() {
-    return this._definition.internalValue;
+    return this._definition;
   }
 
   // permissions - computed: false, optional: true, required: false
@@ -338,7 +940,7 @@ export class QuicksightTemplate extends cdktf.TerraformResource {
       tags_all: cdktf.hashMapper(cdktf.stringToTerraform)(this._tagsAll),
       template_id: cdktf.stringToTerraform(this._templateId),
       version_description: cdktf.stringToTerraform(this._versionDescription),
-      definition: quicksightTemplateDefinitionToTerraform(this._definition.internalValue),
+      definition: cdktf.anyToTerraform(this._definition),
       permissions: cdktf.listMapper(quicksightTemplatePermissionsToTerraform, true)(this._permissions.internalValue),
       source_entity: quicksightTemplateSourceEntityToTerraform(this._sourceEntity.internalValue),
       timeouts: quicksightTemplateTimeoutsToTerraform(this._timeouts.internalValue),

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/skipped-attributes.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/skipped-attributes.test.ts.snap
@@ -1,0 +1,349 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`skips attributes in the disallow list: quicksight-template 1`] = `
+"// generated from terraform resource schema
+
+import { QuicksightTemplateDefinition, 
+quicksightTemplateDefinitionToTerraform, 
+QuicksightTemplateDefinitionOutputReference, 
+QuicksightTemplatePermissions, 
+quicksightTemplatePermissionsToTerraform, 
+QuicksightTemplatePermissionsList, 
+QuicksightTemplateSourceEntity, 
+quicksightTemplateSourceEntityToTerraform, 
+QuicksightTemplateSourceEntityOutputReference, 
+QuicksightTemplateTimeouts, 
+quicksightTemplateTimeoutsToTerraform, 
+QuicksightTemplateTimeoutsOutputReference} from './index-structs'
+export * from './index-structs'
+import { Construct } from 'constructs';
+import * as cdktf from 'cdktf';
+export interface QuicksightTemplateConfig extends cdktf.TerraformMetaArguments {
+  /**
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#aws_account_id QuicksightTemplate#aws_account_id}
+  */
+  readonly awsAccountId?: string;
+  /**
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#id QuicksightTemplate#id}
+  *
+  * Please be aware that the id field is automatically added to all resources in Terraform providers using a Terraform provider SDK version below 2.
+  * If you experience problems setting this value it might not be settable. Please take a look at the provider documentation to ensure it should be settable.
+  */
+  readonly id?: string;
+  /**
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#name QuicksightTemplate#name}
+  */
+  readonly name: string;
+  /**
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#tags QuicksightTemplate#tags}
+  */
+  readonly tags?: { [key: string]: string };
+  /**
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#tags_all QuicksightTemplate#tags_all}
+  */
+  readonly tagsAll?: { [key: string]: string };
+  /**
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#template_id QuicksightTemplate#template_id}
+  */
+  readonly templateId: string;
+  /**
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#version_description QuicksightTemplate#version_description}
+  */
+  readonly versionDescription: string;
+  /**
+  * definition block
+  * 
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#definition QuicksightTemplate#definition}
+  */
+  readonly definition?: QuicksightTemplateDefinition;
+  /**
+  * permissions block
+  * 
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#permissions QuicksightTemplate#permissions}
+  */
+  readonly permissions?: QuicksightTemplatePermissions[] | cdktf.IResolvable;
+  /**
+  * source_entity block
+  * 
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#source_entity QuicksightTemplate#source_entity}
+  */
+  readonly sourceEntity?: QuicksightTemplateSourceEntity;
+  /**
+  * timeouts block
+  * 
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template#timeouts QuicksightTemplate#timeouts}
+  */
+  readonly timeouts?: QuicksightTemplateTimeouts;
+}
+
+/**
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template aws_quicksight_template}
+*/
+export class QuicksightTemplate extends cdktf.TerraformResource {
+
+  // =================
+  // STATIC PROPERTIES
+  // =================
+  public static readonly tfResourceType = "aws_quicksight_template";
+
+  // ===========
+  // INITIALIZER
+  // ===========
+
+  /**
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template aws_quicksight_template} Resource
+  *
+  * @param scope The scope in which to define this construct
+  * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
+  * @param options QuicksightTemplateConfig
+  */
+  public constructor(scope: Construct, id: string, config: QuicksightTemplateConfig) {
+    super(scope, id, {
+      terraformResourceType: 'aws_quicksight_template',
+      terraformGeneratorMetadata: {
+        providerName: 'aws'
+      },
+      provider: config.provider,
+      dependsOn: config.dependsOn,
+      count: config.count,
+      lifecycle: config.lifecycle,
+      provisioners: config.provisioners,
+      connection: config.connection,
+      forEach: config.forEach
+    });
+    this._awsAccountId = config.awsAccountId;
+    this._id = config.id;
+    this._name = config.name;
+    this._tags = config.tags;
+    this._tagsAll = config.tagsAll;
+    this._templateId = config.templateId;
+    this._versionDescription = config.versionDescription;
+    this._definition.internalValue = config.definition;
+    this._permissions.internalValue = config.permissions;
+    this._sourceEntity.internalValue = config.sourceEntity;
+    this._timeouts.internalValue = config.timeouts;
+  }
+
+  // ==========
+  // ATTRIBUTES
+  // ==========
+
+  // arn - computed: true, optional: false, required: false
+  public get arn() {
+    return this.getStringAttribute('arn');
+  }
+
+  // aws_account_id - computed: true, optional: true, required: false
+  private _awsAccountId?: string; 
+  public get awsAccountId() {
+    return this.getStringAttribute('aws_account_id');
+  }
+  public set awsAccountId(value: string) {
+    this._awsAccountId = value;
+  }
+  public resetAwsAccountId() {
+    this._awsAccountId = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get awsAccountIdInput() {
+    return this._awsAccountId;
+  }
+
+  // created_time - computed: true, optional: false, required: false
+  public get createdTime() {
+    return this.getStringAttribute('created_time');
+  }
+
+  // id - computed: true, optional: true, required: false
+  private _id?: string; 
+  public get id() {
+    return this.getStringAttribute('id');
+  }
+  public set id(value: string) {
+    this._id = value;
+  }
+  public resetId() {
+    this._id = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get idInput() {
+    return this._id;
+  }
+
+  // last_updated_time - computed: true, optional: false, required: false
+  public get lastUpdatedTime() {
+    return this.getStringAttribute('last_updated_time');
+  }
+
+  // name - computed: false, optional: false, required: true
+  private _name?: string; 
+  public get name() {
+    return this.getStringAttribute('name');
+  }
+  public set name(value: string) {
+    this._name = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get nameInput() {
+    return this._name;
+  }
+
+  // source_entity_arn - computed: true, optional: false, required: false
+  public get sourceEntityArn() {
+    return this.getStringAttribute('source_entity_arn');
+  }
+
+  // status - computed: true, optional: false, required: false
+  public get status() {
+    return this.getStringAttribute('status');
+  }
+
+  // tags - computed: false, optional: true, required: false
+  private _tags?: { [key: string]: string }; 
+  public get tags() {
+    return this.getStringMapAttribute('tags');
+  }
+  public set tags(value: { [key: string]: string }) {
+    this._tags = value;
+  }
+  public resetTags() {
+    this._tags = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get tagsInput() {
+    return this._tags;
+  }
+
+  // tags_all - computed: true, optional: true, required: false
+  private _tagsAll?: { [key: string]: string }; 
+  public get tagsAll() {
+    return this.getStringMapAttribute('tags_all');
+  }
+  public set tagsAll(value: { [key: string]: string }) {
+    this._tagsAll = value;
+  }
+  public resetTagsAll() {
+    this._tagsAll = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get tagsAllInput() {
+    return this._tagsAll;
+  }
+
+  // template_id - computed: false, optional: false, required: true
+  private _templateId?: string; 
+  public get templateId() {
+    return this.getStringAttribute('template_id');
+  }
+  public set templateId(value: string) {
+    this._templateId = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get templateIdInput() {
+    return this._templateId;
+  }
+
+  // version_description - computed: false, optional: false, required: true
+  private _versionDescription?: string; 
+  public get versionDescription() {
+    return this.getStringAttribute('version_description');
+  }
+  public set versionDescription(value: string) {
+    this._versionDescription = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get versionDescriptionInput() {
+    return this._versionDescription;
+  }
+
+  // version_number - computed: true, optional: false, required: false
+  public get versionNumber() {
+    return this.getNumberAttribute('version_number');
+  }
+
+  // definition - computed: false, optional: true, required: false
+  private _definition = new QuicksightTemplateDefinitionOutputReference(this, "definition");
+  public get definition() {
+    return this._definition;
+  }
+  public putDefinition(value: QuicksightTemplateDefinition) {
+    this._definition.internalValue = value;
+  }
+  public resetDefinition() {
+    this._definition.internalValue = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get definitionInput() {
+    return this._definition.internalValue;
+  }
+
+  // permissions - computed: false, optional: true, required: false
+  private _permissions = new QuicksightTemplatePermissionsList(this, "permissions", false);
+  public get permissions() {
+    return this._permissions;
+  }
+  public putPermissions(value: QuicksightTemplatePermissions[] | cdktf.IResolvable) {
+    this._permissions.internalValue = value;
+  }
+  public resetPermissions() {
+    this._permissions.internalValue = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get permissionsInput() {
+    return this._permissions.internalValue;
+  }
+
+  // source_entity - computed: false, optional: true, required: false
+  private _sourceEntity = new QuicksightTemplateSourceEntityOutputReference(this, "source_entity");
+  public get sourceEntity() {
+    return this._sourceEntity;
+  }
+  public putSourceEntity(value: QuicksightTemplateSourceEntity) {
+    this._sourceEntity.internalValue = value;
+  }
+  public resetSourceEntity() {
+    this._sourceEntity.internalValue = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get sourceEntityInput() {
+    return this._sourceEntity.internalValue;
+  }
+
+  // timeouts - computed: false, optional: true, required: false
+  private _timeouts = new QuicksightTemplateTimeoutsOutputReference(this, "timeouts");
+  public get timeouts() {
+    return this._timeouts;
+  }
+  public putTimeouts(value: QuicksightTemplateTimeouts) {
+    this._timeouts.internalValue = value;
+  }
+  public resetTimeouts() {
+    this._timeouts.internalValue = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get timeoutsInput() {
+    return this._timeouts.internalValue;
+  }
+
+  // =========
+  // SYNTHESIS
+  // =========
+
+  protected synthesizeAttributes(): { [name: string]: any } {
+    return {
+      aws_account_id: cdktf.stringToTerraform(this._awsAccountId),
+      id: cdktf.stringToTerraform(this._id),
+      name: cdktf.stringToTerraform(this._name),
+      tags: cdktf.hashMapper(cdktf.stringToTerraform)(this._tags),
+      tags_all: cdktf.hashMapper(cdktf.stringToTerraform)(this._tagsAll),
+      template_id: cdktf.stringToTerraform(this._templateId),
+      version_description: cdktf.stringToTerraform(this._versionDescription),
+      definition: quicksightTemplateDefinitionToTerraform(this._definition.internalValue),
+      permissions: cdktf.listMapper(quicksightTemplatePermissionsToTerraform, true)(this._permissions.internalValue),
+      source_entity: quicksightTemplateSourceEntityToTerraform(this._sourceEntity.internalValue),
+      timeouts: quicksightTemplateTimeoutsToTerraform(this._timeouts.internalValue),
+    };
+  }
+}
+"
+`;

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/skipped-attributes.test.ts
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/skipped-attributes.test.ts
@@ -1,0 +1,39 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { TerraformProviderGenerator } from "../../generator/provider-generator";
+import { CodeMaker } from "codemaker";
+
+test("skips attributes in the disallow list", async () => {
+  const code = new CodeMaker();
+  const workdir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "skip-attributes.test")
+  );
+  const spec = JSON.parse(
+    fs.readFileSync(
+      path.join(
+        __dirname,
+        "fixtures",
+        "aws_quicksight_template.test.fixture.json"
+      ),
+      "utf-8"
+    )
+  );
+  new TerraformProviderGenerator(code, spec).generateAll();
+  await code.save(workdir);
+
+  const output = fs.readFileSync(
+    path.join(workdir, "providers/aws/quicksight-template/index.ts"),
+    "utf-8"
+  );
+  expect(output).toMatchSnapshot(`quicksight-template`);
+
+  // There should also be no index structs
+  expect(
+    fs.existsSync(
+      path.join(workdir, "providers/aws/quicksight-template/index-structs")
+    )
+  ).toBe(false);
+});

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
@@ -16,6 +16,51 @@ export interface AttributeTypeModel {
   readonly isTokenizable: boolean; // can the type be represented by a token type
 }
 
+export class SkippedAttributeTypeModel implements AttributeTypeModel {
+  constructor() {}
+
+  get typeModelType() {
+    return "simple";
+  }
+
+  get struct() {
+    return undefined;
+  }
+
+  get isComplex() {
+    return false;
+  }
+
+  getStoredClassInitializer(_name: string) {
+    // not used
+    return "";
+  }
+
+  get storedClassType() {
+    return "any";
+  }
+
+  get inputTypeDefinition() {
+    return "any";
+  }
+
+  getAttributeAccessFunction(name: string) {
+    return `this.interpolationForAttribute('${name}')`;
+  }
+
+  get toTerraformFunction() {
+    return `cdktf.anyToTerraform`;
+  }
+
+  get hasReferenceClass() {
+    return false;
+  }
+
+  get isTokenizable() {
+    return false;
+  }
+}
+
 export class SimpleAttributeTypeModel implements AttributeTypeModel {
   constructor(public readonly type: string) {}
 

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/scope.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/scope.ts
@@ -65,8 +65,8 @@ export class Scope {
       if (i === 0) {
         return p;
       }
-      const last = path[i - 1];
-      return p.replace(`${last}_`, "");
+      const prev = path[i - 1];
+      return p.replace(`${prev}_`, "");
     });
   }
 }

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/scope.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/scope.ts
@@ -13,6 +13,7 @@ export interface ScopeProps {
 
 export class Scope {
   public readonly name: string;
+  public readonly provider?: string;
   public readonly parent?: Scope;
   public readonly isProvider: boolean;
   public isComputed: boolean;
@@ -33,13 +34,39 @@ export class Scope {
   }
 
   public fullName(attributeName: string) {
+    return `${this.baseName}.${attributeName}`;
+  }
+
+  public get baseName() {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     let scope: Scope | undefined = this;
-    let name = attributeName;
+    let name = "";
     while (scope) {
-      name = `${scope.name}.${name}`;
+      if (name === "") {
+        name = scope.name;
+      } else {
+        name = `${scope.name}.${name}`;
+      }
       scope = scope.parent;
     }
     return name;
+  }
+
+  public get attributePath() {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let scope: Scope | undefined = this;
+    const path: string[] = [];
+    while (scope) {
+      path.unshift(scope.name);
+      scope = scope.parent;
+    }
+
+    return path.map((p, i) => {
+      if (i === 0) {
+        return p;
+      }
+      const last = path[i - 1];
+      return p.replace(`${last}_`, "");
+    });
   }
 }

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/scope.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/scope.ts
@@ -51,22 +51,4 @@ export class Scope {
     }
     return name;
   }
-
-  public get attributePath() {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    let scope: Scope | undefined = this;
-    const path: string[] = [];
-    while (scope) {
-      path.unshift(scope.name);
-      scope = scope.parent;
-    }
-
-    return path.map((p, i) => {
-      if (i === 0) {
-        return p;
-      }
-      const prev = path[i - 1];
-      return p.replace(`${prev}_`, "");
-    });
-  }
 }

--- a/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
@@ -236,7 +236,7 @@ class Parser {
     parentKind?: string
   ): AttributeTypeModel {
     const parent = scope[scope.length - 1];
-    if (shouldSkipAttribute(parent.attributePath.join("."))) {
+    if (shouldSkipAttribute(parent.baseName)) {
       return new MapAttributeTypeModel(new SimpleAttributeTypeModel("any"));
     }
 
@@ -365,13 +365,11 @@ class Parser {
     for (const [terraformAttributeName, att] of Object.entries(
       block.attributes || {}
     )) {
-      const attributePath = [
-        ...parentType.attributePath,
-        terraformAttributeName,
-      ].join(".");
-      if (shouldSkipAttribute(attributePath)) {
+      if (shouldSkipAttribute(parentType.fullName(terraformAttributeName))) {
         throw Errors.Internal(
-          `Skipping attribute ${attributePath} is not implemented since it's an attribute and not a block type`
+          `Skipping attribute ${parentType.fullName(
+            terraformAttributeName
+          )} is not implemented since it's an attribute and not a block type`
         );
       }
       const type = this.renderAttributeType(
@@ -410,11 +408,7 @@ class Parser {
     for (const [blockTypeName, blockType] of Object.entries(
       block.block_types || {}
     )) {
-      if (
-        shouldSkipAttribute(
-          [...parentType.attributePath, blockTypeName].join(".")
-        )
-      ) {
+      if (shouldSkipAttribute(parentType.fullName(blockTypeName))) {
         const name = toCamelCase(blockTypeName);
         const parent = new Scope({
           name: blockTypeName,

--- a/packages/@cdktf/provider-generator/lib/get/generator/skipped-attributes.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/skipped-attributes.ts
@@ -1,0 +1,12 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+
+/**
+ * There are large attributes on little used resources that blow up the
+ * size and compile time of the generated providers by a lot.
+ * To mitigate this issue we replace their entire tree of attributes with
+ * a single any attribute. This can still be used, although less conveniently.
+ */
+export const SKIPPED_ATTRIBUTES: string[] = [
+  "aws.quicksight_template.definition",
+];

--- a/packages/@cdktf/provider-generator/lib/get/generator/skipped-attributes.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/skipped-attributes.ts
@@ -7,7 +7,11 @@
  * To mitigate this issue we replace their entire tree of attributes with
  * a single any attribute. This can still be used, although less conveniently.
  */
-const SKIPPED_ATTRIBUTES: string[] = ["aws.quicksight_template.definition"];
+const SKIPPED_ATTRIBUTES: string[] = [
+  "aws.quicksight_template.definition",
+  "aws.quicksight_dashboard.definition",
+  "aws.quicksight_analysis.definition",
+];
 
 /**
  * We skip some deeply nested attributes to shorten the generated code.

--- a/packages/@cdktf/provider-generator/lib/get/generator/skipped-attributes.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/skipped-attributes.ts
@@ -7,6 +7,11 @@
  * To mitigate this issue we replace their entire tree of attributes with
  * a single any attribute. This can still be used, although less conveniently.
  */
-export const SKIPPED_ATTRIBUTES: string[] = [
-  "aws.quicksight_template.definition",
-];
+const SKIPPED_ATTRIBUTES: string[] = ["aws.quicksight_template.definition"];
+
+/**
+ * We skip some deeply nested attributes to shorten the generated code.
+ */
+export function shouldSkipAttribute(terraformFullName: string) {
+  return SKIPPED_ATTRIBUTES.includes(terraformFullName);
+}

--- a/website/docs/cdktf/concepts/resources.mdx
+++ b/website/docs/cdktf/concepts/resources.mdx
@@ -917,3 +917,13 @@ new SecurityGroup(this, "security2", new SecurityGroupConfig
 ```
 
 </CodeTabs>
+
+## Special Cases
+
+### Large Resource Configurations
+
+A few individual Terraform Resources have very deeply nested schemas with a lot of attributes. This blows up the config classes and slows down the code generation for languages besides Typescript. To work around this we sometimes limit the depth of the config classes and use `any` on deeper level, some attributes we directly expose as `any` on the top level config class.
+
+- `aws` Provider:
+  - `aws_quicksight_template.definition`, `aws_quicksight_dashboard.definition`, and `aws_quicksight_analysis.definition` are set to `any`
+  - `wafv2` related resources have a lot of deeply nested attributes that might be skipped


### PR DESCRIPTION
## Summary

This change allows us to keep a disallow list of provider attributes that generate an insane amount of classes (in this case over 25.000) in our bindings. I decided to not automatically detect these instances to not prematurely optimise this. For a similar reasoning and since it's not automatically detected I also skipped the implementation of attribute skipping (since it's also very uncertain that attributes will ever be the problem).

