### PR TITLE
chore: trigger project board update when issues modified

### DIFF
--- a/.github/workflows/project-board.yml
+++ b/.github/workflows/project-board.yml
@@ -1,26 +1,32 @@
-name: Project Board
+name: Update project board on issue changes
 
 on:
-  pull_request:
-    paths:
-      - "tools/update-github-project-board/**"
+  issues:
+    types:
+      - opened
+      - edited
+      - closed
+      - reopened
+      - labeled
+      - unlabeled
+      - milestoned
+      - demilestoned
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: "Issue number"
+        required: true
+        type: number
 
-  # schedule:
-  # At every full hour
-  # - cron: "0 * * * *"
-  workflow_dispatch: {}
 jobs:
-  update-project-board:
+  trigger-external-update:
     if: github.repository == 'hashicorp/terraform-cdk'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
-      - name: Get project data
+      - name: Update project board
         env:
-          GITHUB_TOKEN: ${{ secrets.PROJECT_BOARD_UPDATE_GH_TOKEN }}
-          ORGANIZATION: hashicorp
-          PROJECT_NUMBER: 125
+          GH_TOKEN: ${{ secrets.PROJECT_BOARD_UPDATE_GH_TOKEN }}
+          ISSUE: ${{ inputs.issue || github.event.issue.number }}
         run: |
-          cd tools/update-github-project-board
-          npm install
-          npm start
+          sleep 5
+          gh workflow run update-project-board-issue.yml -R hashicorp/terraform-cdk-team -f issue=$ISSUE -f repository=terraform-cdk

--- a/.github/workflows/project-board.yml
+++ b/.github/workflows/project-board.yml
@@ -1,32 +1,26 @@
-name: Update project board on issue changes
+name: Project Board
 
 on:
-  issues:
-    types:
-      - opened
-      - edited
-      - closed
-      - reopened
-      - labeled
-      - unlabeled
-      - milestoned
-      - demilestoned
-  workflow_dispatch:
-    inputs:
-      issue:
-        description: "Issue number"
-        required: true
-        type: number
+  pull_request:
+    paths:
+      - "tools/update-github-project-board/**"
 
+  # schedule:
+  # At every full hour
+  # - cron: "0 * * * *"
+  workflow_dispatch: {}
 jobs:
-  trigger-external-update:
+  update-project-board:
     if: github.repository == 'hashicorp/terraform-cdk'
     runs-on: ubuntu-latest
     steps:
-      - name: Update project board
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+      - name: Get project data
         env:
-          GH_TOKEN: ${{ secrets.PROJECT_BOARD_UPDATE_GH_TOKEN }}
-          ISSUE: ${{ inputs.issue || github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.PROJECT_BOARD_UPDATE_GH_TOKEN }}
+          ORGANIZATION: hashicorp
+          PROJECT_NUMBER: 125
         run: |
-          sleep 5
-          gh workflow run update-project-board-issue.yml -R hashicorp/terraform-cdk-team -f issue=$ISSUE -f repository=terraform-cdk
+          cd tools/update-github-project-board
+          npm install
+          npm start

--- a/.github/workflows/update-project-board-issue.yml
+++ b/.github/workflows/update-project-board-issue.yml
@@ -1,0 +1,32 @@
+name: Update project board on issue changes
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - closed
+      - reopened
+      - labeled
+      - unlabeled
+      - milestoned
+      - demilestoned
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: "Issue number"
+        required: true
+        type: number
+
+jobs:
+  trigger-external-update:
+    if: github.repository == 'hashicorp/terraform-cdk'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update project board
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_BOARD_UPDATE_GH_TOKEN }}
+          ISSUE: ${{ inputs.issue || github.event.issue.number }}
+        run: |
+          sleep 5
+          gh workflow run update-project-board-issue.yml -R hashicorp/terraform-cdk-team -f issue=$ISSUE -f repository=terraform-cdk


### PR DESCRIPTION
While we do have an hourly cron in place, this workflow will be even better if issue creation and updates triggers an update on the project board. We can trigger the script in the other repo with this workflow. (The `workflow_dispatch` is just a nice-to-have for testing.) I've confirmed it works at https://github.com/hashicorp/terraform-cdk-team/actions/runs/5402845986

Should be merged alongside #2970 