### PR TITLE
chore: fix remove-waiting-on-answer workflow

### DIFF
--- a/.github/workflows/remove-waiting-on-answer.yml
+++ b/.github/workflows/remove-waiting-on-answer.yml
@@ -17,6 +17,8 @@ jobs:
       github.event.comment.author_association != 'COLLABORATOR' && github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.3.0
       - name: Remove waiting-on-answer label
         run: gh issue edit $NUMBER --remove-label "waiting-on-answer"
         env:

--- a/.github/workflows/remove-waiting-on-answer.yml
+++ b/.github/workflows/remove-waiting-on-answer.yml
@@ -15,12 +15,12 @@ jobs:
       contains(github.event.issue.labels.*.name, 'waiting-on-answer') && !contains(github.event.issue.labels.*.name, 'stale') && 
       github.event.comment.author_association != 'OWNER' && github.event.comment.author_association != 'MEMBER' && 
       github.event.comment.author_association != 'COLLABORATOR' && github.actor != 'github-actions[bot]'
+    env:
+      REPO: ${{ github.event.repository.full_name }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.3.0
       - name: Remove waiting-on-answer label
-        run: gh issue edit $NUMBER --remove-label "waiting-on-answer"
+        run: gh issue edit $NUMBER --remove-label "waiting-on-answer" --repo $REPO
         env:
           NUMBER: ${{ github.event.issue.number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It took until today for a comment to finally trigger only for this script to fail. 😅 I always forget that you have to do a checkout anytime that you want to use the `gh` CLI...
