### PR TITLE
fix: provider add java integration test failures due to test setup

### DIFF
--- a/packages/@cdktf/cli-core/src/lib/dependencies/package-manager.ts
+++ b/packages/@cdktf/cli-core/src/lib/dependencies/package-manager.ts
@@ -665,8 +665,16 @@ class GradlePackageManager extends JavaPackageManager {
       );
     }
 
+    const existingDependency = buildGradleLines.findIndex((line) =>
+      line.includes(packageName)
+    );
+    if (existingDependency !== -1) {
+      buildGradleLines.splice(existingDependency, 1);
+    }
+
     const newPackageDependency = `\timplementation '${packageName}:${packageVersion}'`;
     buildGradleLines.splice(dependencyBlockStart + 1, 0, newPackageDependency);
+
     await fs.writeFile(buildGradlePath, buildGradleLines.join("\n"));
   }
 

--- a/packages/@cdktf/commons/src/gradle.ts
+++ b/packages/@cdktf/commons/src/gradle.ts
@@ -175,7 +175,7 @@ export async function getGradlePackageVersionFromBuild(packageName: string) {
   const line = buildLines[foundIndex];
 
   const colonSeparatedPackageNameRegex = new RegExp(
-    `([^:]+):${packageName}(?::([^\s]+))?`,
+    `([^:]+):${packageName}(?::([^\\s]+))?`,
     "i"
   );
 
@@ -189,7 +189,7 @@ export async function getGradlePackageVersionFromBuild(packageName: string) {
   }
 
   const fileSeparatedPackageNameRegex = new RegExp(
-    `java/(.*)/${packageName}/([^/]+)/.*\.jar`,
+    `java/(.*)/${packageName}/([^/]+)/.*\\.jar`,
     "i"
   );
 

--- a/packages/cdktf-cli/src/bin/cdktf.ts
+++ b/packages/cdktf-cli/src/bin/cdktf.ts
@@ -143,9 +143,10 @@ yargs
     }
 
     // set if e.g. an handler threw an error while being invoked
