### PR TITLE
fix(cli): catch possible errors when trying to open a url

### DIFF
--- a/packages/cdktf-cli/src/bin/cmds/helper/terraform-login.ts
+++ b/packages/cdktf-cli/src/bin/cmds/helper/terraform-login.ts
@@ -52,17 +52,27 @@ the following file for use by subsequent Terraform commands:
 
     if (tfCloud) {
       isLogin = true;
-      this.openBrowser();
+      await this.openBrowser();
     }
 
     return isLogin;
   }
 
-  openBrowser() {
+  async openBrowser() {
     console.log(`\nopening webpage using your browser.....\n`);
     console.log(chalkColour`If the web browser didn't open the window automatically, you can go to the following url:
         {whiteBright ${this.terraformLoginURL}}\n`);
-    return open.default(this.terraformLoginURL);
+    try {
+      await open.default(this.terraformLoginURL, {
+        allowNonzeroExitCode: true,
+        wait: true,
+      });
+    } catch (e) {
+      logger.debug(
+        `Ignored error while trying to open ${this.terraformLoginURL}`,
+        e
+      );
+    }
   }
 
   public async askForToken() {

--- a/packages/cdktf-cli/src/test/cmds/convert.test.ts
+++ b/packages/cdktf-cli/src/test/cmds/convert.test.ts
@@ -27,11 +27,9 @@ describe("convert command", () => {
         `The following providers are missing schema information and might need manual adjustments to synthesize correctly`
       );
       expect(result.stdout).toContain(
-        `import * as NullProvider from "./.gen/providers/null";`
+        `import { Resource } from "./.gen/providers/null/resource";`
       );
-      expect(result.stdout).toContain(
-        `new NullProvider.resource.Resource(this, "dummy", {});`
-      );
+      expect(result.stdout).toContain(`new Resource(this, "dummy", {});`);
     });
   }, 30_000);
   it("reads provider version from existing cdktf.json", async () => {
@@ -50,11 +48,9 @@ describe("convert command", () => {
         `The following providers are missing schema information and might need manual adjustments to synthesize correctly`
       );
       expect(result.stdout).toContain(
-        `import * as NullProvider from "./.gen/providers/null";`
+        `import { Resource } from "./.gen/providers/null/resource";`
       );
-      expect(result.stdout).toContain(
-        `new NullProvider.resource.Resource(this, "dummy", {});`
-      );
+      expect(result.stdout).toContain(`new Resource(this, "dummy", {});`);
     });
   }, 30_000);
   it("works if no cdktf.json could be found", async () => {
@@ -69,11 +65,9 @@ describe("convert command", () => {
         `The following providers are missing schema information and might need manual adjustments to synthesize correctly`
       );
       expect(result.stdout).toContain(
-        `import * as NullProvider from "./.gen/providers/null";`
+        `import { Resource } from "./.gen/providers/null/resource";`
       );
-      expect(result.stdout).toContain(
-        `new NullProvider.resource.Resource(this, "dummy", {});`
-      );
+      expect(result.stdout).toContain(`new Resource(this, "dummy", {});`);
     });
   }, 30_000);
 
@@ -134,11 +128,9 @@ describe("convert command", () => {
         `The following providers are missing schema information and might need manual adjustments to synthesize correctly`
       );
       expect(result.stdout).toContain(
-        `import * as kubernetes from "./.gen/providers/kubernetes";`
+        `import { Deployment } from "./.gen/providers/kubernetes/deployment";`
       );
-      expect(result.stdout).toContain(
-        `new kubernetes.deployment.Deployment(this, "myapp", {`
-      );
+      expect(result.stdout).toContain(`new Deployment(this, "myapp", {`);
       expect(result.stdout).toContain(`template: {`);
     });
   }, 30_000);
@@ -200,11 +192,9 @@ describe("convert command", () => {
         `The following providers are missing schema information and might need manual adjustments to synthesize correctly`
       );
       expect(result.stdout).toContain(
-        `import * as kubernetes from "./.gen/providers/kubernetes";`
+        `import { Deployment } from "./.gen/providers/kubernetes/deployment";`
       );
-      expect(result.stdout).toContain(
-        `new kubernetes.deployment.Deployment(this, "myapp", {`
-      );
+      expect(result.stdout).toContain(`new Deployment(this, "myapp", {`);
       expect(result.stdout).toContain(`template: {`);
     });
   }, 30_000);


### PR DESCRIPTION
Resolves #2936

Tested it locally by setting a `PATH` that didn't contain `open` (which reproduced the failure and confirmed the fix)
<img width="1541" alt="image" src="https://github.com/hashicorp/terraform-cdk/assets/1112056/a3c1a69d-161f-483c-b7f4-ba65925c1d38">

