### PR TITLE
fix: Upgrade @inquirer/prompts to resolve #2952

### DIFF
--- a/packages/cdktf-cli/package.json
+++ b/packages/cdktf-cli/package.json
@@ -42,7 +42,7 @@
     "@cdktf/commons": "0.0.0",
     "@cdktf/hcl2cdk": "0.0.0",
     "@cdktf/hcl2json": "0.0.0",
-    "@inquirer/prompts": "^2.1.0",
+    "@inquirer/prompts": "^2.3.0",
     "@sentry/node": "^6.19.7",
     "cdktf": "0.0.0",
     "codemaker": "^1.76.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -560,30 +560,30 @@
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
-"@inquirer/checkbox@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@inquirer/checkbox/-/checkbox-1.3.1.tgz#d7454da57e46a4b3185db7a3da5ce687879cb540"
-  integrity sha512-3l3aC6gYOPGaVOa9cNe4dZ8t96e3CFifC3Hee1MD+F7qaRxGAuXnhCQiUr4ngj2P7xd9U3DCDbLXNsLKQoHYCg==
+"@inquirer/checkbox@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@inquirer/checkbox/-/checkbox-1.3.3.tgz#35680d95bf54c02ab8aa8ed6cf19c1cd84928701"
+  integrity sha512-iiAQtwEuMJsQy70Ix4poNauWPLDb8bDo9vQGMGmBEVpAKV2wDOwNvgxSsst3sfPB29iMO2+4NkGCf7hxlMJayw==
   dependencies:
-    "@inquirer/core" "^2.1.0"
+    "@inquirer/core" "^2.3.0"
     "@inquirer/type" "^1.1.0"
     ansi-escapes "^4.3.2"
     chalk "^4.1.2"
     figures "^3.2.0"
 
-"@inquirer/confirm@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@inquirer/confirm/-/confirm-2.0.1.tgz#9a9e7d5b1b028d6974be80d4231b7edb74553197"
-  integrity sha512-0Aj6hsv31c2whBLqTUNwZALfpn94sX85y7Xn12rU4scqyM9fAfBwIMXJQjqcCDk8ifheNVZLeP3wa/xmtW/tDA==
+"@inquirer/confirm@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/confirm/-/confirm-2.0.4.tgz#e2512dd51654c647f85458b4baf9996e9ed7fb15"
+  integrity sha512-wL8TS2vdrYWUypIw4XiwnNhk8k6T0PRE6nsyva8PtKP3MZxd7bKgmmhdl8OqApAFZgW6SWobPCOQNkiAIIOjjQ==
   dependencies:
-    "@inquirer/core" "^2.1.0"
+    "@inquirer/core" "^2.3.0"
     "@inquirer/type" "^1.1.0"
     chalk "^4.1.2"
 
-"@inquirer/core@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@inquirer/core/-/core-2.1.0.tgz#97bcc4eb5286a3a7ec63f20781d75a67aece3cc2"
-  integrity sha512-Hq9hZ5G/VUaeWkSs283HZwwMbe79lcOI5HWwW1GIM1ohouy2/x489Qf/A1BJYvMUj+QG4LSB5LtVMjn9P3Ge6Q==
+"@inquirer/core@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@inquirer/core/-/core-2.3.0.tgz#f756c5491205fd60ee6cc9476db7bb745b3a54c4"
+  integrity sha512-JoJtfplpSa0HOzsCaZA5gcUyibTlMb9h/+d9BiP55OHEB5l2jaQZ/hSnIgjVtyox1BhDYmppzUoa5n1BXc3+aQ==
   dependencies:
     "@inquirer/type" "^1.1.0"
     ansi-escapes "^4.3.2"
@@ -597,74 +597,74 @@
     strip-ansi "^6.0.1"
     wrap-ansi "^6.0.1"
 
