### PR TITLE
fix: use local NPM registry for running integration tests on unix systems

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -7,6 +7,8 @@ project {
   header_ignore = [
     "**node_modules**",
     ".github/ISSUE_TEMPLATE/*.yml",
-    "packages/@cdktf/cli-core/templates/**"
+    "packages/@cdktf/cli-core/templates/**",
+    "test/verdaccio.yaml",
+    "test/local-registry.sh"
   ]
 }

--- a/packages/cdktf-cli/.npmignore
+++ b/packages/cdktf-cli/.npmignore
@@ -14,4 +14,4 @@ dist
 coverage
 
 # include all files from templates
-!templates/**/*
+!bundle/templates/**/*

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -7,3 +7,6 @@ go/edge/translated.go
 provider-tests/providers/**
 !provider-tests/generate-provider-test.js
 !provider-tests/test-provider.sh
+
+# Used by Verdaccio (local NPM Registry)
+storage/

--- a/test/local-registry.sh
+++ b/test/local-registry.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Source: https://github.com/facebook/create-react-app/blob/0a827f69ab0d2ee3871ba9b71350031d8a81b7ae/tasks/local-registry.sh
+
+custom_registry_url=localhost:4873
+original_npm_registry_url=`npm get registry`
+original_yarn_registry_url=`yarn config get registry`
+default_verdaccio_package=verdaccio@^5.26.1
+
+function startLocalRegistry {
+  # Start local registry
+  tmp_registry_log=`mktemp`
+  echo "Verdaccio Registry log file: $tmp_registry_log"
+  
+  storage_dir="$(dirname $1)/storage"
+  echo "Cleaning storage dir ($storage_dir).."
+  rm -rf $storage_dir
+
+  nohup npx ${VERDACCIO_PACKAGE:-$default_verdaccio_package} -c $1 &>$tmp_registry_log &
+  verdaccio_pid="$!"
+  
+  # Wait for Verdaccio to boot
+  echo "Waiting for local Registry to start"
+  grep -q 'http address' <(tail -f $tmp_registry_log)
+
+  # Set registry to local registry
+  npm set registry "http://$custom_registry_url"
+  yarn config set registry "http://$custom_registry_url"
+
+  # Append dummy token for auth, NPM will remove any duplicates for us
+  echo "//${custom_registry_url%%/}/:_authToken=dummy" >> ~/.npmrc
+}
+
+function stopLocalRegistry {
+  # Restore the original NPM and Yarn registry URLs and stop Verdaccio
+  npm set registry "$original_npm_registry_url"
+  yarn config set registry "$original_yarn_registry_url"
+  kill $verdaccio_pid
+}

--- a/test/run-against-dist
+++ b/test/run-against-dist
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+scriptdir=$(cd $(dirname $0) && pwd)
+
 # Load functions for working with local NPM registry (Verdaccio)
-source local-registry.sh
+source "$scriptdir"/local-registry.sh
 
 function cleanup {
   # Restore the original NPM and Yarn registry URLs and stop Verdaccio
@@ -22,8 +24,6 @@ function handle_exit {
 # Cleanup before exit on any termination signal
 trap 'set +x; handle_error' ERR
 trap 'set +x; handle_exit' SIGQUIT SIGTERM SIGINT SIGKILL SIGHUP
-
-scriptdir=$(cd $(dirname $0) && pwd)
 
 export CDKTF_DIST="${scriptdir}/../dist"
 cwd=$PWD

--- a/test/run-against-dist
+++ b/test/run-against-dist
@@ -56,6 +56,11 @@ npm init -y > /dev/null
 # There's only one version in our local registry, so we don't need to specify a version here
 npm install --global-style cdktf-cli
 
+# stop the local registry now that we installed the CLI
+# Some tests install cdktf in an older version from NPM
+# Which we'd block via the local registry otherwise
+stopLocalRegistry
+
 export TEST_PATH_CDKTF_CLI=${staging}/node_modules/.bin
 export PATH=$TEST_PATH_CDKTF_CLI:$PATH
 

--- a/test/run-against-dist
+++ b/test/run-against-dist
@@ -53,7 +53,8 @@ echo "Installing CLI from 'dist'..."
 staging=$(mktemp -d)
 cd ${staging}
 npm init -y > /dev/null
-npm install --global-style cdktf-cli@0.0.0
+# There's only one version in our local registry, so we don't need to specify a version here
+npm install --global-style cdktf-cli
 
 export TEST_PATH_CDKTF_CLI=${staging}/node_modules/.bin
 export PATH=$TEST_PATH_CDKTF_CLI:$PATH

--- a/test/run-against-dist
+++ b/test/run-against-dist
@@ -64,6 +64,8 @@ stopLocalRegistry
 export TEST_PATH_CDKTF_CLI=${staging}/node_modules/.bin
 export PATH=$TEST_PATH_CDKTF_CLI:$PATH
 
+echo "Installed CDKTF-CLI version: $(cdktf --version)"
+
 # restore working directory
 cd $cwd
 $@

--- a/test/run-against-dist
+++ b/test/run-against-dist
@@ -1,9 +1,36 @@
 #!/bin/bash
 set -euo pipefail
+
+# Load functions for working with local NPM registry (Verdaccio)
+source local-registry.sh
+
+function cleanup {
+  # Restore the original NPM and Yarn registry URLs and stop Verdaccio
+  stopLocalRegistry
+}
+
+function handle_error {
+  cleanup
+  exit 1
+}
+
+function handle_exit {
+  cleanup
+  exit
+}
+
+# Cleanup before exit on any termination signal
+trap 'set +x; handle_error' ERR
+trap 'set +x; handle_exit' SIGQUIT SIGTERM SIGINT SIGKILL SIGHUP
+
 scriptdir=$(cd $(dirname $0) && pwd)
 
 export CDKTF_DIST="${scriptdir}/../dist"
 cwd=$PWD
+cdktf_root="${scriptdir}/.."
+
+# Start the local NPM registry
+startLocalRegistry "$scriptdir"/verdaccio.yaml
 
 cd ${CDKTF_DIST}
 
@@ -14,13 +41,22 @@ if [ ! -d "js" ] || [ ! -d "python" ] || [ ! -d "java" ] || [ ! -d "dotnet" ] ||
   exit 1
 fi
 
+echo "Publishing CLI from 'dist'..."
+for pkg in ${CDKTF_DIST}/js/*.tgz
+do
+  echo $pkg
+  npm publish --force "$pkg"
+done
+
 # install the CLI from dist/js in a temporary area and add to path
-echo "Extracting CLI from 'dist'..."
+echo "Installing CLI from 'dist'..."
 staging=$(mktemp -d)
 cd ${staging}
 npm init -y > /dev/null
-npm install ${CDKTF_DIST}/js/*.tgz
-export PATH=${staging}/node_modules/.bin:$PATH
+npm install --global-style cdktf-cli@0.0.0
+
+export TEST_PATH_CDKTF_CLI=${staging}/node_modules/.bin
+export PATH=$TEST_PATH_CDKTF_CLI:$PATH
 
 # restore working directory
 cd $cwd

--- a/test/verdaccio.yaml
+++ b/test/verdaccio.yaml
@@ -33,30 +33,30 @@ uplinks:
 
 packages:
   # not handled by us
-  '@cdktf/node-pty-prebuilt-multiarch':
+  "@cdktf/node-pty-prebuilt-multiarch":
     proxy: npmjs
     access: $all
-  
-  'cdktf**':
+
+  "cdktf**":
     # scoped packages
     access: $all
     publish: $all
     proxy: ""
     # no proxy, so we can publish v0.0.0
 
-  '@cdktf/*':
+  "@cdktf/*":
     # scoped packages
     access: $all
     publish: $all
     # no proxy, so we can publish v0.0.0
 
-  '@*/*':
+  "@*/*":
     # scoped packages
     access: $all
     #publish: $all
     proxy: npmjs
 
