### PR TITLE
fix(docs): bandaid solution for content check errors

### DIFF
--- a/packages/@cdktf/hcl2cdk/lib/function-bindings/functions.generated.ts
+++ b/packages/@cdktf/hcl2cdk/lib/function-bindings/functions.generated.ts
@@ -607,6 +607,11 @@ export const functionsMapGenerated = {
       },
     ],
   },
+  plantimestamp: {
+    name: "plantimestamp",
+    returnType: "string",
+    parameters: [],
+  },
   pow: {
     name: "pow",
     returnType: "number",
@@ -810,6 +815,18 @@ export const functionsMapGenerated = {
   },
   startswith: {
     name: "startswith",
+    returnType: "bool",
+    parameters: [
+      {
+        type: "string",
+      },
+      {
+        type: "string",
+      },
+    ],
+  },
+  strcontains: {
+    name: "strcontains",
     returnType: "bool",
     parameters: [
       {

--- a/packages/cdktf/lib/functions/terraform-functions.generated.ts
+++ b/packages/cdktf/lib/functions/terraform-functions.generated.ts
@@ -35,14 +35,14 @@ export class FnGenerated {
     return asString(terraformFunction("abspath", [stringValue])(path));
   }
   /**
-   * {@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `&#34;true&#34;`. It also returns `true` if the collection is empty.
+   * {@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `"true"`. It also returns `true` if the collection is empty.
    * @param {Array<any>} list
    */
   static alltrue(list: any[]) {
     return asBoolean(terraformFunction("alltrue", [listOf(anyValue)])(list));
   }
   /**
-   * {@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `&#34;true&#34;`. It also returns `false` if the collection is empty.
+   * {@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `"true"`. It also returns `false` if the collection is empty.
    * @param {Array<any>} list
    */
   static anytrue(list: any[]) {
@@ -70,14 +70,14 @@ export class FnGenerated {
     return asString(terraformFunction("base64gzip", [stringValue])(str));
   }
   /**
-   * {@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(&#34;test&#34;))` since `sha256()` returns hexadecimal representation.
+   * {@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256("test"))` since `sha256()` returns hexadecimal representation.
    * @param {string} str
    */
   static base64sha256(str: string) {
     return asString(terraformFunction("base64sha256", [stringValue])(str));
   }
   /**
-   * {@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512(&#34;test&#34;))` since `sha512()` returns hexadecimal representation.
+   * {@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512("test"))` since `sha512()` returns hexadecimal representation.
    * @param {string} str
    */
   static base64sha512(str: string) {
@@ -187,14 +187,14 @@ export class FnGenerated {
     );
   }
   /**
-   * {@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn&#39;t null or an empty string.
+   * {@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn't null or an empty string.
    * @param {Array<any>} vals
    */
   static coalesce(vals: any[]) {
     return asAny(terraformFunction("coalesce", [variadic(anyValue)])(vals));
   }
   /**
-   * {@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn&#39;t empty.
+   * {@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn't empty.
    * @param {Array<any>} vals
    */
   static coalescelist(vals: any[]) {
@@ -553,11 +553,17 @@ export class FnGenerated {
     );
   }
   /**
-   * {@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user&#39;s home directory path.
+   * {@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user's home directory path.
    * @param {string} path
    */
   static pathexpand(path: string) {
     return asString(terraformFunction("pathexpand", [stringValue])(path));
+  }
+  /**
+   * {@link https://developer.hashicorp.com/terraform/language/functions/plantimestamp plantimestamp} returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format, fixed to a constant time representing the time of the plan.
+   */
+  static plantimestamp() {
+    return asString(terraformFunction("plantimestamp", [])());
   }
   /**
    * {@link https://developer.hashicorp.com/terraform/language/functions/pow pow} calculates an exponent, by raising its first argument to the power of the second argument.
@@ -633,7 +639,7 @@ export class FnGenerated {
     );
   }
   /**
-   * {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).
+   * {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).
    * @param {any} value
    */
   static sensitive(value: any) {
@@ -753,6 +759,16 @@ export class FnGenerated {
   static startswith(str: string, prefix: string) {
     return asBoolean(
       terraformFunction("startswith", [stringValue, stringValue])(str, prefix)
+    );
+  }
+  /**
+   * {@link https://developer.hashicorp.com/terraform/language/functions/strcontains strcontains} takes two values: a string to check and an expected substring. The function returns true if the string has the substring contained within it.
+   * @param {string} str
+   * @param {string} substr
+   */
+  static strcontains(str: string, substr: string) {
+    return asBoolean(
+      terraformFunction("strcontains", [stringValue, stringValue])(str, substr)
     );
   }
   /**
@@ -973,7 +989,7 @@ export class FnGenerated {
     return asString(terraformFunction("uuid", [])());
   }
   /**
-   * {@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a &#34;version 5&#34; UUID.
+   * {@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a "version 5" UUID.
    * @param {string} namespace
    * @param {string} name
    */

--- a/tools/generate-function-bindings/scripts/functions.json
+++ b/tools/generate-function-bindings/scripts/functions.json
@@ -12,12 +12,12 @@
       "parameters": [{ "name": "path", "type": "string" }]
     },
     "alltrue": {
-      "description": "`alltrue` returns `true` if all elements in a given collection are `true` or `\u0026#34;true\u0026#34;`. It also returns `true` if the collection is empty.",
+      "description": "`alltrue` returns `true` if all elements in a given collection are `true` or `\"true\"`. It also returns `true` if the collection is empty.",
       "return_type": "bool",
       "parameters": [{ "name": "list", "type": ["list", "bool"] }]
     },
     "anytrue": {
-      "description": "`anytrue` returns `true` if any element in a given collection is `true` or `\u0026#34;true\u0026#34;`. It also returns `false` if the collection is empty.",
+      "description": "`anytrue` returns `true` if any element in a given collection is `true` or `\"true\"`. It also returns `false` if the collection is empty.",
       "return_type": "bool",
       "parameters": [{ "name": "list", "type": ["list", "bool"] }]
     },
@@ -37,12 +37,12 @@
       "parameters": [{ "name": "str", "type": "string" }]
     },
     "base64sha256": {
-      "description": "`base64sha256` computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(\u0026#34;test\u0026#34;))` since `sha256()` returns hexadecimal representation.",
+      "description": "`base64sha256` computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(\"test\"))` since `sha256()` returns hexadecimal representation.",
       "return_type": "string",
       "parameters": [{ "name": "str", "type": "string" }]
     },
     "base64sha512": {
-      "description": "`base64sha512` computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512(\u0026#34;test\u0026#34;))` since `sha512()` returns hexadecimal representation.",
+      "description": "`base64sha512` computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512(\"test\"))` since `sha512()` returns hexadecimal representation.",
       "return_type": "string",
       "parameters": [{ "name": "str", "type": "string" }]
     },
@@ -149,7 +149,7 @@
       "variadic_parameter": { "name": "newbits", "type": "number" }
     },
     "coalesce": {
-      "description": "`coalesce` takes any number of arguments and returns the first one that isn\u0026#39;t null or an empty string.",
+      "description": "`coalesce` takes any number of arguments and returns the first one that isn't null or an empty string.",
       "return_type": "dynamic",
       "variadic_parameter": {
         "name": "vals",
@@ -158,7 +158,7 @@
       }
     },
     "coalescelist": {
-      "description": "`coalescelist` takes any number of list arguments and returns the first one that isn\u0026#39;t empty.",
+      "description": "`coalescelist` takes any number of list arguments and returns the first one that isn't empty.",
       "return_type": "dynamic",
       "variadic_parameter": {
         "name": "vals",
@@ -449,9 +449,13 @@
       ]
     },
     "pathexpand": {
-      "description": "`pathexpand` takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user\u0026#39;s home directory path.",
+      "description": "`pathexpand` takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user's home directory path.",
       "return_type": "string",
       "parameters": [{ "name": "path", "type": "string" }]
+    },
+    "plantimestamp": {
+      "description": "`plantimestamp` returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format, fixed to a constant time representing the time of the plan.",
+      "return_type": "string"
     },
     "pow": {
       "description": "`pow` calculates an exponent, by raising its first argument to the power of the second argument.",
@@ -588,6 +592,14 @@
       "parameters": [
         { "name": "str", "type": "string" },
         { "name": "prefix", "type": "string" }
+      ]
+    },
+    "strcontains": {
+      "description": "`strcontains` takes two values: a string to check and an expected substring. The function returns true if the string has the substring contained within it.",
+      "return_type": "bool",
+      "parameters": [
+        { "name": "str", "type": "string" },
+        { "name": "substr", "type": "string" }
       ]
     },
     "strrev": {
@@ -746,7 +758,7 @@
       "return_type": "string"
     },
     "uuidv5": {
-      "description": "`uuidv5` generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a \u0026#34;version 5\u0026#34; UUID.",
+      "description": "`uuidv5` generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a \"version 5\" UUID.",
       "return_type": "string",
       "parameters": [
         { "name": "namespace", "type": "string" },

--- a/tools/generate-function-bindings/scripts/generate.ts
+++ b/tools/generate-function-bindings/scripts/generate.ts
@@ -87,8 +87,8 @@ async function generateFunctionBindings() {
   const file = path.join(__dirname, FUNCTIONS_METADATA_FILE);
   const json = JSON.parse((await fs.readFile(file)).toString())
     .function_signatures as {
-    [name: string]: FunctionSignature;
-  };
+      [name: string]: FunctionSignature;
+    };
 
   const staticMethods = Object.entries(json).map(([name, signature]) =>
     renderStaticMethod(name, signature)
@@ -128,8 +128,8 @@ async function generateFunctionsMap() {
   const file = path.join(__dirname, FUNCTIONS_METADATA_FILE);
   const json = JSON.parse((await fs.readFile(file)).toString())
     .function_signatures as {
-    [name: string]: FunctionSignature;
-  };
+      [name: string]: FunctionSignature;
+    };
 
   const properties: t.ObjectProperty[] = [];
 
@@ -273,8 +273,7 @@ function mapParameter(p: Parameter) {
       };
     }
     throw new Error(
-      `Function ${name} has parameter ${
-        p.name
+      `Function ${name} has parameter ${p.name
       } with unsupported type ${JSON.stringify(p.type)}`
     );
   };
@@ -340,10 +339,18 @@ function renderStaticMethod(
   );
 
   // comment with docstring for method
-  const descriptionWithLink = signature.description.replace(
+  let descriptionWithLink = signature.description.replace(
     `\`${name}\``,
     `{@link https://developer.hashicorp.com/terraform/language/functions/${name} ${name}}`
   );
+  // Bandaid solution for content check errors https://github.com/hashicorp/terraform-cdk/issues/2816
+  // Must include product in link– unfortunately it comes with it from the generation of terraform function bindings
+  if (name == "sensitive") {
+    descriptionWithLink = descriptionWithLink.replace(
+      "/language/values/variables#suppressing-values-in-cli-output",
+      "/terraform/language/values/variables#suppressing-values-in-cli-output"
+    );
+  }
   t.addComment(
     method,
     "leading",

--- a/website/docs/cdktf/api-reference/csharp.mdx
+++ b/website/docs/cdktf/api-reference/csharp.mdx
@@ -24604,13 +24604,13 @@ new Fn();
 | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | <code><a href="#cdktf.Fn.abs">Abs</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/abs abs} returns the absolute value of the given number. In other words, if the number is zero or positive then it is returned as-is, but if it is negative then it is multiplied by -1 to make it positive before returning it.                                                                  |
 | <code><a href="#cdktf.Fn.abspath">Abspath</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/abspath abspath} takes a string containing a filesystem path and converts it to an absolute path. That is, if the path is not absolute, it will be joined with the current working directory.                                                                                                     |
-| <code><a href="#cdktf.Fn.alltrue">Alltrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `&#34;true&#34;`. It also returns `true` if the collection is empty.                                                                                                                                          |
-| <code><a href="#cdktf.Fn.anytrue">Anytrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `&#34;true&#34;`. It also returns `false` if the collection is empty.                                                                                                                                           |
+| <code><a href="#cdktf.Fn.alltrue">Alltrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `"true"`. It also returns `true` if the collection is empty.                                                                                                                                                  |
+| <code><a href="#cdktf.Fn.anytrue">Anytrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `"true"`. It also returns `false` if the collection is empty.                                                                                                                                                   |
 | <code><a href="#cdktf.Fn.base64decode">Base64decode</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64decode base64decode} takes a string containing a Base64 character sequence and returns the original string.                                                                                                                                                                                 |
 | <code><a href="#cdktf.Fn.base64encode">Base64encode</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64encode base64encode} applies Base64 encoding to a string.                                                                                                                                                                                                                                   |
 | <code><a href="#cdktf.Fn.base64gzip">Base64gzip</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/base64gzip base64gzip} compresses a string with gzip and then encodes the result in Base64 encoding.                                                                                                                                                                                              |
-| <code><a href="#cdktf.Fn.base64sha256">Base64sha256</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(&#34;test&#34;))` since `sha256()` returns hexadecimal representation.                                                                           |
-| <code><a href="#cdktf.Fn.base64sha512">Base64sha512</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512(&#34;test&#34;))` since `sha512()` returns hexadecimal representation.                                                                           |
+| <code><a href="#cdktf.Fn.base64sha256">Base64sha256</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256("test"))` since `sha256()` returns hexadecimal representation.                                                                                   |
+| <code><a href="#cdktf.Fn.base64sha512">Base64sha512</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512("test"))` since `sha512()` returns hexadecimal representation.                                                                                   |
 | <code><a href="#cdktf.Fn.basename">Basename</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/basename basename} takes a string containing a filesystem path and removes all except the last portion from it.                                                                                                                                                                                   |
 | <code><a href="#cdktf.Fn.can">Can</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/can can} evaluates the given expression and returns a boolean value indicating whether the expression produced a result without any errors.                                                                                                                                                       |
 | <code><a href="#cdktf.Fn.ceil">Ceil</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/ceil ceil} returns the closest whole number that is greater than or equal to the given value, which may be a fraction.                                                                                                                                                                            |
@@ -24620,8 +24620,8 @@ new Fn();
 | <code><a href="#cdktf.Fn.cidrnetmask">Cidrnetmask</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/cidrnetmask cidrnetmask} converts an IPv4 address prefix given in CIDR notation into a subnet mask address.                                                                                                                                                                                       |
 | <code><a href="#cdktf.Fn.cidrsubnet">Cidrsubnet</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/cidrsubnet cidrsubnet} calculates a subnet address within given IP network address prefix.                                                                                                                                                                                                        |
 | <code><a href="#cdktf.Fn.cidrsubnets">Cidrsubnets</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/cidrsubnets cidrsubnets} calculates a sequence of consecutive IP address ranges within a particular CIDR prefix.                                                                                                                                                                                  |
-| <code><a href="#cdktf.Fn.coalesce">Coalesce</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn&#39;t null or an empty string.                                                                                                                                                                                |
-| <code><a href="#cdktf.Fn.coalescelist">Coalescelist</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn&#39;t empty.                                                                                                                                                                                     |
+| <code><a href="#cdktf.Fn.coalesce">Coalesce</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn't null or an empty string.                                                                                                                                                                                    |
+| <code><a href="#cdktf.Fn.coalescelist">Coalescelist</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn't empty.                                                                                                                                                                                         |
 | <code><a href="#cdktf.Fn.compact">Compact</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/compact compact} takes a list of strings and returns a new list with any empty string elements removed.                                                                                                                                                                                           |
 | <code><a href="#cdktf.Fn.concat">Concat</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/concat concat} takes two or more lists and combines them into a single list.                                                                                                                                                                                                                      |
 | <code><a href="#cdktf.Fn.contains">Contains</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/contains contains} determines whether a given list or set contains a given single value as one of its elements.                                                                                                                                                                                   |
@@ -24661,14 +24661,15 @@ new Fn();
 | <code><a href="#cdktf.Fn.nonsensitive">Nonsensitive</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/nonsensitive nonsensitive} takes a sensitive value and returns a copy of that value with the sensitive marking removed, thereby exposing the sensitive value.                                                                                                                                     |
 | <code><a href="#cdktf.Fn.one">One</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/one one} takes a list, set, or tuple value with either zero or one elements. If the collection is empty, `one` returns `null`. Otherwise, `one` returns the first element. If there are two or more elements then `one` will return an error.                                                     |
 | <code><a href="#cdktf.Fn.parseint">Parseint</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/parseint parseint} parses the given string as a representation of an integer in the specified base and returns the resulting number. The base must be between 2 and 62 inclusive.                                                                                                                 |
-| <code><a href="#cdktf.Fn.pathexpand">Pathexpand</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user&#39;s home directory path.                                                                                                                           |
+| <code><a href="#cdktf.Fn.pathexpand">Pathexpand</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user's home directory path.                                                                                                                               |
+| <code><a href="#cdktf.Fn.plantimestamp">Plantimestamp</a></code>       | {@link https://developer.hashicorp.com/terraform/language/functions/plantimestamp plantimestamp} returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format, fixed to a constant time representing the time of the plan.                                                                                                                |
 | <code><a href="#cdktf.Fn.pow">Pow</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/pow pow} calculates an exponent, by raising its first argument to the power of the second argument.                                                                                                                                                                                               |
 | <code><a href="#cdktf.Fn.regex">Regex</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/regex regex} applies a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) to a string and returns the matching substrings.                                                                                                                                                    |
 | <code><a href="#cdktf.Fn.regexall">Regexall</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/regexall regexall} applies a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) to a string and returns a list of all matches.                                                                                                                                                |
 | <code><a href="#cdktf.Fn.replace">Replace</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/replace replace} searches a given string for another given substring, and replaces each occurrence with a given replacement string.                                                                                                                                                               |
 | <code><a href="#cdktf.Fn.reverse">Reverse</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/reverse reverse} takes a sequence and produces a new sequence of the same length with all of the same elements as the given sequence but in reverse order.                                                                                                                                        |
 | <code><a href="#cdktf.Fn.rsadecrypt">Rsadecrypt</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/rsadecrypt rsadecrypt} decrypts an RSA-encrypted ciphertext, returning the corresponding cleartext.                                                                                                                                                                                               |
-| <code><a href="#cdktf.Fn.sensitive">Sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).                                            |
+| <code><a href="#cdktf.Fn.sensitive">Sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).                                  |
 | <code><a href="#cdktf.Fn.setintersection">Setintersection</a></code>   | The {@link https://developer.hashicorp.com/terraform/language/functions/setintersection setintersection} function takes multiple sets and produces a single set containing only the elements that all of the given sets have in common. In other words, it computes the [intersection](<https://en.wikipedia.org/wiki/Intersection_(set_theory)>) of the sets.        |
 | <code><a href="#cdktf.Fn.setproduct">Setproduct</a></code>             | The {@link https://developer.hashicorp.com/terraform/language/functions/setproduct setproduct} function finds all of the possible combinations of elements from all of the given sets by computing the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product).                                                                                          |
 | <code><a href="#cdktf.Fn.setsubtract">Setsubtract</a></code>           | The {@link https://developer.hashicorp.com/terraform/language/functions/setsubtract setsubtract} function returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the [relative complement](<https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement>) of the second set.  |
@@ -24681,6 +24682,7 @@ new Fn();
 | <code><a href="#cdktf.Fn.sort">Sort</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/sort sort} takes a list of strings and returns a new list with those strings sorted lexicographically.                                                                                                                                                                                            |
 | <code><a href="#cdktf.Fn.split">Split</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/split split} produces a list by dividing a given string at all occurrences of a given separator.                                                                                                                                                                                                  |
 | <code><a href="#cdktf.Fn.startswith">Startswith</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/startswith startswith} takes two values: a string to check and a prefix string. The function returns true if the string begins with that exact prefix.                                                                                                                                            |
+| <code><a href="#cdktf.Fn.strcontains">Strcontains</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/strcontains strcontains} takes two values: a string to check and an expected substring. The function returns true if the string has the substring contained within it.                                                                                                                            |
 | <code><a href="#cdktf.Fn.strrev">Strrev</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/strrev strrev} reverses the characters in a string. Note that the characters are treated as _Unicode characters_ (in technical terms, Unicode [grapheme cluster boundaries](https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries) are respected).                                        |
 | <code><a href="#cdktf.Fn.substr">Substr</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/substr substr} extracts a substring from a given string by offset and (maximum) length.                                                                                                                                                                                                           |
 | <code><a href="#cdktf.Fn.sum">Sum</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/sum sum} takes a list or set of numbers and returns the sum of those numbers.                                                                                                                                                                                                                     |
@@ -24706,7 +24708,7 @@ new Fn();
 | <code><a href="#cdktf.Fn.upper">Upper</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/upper upper} converts all cased letters in the given string to uppercase.                                                                                                                                                                                                                         |
 | <code><a href="#cdktf.Fn.urlencode">Urlencode</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/urlencode urlencode} applies URL encoding to a given string.                                                                                                                                                                                                                                      |
 | <code><a href="#cdktf.Fn.uuid">Uuid</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/uuid uuid} generates a unique identifier string.                                                                                                                                                                                                                                                  |