-"@inquirer/editor@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@inquirer/editor/-/editor-1.2.0.tgz#e2646bcc471da142285b067433e7a83b88b0e320"
-  integrity sha512-NMXLLNadvqIR6TD6mNZRa/PKHTvdaa4ndGGeXl+DwybQ4K7cVSJNRrztixpM1KDEoG8Ape5ightNwq25cyugTg==
+"@inquirer/editor@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@inquirer/editor/-/editor-1.2.2.tgz#940b80208289cdbc767d2051c5a1af67c157957a"
+  integrity sha512-jIUC7Wy4LXZU/7/DQ2W/sWsyTr8k00QRBWc2fsUlWg+rgoLWV/Gy60irbuyp/VCu/jQ/AHRnEz4sS2IJnSxDjA==
   dependencies:
-    "@inquirer/core" "^2.1.0"
+    "@inquirer/core" "^2.3.0"
     "@inquirer/type" "^1.1.0"
     chalk "^4.1.2"
     external-editor "^3.0.3"
 
-"@inquirer/expand@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@inquirer/expand/-/expand-1.1.1.tgz#61dc7c374ed0a3fc6960f2160ae7954a6c00c480"
-  integrity sha512-fXk5NG2FOAiluDWPYfXHuof3sklL/HhZh3NnXfnBZ2IhTCRzXvlXRcQcPlev2sGcZknHn0g6JdKlxjSa+7H2nQ==
+"@inquirer/expand@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@inquirer/expand/-/expand-1.1.3.tgz#30fce59179104466a213e31dee9eaf94a617afd0"
+  integrity sha512-rd2IH4Na6/EoSdEBwj3PoXQ9XjisrktAaSh8XWLiZs/RbsJh00KQmgVxfSJmVxQNw97vYLPc79UBYRkhvgrnng==
   dependencies:
-    "@inquirer/core" "^2.1.0"
+    "@inquirer/core" "^2.3.0"
     "@inquirer/type" "^1.1.0"
     chalk "^4.1.2"
     figures "^3.2.0"
 
-"@inquirer/input@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@inquirer/input/-/input-1.2.1.tgz#d3af30ed9b312fb410b189c56f0d464b2c02c0ca"
-  integrity sha512-OYwG3dEo1+lMAE6rYB8b1HTg8eSP++jk0pHSjKZu00gTlN5IHW/dliB82nsWe9Bn//93E9LJ1KrhjFMqOzkCFw==
+"@inquirer/input@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@inquirer/input/-/input-1.2.3.tgz#32e8a1f505577109cc3c6432a426530d84b06727"
+  integrity sha512-JDe8Lnl++K+yvqHvMObjxO26/YXpOuJY2Eso5XiTA1TAfGHkQGuRFcemfUK5zuUwuLvYr2fOUiSFBJw+6+w59Q==
   dependencies:
-    "@inquirer/core" "^2.1.0"
+    "@inquirer/core" "^2.3.0"
     "@inquirer/type" "^1.1.0"
     chalk "^4.1.2"
 
-"@inquirer/password@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@inquirer/password/-/password-1.1.1.tgz#4e6d0f3d9033196f7bb56d0cb1045fa7f93094f9"
-  integrity sha512-3M03aA04hOA4lRjLviB9uGoNmmd1YDNo4CYSFM9Uh4qlXdgvhke3xPU07k3kVstRIo0Te1hF14RL7vEgHJQ8tA==
+"@inquirer/password@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@inquirer/password/-/password-1.1.3.tgz#17962c93a6b91cc0aeece5a04fc4425f1c15b4b3"
+  integrity sha512-bGF0FFCMLyS4144SX3kqnaM9qpRQ5KFv/B3C3Ya/l/aTNu9+tTSP2y4z0AB8po8BfA9LTfDebcrlM0VFVTBxng==
   dependencies:
-    "@inquirer/input" "^1.2.1"
+    "@inquirer/input" "^1.2.3"
     "@inquirer/type" "^1.1.0"
     chalk "^4.1.2"
 
