### PR TITLE
fix: improve java synth time

### DIFF
--- a/examples/java/aws/cdktf.json
+++ b/examples/java/aws/cdktf.json
@@ -1,5 +1,5 @@
 {
   "language": "java",
-  "app": "mvn -e -q compile exec:java",
-  "terraformProviders": ["aws@~> 3.0"]
+  "app": "mvn -e -q exec:java",
+  "terraformProviders": ["aws@~> 5.9"]
 }

--- a/examples/java/aws/pom.xml
+++ b/examples/java/aws/pom.xml
@@ -49,7 +49,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>1.6.0</version>
+        <version>3.1.0</version>
         <configuration>
           <mainClass>com.mycompany.app.Main</mainClass>
         </configuration>

--- a/examples/java/azure/cdktf.json
+++ b/examples/java/azure/cdktf.json
@@ -1,5 +1,5 @@
 {
   "language": "java",
-  "app": "mvn -e -q compile exec:java",
+  "app": "mvn -e -q exec:java",
   "terraformProviders": ["azurerm@~> 2.0.0"]
 }

--- a/examples/java/azure/pom.xml
+++ b/examples/java/azure/pom.xml
@@ -49,7 +49,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>1.6.0</version>
+        <version>3.1.0</version>
         <configuration>
           <mainClass>com.mycompany.app.Main</mainClass>
         </configuration>