-| <code><a href="#cdktf.Fn.uuidv5">Uuidv5</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a &#34;version 5&#34; UUID.                                                                                                                  |
+| <code><a href="#cdktf.Fn.uuidv5">Uuidv5</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a "version 5" UUID.                                                                                                                          |
 | <code><a href="#cdktf.Fn.values">Values</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/values values} takes a map and returns a list containing the values of the elements in that map.                                                                                                                                                                                                  |
 | <code><a href="#cdktf.Fn.yamldecode">Yamldecode</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/yamldecode yamldecode} parses a string as a subset of YAML, and produces a representation of its value.                                                                                                                                                                                           |
 | <code><a href="#cdktf.Fn.yamlencode">Yamlencode</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/yamlencode yamlencode} encodes a given value to a string using [YAML 1.2](https://yaml.org/spec/1.2/spec.html) block syntax.                                                                                                                                                                      |
@@ -24714,6 +24716,7 @@ new Fn();
 | <code><a href="#cdktf.Fn.bcrypt">Bcrypt</a></code>                     | {@link /terraform/docs/language/functions/bcrypt.html bcrypt} computes a hash of the given string using the Blowfish cipher, returning a string in [the _Modular Crypt Format_](https://passlib.readthedocs.io/en/stable/modular_crypt_format.html) usually expected in the shadow password file on many Unix systems.                                                |
 | <code><a href="#cdktf.Fn.join">Join</a></code>                         | {@link /terraform/docs/language/functions/join.html join} produces a string by concatenating together all elements of a given list of strings with the given delimiter.                                                                                                                                                                                               |
 | <code><a href="#cdktf.Fn.lookup">Lookup</a></code>                     | {@link /terraform/docs/language/functions/lookup.html lookup} retrieves the value of a single element from a map, given its key. If the given key does not exist, the given default value is returned instead.                                                                                                                                                        |
+| <code><a href="#cdktf.Fn.lookupNested">LookupNested</a></code>         | returns a property access expression that accesses the property at the given path in the given inputMap.                                                                                                                                                                                                                                                              |
 | <code><a href="#cdktf.Fn.range">Range</a></code>                       | {@link /terraform/docs/language/functions/range.html range} generates a list of numbers using a start value, a limit value, and a step value.                                                                                                                                                                                                                         |
 | <code><a href="#cdktf.Fn.rawString">RawString</a></code>               | Use this function to wrap a string and escape it properly for the use in Terraform This is only needed in certain scenarios (e.g., if you have unescaped double quotes in the string).                                                                                                                                                                                |
 
@@ -24759,7 +24762,7 @@ using HashiCorp.Cdktf;
 Fn.Alltrue(object[] List);
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `&#34;true&#34;`. It also returns `true` if the collection is empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `"true"`. It also returns `true` if the collection is empty.
 
 ###### `List`<sup>Required</sup> <a name="List" id="cdktf.Fn.alltrue.parameter.list"></a>
 
@@ -24775,7 +24778,7 @@ using HashiCorp.Cdktf;
 Fn.Anytrue(object[] List);
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `&#34;true&#34;`. It also returns `false` if the collection is empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `"true"`. It also returns `false` if the collection is empty.
 
 ###### `List`<sup>Required</sup> <a name="List" id="cdktf.Fn.anytrue.parameter.list"></a>
 
@@ -24839,7 +24842,7 @@ using HashiCorp.Cdktf;
 Fn.Base64sha256(string Str);
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(&#34;test&#34;))` since `sha256()` returns hexadecimal representation.
+{@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256("test"))` since `sha256()` returns hexadecimal representation.
 
 ###### `Str`<sup>Required</sup> <a name="Str" id="cdktf.Fn.base64sha256.parameter.str"></a>
 
@@ -24855,7 +24858,7 @@ using HashiCorp.Cdktf;
 Fn.Base64sha512(string Str);
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512(&#34;test&#34;))` since `sha512()` returns hexadecimal representation.
+{@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512("test"))` since `sha512()` returns hexadecimal representation.
 
 ###### `Str`<sup>Required</sup> <a name="Str" id="cdktf.Fn.base64sha512.parameter.str"></a>
 
@@ -25045,7 +25048,7 @@ using HashiCorp.Cdktf;
 Fn.Coalesce(object[] Vals);
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn&#39;t null or an empty string.
+{@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn't null or an empty string.
 
 ###### `Vals`<sup>Required</sup> <a name="Vals" id="cdktf.Fn.coalesce.parameter.vals"></a>
 
@@ -25061,7 +25064,7 @@ using HashiCorp.Cdktf;
 Fn.Coalescelist(object[] Vals);
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn&#39;t empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn't empty.
 
 ###### `Vals`<sup>Required</sup> <a name="Vals" id="cdktf.Fn.coalescelist.parameter.vals"></a>
 
@@ -25779,13 +25782,23 @@ using HashiCorp.Cdktf;
 Fn.Pathexpand(string Path);
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user&#39;s home directory path.
+{@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user's home directory path.
 
 ###### `Path`<sup>Required</sup> <a name="Path" id="cdktf.Fn.pathexpand.parameter.path"></a>
 
 - _Type:_ string
 
 ---
+
+##### `Plantimestamp` <a name="Plantimestamp" id="cdktf.Fn.plantimestamp"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+Fn.Plantimestamp();
+```
+
+{@link https://developer.hashicorp.com/terraform/language/functions/plantimestamp plantimestamp} returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format, fixed to a constant time representing the time of the plan.
 
 ##### `Pow` <a name="Pow" id="cdktf.Fn.pow"></a>
 
@@ -25927,7 +25940,7 @@ using HashiCorp.Cdktf;
 Fn.Sensitive(object Value);
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).
+{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).
 
 ###### `Value`<sup>Required</sup> <a name="Value" id="cdktf.Fn.sensitive.parameter.value"></a>
 
@@ -26164,6 +26177,28 @@ Fn.Startswith(string Str, string Prefix);
 ---
 
 ###### `Prefix`<sup>Required</sup> <a name="Prefix" id="cdktf.Fn.startswith.parameter.prefix"></a>
+
+- _Type:_ string
+
+---
+
+##### `Strcontains` <a name="Strcontains" id="cdktf.Fn.strcontains"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+Fn.Strcontains(string Str, string Substr);
+```
+
+{@link https://developer.hashicorp.com/terraform/language/functions/strcontains strcontains} takes two values: a string to check and an expected substring. The function returns true if the string has the substring contained within it.
+
+###### `Str`<sup>Required</sup> <a name="Str" id="cdktf.Fn.strcontains.parameter.str"></a>
+
+- _Type:_ string
+
+---
+
+###### `Substr`<sup>Required</sup> <a name="Substr" id="cdktf.Fn.strcontains.parameter.substr"></a>
 
 - _Type:_ string
 
@@ -26625,7 +26660,7 @@ using HashiCorp.Cdktf;
 Fn.Uuidv5(string Namespace, string Name);
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a &#34;version 5&#34; UUID.
+{@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a "version 5" UUID.
 
 ###### `Namespace`<sup>Required</sup> <a name="Namespace" id="cdktf.Fn.uuidv5.parameter.namespace"></a>
 
@@ -26758,7 +26793,7 @@ Fn.Join(string Separator, string[] List);
 ```csharp
 using HashiCorp.Cdktf;
 
-Fn.Lookup(object InputMap, string Key, object DefaultValue);
+Fn.Lookup(object InputMap, string Key, object DefaultValue = null);
 ```
 
 {@link /terraform/docs/language/functions/lookup.html lookup} retrieves the value of a single element from a map, given its key. If the given key does not exist, the given default value is returned instead.
@@ -26775,9 +26810,33 @@ Fn.Lookup(object InputMap, string Key, object DefaultValue);
 
 ---
 
-###### `DefaultValue`<sup>Required</sup> <a name="DefaultValue" id="cdktf.Fn.lookup.parameter.defaultValue"></a>
+###### `DefaultValue`<sup>Optional</sup> <a name="DefaultValue" id="cdktf.Fn.lookup.parameter.defaultValue"></a>
 
 - _Type:_ object
+
+---
+
+##### `LookupNested` <a name="LookupNested" id="cdktf.Fn.lookupNested"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+Fn.LookupNested(object InputMap, object[] Path);
+```
+
+returns a property access expression that accesses the property at the given path in the given inputMap.
+
+For example lookupNested(x, ["a", "b", "c"]) will return a Terraform expression like x["a"]["b"]["c"]
+
+###### `InputMap`<sup>Required</sup> <a name="InputMap" id="cdktf.Fn.lookupNested.parameter.inputMap"></a>
+
+- _Type:_ object
+
+---
+
+###### `Path`<sup>Required</sup> <a name="Path" id="cdktf.Fn.lookupNested.parameter.path"></a>
+
+- _Type:_ object[]
 
 ---
 
@@ -26846,13 +26905,13 @@ new FnGenerated();
 | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | <code><a href="#cdktf.FnGenerated.abs">Abs</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/abs abs} returns the absolute value of the given number. In other words, if the number is zero or positive then it is returned as-is, but if it is negative then it is multiplied by -1 to make it positive before returning it.                                                                  |
 | <code><a href="#cdktf.FnGenerated.abspath">Abspath</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/abspath abspath} takes a string containing a filesystem path and converts it to an absolute path. That is, if the path is not absolute, it will be joined with the current working directory.                                                                                                     |
-| <code><a href="#cdktf.FnGenerated.alltrue">Alltrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `&#34;true&#34;`. It also returns `true` if the collection is empty.                                                                                                                                          |
-| <code><a href="#cdktf.FnGenerated.anytrue">Anytrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `&#34;true&#34;`. It also returns `false` if the collection is empty.                                                                                                                                           |
+| <code><a href="#cdktf.FnGenerated.alltrue">Alltrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `"true"`. It also returns `true` if the collection is empty.                                                                                                                                                  |
+| <code><a href="#cdktf.FnGenerated.anytrue">Anytrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `"true"`. It also returns `false` if the collection is empty.                                                                                                                                                   |
 | <code><a href="#cdktf.FnGenerated.base64decode">Base64decode</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64decode base64decode} takes a string containing a Base64 character sequence and returns the original string.                                                                                                                                                                                 |
 | <code><a href="#cdktf.FnGenerated.base64encode">Base64encode</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64encode base64encode} applies Base64 encoding to a string.                                                                                                                                                                                                                                   |
 | <code><a href="#cdktf.FnGenerated.base64gzip">Base64gzip</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/base64gzip base64gzip} compresses a string with gzip and then encodes the result in Base64 encoding.                                                                                                                                                                                              |
-| <code><a href="#cdktf.FnGenerated.base64sha256">Base64sha256</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(&#34;test&#34;))` since `sha256()` returns hexadecimal representation.                                                                           |
-| <code><a href="#cdktf.FnGenerated.base64sha512">Base64sha512</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512(&#34;test&#34;))` since `sha512()` returns hexadecimal representation.                                                                           |
+| <code><a href="#cdktf.FnGenerated.base64sha256">Base64sha256</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256("test"))` since `sha256()` returns hexadecimal representation.                                                                                   |
+| <code><a href="#cdktf.FnGenerated.base64sha512">Base64sha512</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512("test"))` since `sha512()` returns hexadecimal representation.                                                                                   |
 | <code><a href="#cdktf.FnGenerated.basename">Basename</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/basename basename} takes a string containing a filesystem path and removes all except the last portion from it.                                                                                                                                                                                   |
 | <code><a href="#cdktf.FnGenerated.can">Can</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/can can} evaluates the given expression and returns a boolean value indicating whether the expression produced a result without any errors.                                                                                                                                                       |
 | <code><a href="#cdktf.FnGenerated.ceil">Ceil</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/ceil ceil} returns the closest whole number that is greater than or equal to the given value, which may be a fraction.                                                                                                                                                                            |
@@ -26862,8 +26921,8 @@ new FnGenerated();
 | <code><a href="#cdktf.FnGenerated.cidrnetmask">Cidrnetmask</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/cidrnetmask cidrnetmask} converts an IPv4 address prefix given in CIDR notation into a subnet mask address.                                                                                                                                                                                       |
 | <code><a href="#cdktf.FnGenerated.cidrsubnet">Cidrsubnet</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/cidrsubnet cidrsubnet} calculates a subnet address within given IP network address prefix.                                                                                                                                                                                                        |
 | <code><a href="#cdktf.FnGenerated.cidrsubnets">Cidrsubnets</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/cidrsubnets cidrsubnets} calculates a sequence of consecutive IP address ranges within a particular CIDR prefix.                                                                                                                                                                                  |
-| <code><a href="#cdktf.FnGenerated.coalesce">Coalesce</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn&#39;t null or an empty string.                                                                                                                                                                                |
-| <code><a href="#cdktf.FnGenerated.coalescelist">Coalescelist</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn&#39;t empty.                                                                                                                                                                                     |
+| <code><a href="#cdktf.FnGenerated.coalesce">Coalesce</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn't null or an empty string.                                                                                                                                                                                    |
+| <code><a href="#cdktf.FnGenerated.coalescelist">Coalescelist</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn't empty.                                                                                                                                                                                         |
 | <code><a href="#cdktf.FnGenerated.compact">Compact</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/compact compact} takes a list of strings and returns a new list with any empty string elements removed.                                                                                                                                                                                           |
 | <code><a href="#cdktf.FnGenerated.concat">Concat</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/concat concat} takes two or more lists and combines them into a single list.                                                                                                                                                                                                                      |
 | <code><a href="#cdktf.FnGenerated.contains">Contains</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/contains contains} determines whether a given list or set contains a given single value as one of its elements.                                                                                                                                                                                   |
@@ -26903,14 +26962,15 @@ new FnGenerated();
 | <code><a href="#cdktf.FnGenerated.nonsensitive">Nonsensitive</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/nonsensitive nonsensitive} takes a sensitive value and returns a copy of that value with the sensitive marking removed, thereby exposing the sensitive value.                                                                                                                                     |
 | <code><a href="#cdktf.FnGenerated.one">One</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/one one} takes a list, set, or tuple value with either zero or one elements. If the collection is empty, `one` returns `null`. Otherwise, `one` returns the first element. If there are two or more elements then `one` will return an error.                                                     |
 | <code><a href="#cdktf.FnGenerated.parseint">Parseint</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/parseint parseint} parses the given string as a representation of an integer in the specified base and returns the resulting number. The base must be between 2 and 62 inclusive.                                                                                                                 |
-| <code><a href="#cdktf.FnGenerated.pathexpand">Pathexpand</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user&#39;s home directory path.                                                                                                                           |
+| <code><a href="#cdktf.FnGenerated.pathexpand">Pathexpand</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user's home directory path.                                                                                                                               |
+| <code><a href="#cdktf.FnGenerated.plantimestamp">Plantimestamp</a></code>       | {@link https://developer.hashicorp.com/terraform/language/functions/plantimestamp plantimestamp} returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format, fixed to a constant time representing the time of the plan.                                                                                                                |
 | <code><a href="#cdktf.FnGenerated.pow">Pow</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/pow pow} calculates an exponent, by raising its first argument to the power of the second argument.                                                                                                                                                                                               |
 | <code><a href="#cdktf.FnGenerated.regex">Regex</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/regex regex} applies a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) to a string and returns the matching substrings.                                                                                                                                                    |
 | <code><a href="#cdktf.FnGenerated.regexall">Regexall</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/regexall regexall} applies a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) to a string and returns a list of all matches.                                                                                                                                                |
 | <code><a href="#cdktf.FnGenerated.replace">Replace</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/replace replace} searches a given string for another given substring, and replaces each occurrence with a given replacement string.                                                                                                                                                               |
 | <code><a href="#cdktf.FnGenerated.reverse">Reverse</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/reverse reverse} takes a sequence and produces a new sequence of the same length with all of the same elements as the given sequence but in reverse order.                                                                                                                                        |
 | <code><a href="#cdktf.FnGenerated.rsadecrypt">Rsadecrypt</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/rsadecrypt rsadecrypt} decrypts an RSA-encrypted ciphertext, returning the corresponding cleartext.                                                                                                                                                                                               |
-| <code><a href="#cdktf.FnGenerated.sensitive">Sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).                                            |
+| <code><a href="#cdktf.FnGenerated.sensitive">Sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).                                  |
 | <code><a href="#cdktf.FnGenerated.setintersection">Setintersection</a></code>   | The {@link https://developer.hashicorp.com/terraform/language/functions/setintersection setintersection} function takes multiple sets and produces a single set containing only the elements that all of the given sets have in common. In other words, it computes the [intersection](<https://en.wikipedia.org/wiki/Intersection_(set_theory)>) of the sets.        |
 | <code><a href="#cdktf.FnGenerated.setproduct">Setproduct</a></code>             | The {@link https://developer.hashicorp.com/terraform/language/functions/setproduct setproduct} function finds all of the possible combinations of elements from all of the given sets by computing the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product).                                                                                          |
 | <code><a href="#cdktf.FnGenerated.setsubtract">Setsubtract</a></code>           | The {@link https://developer.hashicorp.com/terraform/language/functions/setsubtract setsubtract} function returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the [relative complement](<https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement>) of the second set.  |
@@ -26923,6 +26983,7 @@ new FnGenerated();
 | <code><a href="#cdktf.FnGenerated.sort">Sort</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/sort sort} takes a list of strings and returns a new list with those strings sorted lexicographically.                                                                                                                                                                                            |
 | <code><a href="#cdktf.FnGenerated.split">Split</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/split split} produces a list by dividing a given string at all occurrences of a given separator.                                                                                                                                                                                                  |
 | <code><a href="#cdktf.FnGenerated.startswith">Startswith</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/startswith startswith} takes two values: a string to check and a prefix string. The function returns true if the string begins with that exact prefix.                                                                                                                                            |
+| <code><a href="#cdktf.FnGenerated.strcontains">Strcontains</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/strcontains strcontains} takes two values: a string to check and an expected substring. The function returns true if the string has the substring contained within it.                                                                                                                            |
 | <code><a href="#cdktf.FnGenerated.strrev">Strrev</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/strrev strrev} reverses the characters in a string. Note that the characters are treated as _Unicode characters_ (in technical terms, Unicode [grapheme cluster boundaries](https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries) are respected).                                        |
 | <code><a href="#cdktf.FnGenerated.substr">Substr</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/substr substr} extracts a substring from a given string by offset and (maximum) length.                                                                                                                                                                                                           |
 | <code><a href="#cdktf.FnGenerated.sum">Sum</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/sum sum} takes a list or set of numbers and returns the sum of those numbers.                                                                                                                                                                                                                     |
@@ -26948,7 +27009,7 @@ new FnGenerated();
 | <code><a href="#cdktf.FnGenerated.upper">Upper</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/upper upper} converts all cased letters in the given string to uppercase.                                                                                                                                                                                                                         |
 | <code><a href="#cdktf.FnGenerated.urlencode">Urlencode</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/urlencode urlencode} applies URL encoding to a given string.                                                                                                                                                                                                                                      |
 | <code><a href="#cdktf.FnGenerated.uuid">Uuid</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/uuid uuid} generates a unique identifier string.                                                                                                                                                                                                                                                  |
-| <code><a href="#cdktf.FnGenerated.uuidv5">Uuidv5</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a &#34;version 5&#34; UUID.                                                                                                                  |
+| <code><a href="#cdktf.FnGenerated.uuidv5">Uuidv5</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a "version 5" UUID.                                                                                                                          |
 | <code><a href="#cdktf.FnGenerated.values">Values</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/values values} takes a map and returns a list containing the values of the elements in that map.                                                                                                                                                                                                  |
 | <code><a href="#cdktf.FnGenerated.yamldecode">Yamldecode</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/yamldecode yamldecode} parses a string as a subset of YAML, and produces a representation of its value.                                                                                                                                                                                           |
 | <code><a href="#cdktf.FnGenerated.yamlencode">Yamlencode</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/yamlencode yamlencode} encodes a given value to a string using [YAML 1.2](https://yaml.org/spec/1.2/spec.html) block syntax.                                                                                                                                                                      |
@@ -26996,7 +27057,7 @@ using HashiCorp.Cdktf;
 FnGenerated.Alltrue(object[] List);
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `&#34;true&#34;`. It also returns `true` if the collection is empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `"true"`. It also returns `true` if the collection is empty.
 
 ###### `List`<sup>Required</sup> <a name="List" id="cdktf.FnGenerated.alltrue.parameter.list"></a>
 
@@ -27012,7 +27073,7 @@ using HashiCorp.Cdktf;
 FnGenerated.Anytrue(object[] List);
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `&#34;true&#34;`. It also returns `false` if the collection is empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `"true"`. It also returns `false` if the collection is empty.
 
 ###### `List`<sup>Required</sup> <a name="List" id="cdktf.FnGenerated.anytrue.parameter.list"></a>
 
@@ -27076,7 +27137,7 @@ using HashiCorp.Cdktf;
 FnGenerated.Base64sha256(string Str);
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(&#34;test&#34;))` since `sha256()` returns hexadecimal representation.
+{@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256("test"))` since `sha256()` returns hexadecimal representation.
 
 ###### `Str`<sup>Required</sup> <a name="Str" id="cdktf.FnGenerated.base64sha256.parameter.str"></a>
 
@@ -27092,7 +27153,7 @@ using HashiCorp.Cdktf;
 FnGenerated.Base64sha512(string Str);
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512(&#34;test&#34;))` since `sha512()` returns hexadecimal representation.
+{@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512("test"))` since `sha512()` returns hexadecimal representation.
 
 ###### `Str`<sup>Required</sup> <a name="Str" id="cdktf.FnGenerated.base64sha512.parameter.str"></a>
 
@@ -27282,7 +27343,7 @@ using HashiCorp.Cdktf;
 FnGenerated.Coalesce(object[] Vals);
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn&#39;t null or an empty string.
+{@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn't null or an empty string.
 
 ###### `Vals`<sup>Required</sup> <a name="Vals" id="cdktf.FnGenerated.coalesce.parameter.vals"></a>
 
@@ -27298,7 +27359,7 @@ using HashiCorp.Cdktf;
 FnGenerated.Coalescelist(object[] Vals);
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn&#39;t empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn't empty.
 
 ###### `Vals`<sup>Required</sup> <a name="Vals" id="cdktf.FnGenerated.coalescelist.parameter.vals"></a>
 
@@ -28016,13 +28077,23 @@ using HashiCorp.Cdktf;
 FnGenerated.Pathexpand(string Path);
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user&#39;s home directory path.
+{@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user's home directory path.
 
 ###### `Path`<sup>Required</sup> <a name="Path" id="cdktf.FnGenerated.pathexpand.parameter.path"></a>
 
 - _Type:_ string
 
 ---
+
+##### `Plantimestamp` <a name="Plantimestamp" id="cdktf.FnGenerated.plantimestamp"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+FnGenerated.Plantimestamp();
+```
+
+{@link https://developer.hashicorp.com/terraform/language/functions/plantimestamp plantimestamp} returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format, fixed to a constant time representing the time of the plan.
 
 ##### `Pow` <a name="Pow" id="cdktf.FnGenerated.pow"></a>
 
@@ -28164,7 +28235,7 @@ using HashiCorp.Cdktf;
 FnGenerated.Sensitive(object Value);
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).
+{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).
 
 ###### `Value`<sup>Required</sup> <a name="Value" id="cdktf.FnGenerated.sensitive.parameter.value"></a>
 
@@ -28401,6 +28472,28 @@ FnGenerated.Startswith(string Str, string Prefix);
 ---
 
 ###### `Prefix`<sup>Required</sup> <a name="Prefix" id="cdktf.FnGenerated.startswith.parameter.prefix"></a>
+
+- _Type:_ string
+
+---
+
+##### `Strcontains` <a name="Strcontains" id="cdktf.FnGenerated.strcontains"></a>
+
+```csharp
+using HashiCorp.Cdktf;
+
+FnGenerated.Strcontains(string Str, string Substr);
+```
+
+{@link https://developer.hashicorp.com/terraform/language/functions/strcontains strcontains} takes two values: a string to check and an expected substring. The function returns true if the string has the substring contained within it.
+
+###### `Str`<sup>Required</sup> <a name="Str" id="cdktf.FnGenerated.strcontains.parameter.str"></a>
+
+- _Type:_ string
+
+---
+
+###### `Substr`<sup>Required</sup> <a name="Substr" id="cdktf.FnGenerated.strcontains.parameter.substr"></a>
 
 - _Type:_ string
 
@@ -28862,7 +28955,7 @@ using HashiCorp.Cdktf;
 FnGenerated.Uuidv5(string Namespace, string Name);
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a &#34;version 5&#34; UUID.
+{@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a "version 5" UUID.
 
 ###### `Namespace`<sup>Required</sup> <a name="Namespace" id="cdktf.FnGenerated.uuidv5.parameter.namespace"></a>
 

--- a/website/docs/cdktf/api-reference/go.mdx
+++ b/website/docs/cdktf/api-reference/go.mdx
@@ -24604,13 +24604,13 @@ cdktf.NewFn() Fn
 | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | <code><a href="#cdktf.Fn.abs">Abs</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/abs abs} returns the absolute value of the given number. In other words, if the number is zero or positive then it is returned as-is, but if it is negative then it is multiplied by -1 to make it positive before returning it.                                                                  |
 | <code><a href="#cdktf.Fn.abspath">Abspath</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/abspath abspath} takes a string containing a filesystem path and converts it to an absolute path. That is, if the path is not absolute, it will be joined with the current working directory.                                                                                                     |
-| <code><a href="#cdktf.Fn.alltrue">Alltrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `&#34;true&#34;`. It also returns `true` if the collection is empty.                                                                                                                                          |
-| <code><a href="#cdktf.Fn.anytrue">Anytrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `&#34;true&#34;`. It also returns `false` if the collection is empty.                                                                                                                                           |
+| <code><a href="#cdktf.Fn.alltrue">Alltrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `"true"`. It also returns `true` if the collection is empty.                                                                                                                                                  |
+| <code><a href="#cdktf.Fn.anytrue">Anytrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `"true"`. It also returns `false` if the collection is empty.                                                                                                                                                   |
 | <code><a href="#cdktf.Fn.base64decode">Base64decode</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64decode base64decode} takes a string containing a Base64 character sequence and returns the original string.                                                                                                                                                                                 |
 | <code><a href="#cdktf.Fn.base64encode">Base64encode</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64encode base64encode} applies Base64 encoding to a string.                                                                                                                                                                                                                                   |
 | <code><a href="#cdktf.Fn.base64gzip">Base64gzip</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/base64gzip base64gzip} compresses a string with gzip and then encodes the result in Base64 encoding.                                                                                                                                                                                              |