-  '**':
+  "**":
     # allow all users (including non-authenticated users) to read and
     # publish all packages
     #

--- a/test/verdaccio.yaml
+++ b/test/verdaccio.yaml
@@ -1,0 +1,81 @@
+# Source: https://github.com/facebook/create-react-app/blob/0a827f69ab0d2ee3871ba9b71350031d8a81b7ae/tasks/verdaccio.yaml
+
+# This is based on verdaccio's default config file. It allows all users
+# to do anything, so don't use it on production systems.
+#
+# Look here for more config file examples:
+# https://github.com/verdaccio/verdaccio/tree/master/conf
+#
+
+# path to a directory with all packages
+storage: ./storage
+
+auth:
+  htpasswd:
+    file: ./htpasswd
+    # Maximum amount of users allowed to register, defaults to "+inf".
+    # You can set this to -1 to disable registration.
+    #max_users: 1000
+
+# a list of other known repositories we can talk to
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+    max_fails: 40
+    maxage: 30m
+    timeout: 60s
+    agent_options:
+      keepAlive: true
+      # Avoid exceeding the max sockets that are allocated per VM.
+      # https://docs.microsoft.com/en-us/azure/app-service/app-service-web-nodejs-best-practices-and-troubleshoot-guide#my-node-application-is-making-excessive-outbound-calls
+      maxSockets: 40
+      maxFreeSockets: 10
+
+packages:
+  # not handled by us
+  '@cdktf/node-pty-prebuilt-multiarch':
+    proxy: npmjs
+    access: $all
+  
+  'cdktf**':
+    # scoped packages
+    access: $all
+    publish: $all
+    proxy: ""
+    # no proxy, so we can publish v0.0.0
+
+  '@cdktf/*':
+    # scoped packages
+    access: $all
+    publish: $all
+    # no proxy, so we can publish v0.0.0
+
+  '@*/*':
+    # scoped packages
+    access: $all
+    #publish: $all
+    proxy: npmjs
+
+  '**':
+    # allow all users (including non-authenticated users) to read and
+    # publish all packages
+    #
+    # you can specify usernames/groupnames (depending on your auth plugin)
+    # and three keywords: "$all", "$anonymous", "$authenticated"
+    access: $all
+
+    # allow all known users to publish packages
+    # (anyone can register by default, remember?)
+    #publish: $all
+
+    # if package is not available locally, proxy requests to 'npmjs' registry
+    proxy: npmjs
+
+# log settings
+logs:
+  - { type: stdout, format: pretty, level: warn }
+  #- {type: file, path: verdaccio.log, level: info}
+
+# See https://github.com/verdaccio/verdaccio/issues/301
+server:
+  keepAliveTimeout: 0


### PR DESCRIPTION
This ensures we install the cdktf-cli in the same way it is installed on user machines
