### PR TITLE
fix: fix Github workflow caches to restore successfully more often

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,9 @@ jobs:
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: ${{ steps.global-cache-dir-path.outputs.go }}
-          key: go-${{ runner.os }}-build
+          key: go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-build
           restore-keys: |
+            go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
             go-${{ runner.os }}-
       - name: install dependencies
         run: yarn install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,14 +27,26 @@ jobs:
         run: git config --global --add safe.directory /__w/terraform-cdk/terraform-cdk
       - name: ensure correct user
         run: chown -R root /__w/terraform-cdk
-      - name: Get yarn cache directory path
+      # Setup caches for yarn, and go
+      - name: Get cache directory paths
         id: global-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+        run: |
+          echo "yarn=$(yarn cache dir)" >> $GITHUB_OUTPUT
+          mkdir -p /usr/local/share/.cache/go
+          echo "go=/usr/local/share/.cache/go" >> $GITHUB_OUTPUT
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
-        id: global-cache # use this to check for `cache-hit` (`steps.global-cache.outputs.cache-hit != 'true'`)
         with:
-          path: ${{ steps.global-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          path: ${{ steps.global-cache-dir-path.outputs.yarn }}
+          key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-build
+          restore-keys: |
+            yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-
+            yarn-${{ runner.os }}-
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        with:
+          path: ${{ steps.global-cache-dir-path.outputs.go }}
+          key: go-${{ runner.os }}-build
+          restore-keys: |
+            go-${{ runner.os }}-
       - name: install dependencies
         run: yarn install
       - name: build and package
@@ -43,5 +55,4 @@ jobs:
           yarn package
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          TF_PLUGIN_CACHE_DIR: ${{ steps.global-cache-dir-path.outputs.dir }}/terraform-plugins
-          GOCACHE: ${{ steps.global-cache-dir-path.outputs.dir }}/go-cache
+          GOCACHE: ${{ steps.global-cache-dir-path.outputs.go }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -50,16 +50,34 @@ jobs:
         run: git config --global --add safe.directory /__w/terraform-cdk/terraform-cdk
       - name: ensure correct user
         run: chown -R root /__w/terraform-cdk
-      - name: Get yarn cache directory path
+      # Setup caches for yarn, terraform, and go
+      - name: Get cache directory paths
         id: global-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+        run: |
+          echo "yarn=$(yarn cache dir)" >> $GITHUB_OUTPUT
+          mkdir -p /usr/local/share/.cache/terraform
+          echo "terraform=/usr/local/share/.cache/terraform" >> $GITHUB_OUTPUT
+          mkdir -p /usr/local/share/.cache/go
+          echo "go=/usr/local/share/.cache/go" >> $GITHUB_OUTPUT
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
-        id: global-cache # use this to check for `cache-hit` (`steps.global-cache.outputs.cache-hit != 'true'`)
         with:
-          path: ${{ steps.global-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-examples-yarn-${{ hashFiles('**/yarn.lock') }}
+          path: ${{ steps.global-cache-dir-path.outputs.yarn }}
+          key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-examples
           restore-keys: |
-            ${{ runner.os }}-examples-yarn-
+            yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-
+            yarn-${{ runner.os }}-
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        with:
+          path: ${{ steps.global-cache-dir-path.outputs.terraform }}
+          key: terraform-${{ runner.os }}-${{ matrix.terraform }}-examples
+          restore-keys: |
+            terraform-${{ runner.os }}-${{ matrix.terraform }}
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        with:
+          path: ${{ steps.global-cache-dir-path.outputs.go }}
+          key: go-${{ runner.os }}-examples
+          restore-keys: |
+            go-${{ runner.os }}-
       - name: installing dependencies
         run: |
           yarn install --frozen-lockfile --prefer-offline
@@ -72,8 +90,8 @@ jobs:
         run: yarn build
         env:
           TERRAFORM_BINARY_NAME: "terraform${{ matrix.terraform }}"
-          TF_PLUGIN_CACHE_DIR: ${{ steps.global-cache-dir-path.outputs.dir }}/terraform-plugins
-          GOCACHE: ${{ steps.global-cache-dir-path.outputs.dir }}/go-cache
+          TF_PLUGIN_CACHE_DIR: ${{ steps.global-cache-dir-path.outputs.terraform }}
+          GOCACHE: ${{ steps.global-cache-dir-path.outputs.go }}
       - name: create bundle
         run: yarn package
       - name: examples integration tests
@@ -83,5 +101,5 @@ jobs:
           TEST_TARGET: "${{ matrix.target }}"
           TERRAFORM_BINARY_NAME: "terraform${{ matrix.terraform }}"
           MAVEN_OPTS: "-Xmx3G"
-          TF_PLUGIN_CACHE_DIR: ${{ steps.global-cache-dir-path.outputs.dir }}/terraform-plugins
-          GOCACHE: ${{ steps.global-cache-dir-path.outputs.dir }}/go-cache
+          TF_PLUGIN_CACHE_DIR: ${{ steps.global-cache-dir-path.outputs.terraform }}
+          GOCACHE: ${{ steps.global-cache-dir-path.outputs.go }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -75,8 +75,9 @@ jobs:
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: ${{ steps.global-cache-dir-path.outputs.go }}
-          key: go-${{ runner.os }}-examples
+          key: go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-examples
           restore-keys: |
+            go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
             go-${{ runner.os }}-
       - name: installing dependencies
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,8 +50,9 @@ jobs:
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: ${{ steps.global-cache-dir-path.outputs.go }}
-          key: go-${{ runner.os }}-integration
+          key: go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-integration
           restore-keys: |
+            go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
             go-${{ runner.os }}-
       - name: install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
@@ -133,9 +134,10 @@ jobs:
         with:
           path: ${{ steps.global-cache-dir-path.outputs.go }}
           # put matrix before integration to not restore caches from other sibling matrix jobs
-          key: go-${{ runner.os }}-matrix-integration-${{ matrix.target }}
+          key: go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-matrix-integration-${{ matrix.target }}
           restore-keys: |
-            go-${{ runner.os }}-integration
+            go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-integration
+            go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
             go-${{ runner.os }}-
       - name: Download dist
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
@@ -205,9 +207,10 @@ jobs:
         with:
           path: ${{ steps.global-cache-dir-path.outputs.go }}
           # put matrix before integration to not restore caches from other sibling matrix jobs
-          key: go-${{ runner.os }}-matrix-integration-${{ matrix.target }}
+          key: go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-matrix-integration-${{ matrix.target }}
           restore-keys: |
-            go-${{ runner.os }}-integration
+            go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-integration
+            go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
             go-${{ runner.os }}-
       - name: HashiCorp - Setup Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,18 +33,28 @@ jobs:
         run: git config --global --add safe.directory /__w/terraform-cdk/terraform-cdk
       - name: ensure correct user
         run: chown -R root /__w/terraform-cdk
-      - name: Get yarn cache directory path
+      # Setup caches for yarn, and go
+      - name: Get cache directory paths
         id: global-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+        run: |
+          echo "yarn=$(yarn cache dir)" >> $GITHUB_OUTPUT
+          mkdir -p /usr/local/share/.cache/go
+          echo "go=/usr/local/share/.cache/go" >> $GITHUB_OUTPUT
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
-        id: global-cache # use this to check for `cache-hit` (`steps.global-cache.outputs.cache-hit != 'true'`)
         with:
-          path: ${{ steps.global-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-integration-yarn-${{ hashFiles('**/yarn.lock') }}
+          path: ${{ steps.global-cache-dir-path.outputs.yarn }}
+          key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-integration
+          restore-keys: |
+            yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-
+            yarn-${{ runner.os }}-
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        with:
+          path: ${{ steps.global-cache-dir-path.outputs.go }}
+          key: go-${{ runner.os }}-integration
+          restore-keys: |
+            go-${{ runner.os }}-
       - name: install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
-        env:
-          YARN_CACHE_FOLDER: ${{ steps.global-cache-dir-path.outputs.dir }}
       - name: set version
         if: ${{ !inputs.skip_setup }}
         run: tools/align-version.sh "-dev.$GITHUB_RUN_ID"
@@ -55,8 +65,7 @@ jobs:
           yarn package
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          TF_PLUGIN_CACHE_DIR: ${{ steps.global-cache-dir-path.outputs.dir }}/terraform-plugins
-          GOCACHE: ${{ steps.global-cache-dir-path.outputs.dir }}/go-cache
+          GOCACHE: ${{ steps.global-cache-dir-path.outputs.go }}
       - name: Upload dist
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         if: ${{ !inputs.skip_setup }}
@@ -72,8 +81,6 @@ jobs:
       - name: installing test dependencies
         run: |
           cd test && yarn install --frozen-lockfile --prefer-offline
-        env:
-          YARN_CACHE_FOLDER: ${{ steps.global-cache-dir-path.outputs.dir }}
       - id: build-test-matrix
         run: |
           ./tools/build-test-matrix.sh
@@ -95,16 +102,41 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
-      - name: Get yarn cache directory path
-        id: global-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: ensure correct user
         run: chown -R root /__w/terraform-cdk
+      # Setup caches for yarn, terraform, and go
+      - name: Get cache directory paths
+        id: global-cache-dir-path
+        run: |
+          echo "yarn=$(yarn cache dir)" >> $GITHUB_OUTPUT
+          mkdir -p /usr/local/share/.cache/terraform
+          echo "terraform=/usr/local/share/.cache/terraform" >> $GITHUB_OUTPUT
+          mkdir -p /usr/local/share/.cache/go
+          echo "go=/usr/local/share/.cache/go" >> $GITHUB_OUTPUT
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
-        id: global-cache # use this to check for `cache-hit` (`steps.global-cache.outputs.cache-hit != 'true'`)
         with:
-          path: ${{ steps.global-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-integration-yarn-${{ hashFiles('**/yarn.lock') }}
+          path: ${{ steps.global-cache-dir-path.outputs.yarn }}
+          # put matrix before integration to not restore caches from other sibling matrix jobs
+          key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-matrix-integration-${{ matrix.target }}
+          restore-keys: |
+            yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-integration
+            yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-
+            yarn-${{ runner.os }}-
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        with:
+          path: ${{ steps.global-cache-dir-path.outputs.terraform }}
+          # put matrix before integration to not restore caches from other sibling matrix jobs
+          key: terraform-${{ runner.os }}-${{ matrix.terraform }}-matrix-integration-${{ matrix.target }}
+          restore-keys: |
+            terraform-${{ runner.os }}-${{ matrix.terraform }}-
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        with:
+          path: ${{ steps.global-cache-dir-path.outputs.go }}
+          # put matrix before integration to not restore caches from other sibling matrix jobs
+          key: go-${{ runner.os }}-matrix-integration-${{ matrix.target }}
+          restore-keys: |
+            go-${{ runner.os }}-integration
+            go-${{ runner.os }}-
       - name: Download dist
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
@@ -124,8 +156,8 @@ jobs:
           TERRAFORM_CLOUD_TOKEN: ${{ secrets.TERRAFORM_CLOUD_TOKEN }}
           TERRAFORM_BINARY_NAME: "terraform${{ matrix.terraform }}"
           NODE_OPTIONS: "--max-old-space-size=7168"
-          TF_PLUGIN_CACHE_DIR: ${{ steps.global-cache-dir-path.outputs.dir }}/terraform-plugins
-          GOCACHE: ${{ steps.global-cache-dir-path.outputs.dir }}/go-cache
+          TF_PLUGIN_CACHE_DIR: ${{ steps.global-cache-dir-path.outputs.terraform }}
+          GOCACHE: ${{ steps.global-cache-dir-path.outputs.go }}
 
   windows_integration:
     needs: prepare-integration-tests
@@ -143,15 +175,40 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
-      - name: Get yarn cache directory path
+      # Setup caches for yarn, terraform, and go
+      - name: Get cache directory paths
         id: global-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
         shell: bash
+        run: |
+          echo "yarn=$(yarn cache dir)" >> $GITHUB_OUTPUT
+          mkdir -p /usr/local/share/.cache/terraform
+          echo "terraform=/usr/local/share/.cache/terraform" >> $GITHUB_OUTPUT
+          mkdir -p /usr/local/share/.cache/go
+          echo "go=/usr/local/share/.cache/go" >> $GITHUB_OUTPUT
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
-        id: global-cache # use this to check for `cache-hit` (`steps.global-cache.outputs.cache-hit != 'true'`)
         with:
-          path: ${{ steps.global-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-integration-yarn-${{ hashFiles('**/yarn.lock') }}
+          path: ${{ steps.global-cache-dir-path.outputs.yarn }}
+          # put matrix before integration to not restore caches from other sibling matrix jobs
+          key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-matrix-integration-${{ matrix.target }}
+          restore-keys: |
+            yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-integration
+            yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-
+            yarn-${{ runner.os }}-
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        with:
+          path: ${{ steps.global-cache-dir-path.outputs.terraform }}
+          # put matrix before integration to not restore caches from other sibling matrix jobs
+          key: terraform-${{ runner.os }}-${{ matrix.terraform }}-matrix-integration-${{ matrix.target }}
+          restore-keys: |
+            terraform-${{ runner.os }}-${{ matrix.terraform }}-
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        with:
+          path: ${{ steps.global-cache-dir-path.outputs.go }}
+          # put matrix before integration to not restore caches from other sibling matrix jobs
+          key: go-${{ runner.os }}-matrix-integration-${{ matrix.target }}
+          restore-keys: |
+            go-${{ runner.os }}-integration
+            go-${{ runner.os }}-
       - name: HashiCorp - Setup Terraform
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1
         with:
@@ -185,5 +242,5 @@ jobs:
           TEST_TARGET: ${{ matrix.target }}
           TERRAFORM_CLOUD_TOKEN: ${{ secrets.TERRAFORM_CLOUD_TOKEN }}
           NODE_OPTIONS: "--max-old-space-size=7168"
-          TF_PLUGIN_CACHE_DIR: ${{ steps.global-cache-dir-path.outputs.dir }}/terraform-plugins
-          GOCACHE: ${{ steps.global-cache-dir-path.outputs.dir }}/go-cache
+          TF_PLUGIN_CACHE_DIR: ${{ steps.global-cache-dir-path.outputs.terraform }}
+          GOCACHE: ${{ steps.global-cache-dir-path.outputs.go }}

--- a/.github/workflows/provider-integration.yml
+++ b/.github/workflows/provider-integration.yml
@@ -55,8 +55,9 @@ jobs:
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: ${{ steps.global-cache-dir-path.outputs.go }}
-          key: go-${{ runner.os }}-provider-integration
+          key: go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-provider-integration
           restore-keys: |
+            go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
             go-${{ runner.os }}-
       - name: installing dependencies and build
         if: ${{ !inputs.skip_setup }}

--- a/.github/workflows/provider-integration.yml
+++ b/.github/workflows/provider-integration.yml
@@ -11,6 +11,11 @@ on:
         default: pr
         required: false
         type: string
+      terraform_version:
+        description: Version of Terraform to use
+        default: 1.2.8
+        type: string
+        required: false
 
 concurrency:
   group: ${{ inputs.concurrency_group_prefix }}-provider-integration-${{ github.head_ref }}
@@ -33,18 +38,26 @@ jobs:
         run: git config --global --add safe.directory /__w/terraform-cdk/terraform-cdk
       - name: ensure correct user
         run: chown -R root /__w/terraform-cdk
-      - name: Get yarn cache directory path
+      # Setup caches for yarn, and go
+      - name: Get cache directory paths
         id: global-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
-        id: global-cache # use this to check for `cache-hit` (`steps.global-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.global-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-      - name: ensure all plugin directories exist
         run: |
-          mkdir -p ${{ steps.global-cache-dir-path.outputs.dir }}/terraform-plugins
-          mkdir -p ${{ steps.global-cache-dir-path.outputs.dir }}/go-cache
+          echo "yarn=$(yarn cache dir)" >> $GITHUB_OUTPUT
+          mkdir -p /usr/local/share/.cache/go
+          echo "go=/usr/local/share/.cache/go" >> $GITHUB_OUTPUT
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        with:
+          path: ${{ steps.global-cache-dir-path.outputs.yarn }}
+          key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-provider-integration
+          restore-keys: |
+            yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-
+            yarn-${{ runner.os }}-
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        with:
+          path: ${{ steps.global-cache-dir-path.outputs.go }}
+          key: go-${{ runner.os }}-provider-integration
+          restore-keys: |
+            go-${{ runner.os }}-
       - name: installing dependencies and build
         if: ${{ !inputs.skip_setup }}
         run: |
@@ -53,9 +66,10 @@ jobs:
           yarn build
           yarn package
         env:
-          TERRAFORM_BINARY_NAME: "terraform${{ inputs.terraform_version }}"
-          TF_PLUGIN_CACHE_DIR: ${{ steps.global-cache-dir-path.outputs.dir }}/terraform-plugins
-          GOCACHE: ${{ steps.global-cache-dir-path.outputs.dir }}/go-cache
+          GOCACHE: ${{ steps.global-cache-dir-path.outputs.go }}
+      - name: install test dependencies to warm up cache for matrix jobs to use
+        run: |
+          cd test && yarn
       - name: Upload dist
         if: ${{ !inputs.skip_setup }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
@@ -76,7 +90,8 @@ jobs:
       image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     env:
       CHECKPOINT_DISABLE: "1"
-      TERRAFORM_VERSION: ${{ matrix.terraform }}
+      TERRAFORM_VERSION: ${{ inputs.terraform_version }}
+      TERRAFORM_BINARY_NAME: "terraform${{ inputs.terraform_version }}"
     timeout-minutes: 60
 
     steps:
@@ -88,6 +103,27 @@ jobs:
           path: dist
       - name: ensure correct user
         run: chown -R root /__w/terraform-cdk
+      - name: Get cache directory paths
+        id: global-cache-dir-path
+        run: |
+          echo "yarn=$(yarn cache dir)" >> $GITHUB_OUTPUT
+          mkdir -p /usr/local/share/.cache/terraform
+          echo "terraform=/usr/local/share/.cache/terraform" >> $GITHUB_OUTPUT
+      # Only restoring yarn caches as the dependencies are not indiviual to each matrix job
+      - uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        with:
+          path: ${{ steps.global-cache-dir-path.outputs.yarn }}
+          key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-provider-integration
+          restore-keys: |
+            yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-
+            yarn-${{ runner.os }}-
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        with:
+          path: ${{ steps.global-cache-dir-path.outputs.terraform }}
+          # put matrix before provider-integration to not restore caches from other sibling matrix jobs
+          key: terraform-${{ runner.os }}-${{ inputs.terraform_version }}-matrix-provider-integration-${{ matrix.target }}
+          restore-keys: |
+            terraform-${{ runner.os }}-${{ inputs.terraform_version }}-
       - name: install test dependencies
         run: cd test && yarn
       - name: integration tests
@@ -95,8 +131,7 @@ jobs:
         env:
           TEST_TARGET: ${{ matrix.target }}
           NODE_OPTIONS: "--max-old-space-size=7168"
-          TF_PLUGIN_CACHE_DIR: ${{ steps.global-cache-dir-path.outputs.dir }}/terraform-plugins
-          GOCACHE: ${{ steps.global-cache-dir-path.outputs.dir }}/go-cache
+          TF_PLUGIN_CACHE_DIR: ${{ steps.global-cache-dir-path.outputs.terraform }}
 
   windows_provider:
     needs: prepare-provider-tests
@@ -106,7 +141,7 @@ jobs:
       matrix: ${{fromJSON(needs.prepare-provider-tests.outputs.tests)}}
     env:
       CHECKPOINT_DISABLE: "1"
-      TERRAFORM_VERSION: ${{ matrix.terraform }}
+      TERRAFORM_VERSION: ${{ inputs.terraform_version }}
     timeout-minutes: 60
 
     steps:
@@ -115,7 +150,7 @@ jobs:
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1
         with:
           terraform_wrapper: false
-          terraform_version: ${{ matrix.terraform }}
+          terraform_version: ${{ inputs.terraform_version }}
       - name: Install pipenv
         run: pip install pipenv
       - name: Install Go
@@ -127,6 +162,28 @@ jobs:
         with:
           name: dist
           path: dist
+      - name: Get cache directory paths
+        id: global-cache-dir-path
+        shell: bash
+        run: |
+          echo "yarn=$(yarn cache dir)" >> $GITHUB_OUTPUT
+          mkdir -p /usr/local/share/.cache/terraform
+          echo "terraform=/usr/local/share/.cache/terraform" >> $GITHUB_OUTPUT
+      # Only restoring yarn caches to save available cache storage size
+      - uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        with:
+          path: ${{ steps.global-cache-dir-path.outputs.yarn }}
+          key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-provider-integration
+          restore-keys: |
+            yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-
+            yarn-${{ runner.os }}-
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+        with:
+          path: ${{ steps.global-cache-dir-path.outputs.terraform }}
+          # put matrix before provider-integration to not restore caches from other sibling matrix jobs
+          key: terraform-${{ runner.os }}-${{ matrix.terraform }}-matrix-provider-integration-${{ matrix.target }}
+          restore-keys: |
+            terraform-${{ runner.os }}-${{ matrix.terraform }}-
       # tmp fix for https://github.com/npm/cli/issues/4980
       - name: update npm
         run: npm install -g npm@8.12.1
@@ -137,5 +194,4 @@ jobs:
         env:
           TEST_TARGET: ${{ matrix.target }}
           NODE_OPTIONS: "--max-old-space-size=7168"
-          TF_PLUGIN_CACHE_DIR: ${{ steps.global-cache-dir-path.outputs.dir }}/terraform-plugins
-          GOCACHE: ${{ steps.global-cache-dir-path.outputs.dir }}/go-cache
+          TF_PLUGIN_CACHE_DIR: ${{ steps.global-cache-dir-path.outputs.terraform }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -41,25 +41,35 @@ jobs:
         id: global-cache-dir-path
         run: |
           echo "yarn=$(yarn cache dir)" >> $GITHUB_OUTPUT
-          echo "terraform=$(mktemp -d)" >> $GITHUB_OUTPUT
-          echo "go=$(mktemp -d)" >> $GITHUB_OUTPUT
-          echo "providerSchema=$(mktemp -d)" >> $GITHUB_OUTPUT
+          mkdir -p /usr/local/share/.cache/terraform
+          echo "terraform=/usr/local/share/.cache/terraform" >> $GITHUB_OUTPUT
+          mkdir -p /usr/local/share/.cache/go
+          echo "go=/usr/local/share/.cache/go" >> $GITHUB_OUTPUT
+          mkdir -p /usr/local/share/.cache/providerSchema
+          echo "providerSchema=/usr/local/share/.cache/providerSchema" >> $GITHUB_OUTPUT
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: ${{ steps.global-cache-dir-path.outputs.yarn }}
-          key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-unit
+          restore-keys: |
+            yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-
+            yarn-${{ runner.os }}-
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: ${{ steps.global-cache-dir-path.outputs.terraform }}
-          key: terraform-${{ runner.os }}-${{ inputs.terraform_version }}
+          key: terraform-${{ runner.os }}-${{ inputs.terraform_version }}-unit
+          restore-keys: |
+            terraform-${{ runner.os }}-${{ inputs.terraform_version }}
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: ${{ steps.global-cache-dir-path.outputs.go }}
-          key: go-${{ runner.os }}
+          key: go-${{ runner.os }}-unit
+          restore-keys: |
+            go-${{ runner.os }}-
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: ${{ steps.global-cache-dir-path.outputs.providerSchema }}
-          key: providerSchema-${{ runner.os }}-${{ inputs.terraform_version }}
+          key: providerSchema-${{ runner.os }}-${{ inputs.terraform_version }}-unit
 
       - name: installing dependencies
         run: |

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -50,15 +50,17 @@ jobs:
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: ${{ steps.global-cache-dir-path.outputs.yarn }}
-          key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-unit
+          key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-unit-${{ inputs.package }}
           restore-keys: |
+            yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-unit-
             yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-
             yarn-${{ runner.os }}-
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: ${{ steps.global-cache-dir-path.outputs.terraform }}
-          key: terraform-${{ runner.os }}-${{ inputs.terraform_version }}-unit
+          key: terraform-${{ runner.os }}-${{ inputs.terraform_version }}-unit-${{ inputs.package }}
           restore-keys: |
+            terraform-${{ runner.os }}-${{ inputs.terraform_version }}-unit
             terraform-${{ runner.os }}-${{ inputs.terraform_version }}
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
@@ -69,7 +71,7 @@ jobs:
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: ${{ steps.global-cache-dir-path.outputs.providerSchema }}
-          key: providerSchema-${{ runner.os }}-${{ inputs.terraform_version }}-unit
+          key: providerSchema-${{ runner.os }}-${{ inputs.terraform_version }}-unit-${{ inputs.package }}
 
       - name: installing dependencies
         run: |

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -75,13 +75,12 @@ jobs:
           yarn package
         env:
           TERRAFORM_BINARY_NAME: "terraform${{ inputs.terraform_version }}"
-          TF_PLUGIN_CACHE_DIR: ${{ steps.global-cache-dir-path.outputs.terraform }}
           GOCACHE: ${{ steps.global-cache-dir-path.outputs.go }}
       - name: test
         run: |
+          unset TF_PLUGIN_CACHE_DIR
           npx lerna run --scope '${{ inputs.package }}' test:ci
         env:
           TERRAFORM_BINARY_NAME: "terraform${{ inputs.terraform_version }}"
-          TF_PLUGIN_CACHE_DIR: ${{ steps.global-cache-dir-path.outputs.terraform }}
           GOCACHE: ${{ steps.global-cache-dir-path.outputs.go }}
           CDKTF_EXPERIMENTAL_PROVIDER_SCHEMA_CACHE_PATH: ${{ steps.global-cache-dir-path.outputs.providerSchema }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -41,8 +41,6 @@ jobs:
         id: global-cache-dir-path
         run: |
           echo "yarn=$(yarn cache dir)" >> $GITHUB_OUTPUT
-          mkdir -p /usr/local/share/.cache/terraform
-          echo "terraform=/usr/local/share/.cache/terraform" >> $GITHUB_OUTPUT
           mkdir -p /usr/local/share/.cache/go
           echo "go=/usr/local/share/.cache/go" >> $GITHUB_OUTPUT
           mkdir -p /usr/local/share/.cache/providerSchema
@@ -55,12 +53,6 @@ jobs:
             yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-unit-
             yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-
             yarn-${{ runner.os }}-
-      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
-        with:
-          path: ${{ steps.global-cache-dir-path.outputs.terraform }}
-          key: terraform-${{ runner.os }}-${{ inputs.terraform_version }}-unit-${{ inputs.package }}
-          # Note: we are not using restore-keys here as they cause unit tests to fail with Terraform checksum errors
-          # coming from restored sibling caches somehow
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: ${{ steps.global-cache-dir-path.outputs.go }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -64,8 +64,9 @@ jobs:
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: ${{ steps.global-cache-dir-path.outputs.go }}
-          key: go-${{ runner.os }}-unit
+          key: go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-unit
           restore-keys: |
+            go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
             go-${{ runner.os }}-
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -59,9 +59,8 @@ jobs:
         with:
           path: ${{ steps.global-cache-dir-path.outputs.terraform }}
           key: terraform-${{ runner.os }}-${{ inputs.terraform_version }}-unit-${{ inputs.package }}
-          restore-keys: |
-            terraform-${{ runner.os }}-${{ inputs.terraform_version }}-unit
-            terraform-${{ runner.os }}-${{ inputs.terraform_version }}
+          # Note: we are not using restore-keys here as they cause unit tests to fail with Terraform checksum errors
+          # coming from restored sibling caches somehow
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: ${{ steps.global-cache-dir-path.outputs.go }}

--- a/.github/workflows/yarn-upgrade.yml
+++ b/.github/workflows/yarn-upgrade.yml
@@ -21,10 +21,12 @@ jobs:
         id: global-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
-        id: global-cache # use this to check for `cache-hit` (`steps.global-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.global-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-upgrade
+          restore-keys: |
+            yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-
+            yarn-${{ runner.os }}-
       - name: ensure correct user
         run: chown -R root /__w/terraform-cdk
       - name: Install Tools


### PR DESCRIPTION
This PR
* Stops using random temporary directories for caches, as these make cache hits impossible (the cached paths are part of the "cache version" which needs to match in order for caches to be restored)
* Starts using the same cache directories for caches of the same type (e.g. `/usr/local/share/.cache/go` for the Go cache). This allows us to get cache hits between different jobs as a fallback
* Starts using distinct cache directories for all caches of the same type (types being `terraform`, `go`, `yarn` and `providerSchema`).
* Re-names the cache keys to allow cache hits using a hierarchical restore-keys definition
* Defines `restore-keys` for caches of the same type. This allows us to restore e.g. a yarn cache from a different job if there's no cache already for the current job (while the cache might not match 100%, it will still improve the results)
* fixes the specified Terraform version for provider integration tests (used to access a matrix variable that does not exist for these tests; probably a copy&paste error)
* removes the usage of `YARN_CACHE_FOLDER` which is not necessary, since our cache is in the yarn cache dir already
* removes `GOCACHE` for jobs that don't require it