-| <code><a href="#cdktf.Fn.base64sha256">Base64sha256</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(&#34;test&#34;))` since `sha256()` returns hexadecimal representation.                                                                           |
-| <code><a href="#cdktf.Fn.base64sha512">Base64sha512</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512(&#34;test&#34;))` since `sha512()` returns hexadecimal representation.                                                                           |
+| <code><a href="#cdktf.Fn.base64sha256">Base64sha256</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256("test"))` since `sha256()` returns hexadecimal representation.                                                                                   |
+| <code><a href="#cdktf.Fn.base64sha512">Base64sha512</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512("test"))` since `sha512()` returns hexadecimal representation.                                                                                   |
 | <code><a href="#cdktf.Fn.basename">Basename</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/basename basename} takes a string containing a filesystem path and removes all except the last portion from it.                                                                                                                                                                                   |
 | <code><a href="#cdktf.Fn.can">Can</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/can can} evaluates the given expression and returns a boolean value indicating whether the expression produced a result without any errors.                                                                                                                                                       |
 | <code><a href="#cdktf.Fn.ceil">Ceil</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/ceil ceil} returns the closest whole number that is greater than or equal to the given value, which may be a fraction.                                                                                                                                                                            |
@@ -24620,8 +24620,8 @@ cdktf.NewFn() Fn
 | <code><a href="#cdktf.Fn.cidrnetmask">Cidrnetmask</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/cidrnetmask cidrnetmask} converts an IPv4 address prefix given in CIDR notation into a subnet mask address.                                                                                                                                                                                       |
 | <code><a href="#cdktf.Fn.cidrsubnet">Cidrsubnet</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/cidrsubnet cidrsubnet} calculates a subnet address within given IP network address prefix.                                                                                                                                                                                                        |
 | <code><a href="#cdktf.Fn.cidrsubnets">Cidrsubnets</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/cidrsubnets cidrsubnets} calculates a sequence of consecutive IP address ranges within a particular CIDR prefix.                                                                                                                                                                                  |
-| <code><a href="#cdktf.Fn.coalesce">Coalesce</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn&#39;t null or an empty string.                                                                                                                                                                                |
-| <code><a href="#cdktf.Fn.coalescelist">Coalescelist</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn&#39;t empty.                                                                                                                                                                                     |
+| <code><a href="#cdktf.Fn.coalesce">Coalesce</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn't null or an empty string.                                                                                                                                                                                    |
+| <code><a href="#cdktf.Fn.coalescelist">Coalescelist</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn't empty.                                                                                                                                                                                         |
 | <code><a href="#cdktf.Fn.compact">Compact</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/compact compact} takes a list of strings and returns a new list with any empty string elements removed.                                                                                                                                                                                           |
 | <code><a href="#cdktf.Fn.concat">Concat</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/concat concat} takes two or more lists and combines them into a single list.                                                                                                                                                                                                                      |
 | <code><a href="#cdktf.Fn.contains">Contains</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/contains contains} determines whether a given list or set contains a given single value as one of its elements.                                                                                                                                                                                   |
@@ -24661,14 +24661,15 @@ cdktf.NewFn() Fn
 | <code><a href="#cdktf.Fn.nonsensitive">Nonsensitive</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/nonsensitive nonsensitive} takes a sensitive value and returns a copy of that value with the sensitive marking removed, thereby exposing the sensitive value.                                                                                                                                     |
 | <code><a href="#cdktf.Fn.one">One</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/one one} takes a list, set, or tuple value with either zero or one elements. If the collection is empty, `one` returns `null`. Otherwise, `one` returns the first element. If there are two or more elements then `one` will return an error.                                                     |
 | <code><a href="#cdktf.Fn.parseint">Parseint</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/parseint parseint} parses the given string as a representation of an integer in the specified base and returns the resulting number. The base must be between 2 and 62 inclusive.                                                                                                                 |
-| <code><a href="#cdktf.Fn.pathexpand">Pathexpand</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user&#39;s home directory path.                                                                                                                           |
+| <code><a href="#cdktf.Fn.pathexpand">Pathexpand</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user's home directory path.                                                                                                                               |
+| <code><a href="#cdktf.Fn.plantimestamp">Plantimestamp</a></code>       | {@link https://developer.hashicorp.com/terraform/language/functions/plantimestamp plantimestamp} returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format, fixed to a constant time representing the time of the plan.                                                                                                                |
 | <code><a href="#cdktf.Fn.pow">Pow</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/pow pow} calculates an exponent, by raising its first argument to the power of the second argument.                                                                                                                                                                                               |
 | <code><a href="#cdktf.Fn.regex">Regex</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/regex regex} applies a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) to a string and returns the matching substrings.                                                                                                                                                    |
 | <code><a href="#cdktf.Fn.regexall">Regexall</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/regexall regexall} applies a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) to a string and returns a list of all matches.                                                                                                                                                |
 | <code><a href="#cdktf.Fn.replace">Replace</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/replace replace} searches a given string for another given substring, and replaces each occurrence with a given replacement string.                                                                                                                                                               |
 | <code><a href="#cdktf.Fn.reverse">Reverse</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/reverse reverse} takes a sequence and produces a new sequence of the same length with all of the same elements as the given sequence but in reverse order.                                                                                                                                        |
 | <code><a href="#cdktf.Fn.rsadecrypt">Rsadecrypt</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/rsadecrypt rsadecrypt} decrypts an RSA-encrypted ciphertext, returning the corresponding cleartext.                                                                                                                                                                                               |
-| <code><a href="#cdktf.Fn.sensitive">Sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).                                            |
+| <code><a href="#cdktf.Fn.sensitive">Sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).                                  |
 | <code><a href="#cdktf.Fn.setintersection">Setintersection</a></code>   | The {@link https://developer.hashicorp.com/terraform/language/functions/setintersection setintersection} function takes multiple sets and produces a single set containing only the elements that all of the given sets have in common. In other words, it computes the [intersection](<https://en.wikipedia.org/wiki/Intersection_(set_theory)>) of the sets.        |
 | <code><a href="#cdktf.Fn.setproduct">Setproduct</a></code>             | The {@link https://developer.hashicorp.com/terraform/language/functions/setproduct setproduct} function finds all of the possible combinations of elements from all of the given sets by computing the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product).                                                                                          |
 | <code><a href="#cdktf.Fn.setsubtract">Setsubtract</a></code>           | The {@link https://developer.hashicorp.com/terraform/language/functions/setsubtract setsubtract} function returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the [relative complement](<https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement>) of the second set.  |
@@ -24681,6 +24682,7 @@ cdktf.NewFn() Fn
 | <code><a href="#cdktf.Fn.sort">Sort</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/sort sort} takes a list of strings and returns a new list with those strings sorted lexicographically.                                                                                                                                                                                            |
 | <code><a href="#cdktf.Fn.split">Split</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/split split} produces a list by dividing a given string at all occurrences of a given separator.                                                                                                                                                                                                  |
 | <code><a href="#cdktf.Fn.startswith">Startswith</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/startswith startswith} takes two values: a string to check and a prefix string. The function returns true if the string begins with that exact prefix.                                                                                                                                            |
+| <code><a href="#cdktf.Fn.strcontains">Strcontains</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/strcontains strcontains} takes two values: a string to check and an expected substring. The function returns true if the string has the substring contained within it.                                                                                                                            |
 | <code><a href="#cdktf.Fn.strrev">Strrev</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/strrev strrev} reverses the characters in a string. Note that the characters are treated as _Unicode characters_ (in technical terms, Unicode [grapheme cluster boundaries](https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries) are respected).                                        |
 | <code><a href="#cdktf.Fn.substr">Substr</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/substr substr} extracts a substring from a given string by offset and (maximum) length.                                                                                                                                                                                                           |
 | <code><a href="#cdktf.Fn.sum">Sum</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/sum sum} takes a list or set of numbers and returns the sum of those numbers.                                                                                                                                                                                                                     |
@@ -24706,7 +24708,7 @@ cdktf.NewFn() Fn
 | <code><a href="#cdktf.Fn.upper">Upper</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/upper upper} converts all cased letters in the given string to uppercase.                                                                                                                                                                                                                         |
 | <code><a href="#cdktf.Fn.urlencode">Urlencode</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/urlencode urlencode} applies URL encoding to a given string.                                                                                                                                                                                                                                      |
 | <code><a href="#cdktf.Fn.uuid">Uuid</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/uuid uuid} generates a unique identifier string.                                                                                                                                                                                                                                                  |
-| <code><a href="#cdktf.Fn.uuidv5">Uuidv5</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a &#34;version 5&#34; UUID.                                                                                                                  |
+| <code><a href="#cdktf.Fn.uuidv5">Uuidv5</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a "version 5" UUID.                                                                                                                          |
 | <code><a href="#cdktf.Fn.values">Values</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/values values} takes a map and returns a list containing the values of the elements in that map.                                                                                                                                                                                                  |
 | <code><a href="#cdktf.Fn.yamldecode">Yamldecode</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/yamldecode yamldecode} parses a string as a subset of YAML, and produces a representation of its value.                                                                                                                                                                                           |
 | <code><a href="#cdktf.Fn.yamlencode">Yamlencode</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/yamlencode yamlencode} encodes a given value to a string using [YAML 1.2](https://yaml.org/spec/1.2/spec.html) block syntax.                                                                                                                                                                      |
@@ -24714,6 +24716,7 @@ cdktf.NewFn() Fn
 | <code><a href="#cdktf.Fn.bcrypt">Bcrypt</a></code>                     | {@link /terraform/docs/language/functions/bcrypt.html bcrypt} computes a hash of the given string using the Blowfish cipher, returning a string in [the _Modular Crypt Format_](https://passlib.readthedocs.io/en/stable/modular_crypt_format.html) usually expected in the shadow password file on many Unix systems.                                                |
 | <code><a href="#cdktf.Fn.join">Join</a></code>                         | {@link /terraform/docs/language/functions/join.html join} produces a string by concatenating together all elements of a given list of strings with the given delimiter.                                                                                                                                                                                               |
 | <code><a href="#cdktf.Fn.lookup">Lookup</a></code>                     | {@link /terraform/docs/language/functions/lookup.html lookup} retrieves the value of a single element from a map, given its key. If the given key does not exist, the given default value is returned instead.                                                                                                                                                        |
+| <code><a href="#cdktf.Fn.lookupNested">LookupNested</a></code>         | returns a property access expression that accesses the property at the given path in the given inputMap.                                                                                                                                                                                                                                                              |
 | <code><a href="#cdktf.Fn.range">Range</a></code>                       | {@link /terraform/docs/language/functions/range.html range} generates a list of numbers using a start value, a limit value, and a step value.                                                                                                                                                                                                                         |
 | <code><a href="#cdktf.Fn.rawString">RawString</a></code>               | Use this function to wrap a string and escape it properly for the use in Terraform This is only needed in certain scenarios (e.g., if you have unescaped double quotes in the string).                                                                                                                                                                                |
 
@@ -24759,7 +24762,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 cdktf.Fn_Alltrue(list *[]interface{}) IResolvable
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `&#34;true&#34;`. It also returns `true` if the collection is empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `"true"`. It also returns `true` if the collection is empty.
 
 ###### `list`<sup>Required</sup> <a name="list" id="cdktf.Fn.alltrue.parameter.list"></a>
 
@@ -24775,7 +24778,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 cdktf.Fn_Anytrue(list *[]interface{}) IResolvable
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `&#34;true&#34;`. It also returns `false` if the collection is empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `"true"`. It also returns `false` if the collection is empty.
 
 ###### `list`<sup>Required</sup> <a name="list" id="cdktf.Fn.anytrue.parameter.list"></a>
 
@@ -24839,7 +24842,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 cdktf.Fn_Base64sha256(str *string) *string
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(&#34;test&#34;))` since `sha256()` returns hexadecimal representation.
+{@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256("test"))` since `sha256()` returns hexadecimal representation.
 
 ###### `str`<sup>Required</sup> <a name="str" id="cdktf.Fn.base64sha256.parameter.str"></a>
 
@@ -24855,7 +24858,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 cdktf.Fn_Base64sha512(str *string) *string
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512(&#34;test&#34;))` since `sha512()` returns hexadecimal representation.
+{@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512("test"))` since `sha512()` returns hexadecimal representation.
 
 ###### `str`<sup>Required</sup> <a name="str" id="cdktf.Fn.base64sha512.parameter.str"></a>
 
@@ -25045,7 +25048,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 cdktf.Fn_Coalesce(vals *[]interface{}) interface{}
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn&#39;t null or an empty string.
+{@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn't null or an empty string.
 
 ###### `vals`<sup>Required</sup> <a name="vals" id="cdktf.Fn.coalesce.parameter.vals"></a>
 
@@ -25061,7 +25064,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 cdktf.Fn_Coalescelist(vals *[]interface{}) interface{}
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn&#39;t empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn't empty.
 
 ###### `vals`<sup>Required</sup> <a name="vals" id="cdktf.Fn.coalescelist.parameter.vals"></a>
 
@@ -25779,13 +25782,23 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 cdktf.Fn_Pathexpand(path *string) *string
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user&#39;s home directory path.
+{@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user's home directory path.
 
 ###### `path`<sup>Required</sup> <a name="path" id="cdktf.Fn.pathexpand.parameter.path"></a>
 
 - _Type:_ \*string
 
 ---
+
+##### `Plantimestamp` <a name="Plantimestamp" id="cdktf.Fn.plantimestamp"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.Fn_Plantimestamp() *string
+```
+
+{@link https://developer.hashicorp.com/terraform/language/functions/plantimestamp plantimestamp} returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format, fixed to a constant time representing the time of the plan.
 
 ##### `Pow` <a name="Pow" id="cdktf.Fn.pow"></a>
 
@@ -25927,7 +25940,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 cdktf.Fn_Sensitive(value interface{}) interface{}
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).
+{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).
 
 ###### `value`<sup>Required</sup> <a name="value" id="cdktf.Fn.sensitive.parameter.value"></a>
 
@@ -26164,6 +26177,28 @@ cdktf.Fn_Startswith(str *string, prefix *string) IResolvable
 ---
 
 ###### `prefix`<sup>Required</sup> <a name="prefix" id="cdktf.Fn.startswith.parameter.prefix"></a>
+
+- _Type:_ \*string
+
+---
+
+##### `Strcontains` <a name="Strcontains" id="cdktf.Fn.strcontains"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.Fn_Strcontains(str *string, substr *string) IResolvable
+```
+
+{@link https://developer.hashicorp.com/terraform/language/functions/strcontains strcontains} takes two values: a string to check and an expected substring. The function returns true if the string has the substring contained within it.
+
+###### `str`<sup>Required</sup> <a name="str" id="cdktf.Fn.strcontains.parameter.str"></a>
+
+- _Type:_ \*string
+
+---
+
+###### `substr`<sup>Required</sup> <a name="substr" id="cdktf.Fn.strcontains.parameter.substr"></a>
 
 - _Type:_ \*string
 
@@ -26625,7 +26660,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 cdktf.Fn_Uuidv5(namespace *string, name *string) *string
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a &#34;version 5&#34; UUID.
+{@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a "version 5" UUID.
 
 ###### `namespace`<sup>Required</sup> <a name="namespace" id="cdktf.Fn.uuidv5.parameter.namespace"></a>
 
@@ -26775,9 +26810,33 @@ cdktf.Fn_Lookup(inputMap interface{}, key *string, defaultValue interface{}) int
 
 ---
 
-###### `defaultValue`<sup>Required</sup> <a name="defaultValue" id="cdktf.Fn.lookup.parameter.defaultValue"></a>
+###### `defaultValue`<sup>Optional</sup> <a name="defaultValue" id="cdktf.Fn.lookup.parameter.defaultValue"></a>
 
 - _Type:_ interface{}
+
+---
+
+##### `LookupNested` <a name="LookupNested" id="cdktf.Fn.lookupNested"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.Fn_LookupNested(inputMap interface{}, path *[]interface{}) interface{}
+```
+
+returns a property access expression that accesses the property at the given path in the given inputMap.
+
+For example lookupNested(x, ["a", "b", "c"]) will return a Terraform expression like x["a"]["b"]["c"]
+
+###### `inputMap`<sup>Required</sup> <a name="inputMap" id="cdktf.Fn.lookupNested.parameter.inputMap"></a>
+
+- _Type:_ interface{}
+
+---
+
+###### `path`<sup>Required</sup> <a name="path" id="cdktf.Fn.lookupNested.parameter.path"></a>
+
+- _Type:_ \*[]interface{}
 
 ---
 
@@ -26846,13 +26905,13 @@ cdktf.NewFnGenerated() FnGenerated
 | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | <code><a href="#cdktf.FnGenerated.abs">Abs</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/abs abs} returns the absolute value of the given number. In other words, if the number is zero or positive then it is returned as-is, but if it is negative then it is multiplied by -1 to make it positive before returning it.                                                                  |
 | <code><a href="#cdktf.FnGenerated.abspath">Abspath</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/abspath abspath} takes a string containing a filesystem path and converts it to an absolute path. That is, if the path is not absolute, it will be joined with the current working directory.                                                                                                     |
-| <code><a href="#cdktf.FnGenerated.alltrue">Alltrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `&#34;true&#34;`. It also returns `true` if the collection is empty.                                                                                                                                          |
-| <code><a href="#cdktf.FnGenerated.anytrue">Anytrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `&#34;true&#34;`. It also returns `false` if the collection is empty.                                                                                                                                           |
+| <code><a href="#cdktf.FnGenerated.alltrue">Alltrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `"true"`. It also returns `true` if the collection is empty.                                                                                                                                                  |
+| <code><a href="#cdktf.FnGenerated.anytrue">Anytrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `"true"`. It also returns `false` if the collection is empty.                                                                                                                                                   |
 | <code><a href="#cdktf.FnGenerated.base64decode">Base64decode</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64decode base64decode} takes a string containing a Base64 character sequence and returns the original string.                                                                                                                                                                                 |
 | <code><a href="#cdktf.FnGenerated.base64encode">Base64encode</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64encode base64encode} applies Base64 encoding to a string.                                                                                                                                                                                                                                   |
 | <code><a href="#cdktf.FnGenerated.base64gzip">Base64gzip</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/base64gzip base64gzip} compresses a string with gzip and then encodes the result in Base64 encoding.                                                                                                                                                                                              |
-| <code><a href="#cdktf.FnGenerated.base64sha256">Base64sha256</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(&#34;test&#34;))` since `sha256()` returns hexadecimal representation.                                                                           |
-| <code><a href="#cdktf.FnGenerated.base64sha512">Base64sha512</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512(&#34;test&#34;))` since `sha512()` returns hexadecimal representation.                                                                           |
+| <code><a href="#cdktf.FnGenerated.base64sha256">Base64sha256</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256("test"))` since `sha256()` returns hexadecimal representation.                                                                                   |
+| <code><a href="#cdktf.FnGenerated.base64sha512">Base64sha512</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512("test"))` since `sha512()` returns hexadecimal representation.                                                                                   |
 | <code><a href="#cdktf.FnGenerated.basename">Basename</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/basename basename} takes a string containing a filesystem path and removes all except the last portion from it.                                                                                                                                                                                   |
 | <code><a href="#cdktf.FnGenerated.can">Can</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/can can} evaluates the given expression and returns a boolean value indicating whether the expression produced a result without any errors.                                                                                                                                                       |
 | <code><a href="#cdktf.FnGenerated.ceil">Ceil</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/ceil ceil} returns the closest whole number that is greater than or equal to the given value, which may be a fraction.                                                                                                                                                                            |
@@ -26862,8 +26921,8 @@ cdktf.NewFnGenerated() FnGenerated
 | <code><a href="#cdktf.FnGenerated.cidrnetmask">Cidrnetmask</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/cidrnetmask cidrnetmask} converts an IPv4 address prefix given in CIDR notation into a subnet mask address.                                                                                                                                                                                       |
 | <code><a href="#cdktf.FnGenerated.cidrsubnet">Cidrsubnet</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/cidrsubnet cidrsubnet} calculates a subnet address within given IP network address prefix.                                                                                                                                                                                                        |
 | <code><a href="#cdktf.FnGenerated.cidrsubnets">Cidrsubnets</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/cidrsubnets cidrsubnets} calculates a sequence of consecutive IP address ranges within a particular CIDR prefix.                                                                                                                                                                                  |
-| <code><a href="#cdktf.FnGenerated.coalesce">Coalesce</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn&#39;t null or an empty string.                                                                                                                                                                                |
-| <code><a href="#cdktf.FnGenerated.coalescelist">Coalescelist</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn&#39;t empty.                                                                                                                                                                                     |
+| <code><a href="#cdktf.FnGenerated.coalesce">Coalesce</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn't null or an empty string.                                                                                                                                                                                    |
+| <code><a href="#cdktf.FnGenerated.coalescelist">Coalescelist</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn't empty.                                                                                                                                                                                         |
 | <code><a href="#cdktf.FnGenerated.compact">Compact</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/compact compact} takes a list of strings and returns a new list with any empty string elements removed.                                                                                                                                                                                           |
 | <code><a href="#cdktf.FnGenerated.concat">Concat</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/concat concat} takes two or more lists and combines them into a single list.                                                                                                                                                                                                                      |
 | <code><a href="#cdktf.FnGenerated.contains">Contains</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/contains contains} determines whether a given list or set contains a given single value as one of its elements.                                                                                                                                                                                   |
@@ -26903,14 +26962,15 @@ cdktf.NewFnGenerated() FnGenerated
 | <code><a href="#cdktf.FnGenerated.nonsensitive">Nonsensitive</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/nonsensitive nonsensitive} takes a sensitive value and returns a copy of that value with the sensitive marking removed, thereby exposing the sensitive value.                                                                                                                                     |
 | <code><a href="#cdktf.FnGenerated.one">One</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/one one} takes a list, set, or tuple value with either zero or one elements. If the collection is empty, `one` returns `null`. Otherwise, `one` returns the first element. If there are two or more elements then `one` will return an error.                                                     |
 | <code><a href="#cdktf.FnGenerated.parseint">Parseint</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/parseint parseint} parses the given string as a representation of an integer in the specified base and returns the resulting number. The base must be between 2 and 62 inclusive.                                                                                                                 |
