### PR TITLE
feat: include dependencies and dependant flag for deploy

### DIFF
--- a/packages/@cdktf/cli-core/src/lib/cdktf-project.ts
+++ b/packages/@cdktf/cli-core/src/lib/cdktf-project.ts
@@ -492,11 +492,19 @@ export class CdktfProject {
     const stacksToRun = getMultipleStacks(stacks, opts.stackNames, "deploy");
 
     if (!opts.includeDependencies) {
-      this.stacksToRun.concat(getStackDependencies(stacksToRun, stacks).map(s => this.getStackExecutor(s, { autoApprove: true })));
+      this.stacksToRun.concat(
+        getStackDependencies(stacksToRun, stacks).map((s) =>
+          this.getStackExecutor(s, { autoApprove: true })
+        )
+      );
     }
 
     if (!opts.includeDependants) {
-      this.stacksToRun.concat(getDependantStacks(stacksToRun, stacks).map(s => this.getStackExecutor(s, { autoApprove: true })));
+      this.stacksToRun.concat(
+        getDependantStacks(stacksToRun, stacks).map((s) =>
+          this.getStackExecutor(s, { autoApprove: true })
+        )
+      );
     }
 
     if (!opts.ignoreMissingStackDependencies) {

--- a/packages/@cdktf/cli-core/src/lib/helpers/stack-helpers.ts
+++ b/packages/@cdktf/cli-core/src/lib/helpers/stack-helpers.ts
@@ -192,9 +192,10 @@ export async function getStackWithNoUnmetDependants(
   return await getStackWithNoUnmetDependants(stackExecutors);
 }
 
-export function getDependantStacks(stacksToRun: SynthesizedStack[],
-  allStacks: SynthesizedStack[]): SynthesizedStack[] {
-
+export function getDependantStacks(
+  stacksToRun: SynthesizedStack[],
+  allStacks: SynthesizedStack[]
+): SynthesizedStack[] {
   return stacksToRun
     .map((stack) =>
       allStacks.filter((s) => s.dependencies.includes(stack.name))
@@ -202,10 +203,15 @@ export function getDependantStacks(stacksToRun: SynthesizedStack[],
     .flat();
 }
 
-export function getStackDependencies(stacksToRun: SynthesizedStack[], allStacks: SynthesizedStack[]): SynthesizedStack[] {
+export function getStackDependencies(
+  stacksToRun: SynthesizedStack[],
+  allStacks: SynthesizedStack[]
+): SynthesizedStack[] {
   return stacksToRun
     .map((stack) => stack.dependencies)
-    .map((dependencies) => allStacks.filter((stack) => dependencies.includes(stack.name)))
+    .map((dependencies) =>
+      allStacks.filter((stack) => dependencies.includes(stack.name))
+    )
     .flat();
 }
 
@@ -215,7 +221,9 @@ export function checkIfAllDependantsAreIncluded(
   allStacks: SynthesizedStack[]
 ) {
   const allDependants = new Set<string>();
-  getDependantStacks(stacksToRun, allStacks).forEach((dependant) => allDependants.add(dependant.name));
+  getDependantStacks(stacksToRun, allStacks).forEach((dependant) =>
+    allDependants.add(dependant.name)
+  );
 
   const stackNames = stacksToRun.map((stack) => stack.name);
   const missingDependants = [...allDependants].filter(
@@ -242,7 +250,9 @@ export function checkIfAllDependenciesAreIncluded(
   allStacks: SynthesizedStack[]
 ) {
   const allDependencies = new Set<string>();
-  getStackDependencies(stacksToRun, allStacks).forEach((dependency) => allDependencies.add(dependency.name));
+  getStackDependencies(stacksToRun, allStacks).forEach((dependency) =>
+    allDependencies.add(dependency.name)
+  );
 
   const stackNames = stacksToRun.map((stack) => stack.name);
   const missingDependencies = [...allDependencies].filter(

--- a/packages/@cdktf/cli-core/src/test/lib/cdktf-project.test.ts
+++ b/packages/@cdktf/cli-core/src/test/lib/cdktf-project.test.ts
@@ -389,6 +389,52 @@ describe("CdktfProject", () => {
       ]);
     });
 
+    it("includes stack dependencies when requested", async () => {
+      const events: any[] = [];
+      const cdktfProject = new CdktfProject({
+        synthCommand: "npx ts-node ./main.ts",
+        ...inNewWorkingDirectory(),
+        onUpdate: (event) => {
+          events.push(event);
+
+          if (event.type === "waiting for approval") {
+            event.approve();
+          }
+        },
+      });
+
+      await cdktfProject.deploy({
+        stackNames: ["third"],
+        includeDependencies: true,
+        parallelism: 1,
+      });
+
+      return expect(events.length).toBeGreaterThan(3);
+    });
+
+    it("includes dependant stacks when requested", async () => {
+      const events: any[] = [];
+      const cdktfProject = new CdktfProject({
+        synthCommand: "npx ts-node ./main.ts",
+        ...inNewWorkingDirectory(),
+        onUpdate: (event) => {
+          events.push(event);
+
+          if (event.type === "waiting for approval") {
+            event.approve();
+          }
+        },
+      });
+
+      await cdktfProject.deploy({
+        stackNames: ["second"],
+        includeDependants: true,
+        parallelism: 1,
+      });
+
+      return expect(events.length).toBeGreaterThan(3);
+    });
+
     it("error in an deploying stack does not abort already running stacks", async () => {
       const events: any[] = [];
       const cdktfProject = new CdktfProject({

--- a/packages/cdktf-cli/src/bin/cmds/handlers.ts
+++ b/packages/cdktf-cli/src/bin/cmds/handlers.ts
@@ -132,6 +132,8 @@ export async function deploy(argv: any) {
   const terraformParallelism = argv.terraformParallelism;
   const ignoreMissingStackDependencies =
     argv.ignoreMissingStackDependencies || false;
+  const includeDependencies = argv.includeDependencies || false;
+  const includeDependants = argv.includeDependants || false;
   const parallelism = argv.parallelism;
   const vars = argv.var;
   const varFiles = sanitizeVarFiles(argv.varFile);
@@ -157,6 +159,8 @@ export async function deploy(argv: any) {
       onOutputsRetrieved,
       outputsPath,
       ignoreMissingStackDependencies,
+      includeDependencies,
+      includeDependants,
       parallelism,
       refreshOnly,
       terraformParallelism,

--- a/packages/cdktf-cli/src/bin/cmds/ui/deploy.tsx
+++ b/packages/cdktf-cli/src/bin/cmds/ui/deploy.tsx
@@ -59,6 +59,8 @@ interface DeployConfig {
   onOutputsRetrieved: (outputs: NestedTerraformOutputs) => void;
   outputsPath?: string;
   ignoreMissingStackDependencies?: boolean;
+  includeDependencies?: boolean;
+  includeDependants?: boolean;
   parallelism?: number;
   refreshOnly?: boolean;
   terraformParallelism?: number;
@@ -77,6 +79,8 @@ export const Deploy = ({
   onOutputsRetrieved,
   outputsPath,
   ignoreMissingStackDependencies,
+  includeDependencies,
+  includeDependants,
   parallelism,
   refreshOnly,
   terraformParallelism,
@@ -94,6 +98,8 @@ export const Deploy = ({
         stackNames: targetStacks,
         autoApprove,
         ignoreMissingStackDependencies,
+        includeDependencies,
+        includeDependants,
         parallelism,
         refreshOnly,
         terraformParallelism,

--- a/website/docs/cdktf/cli-reference/commands.mdx
+++ b/website/docs/cdktf/cli-reference/commands.mdx
@@ -159,6 +159,8 @@ Options:
       --auto-approve                            Auto approve                                                                                                                                        [boolean] [default: false]
       --outputs-file                            Path to file where stack outputs will be written as JSON                                                                                                              [string]
       --outputs-file-include-sensitive-outputs  Whether to include sensitive outputs in the output file                                                                                             [boolean] [default: false]
+      --include-dependencies                    If stack has dependencies, ensure they are included in deploy  [boolean] [default: false]
+      --include-dependants                      If stack has dependants, ensure they are included in deploy  [boolean] [default: false]
       --ignore-missing-stack-dependencies       Don't check if all stacks specified in the command have their dependencies included as well                                                         [boolean] [default: false]
       --parallelism                             Number of concurrent CDKTF stacks to run. Defaults to infinity, denoted by -1                                                                           [number] [default: -1]
       --refresh-only                            Select the "refresh only" planning mode, which checks whether remote objects still match the outcome of the most recent Terraform apply but does not propose any actions to


### PR DESCRIPTION
### Description

It would be nice to be able to run `cdktf deploy stack --include-dependencies --include-dependants` and have all the correct stacks run, without having to `cdktf list` and then compose the right command. 

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes