### PR TITLE
fix: unpin version of copywrite

### DIFF
--- a/.github/workflows/pr-copyright.yml
+++ b/.github/workflows/pr-copyright.yml
@@ -28,8 +28,6 @@ jobs:
           git config user.email "110428419+hashicorp-copywrite[bot]@users.noreply.github.com"
       - name: Setup Copywrite tool
         uses: hashicorp/setup-copywrite@867a1a2a064a0626db322392806428f7dc59cb3e # v1.1.2
-        with:
-          version: v0.16.4 # pinned as there's a bug causing 0.16.5 to have a different binary name which can't be loaded
       - name: Add headers using Copywrite tool
         run: copywrite headers
       - name: Check if there are any changes


### PR DESCRIPTION
`0.16.6` has been released which fixes the problem why we pinned this version in #3150

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes # <!-- INSERT ISSUE NUMBER -->

### Description

In plain English, describe your approach to addressing the issue linked above. For example, if you made a particular design decision, let us know why you chose this path instead of another solution.

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