--- a/examples/java/documentation/cdktf.json
+++ b/examples/java/documentation/cdktf.json
@@ -1,6 +1,6 @@
 {
   "language": "java",
-  "app": "mvn -e -q compile exec:java",
+  "app": "mvn -e -q exec:java",
   "codeMakerOutput": "src/main/java/imports",
   "terraformProviders": [
     "aws@~> 3.0",

--- a/examples/java/google/cdktf.json
+++ b/examples/java/google/cdktf.json
@@ -1,5 +1,5 @@
 {
   "language": "java",
-  "app": "mvn -e -q compile exec:java",
+  "app": "mvn -e -q exec:java",
   "terraformProviders": ["google@~> 3.0"]
 }

--- a/examples/java/google/pom.xml
+++ b/examples/java/google/pom.xml
@@ -49,7 +49,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>1.6.0</version>
+        <version>3.1.0</version>
         <configuration>
           <mainClass>com.mycompany.app.Main</mainClass>
         </configuration>

--- a/examples/java/kubernetes/cdktf.json
+++ b/examples/java/kubernetes/cdktf.json
@@ -1,6 +1,6 @@
 {
   "language": "java",
-  "app": "mvn -e -q compile exec:java",
+  "app": "mvn -e -q exec:java",
   "terraformProviders": [
     "kubernetes@~> 1.11.3"
   ]

--- a/examples/java/kubernetes/pom.xml
+++ b/examples/java/kubernetes/pom.xml
@@ -49,7 +49,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>1.6.0</version>
+        <version>3.1.0</version>
         <configuration>
           <mainClass>com.mycompany.app.Main</mainClass>
         </configuration>

--- a/examples/java/ucloud/cdktf.json
+++ b/examples/java/ucloud/cdktf.json
@@ -1,5 +1,5 @@
 {
   "language": "java",
-  "app": "mvn -e -q compile exec:java",
+  "app": "mvn -e -q exec:java",
   "terraformProviders": ["ucloud/ucloud@~> 1.29.0"]
 }

--- a/examples/java/ucloud/pom.xml
+++ b/examples/java/ucloud/pom.xml
@@ -49,7 +49,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>1.6.0</version>
+        <version>3.1.0</version>
         <configuration>
           <mainClass>com.mycompany.app.Main</mainClass>
         </configuration>

--- a/packages/@cdktf/cli-core/templates/java/cdktf.json
+++ b/packages/@cdktf/cli-core/templates/java/cdktf.json
@@ -1,6 +1,6 @@
 {
   "language": "java",
-  "app": "mvn -e -q compile exec:java",
+  "app": "mvn -e -q exec:java",
   "projectId": "{{projectId}}",
   "sendCrashReports": "{{sendCrashReports}}",
   "codeMakerOutput": "src/main/java/imports",

--- a/packages/@cdktf/cli-core/templates/java/pom.xml
+++ b/packages/@cdktf/cli-core/templates/java/pom.xml
@@ -54,7 +54,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0</version>
         <configuration>
           <mainClass>com.mycompany.app.Main</mainClass>
         </configuration>

--- a/test/java/edge/cdktf.json
+++ b/test/java/edge/cdktf.json
@@ -1,6 +1,6 @@
 {
   "language": "java",
-  "app": "mvn -e -q compile exec:java",
+  "app": "mvn -e -q exec:java",
   "terraformProviders": ["hashicorp/null@~> 3.1.0"],
   "context": {}
 }

--- a/test/java/no-color-command-option-test/cdktf.json
+++ b/test/java/no-color-command-option-test/cdktf.json
@@ -1,6 +1,6 @@
 {
   "language": "java",
-  "app": "mvn -e -q compile exec:java",
+  "app": "mvn -e -q exec:java",
   "terraformProviders": [],
   "context": {}
 }

--- a/test/java/provider-add-command/cdktf.json
+++ b/test/java/provider-add-command/cdktf.json
@@ -1,6 +1,6 @@
 {
   "language": "java",
-  "app": "mvn -e -q compile exec:java",
+  "app": "mvn -e -q exec:java",
   "terraformProviders": [],
   "context": {}
 }

--- a/test/java/provider-list-command/cdktf.json
+++ b/test/java/provider-list-command/cdktf.json
@@ -1,6 +1,6 @@
 {
   "language": "java",
-  "app": "mvn -e -q compile exec:java",
+  "app": "mvn -e -q exec:java",
   "terraformProviders": [],
   "context": {}
 }

--- a/test/java/provider-upgrade-command/cdktf.json
+++ b/test/java/provider-upgrade-command/cdktf.json
@@ -1,6 +1,6 @@
 {
   "language": "java",
-  "app": "mvn -e -q compile exec:java",
+  "app": "mvn -e -q exec:java",
   "terraformProviders": [],
   "context": {}
 }

--- a/test/java/synth-app/cdktf.json
+++ b/test/java/synth-app/cdktf.json
@@ -1,6 +1,6 @@
 {
   "language": "java",
-  "app": "mvn -e -q compile exec:java",
+  "app": "mvn -e -q exec:java",
   "terraformProviders": ["hashicorp/null@~> 3.1.0", "hashicorp/random@= 3.1.3"],
   "context": {}
 }

--- a/test/java/testing-matchers/cdktf.json
+++ b/test/java/testing-matchers/cdktf.json
@@ -1,6 +1,6 @@
 {
   "language": "java",
-  "app": "mvn -e -q compile exec:java",
+  "app": "mvn -e -q exec:java",
   "terraformProviders": ["kreuzwerker/docker@~> 2.0"],
   "context": {}
 }

--- a/website/data/cdktf-nav-data.json
+++ b/website/data/cdktf-nav-data.json
@@ -184,6 +184,7 @@
         "title": "Overview",
         "path": "release"
       },
+      { "title": "Upgrading to Version 0.18", "path": "release/upgrade-guide-v0-18" },
       { "title": "Upgrading to Version 0.17", "path": "release/upgrade-guide-v0-17" },
       { "title": "Upgrading to Version 0.15", "path": "release/upgrade-guide-v0-15" },
       { "title": "Upgrading to Version 0.13", "path": "release/upgrade-guide-v0-13" },

--- a/website/docs/cdktf/release/upgrade-guide-v0-18.mdx
+++ b/website/docs/cdktf/release/upgrade-guide-v0-18.mdx
@@ -1,0 +1,20 @@
+---
+page_title: Upgrading to CDKTF Version 0.18
+description: >-
+  Performance improvements might require you to update your `cdktf.json` file.
+---
+
+# Upgrading to CDK for Terraform Version 0.18
+
+0.18 is focused around improving the synthetization performance across all languages. This means that the generated code is now faster to compile. We achieved this mostly by changing the way we generate the code for the Terraform configuration but also by updates within JSII, the tool we use to support multiple languages.
+
+## Java: Change the `app` field in your `cdktf.json` file for better performance
+
+If you are using Java and want to improve the performance of `cdktf synth` you can change your `app` field in your `cdktf.json` file from the default `mvn -e -q compile exec:java` to `mvn -e -q exec:java`. This will improve the performance of `cdktf synth` by 70-80%.
+
+```json
+{
+  "language": "java",
+  "app": "mvn -e -q exec:java"
+}
+```


### PR DESCRIPTION
This change in the app field of the `cdktf.json` (from `mvn -e -q compile exec:java` to `mvn -e -q exec:java`) leads to a ~80% speed improvement (from 95s for aws to 11s)