### PR TITLE
fix(docs): python docs for aspect

### DIFF
--- a/examples/python/documentation/aspects.py
+++ b/examples/python/documentation/aspects.py
@@ -10,8 +10,10 @@ from imports.random.provider import RandomProvider
 from imports.random.pet import Pet
 
 # DOCS_BLOCK_START:define-aspects
-from constructs import IConstruct
-from cdktf import Aspects, IAspect
+from constructs import Construct, IConstruct
+from cdktf import TerraformStack, Aspects, IAspect
+from imports.aws.instance import Instance
+from imports.aws.provider import AwsProvider
 
 @jsii.implements(IAspect)
 class TagsAddingAspect:
@@ -25,6 +27,20 @@ class TagsAddingAspect:
             # We need to take the input value to not create a circular reference
             currentTags = node.tags_input if node.tags_input is not None else {}
             node.tags = {**self.tagsToAdd, **currentTags}
+
+class MySingleStack(TerraformStack):
+    def __init__(self, scope: Construct, id: str):
+        super().__init__(scope, id)
+        AwsProvider(self, "aws",
+            region = "us-east-1"
+        )
+        Instance(self, "Hello",
+            ami = "ami-2757f631",
+            instance_type = "t2.micro"
+        )
+
+        # Add tags to every resource defined within `MySingleStack`.
+        Aspects.of(self).add(TagsAddingAspect({ "createdBy": "cdktf" }))
 # DOCS_BLOCK_END:define-aspects
 
 # DOCS_BLOCK_START:aspects-validation

--- a/examples/python/documentation/aspects.py
+++ b/examples/python/documentation/aspects.py
@@ -2,10 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 import jsii
-from constructs import Construct
-from cdktf import TerraformStack
 
-from imports.aws.provider import AwsProvider
 from imports.random.provider import RandomProvider
 from imports.random.pet import Pet
 

--- a/website/docs/cdktf/concepts/aspects.mdx
+++ b/website/docs/cdktf/concepts/aspects.mdx
@@ -146,10 +146,8 @@ export class AspectTaggingStack extends TerraformStack {
 ```
 
 ```python
-from constructs import Construct, IConstruct
-from cdktf import TerraformStack, Aspects, IAspect
-from imports.aws.instance import Instance
-from imports.aws.provider import AwsProvider
+from constructs import IConstruct
+from cdktf import Aspects, IAspect
 
 @jsii.implements(IAspect)
 class TagsAddingAspect:
@@ -164,19 +162,6 @@ class TagsAddingAspect:
             currentTags = node.tags_input if node.tags_input is not None else {}
             node.tags = {**self.tagsToAdd, **currentTags}
 
-
-class MySingleStack(TerraformStack):
-    def __init__(self, scope: Construct, id: str):
-        super().__init__(scope, id)
-
-        AwsProvider(self, "aws",
-            region = "us-east-1"
-        )
-
-        Instance(self, "Hello",
-            ami = "ami-2757f631",
-            instance_type = "t2.micro"
-        )
 
         # Add tags to every resource defined within `myStack`.
         Aspects.of(myStack).add(TagsAddingAspect({ "createdBy": "cdktf" }))

--- a/website/docs/cdktf/concepts/aspects.mdx
+++ b/website/docs/cdktf/concepts/aspects.mdx
@@ -146,8 +146,10 @@ export class AspectTaggingStack extends TerraformStack {
 ```
 
 ```python
-from constructs import IConstruct
-from cdktf import Aspects, IAspect
+from constructs import Construct, IConstruct
+from cdktf import TerraformStack, Aspects, IAspect
+from imports.aws.instance import Instance
+from imports.aws.provider import AwsProvider
 
 @jsii.implements(IAspect)
 class TagsAddingAspect:
@@ -162,6 +164,19 @@ class TagsAddingAspect:
             currentTags = node.tags_input if node.tags_input is not None else {}
             node.tags = {**self.tagsToAdd, **currentTags}
 
+class MySingleStack(TerraformStack):
+    def __init__(self, scope: Construct, id: str):
+        super().__init__(scope, id)
+        AwsProvider(self, "aws",
+            region = "us-east-1"
+        )
+        Instance(self, "Hello",
+            ami = "ami-2757f631",
+            instance_type = "t2.micro"
+        )
+
+        # Add tags to every resource defined within `MySingleStack`.
+        Aspects.of(self).add(TagsAddingAspect({ "createdBy": "cdktf" }))
 
         # Add tags to every resource defined within `myStack`.
         Aspects.of(myStack).add(TagsAddingAspect({ "createdBy": "cdktf" }))

--- a/website/docs/cdktf/concepts/aspects.mdx
+++ b/website/docs/cdktf/concepts/aspects.mdx
@@ -146,8 +146,10 @@ export class AspectTaggingStack extends TerraformStack {
 ```
 
 ```python
-from constructs import IConstruct
-from cdktf import Aspects, IAspect
+from constructs import Construct, IConstruct
+from cdktf import TerraformStack, Aspects, IAspect
+from imports.aws.instance import Instance
+from imports.aws.provider import AwsProvider
 
 @jsii.implements(IAspect)
 class TagsAddingAspect:
@@ -161,6 +163,20 @@ class TagsAddingAspect:
             # We need to take the input value to not create a circular reference
             currentTags = node.tags_input if node.tags_input is not None else {}
             node.tags = {**self.tagsToAdd, **currentTags}
+
+
+class MySingleStack(TerraformStack):
+    def __init__(self, scope: Construct, id: str):
+        super().__init__(scope, id)
+
+        AwsProvider(self, "aws",
+            region = "us-east-1"
+        )
+
+        Instance(self, "Hello",
+            ami = "ami-2757f631",
+            instance_type = "t2.micro"
+        )
 
         # Add tags to every resource defined within `myStack`.
         Aspects.of(myStack).add(TagsAddingAspect({ "createdBy": "cdktf" }))


### PR DESCRIPTION
### Related issue

Fixes # <!-- INSERT ISSUE NUMBER -->

### Description

I noticed that the documentation for Aspects in Python is not so easily understood. The reason is that it should call the Aspect class with the stack instance. 

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