-    if (IsErrorType(error, "Usage")) {
+    if (IsErrorType(error, "Usage") || IsErrorType(error, "External")) {
       console.error(error.message);
     } else if (error) {
+      console.error(error.message);
       console.error(error.stack);
       console.error("Collecting Debug Information...");
       const debugOutput = await collectDebugInformation();

--- a/test/java/provider-add-command/test.ts
+++ b/test/java/provider-add-command/test.ts
@@ -21,7 +21,7 @@ describe("provider add command", () => {
       expect(res.stdout).toContain("cdktf: 0.10.4");
     });
 
-    test("installs pre-built provider using maven", async () => {
+    test("installs pre-built provider using gradle", async () => {
       const res = await driver.exec("cdktf", [
         "provider",
         "add",
@@ -36,18 +36,13 @@ describe("provider add command", () => {
 
 
         [<TIMESTAMP>] [INFO] default - Found pre-built provider.
-
-        Adding com.hashicorp.cdktf-provider-random @ 0.2.55 to pom.xml
-
-        Package installed.
         "
       `);
       expect(res.stderr).toBe("");
 
-      const proj = driver.readLocalFile("pom.xml");
+      const proj = driver.readLocalFile("build.gradle");
 
-      expect(proj).toContain("<artifactId>cdktf-provider-random</artifactId>");
-      expect(proj).toContain("<version>0.2.55</version>");
+      expect(proj).toContain("cdktf-provider-random:0.2.55");
     }, 500_000);
   });
 });

--- a/test/java/provider-upgrade-command/test.ts
+++ b/test/java/provider-upgrade-command/test.ts
@@ -16,7 +16,7 @@ describe("provider upgrade command", () => {
       });
     });
 
-    test("installs pre-built provider using maven", async () => {
+    test("installs pre-built provider using gradle", async () => {
       await driver.exec("cdktf", [
         "provider",
         "add",
@@ -25,11 +25,11 @@ describe("provider upgrade command", () => {
 
       await driver.exec("cdktf", ["provider", "upgrade", "random@=3.2.0"]);
 
-      expect(driver.readLocalFile("pom.xml")).not.toContain(
-        "<version>0.2.55</version>"
+      expect(driver.readLocalFile("build.gradle")).not.toContain(
+        "cdktf-provider-random:0.2.55"
       );
-      expect(driver.readLocalFile("pom.xml")).toContain(
-        "<version>0.2.64</version>"
+      expect(driver.readLocalFile("build.gradle")).toContain(
+        "cdktf-provider-random:0.2.64"
       );
     }, 500_000);
   });

--- a/test/java/synth-app/__snapshots__/test.ts.snap
+++ b/test/java/synth-app/__snapshots__/test.ts.snap
@@ -20,21 +20,21 @@ exports[`java full integration synth generates JSON 1`] = `
   },
   "resource": {
     "null_resource": {
-      "NullResource": {
+      "javasimple_NullResource_0DFEEB47": {
         "//": {
           "metadata": {
             "path": "java-simple/NullResource",
-            "uniqueId": "NullResource"
+            "uniqueId": "javasimple_NullResource_0DFEEB47"
           }
         }
       }
     },
     "random_string": {
-      "RandomString": {
+      "javasimple_RandomString_FB91A61A": {
         "//": {
           "metadata": {
             "path": "java-simple/RandomString",
-            "uniqueId": "RandomString"
+            "uniqueId": "javasimple_RandomString_FB91A61A"
           }
         },
         "length": 42

--- a/test/java/synth-app/__snapshots__/test.ts.snap
+++ b/test/java/synth-app/__snapshots__/test.ts.snap
@@ -20,21 +20,21 @@ exports[`java full integration synth generates JSON 1`] = `
   },
   "resource": {
     "null_resource": {
-      "javasimple_NullResource_0DFEEB47": {
+      "NullResource": {
         "//": {
           "metadata": {
             "path": "java-simple/NullResource",
-            "uniqueId": "javasimple_NullResource_0DFEEB47"
+            "uniqueId": "NullResource"
           }
         }
       }
     },
     "random_string": {
-      "javasimple_RandomString_FB91A61A": {
+      "RandomString": {
         "//": {
           "metadata": {
             "path": "java-simple/RandomString",
-            "uniqueId": "javasimple_RandomString_FB91A61A"
+            "uniqueId": "RandomString"
           }
         },
         "length": 42

--- a/test/java/synth-app/test.ts
+++ b/test/java/synth-app/test.ts
@@ -12,11 +12,9 @@ describe("java full integration", () => {
 
   test("debug command", async () => {
     driver.setEnv("CDKTF_LOG_LEVEL", "debug");
-    const debug = await driver.exec(`cdktf debug --json`);
+    await driver.exec(`cdktf debug --json`);
     driver.setEnv("CDKTF_LOG_LEVEL", "warning");
-    console.log("debug", debug);
     const { stdout } = await driver.exec(`cdktf debug --json`);
-    console.log(stdout);
     const { cdktf, constructs } = JSON.parse(stdout);
     expect(cdktf.length).not.toBe(0);
     expect(constructs.length).not.toBe(0);

--- a/test/java/testing-matchers/test.ts
+++ b/test/java/testing-matchers/test.ts
@@ -23,7 +23,9 @@ describe("java testing assertions", () => {
 
   test("run java testing suite", async () => {
     const output = await runTests();
-    expect(output.stdout).toEqual(expect.stringContaining("Errors: 0"));
-    expect(output.stdout).toEqual(expect.stringContaining("Tests run: 11"));
+    // TODO: Currently Gradle doesn't give the number of tests run.
+    // We need to update that with a change to build.gradle
+    expect(output.stdout).toEqual(expect.stringContaining("BUILD SUCCESSFUL"));
+    expect(output.stdout).toEqual(expect.stringContaining("Task :test"));
   }, 6000000);
 });


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes CI issues

### Description

The tests were failing due to a snapshot difference as well as the `gradle dependencies` file being unable to resolve the cdktf jar file with our test driver setup. This PR adds a fallback to using `build.gradle` for that situation. It shouldn't be used otherwise as `gradle dependencies` should be the source of truth.

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