-| <code><a href="#cdktf.FnGenerated.pathexpand">Pathexpand</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user&#39;s home directory path.                                                                                                                           |
+| <code><a href="#cdktf.FnGenerated.pathexpand">Pathexpand</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user's home directory path.                                                                                                                               |
+| <code><a href="#cdktf.FnGenerated.plantimestamp">Plantimestamp</a></code>       | {@link https://developer.hashicorp.com/terraform/language/functions/plantimestamp plantimestamp} returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format, fixed to a constant time representing the time of the plan.                                                                                                                |
 | <code><a href="#cdktf.FnGenerated.pow">Pow</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/pow pow} calculates an exponent, by raising its first argument to the power of the second argument.                                                                                                                                                                                               |
 | <code><a href="#cdktf.FnGenerated.regex">Regex</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/regex regex} applies a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) to a string and returns the matching substrings.                                                                                                                                                    |
 | <code><a href="#cdktf.FnGenerated.regexall">Regexall</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/regexall regexall} applies a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) to a string and returns a list of all matches.                                                                                                                                                |
 | <code><a href="#cdktf.FnGenerated.replace">Replace</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/replace replace} searches a given string for another given substring, and replaces each occurrence with a given replacement string.                                                                                                                                                               |
 | <code><a href="#cdktf.FnGenerated.reverse">Reverse</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/reverse reverse} takes a sequence and produces a new sequence of the same length with all of the same elements as the given sequence but in reverse order.                                                                                                                                        |
 | <code><a href="#cdktf.FnGenerated.rsadecrypt">Rsadecrypt</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/rsadecrypt rsadecrypt} decrypts an RSA-encrypted ciphertext, returning the corresponding cleartext.                                                                                                                                                                                               |
-| <code><a href="#cdktf.FnGenerated.sensitive">Sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).                                            |
+| <code><a href="#cdktf.FnGenerated.sensitive">Sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).                                  |
 | <code><a href="#cdktf.FnGenerated.setintersection">Setintersection</a></code>   | The {@link https://developer.hashicorp.com/terraform/language/functions/setintersection setintersection} function takes multiple sets and produces a single set containing only the elements that all of the given sets have in common. In other words, it computes the [intersection](<https://en.wikipedia.org/wiki/Intersection_(set_theory)>) of the sets.        |
 | <code><a href="#cdktf.FnGenerated.setproduct">Setproduct</a></code>             | The {@link https://developer.hashicorp.com/terraform/language/functions/setproduct setproduct} function finds all of the possible combinations of elements from all of the given sets by computing the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product).                                                                                          |
 | <code><a href="#cdktf.FnGenerated.setsubtract">Setsubtract</a></code>           | The {@link https://developer.hashicorp.com/terraform/language/functions/setsubtract setsubtract} function returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the [relative complement](<https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement>) of the second set.  |
@@ -26923,6 +26983,7 @@ cdktf.NewFnGenerated() FnGenerated
 | <code><a href="#cdktf.FnGenerated.sort">Sort</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/sort sort} takes a list of strings and returns a new list with those strings sorted lexicographically.                                                                                                                                                                                            |
 | <code><a href="#cdktf.FnGenerated.split">Split</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/split split} produces a list by dividing a given string at all occurrences of a given separator.                                                                                                                                                                                                  |
 | <code><a href="#cdktf.FnGenerated.startswith">Startswith</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/startswith startswith} takes two values: a string to check and a prefix string. The function returns true if the string begins with that exact prefix.                                                                                                                                            |
+| <code><a href="#cdktf.FnGenerated.strcontains">Strcontains</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/strcontains strcontains} takes two values: a string to check and an expected substring. The function returns true if the string has the substring contained within it.                                                                                                                            |
 | <code><a href="#cdktf.FnGenerated.strrev">Strrev</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/strrev strrev} reverses the characters in a string. Note that the characters are treated as _Unicode characters_ (in technical terms, Unicode [grapheme cluster boundaries](https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries) are respected).                                        |
 | <code><a href="#cdktf.FnGenerated.substr">Substr</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/substr substr} extracts a substring from a given string by offset and (maximum) length.                                                                                                                                                                                                           |
 | <code><a href="#cdktf.FnGenerated.sum">Sum</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/sum sum} takes a list or set of numbers and returns the sum of those numbers.                                                                                                                                                                                                                     |
@@ -26948,7 +27009,7 @@ cdktf.NewFnGenerated() FnGenerated
 | <code><a href="#cdktf.FnGenerated.upper">Upper</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/upper upper} converts all cased letters in the given string to uppercase.                                                                                                                                                                                                                         |
 | <code><a href="#cdktf.FnGenerated.urlencode">Urlencode</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/urlencode urlencode} applies URL encoding to a given string.                                                                                                                                                                                                                                      |
 | <code><a href="#cdktf.FnGenerated.uuid">Uuid</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/uuid uuid} generates a unique identifier string.                                                                                                                                                                                                                                                  |
-| <code><a href="#cdktf.FnGenerated.uuidv5">Uuidv5</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a &#34;version 5&#34; UUID.                                                                                                                  |
+| <code><a href="#cdktf.FnGenerated.uuidv5">Uuidv5</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a "version 5" UUID.                                                                                                                          |
 | <code><a href="#cdktf.FnGenerated.values">Values</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/values values} takes a map and returns a list containing the values of the elements in that map.                                                                                                                                                                                                  |
 | <code><a href="#cdktf.FnGenerated.yamldecode">Yamldecode</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/yamldecode yamldecode} parses a string as a subset of YAML, and produces a representation of its value.                                                                                                                                                                                           |
 | <code><a href="#cdktf.FnGenerated.yamlencode">Yamlencode</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/yamlencode yamlencode} encodes a given value to a string using [YAML 1.2](https://yaml.org/spec/1.2/spec.html) block syntax.                                                                                                                                                                      |
@@ -26996,7 +27057,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 cdktf.FnGenerated_Alltrue(list *[]interface{}) IResolvable
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `&#34;true&#34;`. It also returns `true` if the collection is empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `"true"`. It also returns `true` if the collection is empty.
 
 ###### `list`<sup>Required</sup> <a name="list" id="cdktf.FnGenerated.alltrue.parameter.list"></a>
 
@@ -27012,7 +27073,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 cdktf.FnGenerated_Anytrue(list *[]interface{}) IResolvable
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `&#34;true&#34;`. It also returns `false` if the collection is empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `"true"`. It also returns `false` if the collection is empty.
 
 ###### `list`<sup>Required</sup> <a name="list" id="cdktf.FnGenerated.anytrue.parameter.list"></a>
 
@@ -27076,7 +27137,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 cdktf.FnGenerated_Base64sha256(str *string) *string
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(&#34;test&#34;))` since `sha256()` returns hexadecimal representation.
+{@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256("test"))` since `sha256()` returns hexadecimal representation.
 
 ###### `str`<sup>Required</sup> <a name="str" id="cdktf.FnGenerated.base64sha256.parameter.str"></a>
 
@@ -27092,7 +27153,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 cdktf.FnGenerated_Base64sha512(str *string) *string
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512(&#34;test&#34;))` since `sha512()` returns hexadecimal representation.
+{@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512("test"))` since `sha512()` returns hexadecimal representation.
 
 ###### `str`<sup>Required</sup> <a name="str" id="cdktf.FnGenerated.base64sha512.parameter.str"></a>
 
@@ -27282,7 +27343,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 cdktf.FnGenerated_Coalesce(vals *[]interface{}) interface{}
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn&#39;t null or an empty string.
+{@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn't null or an empty string.
 
 ###### `vals`<sup>Required</sup> <a name="vals" id="cdktf.FnGenerated.coalesce.parameter.vals"></a>
 
@@ -27298,7 +27359,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 cdktf.FnGenerated_Coalescelist(vals *[]interface{}) interface{}
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn&#39;t empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn't empty.
 
 ###### `vals`<sup>Required</sup> <a name="vals" id="cdktf.FnGenerated.coalescelist.parameter.vals"></a>
 
@@ -28016,13 +28077,23 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 cdktf.FnGenerated_Pathexpand(path *string) *string
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user&#39;s home directory path.
+{@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user's home directory path.
 
 ###### `path`<sup>Required</sup> <a name="path" id="cdktf.FnGenerated.pathexpand.parameter.path"></a>
 
 - _Type:_ \*string
 
 ---
+
+##### `Plantimestamp` <a name="Plantimestamp" id="cdktf.FnGenerated.plantimestamp"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.FnGenerated_Plantimestamp() *string
+```
+
+{@link https://developer.hashicorp.com/terraform/language/functions/plantimestamp plantimestamp} returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format, fixed to a constant time representing the time of the plan.
 
 ##### `Pow` <a name="Pow" id="cdktf.FnGenerated.pow"></a>
 
@@ -28164,7 +28235,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 cdktf.FnGenerated_Sensitive(value interface{}) interface{}
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).
+{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).
 
 ###### `value`<sup>Required</sup> <a name="value" id="cdktf.FnGenerated.sensitive.parameter.value"></a>
 
@@ -28401,6 +28472,28 @@ cdktf.FnGenerated_Startswith(str *string, prefix *string) IResolvable
 ---
 
 ###### `prefix`<sup>Required</sup> <a name="prefix" id="cdktf.FnGenerated.startswith.parameter.prefix"></a>
+
+- _Type:_ \*string
+
+---
+
+##### `Strcontains` <a name="Strcontains" id="cdktf.FnGenerated.strcontains"></a>
+
+```go
+import "github.com/hashicorp/terraform-cdk-go/cdktf"
+
+cdktf.FnGenerated_Strcontains(str *string, substr *string) IResolvable
+```
+
+{@link https://developer.hashicorp.com/terraform/language/functions/strcontains strcontains} takes two values: a string to check and an expected substring. The function returns true if the string has the substring contained within it.
+
+###### `str`<sup>Required</sup> <a name="str" id="cdktf.FnGenerated.strcontains.parameter.str"></a>
+
+- _Type:_ \*string
+
+---
+
+###### `substr`<sup>Required</sup> <a name="substr" id="cdktf.FnGenerated.strcontains.parameter.substr"></a>
 
 - _Type:_ \*string
 
@@ -28862,7 +28955,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 cdktf.FnGenerated_Uuidv5(namespace *string, name *string) *string
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a &#34;version 5&#34; UUID.
+{@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a "version 5" UUID.
 
 ###### `namespace`<sup>Required</sup> <a name="namespace" id="cdktf.FnGenerated.uuidv5.parameter.namespace"></a>
 

--- a/website/docs/cdktf/api-reference/java.mdx
+++ b/website/docs/cdktf/api-reference/java.mdx
@@ -28827,13 +28827,13 @@ new Fn();
 | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | <code><a href="#cdktf.Fn.abs">abs</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/abs abs} returns the absolute value of the given number. In other words, if the number is zero or positive then it is returned as-is, but if it is negative then it is multiplied by -1 to make it positive before returning it.                                                                  |
 | <code><a href="#cdktf.Fn.abspath">abspath</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/abspath abspath} takes a string containing a filesystem path and converts it to an absolute path. That is, if the path is not absolute, it will be joined with the current working directory.                                                                                                     |
-| <code><a href="#cdktf.Fn.alltrue">alltrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `&#34;true&#34;`. It also returns `true` if the collection is empty.                                                                                                                                          |
-| <code><a href="#cdktf.Fn.anytrue">anytrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `&#34;true&#34;`. It also returns `false` if the collection is empty.                                                                                                                                           |
+| <code><a href="#cdktf.Fn.alltrue">alltrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `"true"`. It also returns `true` if the collection is empty.                                                                                                                                                  |
+| <code><a href="#cdktf.Fn.anytrue">anytrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `"true"`. It also returns `false` if the collection is empty.                                                                                                                                                   |
 | <code><a href="#cdktf.Fn.base64decode">base64decode</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64decode base64decode} takes a string containing a Base64 character sequence and returns the original string.                                                                                                                                                                                 |
 | <code><a href="#cdktf.Fn.base64encode">base64encode</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64encode base64encode} applies Base64 encoding to a string.                                                                                                                                                                                                                                   |
 | <code><a href="#cdktf.Fn.base64gzip">base64gzip</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/base64gzip base64gzip} compresses a string with gzip and then encodes the result in Base64 encoding.                                                                                                                                                                                              |
-| <code><a href="#cdktf.Fn.base64sha256">base64sha256</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(&#34;test&#34;))` since `sha256()` returns hexadecimal representation.                                                                           |
-| <code><a href="#cdktf.Fn.base64sha512">base64sha512</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512(&#34;test&#34;))` since `sha512()` returns hexadecimal representation.                                                                           |
+| <code><a href="#cdktf.Fn.base64sha256">base64sha256</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256("test"))` since `sha256()` returns hexadecimal representation.                                                                                   |
+| <code><a href="#cdktf.Fn.base64sha512">base64sha512</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512("test"))` since `sha512()` returns hexadecimal representation.                                                                                   |
 | <code><a href="#cdktf.Fn.basename">basename</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/basename basename} takes a string containing a filesystem path and removes all except the last portion from it.                                                                                                                                                                                   |
 | <code><a href="#cdktf.Fn.can">can</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/can can} evaluates the given expression and returns a boolean value indicating whether the expression produced a result without any errors.                                                                                                                                                       |
 | <code><a href="#cdktf.Fn.ceil">ceil</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/ceil ceil} returns the closest whole number that is greater than or equal to the given value, which may be a fraction.                                                                                                                                                                            |
@@ -28843,8 +28843,8 @@ new Fn();
 | <code><a href="#cdktf.Fn.cidrnetmask">cidrnetmask</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/cidrnetmask cidrnetmask} converts an IPv4 address prefix given in CIDR notation into a subnet mask address.                                                                                                                                                                                       |
 | <code><a href="#cdktf.Fn.cidrsubnet">cidrsubnet</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/cidrsubnet cidrsubnet} calculates a subnet address within given IP network address prefix.                                                                                                                                                                                                        |
 | <code><a href="#cdktf.Fn.cidrsubnets">cidrsubnets</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/cidrsubnets cidrsubnets} calculates a sequence of consecutive IP address ranges within a particular CIDR prefix.                                                                                                                                                                                  |
-| <code><a href="#cdktf.Fn.coalesce">coalesce</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn&#39;t null or an empty string.                                                                                                                                                                                |
-| <code><a href="#cdktf.Fn.coalescelist">coalescelist</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn&#39;t empty.                                                                                                                                                                                     |
+| <code><a href="#cdktf.Fn.coalesce">coalesce</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn't null or an empty string.                                                                                                                                                                                    |
+| <code><a href="#cdktf.Fn.coalescelist">coalescelist</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn't empty.                                                                                                                                                                                         |
 | <code><a href="#cdktf.Fn.compact">compact</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/compact compact} takes a list of strings and returns a new list with any empty string elements removed.                                                                                                                                                                                           |
 | <code><a href="#cdktf.Fn.concat">concat</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/concat concat} takes two or more lists and combines them into a single list.                                                                                                                                                                                                                      |
 | <code><a href="#cdktf.Fn.contains">contains</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/contains contains} determines whether a given list or set contains a given single value as one of its elements.                                                                                                                                                                                   |
@@ -28884,14 +28884,15 @@ new Fn();
 | <code><a href="#cdktf.Fn.nonsensitive">nonsensitive</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/nonsensitive nonsensitive} takes a sensitive value and returns a copy of that value with the sensitive marking removed, thereby exposing the sensitive value.                                                                                                                                     |
 | <code><a href="#cdktf.Fn.one">one</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/one one} takes a list, set, or tuple value with either zero or one elements. If the collection is empty, `one` returns `null`. Otherwise, `one` returns the first element. If there are two or more elements then `one` will return an error.                                                     |
 | <code><a href="#cdktf.Fn.parseint">parseint</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/parseint parseint} parses the given string as a representation of an integer in the specified base and returns the resulting number. The base must be between 2 and 62 inclusive.                                                                                                                 |
-| <code><a href="#cdktf.Fn.pathexpand">pathexpand</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user&#39;s home directory path.                                                                                                                           |
+| <code><a href="#cdktf.Fn.pathexpand">pathexpand</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user's home directory path.                                                                                                                               |
+| <code><a href="#cdktf.Fn.plantimestamp">plantimestamp</a></code>       | {@link https://developer.hashicorp.com/terraform/language/functions/plantimestamp plantimestamp} returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format, fixed to a constant time representing the time of the plan.                                                                                                                |
 | <code><a href="#cdktf.Fn.pow">pow</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/pow pow} calculates an exponent, by raising its first argument to the power of the second argument.                                                                                                                                                                                               |
 | <code><a href="#cdktf.Fn.regex">regex</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/regex regex} applies a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) to a string and returns the matching substrings.                                                                                                                                                    |
 | <code><a href="#cdktf.Fn.regexall">regexall</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/regexall regexall} applies a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) to a string and returns a list of all matches.                                                                                                                                                |
 | <code><a href="#cdktf.Fn.replace">replace</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/replace replace} searches a given string for another given substring, and replaces each occurrence with a given replacement string.                                                                                                                                                               |
 | <code><a href="#cdktf.Fn.reverse">reverse</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/reverse reverse} takes a sequence and produces a new sequence of the same length with all of the same elements as the given sequence but in reverse order.                                                                                                                                        |
 | <code><a href="#cdktf.Fn.rsadecrypt">rsadecrypt</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/rsadecrypt rsadecrypt} decrypts an RSA-encrypted ciphertext, returning the corresponding cleartext.                                                                                                                                                                                               |
-| <code><a href="#cdktf.Fn.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).                                            |
+| <code><a href="#cdktf.Fn.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).                                  |
 | <code><a href="#cdktf.Fn.setintersection">setintersection</a></code>   | The {@link https://developer.hashicorp.com/terraform/language/functions/setintersection setintersection} function takes multiple sets and produces a single set containing only the elements that all of the given sets have in common. In other words, it computes the [intersection](<https://en.wikipedia.org/wiki/Intersection_(set_theory)>) of the sets.        |
 | <code><a href="#cdktf.Fn.setproduct">setproduct</a></code>             | The {@link https://developer.hashicorp.com/terraform/language/functions/setproduct setproduct} function finds all of the possible combinations of elements from all of the given sets by computing the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product).                                                                                          |
 | <code><a href="#cdktf.Fn.setsubtract">setsubtract</a></code>           | The {@link https://developer.hashicorp.com/terraform/language/functions/setsubtract setsubtract} function returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the [relative complement](<https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement>) of the second set.  |
@@ -28904,6 +28905,7 @@ new Fn();
 | <code><a href="#cdktf.Fn.sort">sort</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/sort sort} takes a list of strings and returns a new list with those strings sorted lexicographically.                                                                                                                                                                                            |
 | <code><a href="#cdktf.Fn.split">split</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/split split} produces a list by dividing a given string at all occurrences of a given separator.                                                                                                                                                                                                  |
 | <code><a href="#cdktf.Fn.startswith">startswith</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/startswith startswith} takes two values: a string to check and a prefix string. The function returns true if the string begins with that exact prefix.                                                                                                                                            |
+| <code><a href="#cdktf.Fn.strcontains">strcontains</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/strcontains strcontains} takes two values: a string to check and an expected substring. The function returns true if the string has the substring contained within it.                                                                                                                            |
 | <code><a href="#cdktf.Fn.strrev">strrev</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/strrev strrev} reverses the characters in a string. Note that the characters are treated as _Unicode characters_ (in technical terms, Unicode [grapheme cluster boundaries](https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries) are respected).                                        |
 | <code><a href="#cdktf.Fn.substr">substr</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/substr substr} extracts a substring from a given string by offset and (maximum) length.                                                                                                                                                                                                           |
 | <code><a href="#cdktf.Fn.sum">sum</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/sum sum} takes a list or set of numbers and returns the sum of those numbers.                                                                                                                                                                                                                     |
@@ -28929,7 +28931,7 @@ new Fn();
 | <code><a href="#cdktf.Fn.upper">upper</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/upper upper} converts all cased letters in the given string to uppercase.                                                                                                                                                                                                                         |
 | <code><a href="#cdktf.Fn.urlencode">urlencode</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/urlencode urlencode} applies URL encoding to a given string.                                                                                                                                                                                                                                      |
 | <code><a href="#cdktf.Fn.uuid">uuid</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/uuid uuid} generates a unique identifier string.                                                                                                                                                                                                                                                  |
