### PR TITLE
feat!: update minimum required Node.js version to 18.12 (LTS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+**Breaking changes**
+
+### Minimum required Node.js version updated to 18.12
+
+Since the long-term support for Node.js 16 ended on 2023-09-11, we updated our minimum compatible Node.js version to 18.12.
+
 ## 0.18.2
 
 Fixes a bug in 0.18.1 that broke crash reporting due to a partial dependency upgrade.

--- a/examples/typescript/aws-cloudfront-proxy/package.json
+++ b/examples/typescript/aws-cloudfront-proxy/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "cdktf-cli": "0.0.0",
     "jest": "^27.5.1",
     "ts-node": "^10.9.1",

--- a/examples/typescript/aws-import/package.json
+++ b/examples/typescript/aws-import/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "cdktf-cli": "0.0.0",
     "jest": "^27.5.1",
     "ts-node": "^10.9.1",

--- a/examples/typescript/aws-kubernetes/package.json
+++ b/examples/typescript/aws-kubernetes/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "dependencies": {
     "cdktf": "0.0.0",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "cdktf-cli": "0.0.0",
     "jest": "^27.5.1",
     "ts-node": "^10.9.1",

--- a/examples/typescript/aws-multiple-stacks/package.json
+++ b/examples/typescript/aws-multiple-stacks/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.2"
   },

--- a/examples/typescript/aws-prebuilt/package.json
+++ b/examples/typescript/aws-prebuilt/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "cdktf-cli": "0.0.0",
     "jest": "^27.5.1",
     "ts-node": "^10.9.1",

--- a/examples/typescript/azure-app-service/package.json
+++ b/examples/typescript/azure-app-service/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "dependencies": {
     "cdktf": "0.0.0",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "cdktf-cli": "0.0.0",
     "jest": "^27.5.1",
     "ts-node": "^10.9.1",

--- a/examples/typescript/azure-service-bus-queue-trigger/package.json
+++ b/examples/typescript/azure-service-bus-queue-trigger/package.json
@@ -15,7 +15,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "dependencies": {
     "@cdktf/provider-azurerm": "^9.0.6",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "jest": "^29.5.0",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",

--- a/examples/typescript/azure/package.json
+++ b/examples/typescript/azure/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "dependencies": {
     "cdktf": "0.0.0",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "cdktf-cli": "0.0.0",
     "jest": "^27.5.1",
     "ts-node": "^10.9.1",

--- a/examples/typescript/backends/azurerm/package.json
+++ b/examples/typescript/backends/azurerm/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "dependencies": {
     "cdktf": "0.0.0",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "cdktf-cli": "0.0.0",
     "jest": "^27.5.1",
     "ts-node": "^10.9.1",

--- a/examples/typescript/backends/cloud/package.json
+++ b/examples/typescript/backends/cloud/package.json
@@ -18,7 +18,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "dependencies": {
     "cdktf": "0.0.0",
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "cdktf-cli": "0.0.0",
     "jest": "^27.5.1",
     "ts-node": "^10.9.1",

--- a/examples/typescript/backends/gcs/package.json
+++ b/examples/typescript/backends/gcs/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "dependencies": {
     "cdktf": "0.0.0",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "cdktf-cli": "0.0.0",
     "jest": "^27.5.1",
     "ts-node": "^10.9.1",

--- a/examples/typescript/backends/remote/package.json
+++ b/examples/typescript/backends/remote/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "dependencies": {
     "cdktf": "0.0.0",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "cdktf-cli": "0.0.0",
     "jest": "^27.5.1",
     "ts-node": "^10.9.1",

--- a/examples/typescript/backends/s3/package.json
+++ b/examples/typescript/backends/s3/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "dependencies": {
     "cdktf": "0.0.0",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "cdktf-cli": "0.0.0",
     "jest": "^27.5.1",
     "ts-node": "^10.9.1",

--- a/examples/typescript/docker/package.json
+++ b/examples/typescript/docker/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.2",
     "jest": "^27.5.1"

--- a/examples/typescript/documentation/package.json
+++ b/examples/typescript/documentation/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "cdktf-cli": "0.0.0",
     "jest": "^27.5.1",
     "ts-node": "^10.9.1",

--- a/examples/typescript/google-cloudrun/package.json
+++ b/examples/typescript/google-cloudrun/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "dependencies": {
     "cdktf": "0.0.0",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "cdktf-cli": "0.0.0",
     "jest": "^27.5.1",
     "ts-node": "^10.9.1",

--- a/examples/typescript/google/package.json
+++ b/examples/typescript/google/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "dependencies": {
     "cdktf": "0.0.0",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "cdktf-cli": "0.0.0",
     "jest": "^27.5.1",
     "ts-node": "^10.9.1",

--- a/examples/typescript/kubernetes/package.json
+++ b/examples/typescript/kubernetes/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "dependencies": {
     "cdktf": "0.0.0",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "cdktf-cli": "0.0.0",
     "jest": "^27.5.1",
     "ts-node": "^10.9.1",

--- a/examples/typescript/provisioner/package.json
+++ b/examples/typescript/provisioner/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "jest": "^27.5.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.2"

--- a/examples/typescript/ucloud/package.json
+++ b/examples/typescript/ucloud/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "dependencies": {
     "cdktf": "0.0.0",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "cdktf-cli": "0.0.0",
     "jest": "^27.5.1",
     "ts-node": "^10.9.1",

--- a/examples/typescript/vault/package.json
+++ b/examples/typescript/vault/package.json
@@ -19,7 +19,7 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   },
   "dependencies": {
     "cdktf": "0.0.0",
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "cdktf-cli": "0.0.0",
     "jest": "^27.5.1",
     "ts-node": "^10.9.1",

--- a/package.json
+++ b/package.json
@@ -114,8 +114,5 @@
       "*.d.ts",
       "*.js"
     ]
-  },
-  "resolutions": {
-    "@types/node": "16.18.23"
   }
 }

--- a/packages/@cdktf/cli-core/package.json
+++ b/packages/@cdktf/cli-core/package.json
@@ -144,7 +144,7 @@
     "@types/json-schema": "^7.0.11",
     "@types/lodash.isequal": "^4.5.6",
     "@types/nock": "^11.1.0",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "@types/node-fetch": "2.6.3",
     "@types/parse-gitignore": "^1.0.0",
     "@types/react": "18.0.25",

--- a/packages/@cdktf/cli-core/templates/typescript/package.json
+++ b/packages/@cdktf/cli-core/templates/typescript/package.json
@@ -17,6 +17,6 @@
     "upgrade:next": "npm i cdktf@next cdktf-cli@next"
   },
   "engines": {
-    "node": ">=16.0"
+    "node": ">=18.0"
   }
 }

--- a/packages/@cdktf/hcl2cdk/package.json
+++ b/packages/@cdktf/hcl2cdk/package.json
@@ -55,7 +55,7 @@
     "@types/deep-equal": "^1.0.1",
     "@types/glob": "^8.1.0",
     "@types/jest": "^29.5.0",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "@types/reserved-words": "^0.1.0",
     "deepmerge": "^4.3.1",
     "jest": "^29.5.0",

--- a/packages/@cdktf/hcl2cdk/test/convertProject.test.ts
+++ b/packages/@cdktf/hcl2cdk/test/convertProject.test.ts
@@ -78,7 +78,7 @@ app.synth();`,
           "upgrade:next": "npm i cdktf@next cdktf-cli@next"
         },
         "engines": {
-          "node": ">=16.0"
+          "node": ">=18.0"
         },
         "dependencies": {
           "cdktf": "latest",

--- a/packages/@cdktf/hcl2json/package.json
+++ b/packages/@cdktf/hcl2json/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@types/fs-extra": "^11.0.1",
     "@types/jest": "^29.5.0",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.0.3"

--- a/packages/@cdktf/provider-generator/package.json
+++ b/packages/@cdktf/provider-generator/package.json
@@ -33,7 +33,7 @@
     "@cdktf/commons": "0.0.0",
     "@cdktf/hcl2json": "0.0.0",
     "@cdktf/provider-schema": "0.0.0",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "codemaker": "^1.87.0",
     "deepmerge": "^4.2.2",
     "fs-extra": "^8.1.0",

--- a/packages/cdktf-cli/package.json
+++ b/packages/cdktf-cli/package.json
@@ -124,7 +124,7 @@
     "@types/json-schema": "^7.0.11",
     "@types/lodash.isequal": "^4.5.6",
     "@types/nock": "^11.1.0",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "@types/parse-gitignore": "^1.0.0",
     "@types/pidusage": "^2.0.2",
     "@types/react": "18.0.25",

--- a/packages/cdktf-cli/src/bin/cmds/helper/check-environment.ts
+++ b/packages/cdktf-cli/src/bin/cmds/helper/check-environment.ts
@@ -46,7 +46,7 @@ async function checkGoVersion() {
 
 async function checkNodeVersion() {
   const out = await getNodeVersion();
-  throwIfLowerVersion("Node.js", "16.13.0", out);
+  throwIfLowerVersion("Node.js", "18.12.0", out);
 }
 
 export async function checkEnvironment() {

--- a/packages/cdktf/package.json
+++ b/packages/cdktf/package.json
@@ -107,7 +107,7 @@
     "@types/jest": "^29.5.0",
     "@types/json-stable-stringify": "^1.0.34",
     "@types/minimatch": "^5.1.2",
-    "@types/node": "16.18.23",
+    "@types/node": "18.11.19",
     "@types/semver": "^7.3.13",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",

--- a/website/docs/cdktf/cli-reference/cli-configuration.mdx
+++ b/website/docs/cdktf/cli-reference/cli-configuration.mdx
@@ -107,4 +107,4 @@ npm ERR! gyp ERR! not ok
 
 If you encounter this or a similar error message, install the additional tools, as described in the `node-gyp` documentation for [UNIX](https://github.com/nodejs/node-gyp#on-unix), [Mac OS X](https://github.com/nodejs/node-gyp#on-macos), and [Windows](https://github.com/nodejs/node-gyp#on-windows).
 
-You might also encounter this message if you're using a Node.js version for which we don't pre-compile native code. We currently support Node.js versions 14, 15, 16, 17, 18, and 19. If you're using a different Node.js version you can either install the required additional software as described above or switch your Node.js versions to a supported one.
+You might also encounter this message if you're using a Node.js version for which we don't pre-compile native code. We currently support Node.js versions 17, 18, 19, and 20. If you're using a different Node.js version you can either install the required additional software as described above or switch your Node.js versions to a supported one.

--- a/website/docs/cdktf/create-and-deploy/deployment-patterns.mdx
+++ b/website/docs/cdktf/create-and-deploy/deployment-patterns.mdx
@@ -72,10 +72,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 16.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: "npm"
       - name: Install CDKTF CLI
         run: npm install -g cdktf-cli

--- a/yarn.lock
+++ b/yarn.lock
@@ -2327,10 +2327,15 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@16.18.23":
+"@types/node@*":
   version "16.18.23"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.23.tgz#b6e934fe427eb7081d0015aad070acb3373c3c90"
   integrity sha512-XAMpaw1s1+6zM+jn2tmw8MyaRDIJfXxqmIQIS0HfoGYPuf7dUWeiUKopwq13KFX9lEp1+THGtlaaYx39Nxr58g==
+
+"@types/node@18.11.19":
+  version "18.11.19"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.19.tgz#35e26df9ec441ab99d73e99e9aca82935eea216d"
+  integrity sha512-YUgMWAQBWLObABqrvx8qKO1enAvBUdjZOAWQ5grBAkp5LQv45jBvYKZ3oFS9iKRCQyFjqw6iuEa1vmFqtxYLZw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
Node.js 16 LTS went EOL on 2023-09-11
