### PR TITLE
fix: remove old lerna option causing it to fail when building a matrix in CI runs

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -13,6 +13,5 @@
     "tools/*"
   ],
   "npmClient": "yarn",
-  "useWorkspaces": true,
   "version": "0.0.0"
 }


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes integration examples not running in CI currently, example: https://github.com/hashicorp/terraform-cdk/actions/runs/5529364286/jobs/10087325820?pr=3003#step:3:9