-| <code><a href="#cdktf.Fn.uuidv5">uuidv5</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a &#34;version 5&#34; UUID.                                                                                                                  |
+| <code><a href="#cdktf.Fn.uuidv5">uuidv5</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a "version 5" UUID.                                                                                                                          |
 | <code><a href="#cdktf.Fn.values">values</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/values values} takes a map and returns a list containing the values of the elements in that map.                                                                                                                                                                                                  |
 | <code><a href="#cdktf.Fn.yamldecode">yamldecode</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/yamldecode yamldecode} parses a string as a subset of YAML, and produces a representation of its value.                                                                                                                                                                                           |
 | <code><a href="#cdktf.Fn.yamlencode">yamlencode</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/yamlencode yamlencode} encodes a given value to a string using [YAML 1.2](https://yaml.org/spec/1.2/spec.html) block syntax.                                                                                                                                                                      |
@@ -28937,6 +28939,7 @@ new Fn();
 | <code><a href="#cdktf.Fn.bcrypt">bcrypt</a></code>                     | {@link /terraform/docs/language/functions/bcrypt.html bcrypt} computes a hash of the given string using the Blowfish cipher, returning a string in [the _Modular Crypt Format_](https://passlib.readthedocs.io/en/stable/modular_crypt_format.html) usually expected in the shadow password file on many Unix systems.                                                |
 | <code><a href="#cdktf.Fn.join">join</a></code>                         | {@link /terraform/docs/language/functions/join.html join} produces a string by concatenating together all elements of a given list of strings with the given delimiter.                                                                                                                                                                                               |
 | <code><a href="#cdktf.Fn.lookup">lookup</a></code>                     | {@link /terraform/docs/language/functions/lookup.html lookup} retrieves the value of a single element from a map, given its key. If the given key does not exist, the given default value is returned instead.                                                                                                                                                        |
+| <code><a href="#cdktf.Fn.lookupNested">lookupNested</a></code>         | returns a property access expression that accesses the property at the given path in the given inputMap.                                                                                                                                                                                                                                                              |
 | <code><a href="#cdktf.Fn.range">range</a></code>                       | {@link /terraform/docs/language/functions/range.html range} generates a list of numbers using a start value, a limit value, and a step value.                                                                                                                                                                                                                         |
 | <code><a href="#cdktf.Fn.rawString">rawString</a></code>               | Use this function to wrap a string and escape it properly for the use in Terraform This is only needed in certain scenarios (e.g., if you have unescaped double quotes in the string).                                                                                                                                                                                |
 
@@ -28982,7 +28985,7 @@ import com.hashicorp.cdktf.Fn;
 Fn.alltrue(java.util.List< java.lang.Object > list)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `&#34;true&#34;`. It also returns `true` if the collection is empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `"true"`. It also returns `true` if the collection is empty.
 
 ###### `list`<sup>Required</sup> <a name="list" id="cdktf.Fn.alltrue.parameter.list"></a>
 
@@ -28998,7 +29001,7 @@ import com.hashicorp.cdktf.Fn;
 Fn.anytrue(java.util.List< java.lang.Object > list)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `&#34;true&#34;`. It also returns `false` if the collection is empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `"true"`. It also returns `false` if the collection is empty.
 
 ###### `list`<sup>Required</sup> <a name="list" id="cdktf.Fn.anytrue.parameter.list"></a>
 
@@ -29062,7 +29065,7 @@ import com.hashicorp.cdktf.Fn;
 Fn.base64sha256(java.lang.String str)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(&#34;test&#34;))` since `sha256()` returns hexadecimal representation.
+{@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256("test"))` since `sha256()` returns hexadecimal representation.
 
 ###### `str`<sup>Required</sup> <a name="str" id="cdktf.Fn.base64sha256.parameter.str"></a>
 
@@ -29078,7 +29081,7 @@ import com.hashicorp.cdktf.Fn;
 Fn.base64sha512(java.lang.String str)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512(&#34;test&#34;))` since `sha512()` returns hexadecimal representation.
+{@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512("test"))` since `sha512()` returns hexadecimal representation.
 
 ###### `str`<sup>Required</sup> <a name="str" id="cdktf.Fn.base64sha512.parameter.str"></a>
 
@@ -29268,7 +29271,7 @@ import com.hashicorp.cdktf.Fn;
 Fn.coalesce(java.util.List< java.lang.Object > vals)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn&#39;t null or an empty string.
+{@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn't null or an empty string.
 
 ###### `vals`<sup>Required</sup> <a name="vals" id="cdktf.Fn.coalesce.parameter.vals"></a>
 
@@ -29284,7 +29287,7 @@ import com.hashicorp.cdktf.Fn;
 Fn.coalescelist(java.util.List< java.lang.Object > vals)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn&#39;t empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn't empty.
 
 ###### `vals`<sup>Required</sup> <a name="vals" id="cdktf.Fn.coalescelist.parameter.vals"></a>
 
@@ -30002,13 +30005,23 @@ import com.hashicorp.cdktf.Fn;
 Fn.pathexpand(java.lang.String path)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user&#39;s home directory path.
+{@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user's home directory path.
 
 ###### `path`<sup>Required</sup> <a name="path" id="cdktf.Fn.pathexpand.parameter.path"></a>
 
 - _Type:_ java.lang.String
 
 ---
+
+##### `plantimestamp` <a name="plantimestamp" id="cdktf.Fn.plantimestamp"></a>
+
+```java
+import com.hashicorp.cdktf.Fn;
+
+Fn.plantimestamp()
+```
+
+{@link https://developer.hashicorp.com/terraform/language/functions/plantimestamp plantimestamp} returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format, fixed to a constant time representing the time of the plan.
 
 ##### `pow` <a name="pow" id="cdktf.Fn.pow"></a>
 
@@ -30150,7 +30163,7 @@ import com.hashicorp.cdktf.Fn;
 Fn.sensitive(java.lang.Object value)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).
+{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).
 
 ###### `value`<sup>Required</sup> <a name="value" id="cdktf.Fn.sensitive.parameter.value"></a>
 
@@ -30387,6 +30400,28 @@ Fn.startswith(java.lang.String str, java.lang.String prefix)
 ---
 
 ###### `prefix`<sup>Required</sup> <a name="prefix" id="cdktf.Fn.startswith.parameter.prefix"></a>
+
+- _Type:_ java.lang.String
+
+---
+
+##### `strcontains` <a name="strcontains" id="cdktf.Fn.strcontains"></a>
+
+```java
+import com.hashicorp.cdktf.Fn;
+
+Fn.strcontains(java.lang.String str, java.lang.String substr)
+```
+
+{@link https://developer.hashicorp.com/terraform/language/functions/strcontains strcontains} takes two values: a string to check and an expected substring. The function returns true if the string has the substring contained within it.
+
+###### `str`<sup>Required</sup> <a name="str" id="cdktf.Fn.strcontains.parameter.str"></a>
+
+- _Type:_ java.lang.String
+
+---
+
+###### `substr`<sup>Required</sup> <a name="substr" id="cdktf.Fn.strcontains.parameter.substr"></a>
 
 - _Type:_ java.lang.String
 
@@ -30848,7 +30883,7 @@ import com.hashicorp.cdktf.Fn;
 Fn.uuidv5(java.lang.String namespace, java.lang.String name)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a &#34;version 5&#34; UUID.
+{@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a "version 5" UUID.
 
 ###### `namespace`<sup>Required</sup> <a name="namespace" id="cdktf.Fn.uuidv5.parameter.namespace"></a>
 
@@ -30981,7 +31016,7 @@ Fn.join(java.lang.String separator, java.util.List< java.lang.String > list)
 ```java
 import com.hashicorp.cdktf.Fn;
 
-Fn.lookup(java.lang.Object inputMap, java.lang.String key, java.lang.Object defaultValue)
+Fn.lookup(java.lang.Object inputMap, java.lang.String key),Fn.lookup(java.lang.Object inputMap, java.lang.String key, java.lang.Object defaultValue)
 ```
 
 {@link /terraform/docs/language/functions/lookup.html lookup} retrieves the value of a single element from a map, given its key. If the given key does not exist, the given default value is returned instead.
@@ -30998,9 +31033,33 @@ Fn.lookup(java.lang.Object inputMap, java.lang.String key, java.lang.Object defa
 
 ---
 
-###### `defaultValue`<sup>Required</sup> <a name="defaultValue" id="cdktf.Fn.lookup.parameter.defaultValue"></a>
+###### `defaultValue`<sup>Optional</sup> <a name="defaultValue" id="cdktf.Fn.lookup.parameter.defaultValue"></a>
 
 - _Type:_ java.lang.Object
+
+---
+
+##### `lookupNested` <a name="lookupNested" id="cdktf.Fn.lookupNested"></a>
+
+```java
+import com.hashicorp.cdktf.Fn;
+
+Fn.lookupNested(java.lang.Object inputMap, java.util.List< java.lang.Object > path)
+```
+
+returns a property access expression that accesses the property at the given path in the given inputMap.
+
+For example lookupNested(x, ["a", "b", "c"]) will return a Terraform expression like x["a"]["b"]["c"]
+
+###### `inputMap`<sup>Required</sup> <a name="inputMap" id="cdktf.Fn.lookupNested.parameter.inputMap"></a>
+
+- _Type:_ java.lang.Object
+
+---
+
+###### `path`<sup>Required</sup> <a name="path" id="cdktf.Fn.lookupNested.parameter.path"></a>
+
+- _Type:_ java.util.List< java.lang.Object >
 
 ---
 
@@ -31069,13 +31128,13 @@ new FnGenerated();
 | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | <code><a href="#cdktf.FnGenerated.abs">abs</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/abs abs} returns the absolute value of the given number. In other words, if the number is zero or positive then it is returned as-is, but if it is negative then it is multiplied by -1 to make it positive before returning it.                                                                  |
 | <code><a href="#cdktf.FnGenerated.abspath">abspath</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/abspath abspath} takes a string containing a filesystem path and converts it to an absolute path. That is, if the path is not absolute, it will be joined with the current working directory.                                                                                                     |
-| <code><a href="#cdktf.FnGenerated.alltrue">alltrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `&#34;true&#34;`. It also returns `true` if the collection is empty.                                                                                                                                          |
-| <code><a href="#cdktf.FnGenerated.anytrue">anytrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `&#34;true&#34;`. It also returns `false` if the collection is empty.                                                                                                                                           |
+| <code><a href="#cdktf.FnGenerated.alltrue">alltrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `"true"`. It also returns `true` if the collection is empty.                                                                                                                                                  |
+| <code><a href="#cdktf.FnGenerated.anytrue">anytrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `"true"`. It also returns `false` if the collection is empty.                                                                                                                                                   |
 | <code><a href="#cdktf.FnGenerated.base64decode">base64decode</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64decode base64decode} takes a string containing a Base64 character sequence and returns the original string.                                                                                                                                                                                 |
 | <code><a href="#cdktf.FnGenerated.base64encode">base64encode</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64encode base64encode} applies Base64 encoding to a string.                                                                                                                                                                                                                                   |
 | <code><a href="#cdktf.FnGenerated.base64gzip">base64gzip</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/base64gzip base64gzip} compresses a string with gzip and then encodes the result in Base64 encoding.                                                                                                                                                                                              |
-| <code><a href="#cdktf.FnGenerated.base64sha256">base64sha256</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(&#34;test&#34;))` since `sha256()` returns hexadecimal representation.                                                                           |
-| <code><a href="#cdktf.FnGenerated.base64sha512">base64sha512</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512(&#34;test&#34;))` since `sha512()` returns hexadecimal representation.                                                                           |
+| <code><a href="#cdktf.FnGenerated.base64sha256">base64sha256</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256("test"))` since `sha256()` returns hexadecimal representation.                                                                                   |
+| <code><a href="#cdktf.FnGenerated.base64sha512">base64sha512</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512("test"))` since `sha512()` returns hexadecimal representation.                                                                                   |
 | <code><a href="#cdktf.FnGenerated.basename">basename</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/basename basename} takes a string containing a filesystem path and removes all except the last portion from it.                                                                                                                                                                                   |
 | <code><a href="#cdktf.FnGenerated.can">can</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/can can} evaluates the given expression and returns a boolean value indicating whether the expression produced a result without any errors.                                                                                                                                                       |
 | <code><a href="#cdktf.FnGenerated.ceil">ceil</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/ceil ceil} returns the closest whole number that is greater than or equal to the given value, which may be a fraction.                                                                                                                                                                            |
@@ -31085,8 +31144,8 @@ new FnGenerated();
 | <code><a href="#cdktf.FnGenerated.cidrnetmask">cidrnetmask</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/cidrnetmask cidrnetmask} converts an IPv4 address prefix given in CIDR notation into a subnet mask address.                                                                                                                                                                                       |
 | <code><a href="#cdktf.FnGenerated.cidrsubnet">cidrsubnet</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/cidrsubnet cidrsubnet} calculates a subnet address within given IP network address prefix.                                                                                                                                                                                                        |
 | <code><a href="#cdktf.FnGenerated.cidrsubnets">cidrsubnets</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/cidrsubnets cidrsubnets} calculates a sequence of consecutive IP address ranges within a particular CIDR prefix.                                                                                                                                                                                  |
-| <code><a href="#cdktf.FnGenerated.coalesce">coalesce</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn&#39;t null or an empty string.                                                                                                                                                                                |
-| <code><a href="#cdktf.FnGenerated.coalescelist">coalescelist</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn&#39;t empty.                                                                                                                                                                                     |
+| <code><a href="#cdktf.FnGenerated.coalesce">coalesce</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn't null or an empty string.                                                                                                                                                                                    |
+| <code><a href="#cdktf.FnGenerated.coalescelist">coalescelist</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn't empty.                                                                                                                                                                                         |
 | <code><a href="#cdktf.FnGenerated.compact">compact</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/compact compact} takes a list of strings and returns a new list with any empty string elements removed.                                                                                                                                                                                           |
 | <code><a href="#cdktf.FnGenerated.concat">concat</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/concat concat} takes two or more lists and combines them into a single list.                                                                                                                                                                                                                      |
 | <code><a href="#cdktf.FnGenerated.contains">contains</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/contains contains} determines whether a given list or set contains a given single value as one of its elements.                                                                                                                                                                                   |
@@ -31126,14 +31185,15 @@ new FnGenerated();
 | <code><a href="#cdktf.FnGenerated.nonsensitive">nonsensitive</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/nonsensitive nonsensitive} takes a sensitive value and returns a copy of that value with the sensitive marking removed, thereby exposing the sensitive value.                                                                                                                                     |
 | <code><a href="#cdktf.FnGenerated.one">one</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/one one} takes a list, set, or tuple value with either zero or one elements. If the collection is empty, `one` returns `null`. Otherwise, `one` returns the first element. If there are two or more elements then `one` will return an error.                                                     |
 | <code><a href="#cdktf.FnGenerated.parseint">parseint</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/parseint parseint} parses the given string as a representation of an integer in the specified base and returns the resulting number. The base must be between 2 and 62 inclusive.                                                                                                                 |
-| <code><a href="#cdktf.FnGenerated.pathexpand">pathexpand</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user&#39;s home directory path.                                                                                                                           |
+| <code><a href="#cdktf.FnGenerated.pathexpand">pathexpand</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user's home directory path.                                                                                                                               |
+| <code><a href="#cdktf.FnGenerated.plantimestamp">plantimestamp</a></code>       | {@link https://developer.hashicorp.com/terraform/language/functions/plantimestamp plantimestamp} returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format, fixed to a constant time representing the time of the plan.                                                                                                                |
 | <code><a href="#cdktf.FnGenerated.pow">pow</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/pow pow} calculates an exponent, by raising its first argument to the power of the second argument.                                                                                                                                                                                               |
 | <code><a href="#cdktf.FnGenerated.regex">regex</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/regex regex} applies a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) to a string and returns the matching substrings.                                                                                                                                                    |
 | <code><a href="#cdktf.FnGenerated.regexall">regexall</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/regexall regexall} applies a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) to a string and returns a list of all matches.                                                                                                                                                |
 | <code><a href="#cdktf.FnGenerated.replace">replace</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/replace replace} searches a given string for another given substring, and replaces each occurrence with a given replacement string.                                                                                                                                                               |
 | <code><a href="#cdktf.FnGenerated.reverse">reverse</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/reverse reverse} takes a sequence and produces a new sequence of the same length with all of the same elements as the given sequence but in reverse order.                                                                                                                                        |
 | <code><a href="#cdktf.FnGenerated.rsadecrypt">rsadecrypt</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/rsadecrypt rsadecrypt} decrypts an RSA-encrypted ciphertext, returning the corresponding cleartext.                                                                                                                                                                                               |
-| <code><a href="#cdktf.FnGenerated.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).                                            |
+| <code><a href="#cdktf.FnGenerated.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).                                  |
 | <code><a href="#cdktf.FnGenerated.setintersection">setintersection</a></code>   | The {@link https://developer.hashicorp.com/terraform/language/functions/setintersection setintersection} function takes multiple sets and produces a single set containing only the elements that all of the given sets have in common. In other words, it computes the [intersection](<https://en.wikipedia.org/wiki/Intersection_(set_theory)>) of the sets.        |
 | <code><a href="#cdktf.FnGenerated.setproduct">setproduct</a></code>             | The {@link https://developer.hashicorp.com/terraform/language/functions/setproduct setproduct} function finds all of the possible combinations of elements from all of the given sets by computing the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product).                                                                                          |
 | <code><a href="#cdktf.FnGenerated.setsubtract">setsubtract</a></code>           | The {@link https://developer.hashicorp.com/terraform/language/functions/setsubtract setsubtract} function returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the [relative complement](<https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement>) of the second set.  |
@@ -31146,6 +31206,7 @@ new FnGenerated();
 | <code><a href="#cdktf.FnGenerated.sort">sort</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/sort sort} takes a list of strings and returns a new list with those strings sorted lexicographically.                                                                                                                                                                                            |
 | <code><a href="#cdktf.FnGenerated.split">split</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/split split} produces a list by dividing a given string at all occurrences of a given separator.                                                                                                                                                                                                  |
 | <code><a href="#cdktf.FnGenerated.startswith">startswith</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/startswith startswith} takes two values: a string to check and a prefix string. The function returns true if the string begins with that exact prefix.                                                                                                                                            |
+| <code><a href="#cdktf.FnGenerated.strcontains">strcontains</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/strcontains strcontains} takes two values: a string to check and an expected substring. The function returns true if the string has the substring contained within it.                                                                                                                            |
 | <code><a href="#cdktf.FnGenerated.strrev">strrev</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/strrev strrev} reverses the characters in a string. Note that the characters are treated as _Unicode characters_ (in technical terms, Unicode [grapheme cluster boundaries](https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries) are respected).                                        |
 | <code><a href="#cdktf.FnGenerated.substr">substr</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/substr substr} extracts a substring from a given string by offset and (maximum) length.                                                                                                                                                                                                           |
 | <code><a href="#cdktf.FnGenerated.sum">sum</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/sum sum} takes a list or set of numbers and returns the sum of those numbers.                                                                                                                                                                                                                     |
@@ -31171,7 +31232,7 @@ new FnGenerated();
 | <code><a href="#cdktf.FnGenerated.upper">upper</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/upper upper} converts all cased letters in the given string to uppercase.                                                                                                                                                                                                                         |
 | <code><a href="#cdktf.FnGenerated.urlencode">urlencode</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/urlencode urlencode} applies URL encoding to a given string.                                                                                                                                                                                                                                      |
 | <code><a href="#cdktf.FnGenerated.uuid">uuid</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/uuid uuid} generates a unique identifier string.                                                                                                                                                                                                                                                  |
-| <code><a href="#cdktf.FnGenerated.uuidv5">uuidv5</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a &#34;version 5&#34; UUID.                                                                                                                  |
+| <code><a href="#cdktf.FnGenerated.uuidv5">uuidv5</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a "version 5" UUID.                                                                                                                          |
 | <code><a href="#cdktf.FnGenerated.values">values</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/values values} takes a map and returns a list containing the values of the elements in that map.                                                                                                                                                                                                  |
 | <code><a href="#cdktf.FnGenerated.yamldecode">yamldecode</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/yamldecode yamldecode} parses a string as a subset of YAML, and produces a representation of its value.                                                                                                                                                                                           |
 | <code><a href="#cdktf.FnGenerated.yamlencode">yamlencode</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/yamlencode yamlencode} encodes a given value to a string using [YAML 1.2](https://yaml.org/spec/1.2/spec.html) block syntax.                                                                                                                                                                      |
@@ -31219,7 +31280,7 @@ import com.hashicorp.cdktf.FnGenerated;
 FnGenerated.alltrue(java.util.List< java.lang.Object > list)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `&#34;true&#34;`. It also returns `true` if the collection is empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `"true"`. It also returns `true` if the collection is empty.
 
 ###### `list`<sup>Required</sup> <a name="list" id="cdktf.FnGenerated.alltrue.parameter.list"></a>
 
@@ -31235,7 +31296,7 @@ import com.hashicorp.cdktf.FnGenerated;
 FnGenerated.anytrue(java.util.List< java.lang.Object > list)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `&#34;true&#34;`. It also returns `false` if the collection is empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `"true"`. It also returns `false` if the collection is empty.
 
 ###### `list`<sup>Required</sup> <a name="list" id="cdktf.FnGenerated.anytrue.parameter.list"></a>
 
@@ -31299,7 +31360,7 @@ import com.hashicorp.cdktf.FnGenerated;
 FnGenerated.base64sha256(java.lang.String str)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(&#34;test&#34;))` since `sha256()` returns hexadecimal representation.
+{@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256("test"))` since `sha256()` returns hexadecimal representation.
 
 ###### `str`<sup>Required</sup> <a name="str" id="cdktf.FnGenerated.base64sha256.parameter.str"></a>
 
@@ -31315,7 +31376,7 @@ import com.hashicorp.cdktf.FnGenerated;
 FnGenerated.base64sha512(java.lang.String str)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512(&#34;test&#34;))` since `sha512()` returns hexadecimal representation.
+{@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512("test"))` since `sha512()` returns hexadecimal representation.
 
 ###### `str`<sup>Required</sup> <a name="str" id="cdktf.FnGenerated.base64sha512.parameter.str"></a>
 
@@ -31505,7 +31566,7 @@ import com.hashicorp.cdktf.FnGenerated;
 FnGenerated.coalesce(java.util.List< java.lang.Object > vals)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn&#39;t null or an empty string.
+{@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn't null or an empty string.
 
 ###### `vals`<sup>Required</sup> <a name="vals" id="cdktf.FnGenerated.coalesce.parameter.vals"></a>
 
@@ -31521,7 +31582,7 @@ import com.hashicorp.cdktf.FnGenerated;
 FnGenerated.coalescelist(java.util.List< java.lang.Object > vals)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn&#39;t empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn't empty.
 
 ###### `vals`<sup>Required</sup> <a name="vals" id="cdktf.FnGenerated.coalescelist.parameter.vals"></a>
 
@@ -32239,13 +32300,23 @@ import com.hashicorp.cdktf.FnGenerated;
 FnGenerated.pathexpand(java.lang.String path)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user&#39;s home directory path.
+{@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user's home directory path.
 
 ###### `path`<sup>Required</sup> <a name="path" id="cdktf.FnGenerated.pathexpand.parameter.path"></a>
 
 - _Type:_ java.lang.String
 
 ---
+
+##### `plantimestamp` <a name="plantimestamp" id="cdktf.FnGenerated.plantimestamp"></a>
+
+```java
+import com.hashicorp.cdktf.FnGenerated;
+
+FnGenerated.plantimestamp()
+```
+
+{@link https://developer.hashicorp.com/terraform/language/functions/plantimestamp plantimestamp} returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format, fixed to a constant time representing the time of the plan.
 
 ##### `pow` <a name="pow" id="cdktf.FnGenerated.pow"></a>
 
@@ -32387,7 +32458,7 @@ import com.hashicorp.cdktf.FnGenerated;
 FnGenerated.sensitive(java.lang.Object value)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).
+{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).
 
 ###### `value`<sup>Required</sup> <a name="value" id="cdktf.FnGenerated.sensitive.parameter.value"></a>
 
@@ -32624,6 +32695,28 @@ FnGenerated.startswith(java.lang.String str, java.lang.String prefix)
 ---
 
 ###### `prefix`<sup>Required</sup> <a name="prefix" id="cdktf.FnGenerated.startswith.parameter.prefix"></a>
+
+- _Type:_ java.lang.String
+
+---
+
+##### `strcontains` <a name="strcontains" id="cdktf.FnGenerated.strcontains"></a>
+
+```java
+import com.hashicorp.cdktf.FnGenerated;
+
+FnGenerated.strcontains(java.lang.String str, java.lang.String substr)
+```
+
+{@link https://developer.hashicorp.com/terraform/language/functions/strcontains strcontains} takes two values: a string to check and an expected substring. The function returns true if the string has the substring contained within it.
+
+###### `str`<sup>Required</sup> <a name="str" id="cdktf.FnGenerated.strcontains.parameter.str"></a>
+
+- _Type:_ java.lang.String
+
+---
+
+###### `substr`<sup>Required</sup> <a name="substr" id="cdktf.FnGenerated.strcontains.parameter.substr"></a>
 
 - _Type:_ java.lang.String
 
@@ -33085,7 +33178,7 @@ import com.hashicorp.cdktf.FnGenerated;
 FnGenerated.uuidv5(java.lang.String namespace, java.lang.String name)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a &#34;version 5&#34; UUID.
+{@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a "version 5" UUID.
 
 ###### `namespace`<sup>Required</sup> <a name="namespace" id="cdktf.FnGenerated.uuidv5.parameter.namespace"></a>
 

--- a/website/docs/cdktf/api-reference/python.mdx
+++ b/website/docs/cdktf/api-reference/python.mdx
@@ -29816,13 +29816,13 @@ cdktf.Fn()
 | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | <code><a href="#cdktf.Fn.abs">abs</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/abs abs} returns the absolute value of the given number. In other words, if the number is zero or positive then it is returned as-is, but if it is negative then it is multiplied by -1 to make it positive before returning it.                                                                  |
 | <code><a href="#cdktf.Fn.abspath">abspath</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/abspath abspath} takes a string containing a filesystem path and converts it to an absolute path. That is, if the path is not absolute, it will be joined with the current working directory.                                                                                                     |
-| <code><a href="#cdktf.Fn.alltrue">alltrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `&#34;true&#34;`. It also returns `true` if the collection is empty.                                                                                                                                          |
-| <code><a href="#cdktf.Fn.anytrue">anytrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `&#34;true&#34;`. It also returns `false` if the collection is empty.                                                                                                                                           |
+| <code><a href="#cdktf.Fn.alltrue">alltrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `"true"`. It also returns `true` if the collection is empty.                                                                                                                                                  |
+| <code><a href="#cdktf.Fn.anytrue">anytrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `"true"`. It also returns `false` if the collection is empty.                                                                                                                                                   |
 | <code><a href="#cdktf.Fn.base64decode">base64decode</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64decode base64decode} takes a string containing a Base64 character sequence and returns the original string.                                                                                                                                                                                 |
 | <code><a href="#cdktf.Fn.base64encode">base64encode</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64encode base64encode} applies Base64 encoding to a string.                                                                                                                                                                                                                                   |
 | <code><a href="#cdktf.Fn.base64gzip">base64gzip</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/base64gzip base64gzip} compresses a string with gzip and then encodes the result in Base64 encoding.                                                                                                                                                                                              |
