### PR TITLE
chore: ensure GitHub treats us as a TypeScript project

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+docs/** linguist-documentation
+website/** linguist-documentation


### PR DESCRIPTION
I'd been wondering for some time why GitHub seems to think we're an MDX project:

![Screen Shot 2023-08-18 at 11 43 13](https://github.com/hashicorp/terraform-cdk/assets/855115/593ca706-4d87-4b9d-a680-381b383508d7)

Did some Googling this morning and ended up at https://github.com/github-linguist/linguist/blob/master/docs/overrides.md which seems to suggest this is the fix.