### PR TITLE
chore(examples): change debian image version in gcp example

### DIFF
--- a/examples/typescript/google/main.ts
+++ b/examples/typescript/google/main.ts
@@ -33,7 +33,7 @@ class MyStack extends TerraformStack {
       machineType: "f1-micro",
       bootDisk: {
         initializeParams: {
-          image: "debian-cloud/debian-9",
+          image: "debian-cloud/debian-12",
         },
       },
 


### PR DESCRIPTION
### Description

Changed image from debian-cloud/debian-9 to debian-cloud/debian-12 because debian-cloud/debian-9 image is not available.

```zsh
➜  terraform-cdk git:(fix/machine_image) gcloud compute images list | grep debian
debian-10-buster-v20231010                            debian-cloud         debian-10                                      READY
debian-11-bullseye-arm64-v20231010                    debian-cloud         debian-11-arm64                                READY
debian-11-bullseye-v20231010                          debian-cloud         debian-11                                      READY
debian-12-bookworm-arm64-v20231010                    debian-cloud         debian-12-arm64                                READY
debian-12-bookworm-v20231010                          debian-cloud         debian-12                                      READY
```

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