-| <code><a href="#cdktf.Fn.base64sha256">base64sha256</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(&#34;test&#34;))` since `sha256()` returns hexadecimal representation.                                                                           |
-| <code><a href="#cdktf.Fn.base64sha512">base64sha512</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512(&#34;test&#34;))` since `sha512()` returns hexadecimal representation.                                                                           |
+| <code><a href="#cdktf.Fn.base64sha256">base64sha256</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256("test"))` since `sha256()` returns hexadecimal representation.                                                                                   |
+| <code><a href="#cdktf.Fn.base64sha512">base64sha512</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512("test"))` since `sha512()` returns hexadecimal representation.                                                                                   |
 | <code><a href="#cdktf.Fn.basename">basename</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/basename basename} takes a string containing a filesystem path and removes all except the last portion from it.                                                                                                                                                                                   |
 | <code><a href="#cdktf.Fn.can">can</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/can can} evaluates the given expression and returns a boolean value indicating whether the expression produced a result without any errors.                                                                                                                                                       |
 | <code><a href="#cdktf.Fn.ceil">ceil</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/ceil ceil} returns the closest whole number that is greater than or equal to the given value, which may be a fraction.                                                                                                                                                                            |
@@ -29832,8 +29832,8 @@ cdktf.Fn()
 | <code><a href="#cdktf.Fn.cidrnetmask">cidrnetmask</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/cidrnetmask cidrnetmask} converts an IPv4 address prefix given in CIDR notation into a subnet mask address.                                                                                                                                                                                       |
 | <code><a href="#cdktf.Fn.cidrsubnet">cidrsubnet</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/cidrsubnet cidrsubnet} calculates a subnet address within given IP network address prefix.                                                                                                                                                                                                        |
 | <code><a href="#cdktf.Fn.cidrsubnets">cidrsubnets</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/cidrsubnets cidrsubnets} calculates a sequence of consecutive IP address ranges within a particular CIDR prefix.                                                                                                                                                                                  |
-| <code><a href="#cdktf.Fn.coalesce">coalesce</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn&#39;t null or an empty string.                                                                                                                                                                                |
-| <code><a href="#cdktf.Fn.coalescelist">coalescelist</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn&#39;t empty.                                                                                                                                                                                     |
+| <code><a href="#cdktf.Fn.coalesce">coalesce</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn't null or an empty string.                                                                                                                                                                                    |
+| <code><a href="#cdktf.Fn.coalescelist">coalescelist</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn't empty.                                                                                                                                                                                         |
 | <code><a href="#cdktf.Fn.compact">compact</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/compact compact} takes a list of strings and returns a new list with any empty string elements removed.                                                                                                                                                                                           |
 | <code><a href="#cdktf.Fn.concat">concat</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/concat concat} takes two or more lists and combines them into a single list.                                                                                                                                                                                                                      |
 | <code><a href="#cdktf.Fn.contains">contains</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/contains contains} determines whether a given list or set contains a given single value as one of its elements.                                                                                                                                                                                   |
@@ -29873,14 +29873,15 @@ cdktf.Fn()
 | <code><a href="#cdktf.Fn.nonsensitive">nonsensitive</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/nonsensitive nonsensitive} takes a sensitive value and returns a copy of that value with the sensitive marking removed, thereby exposing the sensitive value.                                                                                                                                     |
 | <code><a href="#cdktf.Fn.one">one</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/one one} takes a list, set, or tuple value with either zero or one elements. If the collection is empty, `one` returns `null`. Otherwise, `one` returns the first element. If there are two or more elements then `one` will return an error.                                                     |
 | <code><a href="#cdktf.Fn.parseint">parseint</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/parseint parseint} parses the given string as a representation of an integer in the specified base and returns the resulting number. The base must be between 2 and 62 inclusive.                                                                                                                 |
-| <code><a href="#cdktf.Fn.pathexpand">pathexpand</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user&#39;s home directory path.                                                                                                                           |
+| <code><a href="#cdktf.Fn.pathexpand">pathexpand</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user's home directory path.                                                                                                                               |
+| <code><a href="#cdktf.Fn.plantimestamp">plantimestamp</a></code>       | {@link https://developer.hashicorp.com/terraform/language/functions/plantimestamp plantimestamp} returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format, fixed to a constant time representing the time of the plan.                                                                                                                |
 | <code><a href="#cdktf.Fn.pow">pow</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/pow pow} calculates an exponent, by raising its first argument to the power of the second argument.                                                                                                                                                                                               |
 | <code><a href="#cdktf.Fn.regex">regex</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/regex regex} applies a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) to a string and returns the matching substrings.                                                                                                                                                    |
 | <code><a href="#cdktf.Fn.regexall">regexall</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/regexall regexall} applies a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) to a string and returns a list of all matches.                                                                                                                                                |
 | <code><a href="#cdktf.Fn.replace">replace</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/replace replace} searches a given string for another given substring, and replaces each occurrence with a given replacement string.                                                                                                                                                               |
 | <code><a href="#cdktf.Fn.reverse">reverse</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/reverse reverse} takes a sequence and produces a new sequence of the same length with all of the same elements as the given sequence but in reverse order.                                                                                                                                        |
 | <code><a href="#cdktf.Fn.rsadecrypt">rsadecrypt</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/rsadecrypt rsadecrypt} decrypts an RSA-encrypted ciphertext, returning the corresponding cleartext.                                                                                                                                                                                               |
-| <code><a href="#cdktf.Fn.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).                                            |
+| <code><a href="#cdktf.Fn.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).                                  |
 | <code><a href="#cdktf.Fn.setintersection">setintersection</a></code>   | The {@link https://developer.hashicorp.com/terraform/language/functions/setintersection setintersection} function takes multiple sets and produces a single set containing only the elements that all of the given sets have in common. In other words, it computes the [intersection](<https://en.wikipedia.org/wiki/Intersection_(set_theory)>) of the sets.        |
 | <code><a href="#cdktf.Fn.setproduct">setproduct</a></code>             | The {@link https://developer.hashicorp.com/terraform/language/functions/setproduct setproduct} function finds all of the possible combinations of elements from all of the given sets by computing the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product).                                                                                          |
 | <code><a href="#cdktf.Fn.setsubtract">setsubtract</a></code>           | The {@link https://developer.hashicorp.com/terraform/language/functions/setsubtract setsubtract} function returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the [relative complement](<https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement>) of the second set.  |
@@ -29893,6 +29894,7 @@ cdktf.Fn()
 | <code><a href="#cdktf.Fn.sort">sort</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/sort sort} takes a list of strings and returns a new list with those strings sorted lexicographically.                                                                                                                                                                                            |
 | <code><a href="#cdktf.Fn.split">split</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/split split} produces a list by dividing a given string at all occurrences of a given separator.                                                                                                                                                                                                  |
 | <code><a href="#cdktf.Fn.startswith">startswith</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/startswith startswith} takes two values: a string to check and a prefix string. The function returns true if the string begins with that exact prefix.                                                                                                                                            |
+| <code><a href="#cdktf.Fn.strcontains">strcontains</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/strcontains strcontains} takes two values: a string to check and an expected substring. The function returns true if the string has the substring contained within it.                                                                                                                            |
 | <code><a href="#cdktf.Fn.strrev">strrev</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/strrev strrev} reverses the characters in a string. Note that the characters are treated as _Unicode characters_ (in technical terms, Unicode [grapheme cluster boundaries](https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries) are respected).                                        |
 | <code><a href="#cdktf.Fn.substr">substr</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/substr substr} extracts a substring from a given string by offset and (maximum) length.                                                                                                                                                                                                           |
 | <code><a href="#cdktf.Fn.sum">sum</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/sum sum} takes a list or set of numbers and returns the sum of those numbers.                                                                                                                                                                                                                     |
@@ -29918,7 +29920,7 @@ cdktf.Fn()
 | <code><a href="#cdktf.Fn.upper">upper</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/upper upper} converts all cased letters in the given string to uppercase.                                                                                                                                                                                                                         |
 | <code><a href="#cdktf.Fn.urlencode">urlencode</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/urlencode urlencode} applies URL encoding to a given string.                                                                                                                                                                                                                                      |
 | <code><a href="#cdktf.Fn.uuid">uuid</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/uuid uuid} generates a unique identifier string.                                                                                                                                                                                                                                                  |
-| <code><a href="#cdktf.Fn.uuidv5">uuidv5</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a &#34;version 5&#34; UUID.                                                                                                                  |
+| <code><a href="#cdktf.Fn.uuidv5">uuidv5</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a "version 5" UUID.                                                                                                                          |
 | <code><a href="#cdktf.Fn.values">values</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/values values} takes a map and returns a list containing the values of the elements in that map.                                                                                                                                                                                                  |
 | <code><a href="#cdktf.Fn.yamldecode">yamldecode</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/yamldecode yamldecode} parses a string as a subset of YAML, and produces a representation of its value.                                                                                                                                                                                           |
 | <code><a href="#cdktf.Fn.yamlencode">yamlencode</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/yamlencode yamlencode} encodes a given value to a string using [YAML 1.2](https://yaml.org/spec/1.2/spec.html) block syntax.                                                                                                                                                                      |
@@ -29926,6 +29928,7 @@ cdktf.Fn()
 | <code><a href="#cdktf.Fn.bcrypt">bcrypt</a></code>                     | {@link /terraform/docs/language/functions/bcrypt.html bcrypt} computes a hash of the given string using the Blowfish cipher, returning a string in [the _Modular Crypt Format_](https://passlib.readthedocs.io/en/stable/modular_crypt_format.html) usually expected in the shadow password file on many Unix systems.                                                |
 | <code><a href="#cdktf.Fn.join">join</a></code>                         | {@link /terraform/docs/language/functions/join.html join} produces a string by concatenating together all elements of a given list of strings with the given delimiter.                                                                                                                                                                                               |
 | <code><a href="#cdktf.Fn.lookup">lookup</a></code>                     | {@link /terraform/docs/language/functions/lookup.html lookup} retrieves the value of a single element from a map, given its key. If the given key does not exist, the given default value is returned instead.                                                                                                                                                        |
+| <code><a href="#cdktf.Fn.lookupNested">lookup_nested</a></code>        | returns a property access expression that accesses the property at the given path in the given inputMap.                                                                                                                                                                                                                                                              |
 | <code><a href="#cdktf.Fn.range">range</a></code>                       | {@link /terraform/docs/language/functions/range.html range} generates a list of numbers using a start value, a limit value, and a step value.                                                                                                                                                                                                                         |
 | <code><a href="#cdktf.Fn.rawString">raw_string</a></code>              | Use this function to wrap a string and escape it properly for the use in Terraform This is only needed in certain scenarios (e.g., if you have unescaped double quotes in the string).                                                                                                                                                                                |
 
@@ -29977,7 +29980,7 @@ cdktf.Fn.alltrue(
 )
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `&#34;true&#34;`. It also returns `true` if the collection is empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `"true"`. It also returns `true` if the collection is empty.
 
 ###### `list`<sup>Required</sup> <a name="list" id="cdktf.Fn.alltrue.parameter.list"></a>
 
@@ -29995,7 +29998,7 @@ cdktf.Fn.anytrue(
 )
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `&#34;true&#34;`. It also returns `false` if the collection is empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `"true"`. It also returns `false` if the collection is empty.
 
 ###### `list`<sup>Required</sup> <a name="list" id="cdktf.Fn.anytrue.parameter.list"></a>
 
@@ -30067,7 +30070,7 @@ cdktf.Fn.base64sha256(
 )
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(&#34;test&#34;))` since `sha256()` returns hexadecimal representation.
+{@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256("test"))` since `sha256()` returns hexadecimal representation.
 
 ###### `str`<sup>Required</sup> <a name="str" id="cdktf.Fn.base64sha256.parameter.str"></a>
 
@@ -30085,7 +30088,7 @@ cdktf.Fn.base64sha512(
 )
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512(&#34;test&#34;))` since `sha512()` returns hexadecimal representation.
+{@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512("test"))` since `sha512()` returns hexadecimal representation.
 
 ###### `str`<sup>Required</sup> <a name="str" id="cdktf.Fn.base64sha512.parameter.str"></a>
 
@@ -30300,7 +30303,7 @@ cdktf.Fn.coalesce(
 )
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn&#39;t null or an empty string.
+{@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn't null or an empty string.
 
 ###### `vals`<sup>Required</sup> <a name="vals" id="cdktf.Fn.coalesce.parameter.vals"></a>
 
@@ -30318,7 +30321,7 @@ cdktf.Fn.coalescelist(
 )
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn&#39;t empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn't empty.
 
 ###### `vals`<sup>Required</sup> <a name="vals" id="cdktf.Fn.coalescelist.parameter.vals"></a>
 
@@ -31129,13 +31132,23 @@ cdktf.Fn.pathexpand(
 )
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user&#39;s home directory path.
+{@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user's home directory path.
 
 ###### `path`<sup>Required</sup> <a name="path" id="cdktf.Fn.pathexpand.parameter.path"></a>
 
 - _Type:_ str
 
 ---
+
+##### `plantimestamp` <a name="plantimestamp" id="cdktf.Fn.plantimestamp"></a>
+
+```python
+import cdktf
+
+cdktf.Fn.plantimestamp()
+```
+
+{@link https://developer.hashicorp.com/terraform/language/functions/plantimestamp plantimestamp} returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format, fixed to a constant time representing the time of the plan.
 
 ##### `pow` <a name="pow" id="cdktf.Fn.pow"></a>
 
@@ -31297,7 +31310,7 @@ cdktf.Fn.sensitive(
 )
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).
+{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).
 
 ###### `value`<sup>Required</sup> <a name="value" id="cdktf.Fn.sensitive.parameter.value"></a>
 
@@ -31565,6 +31578,31 @@ cdktf.Fn.startswith(
 ---
 
 ###### `prefix`<sup>Required</sup> <a name="prefix" id="cdktf.Fn.startswith.parameter.prefix"></a>
+
+- _Type:_ str
+
+---
+
+##### `strcontains` <a name="strcontains" id="cdktf.Fn.strcontains"></a>
+
+```python
+import cdktf
+
+cdktf.Fn.strcontains(
+  str: str,
+  substr: str
+)
+```
+
+{@link https://developer.hashicorp.com/terraform/language/functions/strcontains strcontains} takes two values: a string to check and an expected substring. The function returns true if the string has the substring contained within it.
+
+###### `str`<sup>Required</sup> <a name="str" id="cdktf.Fn.strcontains.parameter.str"></a>
+
+- _Type:_ str
+
+---
+
+###### `substr`<sup>Required</sup> <a name="substr" id="cdktf.Fn.strcontains.parameter.substr"></a>
 
 - _Type:_ str
 
@@ -32085,7 +32123,7 @@ cdktf.Fn.uuidv5(
 )
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a &#34;version 5&#34; UUID.
+{@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a "version 5" UUID.
 
 ###### `namespace`<sup>Required</sup> <a name="namespace" id="cdktf.Fn.uuidv5.parameter.namespace"></a>
 
@@ -32236,7 +32274,7 @@ import cdktf
 cdktf.Fn.lookup(
   input_map: typing.Any,
   key: str,
-  default_value: typing.Any
+  default_value: typing.Any = None
 )
 ```
 
@@ -32254,9 +32292,36 @@ cdktf.Fn.lookup(
 
 ---
 
-###### `default_value`<sup>Required</sup> <a name="default_value" id="cdktf.Fn.lookup.parameter.defaultValue"></a>
+###### `default_value`<sup>Optional</sup> <a name="default_value" id="cdktf.Fn.lookup.parameter.defaultValue"></a>
 
 - _Type:_ typing.Any
+
+---
+
+##### `lookup_nested` <a name="lookup_nested" id="cdktf.Fn.lookupNested"></a>
+
+```python
+import cdktf
+
+cdktf.Fn.lookup_nested(
+  input_map: typing.Any,
+  path: typing.List[typing.Any]
+)
+```
+
+returns a property access expression that accesses the property at the given path in the given inputMap.
+
+For example lookupNested(x, ["a", "b", "c"]) will return a Terraform expression like x["a"]["b"]["c"]
+
+###### `input_map`<sup>Required</sup> <a name="input_map" id="cdktf.Fn.lookupNested.parameter.inputMap"></a>
+
+- _Type:_ typing.Any
+
+---
+
+###### `path`<sup>Required</sup> <a name="path" id="cdktf.Fn.lookupNested.parameter.path"></a>
+
+- _Type:_ typing.List[typing.Any]
 
 ---
 
@@ -32331,13 +32396,13 @@ cdktf.FnGenerated()
 | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | <code><a href="#cdktf.FnGenerated.abs">abs</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/abs abs} returns the absolute value of the given number. In other words, if the number is zero or positive then it is returned as-is, but if it is negative then it is multiplied by -1 to make it positive before returning it.                                                                  |
 | <code><a href="#cdktf.FnGenerated.abspath">abspath</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/abspath abspath} takes a string containing a filesystem path and converts it to an absolute path. That is, if the path is not absolute, it will be joined with the current working directory.                                                                                                     |
-| <code><a href="#cdktf.FnGenerated.alltrue">alltrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `&#34;true&#34;`. It also returns `true` if the collection is empty.                                                                                                                                          |
-| <code><a href="#cdktf.FnGenerated.anytrue">anytrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `&#34;true&#34;`. It also returns `false` if the collection is empty.                                                                                                                                           |
+| <code><a href="#cdktf.FnGenerated.alltrue">alltrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `"true"`. It also returns `true` if the collection is empty.                                                                                                                                                  |
+| <code><a href="#cdktf.FnGenerated.anytrue">anytrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `"true"`. It also returns `false` if the collection is empty.                                                                                                                                                   |
 | <code><a href="#cdktf.FnGenerated.base64decode">base64decode</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64decode base64decode} takes a string containing a Base64 character sequence and returns the original string.                                                                                                                                                                                 |
 | <code><a href="#cdktf.FnGenerated.base64encode">base64encode</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64encode base64encode} applies Base64 encoding to a string.                                                                                                                                                                                                                                   |
 | <code><a href="#cdktf.FnGenerated.base64gzip">base64gzip</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/base64gzip base64gzip} compresses a string with gzip and then encodes the result in Base64 encoding.                                                                                                                                                                                              |
-| <code><a href="#cdktf.FnGenerated.base64sha256">base64sha256</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(&#34;test&#34;))` since `sha256()` returns hexadecimal representation.                                                                           |
-| <code><a href="#cdktf.FnGenerated.base64sha512">base64sha512</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512(&#34;test&#34;))` since `sha512()` returns hexadecimal representation.                                                                           |
+| <code><a href="#cdktf.FnGenerated.base64sha256">base64sha256</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256("test"))` since `sha256()` returns hexadecimal representation.                                                                                   |
+| <code><a href="#cdktf.FnGenerated.base64sha512">base64sha512</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512("test"))` since `sha512()` returns hexadecimal representation.                                                                                   |
 | <code><a href="#cdktf.FnGenerated.basename">basename</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/basename basename} takes a string containing a filesystem path and removes all except the last portion from it.                                                                                                                                                                                   |
 | <code><a href="#cdktf.FnGenerated.can">can</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/can can} evaluates the given expression and returns a boolean value indicating whether the expression produced a result without any errors.                                                                                                                                                       |
 | <code><a href="#cdktf.FnGenerated.ceil">ceil</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/ceil ceil} returns the closest whole number that is greater than or equal to the given value, which may be a fraction.                                                                                                                                                                            |
@@ -32347,8 +32412,8 @@ cdktf.FnGenerated()
 | <code><a href="#cdktf.FnGenerated.cidrnetmask">cidrnetmask</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/cidrnetmask cidrnetmask} converts an IPv4 address prefix given in CIDR notation into a subnet mask address.                                                                                                                                                                                       |
 | <code><a href="#cdktf.FnGenerated.cidrsubnet">cidrsubnet</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/cidrsubnet cidrsubnet} calculates a subnet address within given IP network address prefix.                                                                                                                                                                                                        |
 | <code><a href="#cdktf.FnGenerated.cidrsubnets">cidrsubnets</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/cidrsubnets cidrsubnets} calculates a sequence of consecutive IP address ranges within a particular CIDR prefix.                                                                                                                                                                                  |
-| <code><a href="#cdktf.FnGenerated.coalesce">coalesce</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn&#39;t null or an empty string.                                                                                                                                                                                |
-| <code><a href="#cdktf.FnGenerated.coalescelist">coalescelist</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn&#39;t empty.                                                                                                                                                                                     |
+| <code><a href="#cdktf.FnGenerated.coalesce">coalesce</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn't null or an empty string.                                                                                                                                                                                    |
+| <code><a href="#cdktf.FnGenerated.coalescelist">coalescelist</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn't empty.                                                                                                                                                                                         |
 | <code><a href="#cdktf.FnGenerated.compact">compact</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/compact compact} takes a list of strings and returns a new list with any empty string elements removed.                                                                                                                                                                                           |
 | <code><a href="#cdktf.FnGenerated.concat">concat</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/concat concat} takes two or more lists and combines them into a single list.                                                                                                                                                                                                                      |
 | <code><a href="#cdktf.FnGenerated.contains">contains</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/contains contains} determines whether a given list or set contains a given single value as one of its elements.                                                                                                                                                                                   |
@@ -32388,14 +32453,15 @@ cdktf.FnGenerated()
 | <code><a href="#cdktf.FnGenerated.nonsensitive">nonsensitive</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/nonsensitive nonsensitive} takes a sensitive value and returns a copy of that value with the sensitive marking removed, thereby exposing the sensitive value.                                                                                                                                     |
 | <code><a href="#cdktf.FnGenerated.one">one</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/one one} takes a list, set, or tuple value with either zero or one elements. If the collection is empty, `one` returns `null`. Otherwise, `one` returns the first element. If there are two or more elements then `one` will return an error.                                                     |
 | <code><a href="#cdktf.FnGenerated.parseint">parseint</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/parseint parseint} parses the given string as a representation of an integer in the specified base and returns the resulting number. The base must be between 2 and 62 inclusive.                                                                                                                 |
-| <code><a href="#cdktf.FnGenerated.pathexpand">pathexpand</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user&#39;s home directory path.                                                                                                                           |
+| <code><a href="#cdktf.FnGenerated.pathexpand">pathexpand</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user's home directory path.                                                                                                                               |
+| <code><a href="#cdktf.FnGenerated.plantimestamp">plantimestamp</a></code>       | {@link https://developer.hashicorp.com/terraform/language/functions/plantimestamp plantimestamp} returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format, fixed to a constant time representing the time of the plan.                                                                                                                |
 | <code><a href="#cdktf.FnGenerated.pow">pow</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/pow pow} calculates an exponent, by raising its first argument to the power of the second argument.                                                                                                                                                                                               |
 | <code><a href="#cdktf.FnGenerated.regex">regex</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/regex regex} applies a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) to a string and returns the matching substrings.                                                                                                                                                    |
 | <code><a href="#cdktf.FnGenerated.regexall">regexall</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/regexall regexall} applies a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) to a string and returns a list of all matches.                                                                                                                                                |
 | <code><a href="#cdktf.FnGenerated.replace">replace</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/replace replace} searches a given string for another given substring, and replaces each occurrence with a given replacement string.                                                                                                                                                               |
 | <code><a href="#cdktf.FnGenerated.reverse">reverse</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/reverse reverse} takes a sequence and produces a new sequence of the same length with all of the same elements as the given sequence but in reverse order.                                                                                                                                        |
 | <code><a href="#cdktf.FnGenerated.rsadecrypt">rsadecrypt</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/rsadecrypt rsadecrypt} decrypts an RSA-encrypted ciphertext, returning the corresponding cleartext.                                                                                                                                                                                               |
