### PR TITLE
chore(release): Update CHANGELOG.md and version to 0.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.18.2
+
+Fixes a bug in 0.18.1 that broke crash reporting due to a partial dependency upgrade.
+
+### fix
+
+- fix: Fix partial dependency update for Sentry [\#3172](https://github.com/hashicorp/terraform-cdk/pull/3172)
+
 ## 0.18.1
 
 ### fix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "private": true,
   "scripts": {
     "build-and-package": "lerna run --scope 'cdktf*' --scope @cdktf/* build,package && tools/collect-dist.sh",


### PR DESCRIPTION
## 0.18.2

Fixes a bug in 0.18.1 that broke crash reporting due to a partial dependency upgrade.

### fix

- fix: Fix partial dependency update for Sentry [\#3172](https://github.com/hashicorp/terraform-cdk/pull/3172)