-"@inquirer/prompts@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@inquirer/prompts/-/prompts-2.1.0.tgz#0e274d8a3f824eb83417e11f47318f600b70c215"
-  integrity sha512-YpfNrTjItyB9CYJUdIBp+9hRUu0e5JR//qC55gRrKjpGZP7CwrMvFJiS1LMZNG5vzd61CDxpOvNmkHcmMe6QmA==
+"@inquirer/prompts@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@inquirer/prompts/-/prompts-2.3.0.tgz#b3f13d58c9c4d88b84af62ab582363fa410db8d6"
+  integrity sha512-x79tSDIZAibOl9WaBoOuyaQqNnisOO8Pk0qWyulP/nPaD/WkoRvkzk7hR4WTRmWAyE8CNbjdYgGltvd0qmvCGQ==
   dependencies:
-    "@inquirer/checkbox" "^1.3.1"
-    "@inquirer/confirm" "^2.0.1"
-    "@inquirer/core" "^2.1.0"
-    "@inquirer/editor" "^1.2.0"
-    "@inquirer/expand" "^1.1.1"
-    "@inquirer/input" "^1.2.1"
-    "@inquirer/password" "^1.1.1"
-    "@inquirer/rawlist" "^1.2.1"
-    "@inquirer/select" "^1.2.1"
+    "@inquirer/checkbox" "^1.3.3"
+    "@inquirer/confirm" "^2.0.4"
+    "@inquirer/core" "^2.3.0"
+    "@inquirer/editor" "^1.2.2"
+    "@inquirer/expand" "^1.1.3"
+    "@inquirer/input" "^1.2.3"
+    "@inquirer/password" "^1.1.3"
+    "@inquirer/rawlist" "^1.2.3"
+    "@inquirer/select" "^1.2.3"
 
-"@inquirer/rawlist@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@inquirer/rawlist/-/rawlist-1.2.1.tgz#fe41c813f547c6abab1d6b0f81470f2cedaaadec"
-  integrity sha512-t8lMbE3Gqook4PvQYQl9eVJrl/mBy5kCgolwY9El8HLyGZ7Wc3SGIqHnQUlha4qms8HPOdUIBzyPfcAXl5+3SQ==
+"@inquirer/rawlist@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@inquirer/rawlist/-/rawlist-1.2.3.tgz#4af40249bb6f3e6fde360d334e42c1cccff40df4"
+  integrity sha512-Rmb+5Ju7JHN1xTa1H7BwO5vsy3FqQz7kefEAGoZOawfeeB1zenJolb7LKVvv3nrpH16itDLl79sBTixokoe9lg==
   dependencies:
-    "@inquirer/core" "^2.1.0"
+    "@inquirer/core" "^2.3.0"
     "@inquirer/type" "^1.1.0"
     chalk "^4.1.2"
 
-"@inquirer/select@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@inquirer/select/-/select-1.2.1.tgz#51c68ae116ab1e220fedacc225d7e7a7fd017b42"
-  integrity sha512-13JDLtlwFoqQUYRdMzz5wP3a4DWccJfNA/8M8MDUhhZ8HeKZ3MPaTMlpxwY+Q0Jgbmt56nf7xUuck0XXPce8Xw==
+"@inquirer/select@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@inquirer/select/-/select-1.2.3.tgz#95062d783478cefa089f7050ec82c3f09f4316f2"
+  integrity sha512-kipYkf5iVok9i22YSLJiwf4m0Ek6S67tJm20jJr/kjuSmbnbpO0mJGFuhgbrGS4uDqkeEOB3tQ81mqb7cVIVbA==
   dependencies:
-    "@inquirer/core" "^2.1.0"
+    "@inquirer/core" "^2.3.0"
     "@inquirer/type" "^1.1.0"
     ansi-escapes "^4.3.2"
     chalk "^4.1.2"


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes #2952 

### Description

I'm still unsure why @inquirer/confirm version 2.0.1 has the bug where it takes all input as 'yes', but it does. From my local testing, changing the version to almost any other version resolves the issue. The library's code also doesn't give a hint about this, so I'm going to stop digging the 'why' and use the easy way forward with upgrading the library.

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
