### PR TITLE
fix(cli): cdktf debug to read gradle package versions

### DIFF
--- a/packages/@cdktf/cli-core/src/lib/dependencies/package-manager.ts
+++ b/packages/@cdktf/cli-core/src/lib/dependencies/package-manager.ts
@@ -1,6 +1,12 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import { Language, exec, Errors, logger } from "@cdktf/commons";
+import {
+  Language,
+  exec,
+  Errors,
+  logger,
+  isGradleProject,
+} from "@cdktf/commons";
 import { existsSync } from "fs-extra";
 import path from "path";
 import { xml2js, js2xml, Element } from "xml-js";
@@ -636,14 +642,7 @@ class MavenPackageManager extends JavaPackageManager {
 
 class GradlePackageManager extends JavaPackageManager {
   public static isGradleProject(workingDirectory: string): boolean {
-    const buildGradlePath = path.join(workingDirectory, "build.gradle");
-
-    try {
-      fs.accessSync(buildGradlePath, fs.constants.R_OK | fs.constants.W_OK);
-      return true;
-    } catch {
-      return false;
-    }
+    return isGradleProject(workingDirectory);
   }
 
   public async addPackage(

--- a/packages/@cdktf/commons/src/debug.ts
+++ b/packages/@cdktf/commons/src/debug.ts
@@ -7,6 +7,7 @@ import { exec } from "./util";
 import { terraformVersion } from "./terraform";
 import { DISPLAY_VERSION } from "./version";
 import { pathExists } from "fs-extra";
+import { isGradleProject } from "./gradle";
 
 export function getLanguage(projectPath = process.cwd()): string | undefined {
   try {
@@ -286,7 +287,7 @@ async function getGoPackageVersion(packageName: string) {
   return versionLine.split(" ").pop()?.replace("v", "");
 }
 
-async function getJavaPackageVersion(packageName: string) {
+async function getMavenPackageVersion(packageName: string) {
   const translationMap: Record<string, string> = {
     jsii: "jsii-runtime",
   };
@@ -333,6 +334,75 @@ async function getJavaPackageVersion(packageName: string) {
   const versionEndDelemiter = ":compile";
   const versionEnd = versionLine.indexOf(versionEndDelemiter);
   return versionLine.substring(versionStart, versionEnd);
+}
+
+/*
+ * Example output:
+  implementation - Implementation dependencies for the 'main' feature. (n)
+  +--- com.hashicorp:cdktf:0.18.0 (n)
+  +--- software.constructs:constructs:10.0.25 (n)
+  +--- junit:junit:4.13.2 (n)
+  \--- org.junit.jupiter:junit-jupiter:5.8.0 (n)
+*/
+async function getGradlePackageVersion(packageName: string) {
+  const translationMap: Record<string, string> = {
+    jsii: "jsii-runtime",
+  };
+  const gradlePackageName = translationMap[packageName] || packageName;
+
+  let output;
+  try {
+    output = await exec("gradle", ["dependencies", "--console=plain"], {
+      env: process.env,
+    });
+  } catch (e) {
+    logger.debug(`Unable to run 'gradle dependencies': ${e}`);
+    return undefined;
+  }
+
+  const lines = output.split(/\r\n|\r|\n/);
+
+  // find the implementation section
+  const implementationSection = lines.findIndex((line) =>
+    line.includes("implementation - ")
+  );
+  if (implementationSection === -1) {
+    logger.debug(
+      `Unable to find implementation section in output of 'gradle dependencies': ${output}`
+    );
+    return undefined;
+  }
+
+  // loop through the subsequent lines to find the one starting with package name
+  for (let i = implementationSection + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.includes(`:${gradlePackageName}:`)) {
+      const packageNameRegex = /^.*\s+[^:]+:[^:]+:([^\s]+)/;
+      const matches = line.match(packageNameRegex);
+      if (!matches) {
+        logger.debug(
+          "Unexpected format for gradle build. Please file an issue at https://cdk.tf/bug"
+        );
+        return undefined;
+      }
+
+      return matches[1];
+    }
+
+    if (line.trim() === "") {
+      break;
+    }
+  }
+
+  return undefined;
+}
+
+async function getJavaPackageVersion(packageName: string) {
+  if (isGradleProject("./")) {
+    return getGradlePackageVersion(packageName);
+  }
+
+  return getMavenPackageVersion(packageName);
 }
 
 export async function getPackageVersion(

--- a/packages/@cdktf/commons/src/gradle.ts
+++ b/packages/@cdktf/commons/src/gradle.ts
@@ -1,0 +1,13 @@
+import path from "path";
+import fs from "fs-extra";
+
+export function isGradleProject(workingDirectory: string): boolean {
+  const buildGradlePath = path.join(workingDirectory, "build.gradle");
+
+  try {
+    fs.accessSync(buildGradlePath, fs.constants.R_OK | fs.constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/@cdktf/commons/src/gradle.ts
+++ b/packages/@cdktf/commons/src/gradle.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 import path from "path";
 import fs from "fs-extra";
 

--- a/packages/@cdktf/commons/src/index.ts
+++ b/packages/@cdktf/commons/src/index.ts
@@ -15,3 +15,4 @@ export * from "./terraform-module";
 export * from "./terraform";
 export * from "./util";
 export * from "./version";
+export * from "./gradle";


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes integration issues in release pipeline

### Description

Due to the move to Gradle, we need to be able to read gradle dependencies in `cdktf debug` instead of using Maven.

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
