### PR TITLE
chore: release 0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+## 0.17.1
+
+### fix
+
+- fix: Handle \*/ sequences within variable descriptions and defaults for variables in modules [\#2986](https://github.com/hashicorp/terraform-cdk/pull/2986)
+- fix: Upgrade @inquirer/prompts to resolve #2952 [\#2977](https://github.com/hashicorp/terraform-cdk/pull/2977)
+- fix(tests): update integration test snapshot [\#2962](https://github.com/hashicorp/terraform-cdk/pull/2962)
+- fix(cli): catch possible errors when trying to open a url [\#2961](https://github.com/hashicorp/terraform-cdk/pull/2961)
+- fix(cli): Support PNPM when retrieving package dependency information [\#2959](https://github.com/hashicorp/terraform-cdk/pull/2959)
+- fix(hcl2cdk): parse handling of null providers and aliases [\#2947](https://github.com/hashicorp/terraform-cdk/pull/2947)
+- fix(hcl2cdk): use correct import path per language [\#2935](https://github.com/hashicorp/terraform-cdk/pull/2935)
+- fix: do not always overwrite global.performance [\#2922](https://github.com/hashicorp/terraform-cdk/pull/2922)
+
+### chore
+
+- chore(deps): upgrade semver version [\#2981](https://github.com/hashicorp/terraform-cdk/pull/2981)
+- chore(docs): update doc links to new URLs [\#2979](https://github.com/hashicorp/terraform-cdk/pull/2979)
+- chore: Add regression test for input on init [\#2978](https://github.com/hashicorp/terraform-cdk/pull/2978)
+- chore: Update diagram in docs with new provider count [\#2974](https://github.com/hashicorp/terraform-cdk/pull/2974)
+- chore: trigger project board update when issues modified [\#2973](https://github.com/hashicorp/terraform-cdk/pull/2973)
+- chore: remove project board update script [\#2970](https://github.com/hashicorp/terraform-cdk/pull/2970)
+- chore: use resource name only unless conflict [\#2956](https://github.com/hashicorp/terraform-cdk/pull/2956)
+- chore: remove dependency updates [\#2950](https://github.com/hashicorp/terraform-cdk/pull/2950)
+- chore: correct constructs docs "Through Validations" example [\#2927](https://github.com/hashicorp/terraform-cdk/pull/2927)
+
+### feat
+
+- feat: Specific imports for convert [\#2946](https://github.com/hashicorp/terraform-cdk/pull/2946)
+- feat: allow partial snippet translation [\#2920](https://github.com/hashicorp/terraform-cdk/pull/2920)
+
 ## 0.17.0
 
 ### feat

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "private": true,
   "scripts": {
     "build-and-package": "lerna run --scope 'cdktf*' --scope @cdktf/* build,package && tools/collect-dist.sh",

--- a/tools/documentation-generation/yarn.lock
+++ b/tools/documentation-generation/yarn.lock
@@ -181,7 +181,7 @@ case@^1.6.3:
   dependencies:
     archiver "5.3.1"
     json-stable-stringify "^1.0.2"
-    semver "^7.3.8"
+    semver "^7.5.3"
 
 chalk@^4, chalk@^4.1.2:
   version "4.1.2"
@@ -766,6 +766,13 @@ semver@^7.3.8:
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.5.3:
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
+  integrity sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
## 0.17.1

### fix

- fix: Handle \*/ sequences within variable descriptions and defaults for variables in modules [\#2986](https://github.com/hashicorp/terraform-cdk/pull/2986)
- fix: Upgrade @inquirer/prompts to resolve #2952 [\#2977](https://github.com/hashicorp/terraform-cdk/pull/2977)
- fix(tests): update integration test snapshot [\#2962](https://github.com/hashicorp/terraform-cdk/pull/2962)
- fix(cli): catch possible errors when trying to open a url [\#2961](https://github.com/hashicorp/terraform-cdk/pull/2961)
- fix(cli): Support PNPM when retrieving package dependency information [\#2959](https://github.com/hashicorp/terraform-cdk/pull/2959)
- fix(hcl2cdk): parse handling of null providers and aliases [\#2947](https://github.com/hashicorp/terraform-cdk/pull/2947)
- fix(hcl2cdk): use correct import path per language [\#2935](https://github.com/hashicorp/terraform-cdk/pull/2935)
- fix: do not always overwrite global.performance [\#2922](https://github.com/hashicorp/terraform-cdk/pull/2922)

### chore

- chore(deps): upgrade semver version [\#2981](https://github.com/hashicorp/terraform-cdk/pull/2981)
- chore(docs): update doc links to new URLs [\#2979](https://github.com/hashicorp/terraform-cdk/pull/2979)
- chore: Add regression test for input on init [\#2978](https://github.com/hashicorp/terraform-cdk/pull/2978)
- chore: Update diagram in docs with new provider count [\#2974](https://github.com/hashicorp/terraform-cdk/pull/2974)
- chore: trigger project board update when issues modified [\#2973](https://github.com/hashicorp/terraform-cdk/pull/2973)
- chore: remove project board update script [\#2970](https://github.com/hashicorp/terraform-cdk/pull/2970)
- chore: use resource name only unless conflict [\#2956](https://github.com/hashicorp/terraform-cdk/pull/2956)
- chore: remove dependency updates [\#2950](https://github.com/hashicorp/terraform-cdk/pull/2950)
- chore: correct constructs docs "Through Validations" example [\#2927](https://github.com/hashicorp/terraform-cdk/pull/2927)

### feat

- feat: Specific imports for convert [\#2946](https://github.com/hashicorp/terraform-cdk/pull/2946)
- feat: allow partial snippet translation [\#2920](https://github.com/hashicorp/terraform-cdk/pull/2920)
