### PR TITLE
fix(cli): Support PNPM when retrieving package dependency information

### DIFF
--- a/packages/@cdktf/commons/src/debug.ts
+++ b/packages/@cdktf/commons/src/debug.ts
@@ -114,7 +114,7 @@ async function getPnpmNodeModuleVersion(
     !json[0]?.dependencies?.[packageName]?.version
   ) {
     logger.debug(
-      `Unable to find '${packageName}' in 'npm list ${packageName} --json': ${output}`
+      `Unable to find '${packageName}' in 'pnpm list ${packageName} --json': ${output}`
     );
     return undefined;
   }


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes #2903 

### Description

`pnpm` uses a lock file called `pnpm-lock.yaml`, which can be used as a strong signal about which package manager is in use. There is an upcoming `packageManager` element in `package.json` that could also be used, but in practice this is not yet widespread.

Given the presence of this file, the updated logic switches to use `pnpm list` instead of `npm list`, and adapts to the updated file structure. I think it is fairly unlikely that a `pnpm-lock.yaml` file will exist if `pnpm` is not in use, so I've kept this very simple.

Further, I haven't made DRY efforts between the two methods, as I wasn't certain how useful that would be. I'm very happy to go further if the reviewers would like me to.

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

**Notes on tests:**

* no new unit tests are added -- there does not seem to be any tests around the existing functionality
* test cases run the same locally -- for me `main` is not clean, but the results between `main` and this branch are the same.
* I have tested projects that use yarn and pnpm with this change without issue

I'm happy to adjust the PR given feedback on any aspect.

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
