### PR TITLE
fix(examples): Properly set the Aspect on the stack instead of on the S3Bucket only

### DIFF
--- a/examples/python/documentation/aspects.py
+++ b/examples/python/documentation/aspects.py
@@ -52,18 +52,17 @@ class MainAspects(TerraformStack):
   def __init__(self, scope: Construct, id: str):
         super().__init__(scope, id)
 
+        myStack = self # for clarification, as the MainAspects stack is not included in the snippet
+
         AwsProvider(self, "aws",
           region="us-east-1"
         )
-        myStack = S3Bucket(self, "bucket", 
+        S3Bucket(self, "bucket", 
           tags = {"owner" : "cdktf"}
         )
 
         RandomProvider(self, "random")
         pet = Pet(self, "pet")
-        
-        # Un-taggable resource -> included to verify functionality 
-        Aspects.of(pet).add(TagsAddingAspect({ "createdBy": "cdktf" }))
 
         # DOCS_BLOCK_START:define-aspects
         


### PR DESCRIPTION
This also removes the need for another Aspect instance to test that it does work with the pet resource, as adding it to the stack will also invoke it for the pet resource

This change helps users that read the source of this example as adding an Aspect to a single resource serves not much purpose