-| <code><a href="#cdktf.FnGenerated.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).                                            |
+| <code><a href="#cdktf.FnGenerated.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).                                  |
 | <code><a href="#cdktf.FnGenerated.setintersection">setintersection</a></code>   | The {@link https://developer.hashicorp.com/terraform/language/functions/setintersection setintersection} function takes multiple sets and produces a single set containing only the elements that all of the given sets have in common. In other words, it computes the [intersection](<https://en.wikipedia.org/wiki/Intersection_(set_theory)>) of the sets.        |
 | <code><a href="#cdktf.FnGenerated.setproduct">setproduct</a></code>             | The {@link https://developer.hashicorp.com/terraform/language/functions/setproduct setproduct} function finds all of the possible combinations of elements from all of the given sets by computing the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product).                                                                                          |
 | <code><a href="#cdktf.FnGenerated.setsubtract">setsubtract</a></code>           | The {@link https://developer.hashicorp.com/terraform/language/functions/setsubtract setsubtract} function returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the [relative complement](<https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement>) of the second set.  |
@@ -32408,6 +32474,7 @@ cdktf.FnGenerated()
 | <code><a href="#cdktf.FnGenerated.sort">sort</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/sort sort} takes a list of strings and returns a new list with those strings sorted lexicographically.                                                                                                                                                                                            |
 | <code><a href="#cdktf.FnGenerated.split">split</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/split split} produces a list by dividing a given string at all occurrences of a given separator.                                                                                                                                                                                                  |
 | <code><a href="#cdktf.FnGenerated.startswith">startswith</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/startswith startswith} takes two values: a string to check and a prefix string. The function returns true if the string begins with that exact prefix.                                                                                                                                            |
+| <code><a href="#cdktf.FnGenerated.strcontains">strcontains</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/strcontains strcontains} takes two values: a string to check and an expected substring. The function returns true if the string has the substring contained within it.                                                                                                                            |
 | <code><a href="#cdktf.FnGenerated.strrev">strrev</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/strrev strrev} reverses the characters in a string. Note that the characters are treated as _Unicode characters_ (in technical terms, Unicode [grapheme cluster boundaries](https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries) are respected).                                        |
 | <code><a href="#cdktf.FnGenerated.substr">substr</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/substr substr} extracts a substring from a given string by offset and (maximum) length.                                                                                                                                                                                                           |
 | <code><a href="#cdktf.FnGenerated.sum">sum</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/sum sum} takes a list or set of numbers and returns the sum of those numbers.                                                                                                                                                                                                                     |
@@ -32433,7 +32500,7 @@ cdktf.FnGenerated()
 | <code><a href="#cdktf.FnGenerated.upper">upper</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/upper upper} converts all cased letters in the given string to uppercase.                                                                                                                                                                                                                         |
 | <code><a href="#cdktf.FnGenerated.urlencode">urlencode</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/urlencode urlencode} applies URL encoding to a given string.                                                                                                                                                                                                                                      |
 | <code><a href="#cdktf.FnGenerated.uuid">uuid</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/uuid uuid} generates a unique identifier string.                                                                                                                                                                                                                                                  |
-| <code><a href="#cdktf.FnGenerated.uuidv5">uuidv5</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a &#34;version 5&#34; UUID.                                                                                                                  |
+| <code><a href="#cdktf.FnGenerated.uuidv5">uuidv5</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a "version 5" UUID.                                                                                                                          |
 | <code><a href="#cdktf.FnGenerated.values">values</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/values values} takes a map and returns a list containing the values of the elements in that map.                                                                                                                                                                                                  |
 | <code><a href="#cdktf.FnGenerated.yamldecode">yamldecode</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/yamldecode yamldecode} parses a string as a subset of YAML, and produces a representation of its value.                                                                                                                                                                                           |
 | <code><a href="#cdktf.FnGenerated.yamlencode">yamlencode</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/yamlencode yamlencode} encodes a given value to a string using [YAML 1.2](https://yaml.org/spec/1.2/spec.html) block syntax.                                                                                                                                                                      |
@@ -32487,7 +32554,7 @@ cdktf.FnGenerated.alltrue(
 )
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `&#34;true&#34;`. It also returns `true` if the collection is empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `"true"`. It also returns `true` if the collection is empty.
 
 ###### `list`<sup>Required</sup> <a name="list" id="cdktf.FnGenerated.alltrue.parameter.list"></a>
 
@@ -32505,7 +32572,7 @@ cdktf.FnGenerated.anytrue(
 )
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `&#34;true&#34;`. It also returns `false` if the collection is empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `"true"`. It also returns `false` if the collection is empty.
 
 ###### `list`<sup>Required</sup> <a name="list" id="cdktf.FnGenerated.anytrue.parameter.list"></a>
 
@@ -32577,7 +32644,7 @@ cdktf.FnGenerated.base64sha256(
 )
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(&#34;test&#34;))` since `sha256()` returns hexadecimal representation.
+{@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256("test"))` since `sha256()` returns hexadecimal representation.
 
 ###### `str`<sup>Required</sup> <a name="str" id="cdktf.FnGenerated.base64sha256.parameter.str"></a>
 
@@ -32595,7 +32662,7 @@ cdktf.FnGenerated.base64sha512(
 )
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512(&#34;test&#34;))` since `sha512()` returns hexadecimal representation.
+{@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512("test"))` since `sha512()` returns hexadecimal representation.
 
 ###### `str`<sup>Required</sup> <a name="str" id="cdktf.FnGenerated.base64sha512.parameter.str"></a>
 
@@ -32810,7 +32877,7 @@ cdktf.FnGenerated.coalesce(
 )
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn&#39;t null or an empty string.
+{@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn't null or an empty string.
 
 ###### `vals`<sup>Required</sup> <a name="vals" id="cdktf.FnGenerated.coalesce.parameter.vals"></a>
 
@@ -32828,7 +32895,7 @@ cdktf.FnGenerated.coalescelist(
 )
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn&#39;t empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn't empty.
 
 ###### `vals`<sup>Required</sup> <a name="vals" id="cdktf.FnGenerated.coalescelist.parameter.vals"></a>
 
@@ -33639,13 +33706,23 @@ cdktf.FnGenerated.pathexpand(
 )
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user&#39;s home directory path.
+{@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user's home directory path.
 
 ###### `path`<sup>Required</sup> <a name="path" id="cdktf.FnGenerated.pathexpand.parameter.path"></a>
 
 - _Type:_ str
 
 ---
+
+##### `plantimestamp` <a name="plantimestamp" id="cdktf.FnGenerated.plantimestamp"></a>
+
+```python
+import cdktf
+
+cdktf.FnGenerated.plantimestamp()
+```
+
+{@link https://developer.hashicorp.com/terraform/language/functions/plantimestamp plantimestamp} returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format, fixed to a constant time representing the time of the plan.
 
 ##### `pow` <a name="pow" id="cdktf.FnGenerated.pow"></a>
 
@@ -33807,7 +33884,7 @@ cdktf.FnGenerated.sensitive(
 )
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).
+{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).
 
 ###### `value`<sup>Required</sup> <a name="value" id="cdktf.FnGenerated.sensitive.parameter.value"></a>
 
@@ -34075,6 +34152,31 @@ cdktf.FnGenerated.startswith(
 ---
 
 ###### `prefix`<sup>Required</sup> <a name="prefix" id="cdktf.FnGenerated.startswith.parameter.prefix"></a>
+
+- _Type:_ str
+
+---
+
+##### `strcontains` <a name="strcontains" id="cdktf.FnGenerated.strcontains"></a>
+
+```python
+import cdktf
+
+cdktf.FnGenerated.strcontains(
+  str: str,
+  substr: str
+)
+```
+
+{@link https://developer.hashicorp.com/terraform/language/functions/strcontains strcontains} takes two values: a string to check and an expected substring. The function returns true if the string has the substring contained within it.
+
+###### `str`<sup>Required</sup> <a name="str" id="cdktf.FnGenerated.strcontains.parameter.str"></a>
+
+- _Type:_ str
+
+---
+
+###### `substr`<sup>Required</sup> <a name="substr" id="cdktf.FnGenerated.strcontains.parameter.substr"></a>
 
 - _Type:_ str
 
@@ -34595,7 +34697,7 @@ cdktf.FnGenerated.uuidv5(
 )
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a &#34;version 5&#34; UUID.
+{@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a "version 5" UUID.
 
 ###### `namespace`<sup>Required</sup> <a name="namespace" id="cdktf.FnGenerated.uuidv5.parameter.namespace"></a>
 

--- a/website/docs/cdktf/api-reference/typescript.mdx
+++ b/website/docs/cdktf/api-reference/typescript.mdx
@@ -24005,13 +24005,13 @@ new Fn();
 | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | <code><a href="#cdktf.Fn.abs">abs</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/abs abs} returns the absolute value of the given number. In other words, if the number is zero or positive then it is returned as-is, but if it is negative then it is multiplied by -1 to make it positive before returning it.                                                                  |
 | <code><a href="#cdktf.Fn.abspath">abspath</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/abspath abspath} takes a string containing a filesystem path and converts it to an absolute path. That is, if the path is not absolute, it will be joined with the current working directory.                                                                                                     |
-| <code><a href="#cdktf.Fn.alltrue">alltrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `&#34;true&#34;`. It also returns `true` if the collection is empty.                                                                                                                                          |
-| <code><a href="#cdktf.Fn.anytrue">anytrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `&#34;true&#34;`. It also returns `false` if the collection is empty.                                                                                                                                           |
+| <code><a href="#cdktf.Fn.alltrue">alltrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `"true"`. It also returns `true` if the collection is empty.                                                                                                                                                  |
+| <code><a href="#cdktf.Fn.anytrue">anytrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `"true"`. It also returns `false` if the collection is empty.                                                                                                                                                   |
 | <code><a href="#cdktf.Fn.base64decode">base64decode</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64decode base64decode} takes a string containing a Base64 character sequence and returns the original string.                                                                                                                                                                                 |
 | <code><a href="#cdktf.Fn.base64encode">base64encode</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64encode base64encode} applies Base64 encoding to a string.                                                                                                                                                                                                                                   |
 | <code><a href="#cdktf.Fn.base64gzip">base64gzip</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/base64gzip base64gzip} compresses a string with gzip and then encodes the result in Base64 encoding.                                                                                                                                                                                              |
-| <code><a href="#cdktf.Fn.base64sha256">base64sha256</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(&#34;test&#34;))` since `sha256()` returns hexadecimal representation.                                                                           |
-| <code><a href="#cdktf.Fn.base64sha512">base64sha512</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512(&#34;test&#34;))` since `sha512()` returns hexadecimal representation.                                                                           |
+| <code><a href="#cdktf.Fn.base64sha256">base64sha256</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256("test"))` since `sha256()` returns hexadecimal representation.                                                                                   |
+| <code><a href="#cdktf.Fn.base64sha512">base64sha512</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512("test"))` since `sha512()` returns hexadecimal representation.                                                                                   |
 | <code><a href="#cdktf.Fn.basename">basename</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/basename basename} takes a string containing a filesystem path and removes all except the last portion from it.                                                                                                                                                                                   |
 | <code><a href="#cdktf.Fn.can">can</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/can can} evaluates the given expression and returns a boolean value indicating whether the expression produced a result without any errors.                                                                                                                                                       |
 | <code><a href="#cdktf.Fn.ceil">ceil</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/ceil ceil} returns the closest whole number that is greater than or equal to the given value, which may be a fraction.                                                                                                                                                                            |
@@ -24021,8 +24021,8 @@ new Fn();
 | <code><a href="#cdktf.Fn.cidrnetmask">cidrnetmask</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/cidrnetmask cidrnetmask} converts an IPv4 address prefix given in CIDR notation into a subnet mask address.                                                                                                                                                                                       |
 | <code><a href="#cdktf.Fn.cidrsubnet">cidrsubnet</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/cidrsubnet cidrsubnet} calculates a subnet address within given IP network address prefix.                                                                                                                                                                                                        |
 | <code><a href="#cdktf.Fn.cidrsubnets">cidrsubnets</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/cidrsubnets cidrsubnets} calculates a sequence of consecutive IP address ranges within a particular CIDR prefix.                                                                                                                                                                                  |
-| <code><a href="#cdktf.Fn.coalesce">coalesce</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn&#39;t null or an empty string.                                                                                                                                                                                |
-| <code><a href="#cdktf.Fn.coalescelist">coalescelist</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn&#39;t empty.                                                                                                                                                                                     |
+| <code><a href="#cdktf.Fn.coalesce">coalesce</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn't null or an empty string.                                                                                                                                                                                    |
+| <code><a href="#cdktf.Fn.coalescelist">coalescelist</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn't empty.                                                                                                                                                                                         |
 | <code><a href="#cdktf.Fn.compact">compact</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/compact compact} takes a list of strings and returns a new list with any empty string elements removed.                                                                                                                                                                                           |
 | <code><a href="#cdktf.Fn.concat">concat</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/concat concat} takes two or more lists and combines them into a single list.                                                                                                                                                                                                                      |
 | <code><a href="#cdktf.Fn.contains">contains</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/contains contains} determines whether a given list or set contains a given single value as one of its elements.                                                                                                                                                                                   |
@@ -24062,14 +24062,15 @@ new Fn();
 | <code><a href="#cdktf.Fn.nonsensitive">nonsensitive</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/nonsensitive nonsensitive} takes a sensitive value and returns a copy of that value with the sensitive marking removed, thereby exposing the sensitive value.                                                                                                                                     |
 | <code><a href="#cdktf.Fn.one">one</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/one one} takes a list, set, or tuple value with either zero or one elements. If the collection is empty, `one` returns `null`. Otherwise, `one` returns the first element. If there are two or more elements then `one` will return an error.                                                     |
 | <code><a href="#cdktf.Fn.parseint">parseint</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/parseint parseint} parses the given string as a representation of an integer in the specified base and returns the resulting number. The base must be between 2 and 62 inclusive.                                                                                                                 |
-| <code><a href="#cdktf.Fn.pathexpand">pathexpand</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user&#39;s home directory path.                                                                                                                           |
+| <code><a href="#cdktf.Fn.pathexpand">pathexpand</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user's home directory path.                                                                                                                               |
+| <code><a href="#cdktf.Fn.plantimestamp">plantimestamp</a></code>       | {@link https://developer.hashicorp.com/terraform/language/functions/plantimestamp plantimestamp} returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format, fixed to a constant time representing the time of the plan.                                                                                                                |
 | <code><a href="#cdktf.Fn.pow">pow</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/pow pow} calculates an exponent, by raising its first argument to the power of the second argument.                                                                                                                                                                                               |
 | <code><a href="#cdktf.Fn.regex">regex</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/regex regex} applies a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) to a string and returns the matching substrings.                                                                                                                                                    |
 | <code><a href="#cdktf.Fn.regexall">regexall</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/regexall regexall} applies a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) to a string and returns a list of all matches.                                                                                                                                                |
 | <code><a href="#cdktf.Fn.replace">replace</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/replace replace} searches a given string for another given substring, and replaces each occurrence with a given replacement string.                                                                                                                                                               |
 | <code><a href="#cdktf.Fn.reverse">reverse</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/reverse reverse} takes a sequence and produces a new sequence of the same length with all of the same elements as the given sequence but in reverse order.                                                                                                                                        |
 | <code><a href="#cdktf.Fn.rsadecrypt">rsadecrypt</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/rsadecrypt rsadecrypt} decrypts an RSA-encrypted ciphertext, returning the corresponding cleartext.                                                                                                                                                                                               |
-| <code><a href="#cdktf.Fn.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).                                            |
+| <code><a href="#cdktf.Fn.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).                                  |
 | <code><a href="#cdktf.Fn.setintersection">setintersection</a></code>   | The {@link https://developer.hashicorp.com/terraform/language/functions/setintersection setintersection} function takes multiple sets and produces a single set containing only the elements that all of the given sets have in common. In other words, it computes the [intersection](<https://en.wikipedia.org/wiki/Intersection_(set_theory)>) of the sets.        |
 | <code><a href="#cdktf.Fn.setproduct">setproduct</a></code>             | The {@link https://developer.hashicorp.com/terraform/language/functions/setproduct setproduct} function finds all of the possible combinations of elements from all of the given sets by computing the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product).                                                                                          |
 | <code><a href="#cdktf.Fn.setsubtract">setsubtract</a></code>           | The {@link https://developer.hashicorp.com/terraform/language/functions/setsubtract setsubtract} function returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the [relative complement](<https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement>) of the second set.  |
@@ -24082,6 +24083,7 @@ new Fn();
 | <code><a href="#cdktf.Fn.sort">sort</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/sort sort} takes a list of strings and returns a new list with those strings sorted lexicographically.                                                                                                                                                                                            |
 | <code><a href="#cdktf.Fn.split">split</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/split split} produces a list by dividing a given string at all occurrences of a given separator.                                                                                                                                                                                                  |
 | <code><a href="#cdktf.Fn.startswith">startswith</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/startswith startswith} takes two values: a string to check and a prefix string. The function returns true if the string begins with that exact prefix.                                                                                                                                            |
+| <code><a href="#cdktf.Fn.strcontains">strcontains</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/strcontains strcontains} takes two values: a string to check and an expected substring. The function returns true if the string has the substring contained within it.                                                                                                                            |
 | <code><a href="#cdktf.Fn.strrev">strrev</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/strrev strrev} reverses the characters in a string. Note that the characters are treated as _Unicode characters_ (in technical terms, Unicode [grapheme cluster boundaries](https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries) are respected).                                        |
 | <code><a href="#cdktf.Fn.substr">substr</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/substr substr} extracts a substring from a given string by offset and (maximum) length.                                                                                                                                                                                                           |
 | <code><a href="#cdktf.Fn.sum">sum</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/sum sum} takes a list or set of numbers and returns the sum of those numbers.                                                                                                                                                                                                                     |
@@ -24107,7 +24109,7 @@ new Fn();
 | <code><a href="#cdktf.Fn.upper">upper</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/upper upper} converts all cased letters in the given string to uppercase.                                                                                                                                                                                                                         |
 | <code><a href="#cdktf.Fn.urlencode">urlencode</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/urlencode urlencode} applies URL encoding to a given string.                                                                                                                                                                                                                                      |
 | <code><a href="#cdktf.Fn.uuid">uuid</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/uuid uuid} generates a unique identifier string.                                                                                                                                                                                                                                                  |
