### PR TITLE
fix(docs): Fix typo in example of using TF_VAR_ to set TerraformVariable

### DIFF
--- a/website/docs/cdktf/create-and-deploy/best-practices.mdx
+++ b/website/docs/cdktf/create-and-deploy/best-practices.mdx
@@ -25,7 +25,7 @@ new MyResource(this, "hello", {
 });
 ```
 
-To pass a [Terraform variable through environment variables](/terraform/cli/config/environment-variables#tf_var_name), name the environment variable `TF_VAR_NAME`. For example, set `TF_VAR_adminPasword='<your password>'` in the execution environment.
+To pass a [Terraform variable through environment variables](/terraform/cli/config/environment-variables#tf_var_name), name the environment variable `TF_VAR_NAME`. For example, set `TF_VAR_adminPassword='<your password>'` in the execution environment.
 
 If you use Terraform Cloud with [remote execution](/terraform/cloud-docs/run/remote-operations#remote-operations), you can store your secrets in Terraform Cloud. Refer to the Terraform Cloud documentation about [workspace variables](/terraform/cloud-docs/workspaces/variables/managing-variables#workspace-specific-variables) for more details.
 


### PR DESCRIPTION
Minor: Changing TF_VAR_adminPasword to TF_VAR_adminPassword to match the text in the block above and resolve typo.

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes: NA

### Description

Noticed a typo in the Read Secrets with Terraform Variables on https://developer.hashicorp.com/terraform/cdktf/create-and-deploy/best-practices#read-secrets-with-terraform-variables

In particular the example code says `TF_VAR_adminPasword='<your password>'` and missing the second s in password, which is correctly spelled in the preceding code block.

### Checklist
This is a one character change to documentation. If you feel the need to run the checklist please let me know.