-| <code><a href="#cdktf.Fn.uuidv5">uuidv5</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a &#34;version 5&#34; UUID.                                                                                                                  |
+| <code><a href="#cdktf.Fn.uuidv5">uuidv5</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a "version 5" UUID.                                                                                                                          |
 | <code><a href="#cdktf.Fn.values">values</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/values values} takes a map and returns a list containing the values of the elements in that map.                                                                                                                                                                                                  |
 | <code><a href="#cdktf.Fn.yamldecode">yamldecode</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/yamldecode yamldecode} parses a string as a subset of YAML, and produces a representation of its value.                                                                                                                                                                                           |
 | <code><a href="#cdktf.Fn.yamlencode">yamlencode</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/yamlencode yamlencode} encodes a given value to a string using [YAML 1.2](https://yaml.org/spec/1.2/spec.html) block syntax.                                                                                                                                                                      |
@@ -24115,6 +24117,7 @@ new Fn();
 | <code><a href="#cdktf.Fn.bcrypt">bcrypt</a></code>                     | {@link /terraform/docs/language/functions/bcrypt.html bcrypt} computes a hash of the given string using the Blowfish cipher, returning a string in [the _Modular Crypt Format_](https://passlib.readthedocs.io/en/stable/modular_crypt_format.html) usually expected in the shadow password file on many Unix systems.                                                |
 | <code><a href="#cdktf.Fn.join">join</a></code>                         | {@link /terraform/docs/language/functions/join.html join} produces a string by concatenating together all elements of a given list of strings with the given delimiter.                                                                                                                                                                                               |
 | <code><a href="#cdktf.Fn.lookup">lookup</a></code>                     | {@link /terraform/docs/language/functions/lookup.html lookup} retrieves the value of a single element from a map, given its key. If the given key does not exist, the given default value is returned instead.                                                                                                                                                        |
+| <code><a href="#cdktf.Fn.lookupNested">lookupNested</a></code>         | returns a property access expression that accesses the property at the given path in the given inputMap.                                                                                                                                                                                                                                                              |
 | <code><a href="#cdktf.Fn.range">range</a></code>                       | {@link /terraform/docs/language/functions/range.html range} generates a list of numbers using a start value, a limit value, and a step value.                                                                                                                                                                                                                         |
 | <code><a href="#cdktf.Fn.rawString">rawString</a></code>               | Use this function to wrap a string and escape it properly for the use in Terraform This is only needed in certain scenarios (e.g., if you have unescaped double quotes in the string).                                                                                                                                                                                |
 
@@ -24160,7 +24163,7 @@ import { Fn } from 'cdktf'
 Fn.alltrue(list: any[])
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `&#34;true&#34;`. It also returns `true` if the collection is empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `"true"`. It also returns `true` if the collection is empty.
 
 ###### `list`<sup>Required</sup> <a name="list" id="cdktf.Fn.alltrue.parameter.list"></a>
 
@@ -24176,7 +24179,7 @@ import { Fn } from 'cdktf'
 Fn.anytrue(list: any[])
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `&#34;true&#34;`. It also returns `false` if the collection is empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `"true"`. It also returns `false` if the collection is empty.
 
 ###### `list`<sup>Required</sup> <a name="list" id="cdktf.Fn.anytrue.parameter.list"></a>
 
@@ -24240,7 +24243,7 @@ import { Fn } from 'cdktf'
 Fn.base64sha256(str: string)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(&#34;test&#34;))` since `sha256()` returns hexadecimal representation.
+{@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256("test"))` since `sha256()` returns hexadecimal representation.
 
 ###### `str`<sup>Required</sup> <a name="str" id="cdktf.Fn.base64sha256.parameter.str"></a>
 
@@ -24256,7 +24259,7 @@ import { Fn } from 'cdktf'
 Fn.base64sha512(str: string)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512(&#34;test&#34;))` since `sha512()` returns hexadecimal representation.
+{@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512("test"))` since `sha512()` returns hexadecimal representation.
 
 ###### `str`<sup>Required</sup> <a name="str" id="cdktf.Fn.base64sha512.parameter.str"></a>
 
@@ -24446,7 +24449,7 @@ import { Fn } from 'cdktf'
 Fn.coalesce(vals: any[])
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn&#39;t null or an empty string.
+{@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn't null or an empty string.
 
 ###### `vals`<sup>Required</sup> <a name="vals" id="cdktf.Fn.coalesce.parameter.vals"></a>
 
@@ -24462,7 +24465,7 @@ import { Fn } from 'cdktf'
 Fn.coalescelist(vals: any[])
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn&#39;t empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn't empty.
 
 ###### `vals`<sup>Required</sup> <a name="vals" id="cdktf.Fn.coalescelist.parameter.vals"></a>
 
@@ -25180,13 +25183,23 @@ import { Fn } from 'cdktf'
 Fn.pathexpand(path: string)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user&#39;s home directory path.
+{@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user's home directory path.
 
 ###### `path`<sup>Required</sup> <a name="path" id="cdktf.Fn.pathexpand.parameter.path"></a>
 
 - _Type:_ string
 
 ---
+
+##### `plantimestamp` <a name="plantimestamp" id="cdktf.Fn.plantimestamp"></a>
+
+```typescript
+import { Fn } from "cdktf";
+
+Fn.plantimestamp();
+```
+
+{@link https://developer.hashicorp.com/terraform/language/functions/plantimestamp plantimestamp} returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format, fixed to a constant time representing the time of the plan.
 
 ##### `pow` <a name="pow" id="cdktf.Fn.pow"></a>
 
@@ -25328,7 +25341,7 @@ import { Fn } from 'cdktf'
 Fn.sensitive(value: any)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).
+{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).
 
 ###### `value`<sup>Required</sup> <a name="value" id="cdktf.Fn.sensitive.parameter.value"></a>
 
@@ -25565,6 +25578,28 @@ Fn.startswith(str: string, prefix: string)
 ---
 
 ###### `prefix`<sup>Required</sup> <a name="prefix" id="cdktf.Fn.startswith.parameter.prefix"></a>
+
+- _Type:_ string
+
+---
+
+##### `strcontains` <a name="strcontains" id="cdktf.Fn.strcontains"></a>
+
+```typescript
+import { Fn } from 'cdktf'
+
+Fn.strcontains(str: string, substr: string)
+```
+
+{@link https://developer.hashicorp.com/terraform/language/functions/strcontains strcontains} takes two values: a string to check and an expected substring. The function returns true if the string has the substring contained within it.
+
+###### `str`<sup>Required</sup> <a name="str" id="cdktf.Fn.strcontains.parameter.str"></a>
+
+- _Type:_ string
+
+---
+
+###### `substr`<sup>Required</sup> <a name="substr" id="cdktf.Fn.strcontains.parameter.substr"></a>
 
 - _Type:_ string
 
@@ -26026,7 +26061,7 @@ import { Fn } from 'cdktf'
 Fn.uuidv5(namespace: string, name: string)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a &#34;version 5&#34; UUID.
+{@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a "version 5" UUID.
 
 ###### `namespace`<sup>Required</sup> <a name="namespace" id="cdktf.Fn.uuidv5.parameter.namespace"></a>
 
@@ -26159,7 +26194,7 @@ Fn.join(separator: string, list: string[])
 ```typescript
 import { Fn } from 'cdktf'
 
-Fn.lookup(inputMap: any, key: string, defaultValue: any)
+Fn.lookup(inputMap: any, key: string, defaultValue?: any)
 ```
 
 {@link /terraform/docs/language/functions/lookup.html lookup} retrieves the value of a single element from a map, given its key. If the given key does not exist, the given default value is returned instead.
@@ -26176,9 +26211,33 @@ Fn.lookup(inputMap: any, key: string, defaultValue: any)
 
 ---
 
-###### `defaultValue`<sup>Required</sup> <a name="defaultValue" id="cdktf.Fn.lookup.parameter.defaultValue"></a>
+###### `defaultValue`<sup>Optional</sup> <a name="defaultValue" id="cdktf.Fn.lookup.parameter.defaultValue"></a>
 
 - _Type:_ any
+
+---
+
+##### `lookupNested` <a name="lookupNested" id="cdktf.Fn.lookupNested"></a>
+
+```typescript
+import { Fn } from 'cdktf'
+
+Fn.lookupNested(inputMap: any, path: any[])
+```
+
+returns a property access expression that accesses the property at the given path in the given inputMap.
+
+For example lookupNested(x, ["a", "b", "c"]) will return a Terraform expression like x["a"]["b"]["c"]
+
+###### `inputMap`<sup>Required</sup> <a name="inputMap" id="cdktf.Fn.lookupNested.parameter.inputMap"></a>
+
+- _Type:_ any
+
+---
+
+###### `path`<sup>Required</sup> <a name="path" id="cdktf.Fn.lookupNested.parameter.path"></a>
+
+- _Type:_ any[]
 
 ---
 
@@ -26247,13 +26306,13 @@ new FnGenerated();
 | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | <code><a href="#cdktf.FnGenerated.abs">abs</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/abs abs} returns the absolute value of the given number. In other words, if the number is zero or positive then it is returned as-is, but if it is negative then it is multiplied by -1 to make it positive before returning it.                                                                  |
 | <code><a href="#cdktf.FnGenerated.abspath">abspath</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/abspath abspath} takes a string containing a filesystem path and converts it to an absolute path. That is, if the path is not absolute, it will be joined with the current working directory.                                                                                                     |
-| <code><a href="#cdktf.FnGenerated.alltrue">alltrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `&#34;true&#34;`. It also returns `true` if the collection is empty.                                                                                                                                          |
-| <code><a href="#cdktf.FnGenerated.anytrue">anytrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `&#34;true&#34;`. It also returns `false` if the collection is empty.                                                                                                                                           |
+| <code><a href="#cdktf.FnGenerated.alltrue">alltrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `"true"`. It also returns `true` if the collection is empty.                                                                                                                                                  |
+| <code><a href="#cdktf.FnGenerated.anytrue">anytrue</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `"true"`. It also returns `false` if the collection is empty.                                                                                                                                                   |
 | <code><a href="#cdktf.FnGenerated.base64decode">base64decode</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64decode base64decode} takes a string containing a Base64 character sequence and returns the original string.                                                                                                                                                                                 |
 | <code><a href="#cdktf.FnGenerated.base64encode">base64encode</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64encode base64encode} applies Base64 encoding to a string.                                                                                                                                                                                                                                   |
 | <code><a href="#cdktf.FnGenerated.base64gzip">base64gzip</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/base64gzip base64gzip} compresses a string with gzip and then encodes the result in Base64 encoding.                                                                                                                                                                                              |
-| <code><a href="#cdktf.FnGenerated.base64sha256">base64sha256</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(&#34;test&#34;))` since `sha256()` returns hexadecimal representation.                                                                           |
-| <code><a href="#cdktf.FnGenerated.base64sha512">base64sha512</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512(&#34;test&#34;))` since `sha512()` returns hexadecimal representation.                                                                           |
+| <code><a href="#cdktf.FnGenerated.base64sha256">base64sha256</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256("test"))` since `sha256()` returns hexadecimal representation.                                                                                   |
+| <code><a href="#cdktf.FnGenerated.base64sha512">base64sha512</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512("test"))` since `sha512()` returns hexadecimal representation.                                                                                   |
 | <code><a href="#cdktf.FnGenerated.basename">basename</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/basename basename} takes a string containing a filesystem path and removes all except the last portion from it.                                                                                                                                                                                   |
 | <code><a href="#cdktf.FnGenerated.can">can</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/can can} evaluates the given expression and returns a boolean value indicating whether the expression produced a result without any errors.                                                                                                                                                       |
 | <code><a href="#cdktf.FnGenerated.ceil">ceil</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/ceil ceil} returns the closest whole number that is greater than or equal to the given value, which may be a fraction.                                                                                                                                                                            |
@@ -26263,8 +26322,8 @@ new FnGenerated();
 | <code><a href="#cdktf.FnGenerated.cidrnetmask">cidrnetmask</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/cidrnetmask cidrnetmask} converts an IPv4 address prefix given in CIDR notation into a subnet mask address.                                                                                                                                                                                       |
 | <code><a href="#cdktf.FnGenerated.cidrsubnet">cidrsubnet</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/cidrsubnet cidrsubnet} calculates a subnet address within given IP network address prefix.                                                                                                                                                                                                        |
 | <code><a href="#cdktf.FnGenerated.cidrsubnets">cidrsubnets</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/cidrsubnets cidrsubnets} calculates a sequence of consecutive IP address ranges within a particular CIDR prefix.                                                                                                                                                                                  |
-| <code><a href="#cdktf.FnGenerated.coalesce">coalesce</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn&#39;t null or an empty string.                                                                                                                                                                                |
-| <code><a href="#cdktf.FnGenerated.coalescelist">coalescelist</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn&#39;t empty.                                                                                                                                                                                     |
+| <code><a href="#cdktf.FnGenerated.coalesce">coalesce</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn't null or an empty string.                                                                                                                                                                                    |
+| <code><a href="#cdktf.FnGenerated.coalescelist">coalescelist</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn't empty.                                                                                                                                                                                         |
 | <code><a href="#cdktf.FnGenerated.compact">compact</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/compact compact} takes a list of strings and returns a new list with any empty string elements removed.                                                                                                                                                                                           |
 | <code><a href="#cdktf.FnGenerated.concat">concat</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/concat concat} takes two or more lists and combines them into a single list.                                                                                                                                                                                                                      |
 | <code><a href="#cdktf.FnGenerated.contains">contains</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/contains contains} determines whether a given list or set contains a given single value as one of its elements.                                                                                                                                                                                   |
@@ -26304,14 +26363,15 @@ new FnGenerated();
 | <code><a href="#cdktf.FnGenerated.nonsensitive">nonsensitive</a></code>         | {@link https://developer.hashicorp.com/terraform/language/functions/nonsensitive nonsensitive} takes a sensitive value and returns a copy of that value with the sensitive marking removed, thereby exposing the sensitive value.                                                                                                                                     |
 | <code><a href="#cdktf.FnGenerated.one">one</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/one one} takes a list, set, or tuple value with either zero or one elements. If the collection is empty, `one` returns `null`. Otherwise, `one` returns the first element. If there are two or more elements then `one` will return an error.                                                     |
 | <code><a href="#cdktf.FnGenerated.parseint">parseint</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/parseint parseint} parses the given string as a representation of an integer in the specified base and returns the resulting number. The base must be between 2 and 62 inclusive.                                                                                                                 |
-| <code><a href="#cdktf.FnGenerated.pathexpand">pathexpand</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user&#39;s home directory path.                                                                                                                           |
+| <code><a href="#cdktf.FnGenerated.pathexpand">pathexpand</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user's home directory path.                                                                                                                               |
+| <code><a href="#cdktf.FnGenerated.plantimestamp">plantimestamp</a></code>       | {@link https://developer.hashicorp.com/terraform/language/functions/plantimestamp plantimestamp} returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format, fixed to a constant time representing the time of the plan.                                                                                                                |
 | <code><a href="#cdktf.FnGenerated.pow">pow</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/pow pow} calculates an exponent, by raising its first argument to the power of the second argument.                                                                                                                                                                                               |
 | <code><a href="#cdktf.FnGenerated.regex">regex</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/regex regex} applies a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) to a string and returns the matching substrings.                                                                                                                                                    |
 | <code><a href="#cdktf.FnGenerated.regexall">regexall</a></code>                 | {@link https://developer.hashicorp.com/terraform/language/functions/regexall regexall} applies a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) to a string and returns a list of all matches.                                                                                                                                                |
 | <code><a href="#cdktf.FnGenerated.replace">replace</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/replace replace} searches a given string for another given substring, and replaces each occurrence with a given replacement string.                                                                                                                                                               |
 | <code><a href="#cdktf.FnGenerated.reverse">reverse</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/reverse reverse} takes a sequence and produces a new sequence of the same length with all of the same elements as the given sequence but in reverse order.                                                                                                                                        |
 | <code><a href="#cdktf.FnGenerated.rsadecrypt">rsadecrypt</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/rsadecrypt rsadecrypt} decrypts an RSA-encrypted ciphertext, returning the corresponding cleartext.                                                                                                                                                                                               |
-| <code><a href="#cdktf.FnGenerated.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).                                            |
+| <code><a href="#cdktf.FnGenerated.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).                                  |
 | <code><a href="#cdktf.FnGenerated.setintersection">setintersection</a></code>   | The {@link https://developer.hashicorp.com/terraform/language/functions/setintersection setintersection} function takes multiple sets and produces a single set containing only the elements that all of the given sets have in common. In other words, it computes the [intersection](<https://en.wikipedia.org/wiki/Intersection_(set_theory)>) of the sets.        |
 | <code><a href="#cdktf.FnGenerated.setproduct">setproduct</a></code>             | The {@link https://developer.hashicorp.com/terraform/language/functions/setproduct setproduct} function finds all of the possible combinations of elements from all of the given sets by computing the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product).                                                                                          |
 | <code><a href="#cdktf.FnGenerated.setsubtract">setsubtract</a></code>           | The {@link https://developer.hashicorp.com/terraform/language/functions/setsubtract setsubtract} function returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the [relative complement](<https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement>) of the second set.  |
@@ -26324,6 +26384,7 @@ new FnGenerated();
 | <code><a href="#cdktf.FnGenerated.sort">sort</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/sort sort} takes a list of strings and returns a new list with those strings sorted lexicographically.                                                                                                                                                                                            |
 | <code><a href="#cdktf.FnGenerated.split">split</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/split split} produces a list by dividing a given string at all occurrences of a given separator.                                                                                                                                                                                                  |
 | <code><a href="#cdktf.FnGenerated.startswith">startswith</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/startswith startswith} takes two values: a string to check and a prefix string. The function returns true if the string begins with that exact prefix.                                                                                                                                            |
+| <code><a href="#cdktf.FnGenerated.strcontains">strcontains</a></code>           | {@link https://developer.hashicorp.com/terraform/language/functions/strcontains strcontains} takes two values: a string to check and an expected substring. The function returns true if the string has the substring contained within it.                                                                                                                            |
 | <code><a href="#cdktf.FnGenerated.strrev">strrev</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/strrev strrev} reverses the characters in a string. Note that the characters are treated as _Unicode characters_ (in technical terms, Unicode [grapheme cluster boundaries](https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries) are respected).                                        |
 | <code><a href="#cdktf.FnGenerated.substr">substr</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/substr substr} extracts a substring from a given string by offset and (maximum) length.                                                                                                                                                                                                           |
 | <code><a href="#cdktf.FnGenerated.sum">sum</a></code>                           | {@link https://developer.hashicorp.com/terraform/language/functions/sum sum} takes a list or set of numbers and returns the sum of those numbers.                                                                                                                                                                                                                     |
@@ -26349,7 +26410,7 @@ new FnGenerated();
 | <code><a href="#cdktf.FnGenerated.upper">upper</a></code>                       | {@link https://developer.hashicorp.com/terraform/language/functions/upper upper} converts all cased letters in the given string to uppercase.                                                                                                                                                                                                                         |
 | <code><a href="#cdktf.FnGenerated.urlencode">urlencode</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/urlencode urlencode} applies URL encoding to a given string.                                                                                                                                                                                                                                      |
 | <code><a href="#cdktf.FnGenerated.uuid">uuid</a></code>                         | {@link https://developer.hashicorp.com/terraform/language/functions/uuid uuid} generates a unique identifier string.                                                                                                                                                                                                                                                  |
-| <code><a href="#cdktf.FnGenerated.uuidv5">uuidv5</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a &#34;version 5&#34; UUID.                                                                                                                  |
+| <code><a href="#cdktf.FnGenerated.uuidv5">uuidv5</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a "version 5" UUID.                                                                                                                          |
 | <code><a href="#cdktf.FnGenerated.values">values</a></code>                     | {@link https://developer.hashicorp.com/terraform/language/functions/values values} takes a map and returns a list containing the values of the elements in that map.                                                                                                                                                                                                  |
 | <code><a href="#cdktf.FnGenerated.yamldecode">yamldecode</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/yamldecode yamldecode} parses a string as a subset of YAML, and produces a representation of its value.                                                                                                                                                                                           |
 | <code><a href="#cdktf.FnGenerated.yamlencode">yamlencode</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/yamlencode yamlencode} encodes a given value to a string using [YAML 1.2](https://yaml.org/spec/1.2/spec.html) block syntax.                                                                                                                                                                      |
@@ -26397,7 +26458,7 @@ import { FnGenerated } from 'cdktf'
 FnGenerated.alltrue(list: any[])
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `&#34;true&#34;`. It also returns `true` if the collection is empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/alltrue alltrue} returns `true` if all elements in a given collection are `true` or `"true"`. It also returns `true` if the collection is empty.
 
 ###### `list`<sup>Required</sup> <a name="list" id="cdktf.FnGenerated.alltrue.parameter.list"></a>
 
@@ -26413,7 +26474,7 @@ import { FnGenerated } from 'cdktf'
 FnGenerated.anytrue(list: any[])
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `&#34;true&#34;`. It also returns `false` if the collection is empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/anytrue anytrue} returns `true` if any element in a given collection is `true` or `"true"`. It also returns `false` if the collection is empty.
 
 ###### `list`<sup>Required</sup> <a name="list" id="cdktf.FnGenerated.anytrue.parameter.list"></a>
 
@@ -26477,7 +26538,7 @@ import { FnGenerated } from 'cdktf'
 FnGenerated.base64sha256(str: string)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256(&#34;test&#34;))` since `sha256()` returns hexadecimal representation.
+{@link https://developer.hashicorp.com/terraform/language/functions/base64sha256 base64sha256} computes the SHA256 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha256("test"))` since `sha256()` returns hexadecimal representation.
 
 ###### `str`<sup>Required</sup> <a name="str" id="cdktf.FnGenerated.base64sha256.parameter.str"></a>
 
@@ -26493,7 +26554,7 @@ import { FnGenerated } from 'cdktf'
 FnGenerated.base64sha512(str: string)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512(&#34;test&#34;))` since `sha512()` returns hexadecimal representation.
+{@link https://developer.hashicorp.com/terraform/language/functions/base64sha512 base64sha512} computes the SHA512 hash of a given string and encodes it with Base64. This is not equivalent to `base64encode(sha512("test"))` since `sha512()` returns hexadecimal representation.
 
 ###### `str`<sup>Required</sup> <a name="str" id="cdktf.FnGenerated.base64sha512.parameter.str"></a>
 
@@ -26683,7 +26744,7 @@ import { FnGenerated } from 'cdktf'
 FnGenerated.coalesce(vals: any[])
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn&#39;t null or an empty string.
+{@link https://developer.hashicorp.com/terraform/language/functions/coalesce coalesce} takes any number of arguments and returns the first one that isn't null or an empty string.
 
 ###### `vals`<sup>Required</sup> <a name="vals" id="cdktf.FnGenerated.coalesce.parameter.vals"></a>
 
@@ -26699,7 +26760,7 @@ import { FnGenerated } from 'cdktf'
 FnGenerated.coalescelist(vals: any[])
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn&#39;t empty.
+{@link https://developer.hashicorp.com/terraform/language/functions/coalescelist coalescelist} takes any number of list arguments and returns the first one that isn't empty.
 
 ###### `vals`<sup>Required</sup> <a name="vals" id="cdktf.FnGenerated.coalescelist.parameter.vals"></a>
 
@@ -27417,13 +27478,23 @@ import { FnGenerated } from 'cdktf'
 FnGenerated.pathexpand(path: string)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user&#39;s home directory path.
+{@link https://developer.hashicorp.com/terraform/language/functions/pathexpand pathexpand} takes a filesystem path that might begin with a `~` segment, and if so it replaces that segment with the current user's home directory path.
 
 ###### `path`<sup>Required</sup> <a name="path" id="cdktf.FnGenerated.pathexpand.parameter.path"></a>
 
 - _Type:_ string
 
 ---
+
+##### `plantimestamp` <a name="plantimestamp" id="cdktf.FnGenerated.plantimestamp"></a>
+
+```typescript
+import { FnGenerated } from "cdktf";
+
+FnGenerated.plantimestamp();
+```
+
+{@link https://developer.hashicorp.com/terraform/language/functions/plantimestamp plantimestamp} returns a UTC timestamp string in [RFC 3339](https://tools.ietf.org/html/rfc3339) format, fixed to a constant time representing the time of the plan.
 
 ##### `pow` <a name="pow" id="cdktf.FnGenerated.pow"></a>
 
@@ -27565,7 +27636,7 @@ import { FnGenerated } from 'cdktf'
 FnGenerated.sensitive(value: any)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).
+{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).
 
 ###### `value`<sup>Required</sup> <a name="value" id="cdktf.FnGenerated.sensitive.parameter.value"></a>
 
@@ -27802,6 +27873,28 @@ FnGenerated.startswith(str: string, prefix: string)
 ---
 
 ###### `prefix`<sup>Required</sup> <a name="prefix" id="cdktf.FnGenerated.startswith.parameter.prefix"></a>
+
+- _Type:_ string
+
+---
+
+##### `strcontains` <a name="strcontains" id="cdktf.FnGenerated.strcontains"></a>
+
+```typescript
+import { FnGenerated } from 'cdktf'
+
+FnGenerated.strcontains(str: string, substr: string)
+```
+
+{@link https://developer.hashicorp.com/terraform/language/functions/strcontains strcontains} takes two values: a string to check and an expected substring. The function returns true if the string has the substring contained within it.
+
+###### `str`<sup>Required</sup> <a name="str" id="cdktf.FnGenerated.strcontains.parameter.str"></a>
+
+- _Type:_ string
+
+---
+
+###### `substr`<sup>Required</sup> <a name="substr" id="cdktf.FnGenerated.strcontains.parameter.substr"></a>
 
 - _Type:_ string
 
@@ -28263,7 +28356,7 @@ import { FnGenerated } from 'cdktf'
 FnGenerated.uuidv5(namespace: string, name: string)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a &#34;version 5&#34; UUID.
+{@link https://developer.hashicorp.com/terraform/language/functions/uuidv5 uuidv5} generates a _name-based_ UUID, as described in [RFC 4122 section 4.3](https://tools.ietf.org/html/rfc4122#section-4.3), also known as a "version 5" UUID.
 
 ###### `namespace`<sup>Required</sup> <a name="namespace" id="cdktf.FnGenerated.uuidv5.parameter.namespace"></a>
 


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes #2816 

### Description

**Initial Problem:** 
Our generated function bindings give a incomplete relative link in the `sensitive` static terraform function description. 

The products of our terraform function binding generation are then used in the `api-reference` page of our docs. For content checking purposes, the link must include the product it's associated with at the beginning– in our case it being `terraform`. 

**Solution:** 
Can't find a very pretty way to solve this issue

Resorted to use a conditional in `renderStaticMethod` of `tools/generate-function-bindings/generate.ts` that amends the relative link to its fully qualified version upon encountering the static method named `sensitive`.
```typescript
// comment with docstring for method
  let descriptionWithLink = signature.description.replace(
    `\`${name}\``,
    `{@link https://developer.hashicorp.com/terraform/language/functions/${name} ${name}}`
  );
  // Bandaid solution for content check errors https://github.com/hashicorp/terraform-cdk/issues/2816
  // Must include product in link– unfortunately it comes with it from the generation of terraform function bindings
  if (name == "sensitive") {
    descriptionWithLink = descriptionWithLink.replace(
      "/language/values/variables#suppressing-values-in-cli-output",
      "/terraform/language/values/variables#suppressing-values-in-cli-output"
    );
  }
  t.
```
The only better way to go about this is to solve it on the side of terraform core (at least I think they'd be the ones responsible) where the description on the `sensitive` static method is coming from. Though I don't know how it couldn't be a bug for them aswell.

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
