### PR TITLE
feat(cli): Include provider info in cdktf debug 

### DIFF
--- a/packages/cdktf-cli/src/bin/cmds/handlers.ts
+++ b/packages/cdktf-cli/src/bin/cmds/handlers.ts
@@ -520,6 +520,7 @@ export async function output(argv: any) {
 }
 
 export async function debug(argv: any) {
+  // Ideally the provider info gathering happens in `collectDebugInformation()` but the inclusion of `CdktfConfig.read()` in @cdktf/commons causes the build to fail with "error TS5055"
   const config = CdktfConfig.read();
   const language = config.language;
   const cdktfVersion = await getPackageVersion(language, "cdktf");

--- a/website/docs/cdktf/cli-reference/commands.mdx
+++ b/website/docs/cdktf/cli-reference/commands.mdx
@@ -657,18 +657,24 @@ The debug information depends on the programming language. The following example
 
 ```
 $ cdktf debug
-
 language: java
-cdktf-cli: 0.10.4
-node: v16.15.0
-cdktf: 0.10.4
-constructs: 10.0.5
+cdktf-cli: 0.18.2
+node: v18.18.1
+cdktf: 0.18.2
+constructs: 10.3.0
 jsii: 1.59.0
-terraform: 1.1.8
-arch: x64
-os: darwin 21.4.0
+terraform: 1.5.5
+arch: arm64
+os: darwin 22.6.0
 java: 17.0.1
-maven: Apache Maven 3.8.2 (ea98e05a04480131370aa0c110b8c54cf726c06f)Maven home: /usr/local/Cellar/maven/3.8.2/libexecJava version: 17.0.1, vendor: Homebrew, runtime: /usr/local/Cellar/openjdk/17.0.1_1/libexec/openjdk.jdk/Contents/HomeDefault locale: en_DE, platform encoding: UTF-8OS name: "mac os x", version: "12.3.1", arch: "x86_64", family: "mac"
+maven: Apache Maven 3.8.2 (ea98e05a04480131370aa0c110b8c54cf726c06f)Maven home: /usr/local/Cellar/maven/3.8.2/libexecJava version: 17.0.1, vendor: Homebrew, runtime: /usr/local/Cellar/openjdk/17.0.1_1/libexec/openjdk.jdk/Contents/HomeDefault locale: en_DE, platform encoding: UTF-8OS name: "mac os x", version: "12.3.1", arch: "arm64", family: "mac"
+providers
+kreuzwerker/docker@~> 2.0 (LOCAL)
+        terraform provider version: 2.25.0
+@cdktf/provider-ad (PREBUILT)
+        terraform provider version: 0.4.4
+        prebuilt provider version: 6.0.0
+        cdktf version: ^0.18.0
 ```
 
 ## provider add


### PR DESCRIPTION
### Related issue

Fixes #2190

### Description

Includes provider info (local and prebuilt) into `cdktf debug`.

#### `cdktf debug`
<img width="309" alt="Screenshot 2023-10-16 at 5 53 57 PM" src="https://github.com/hashicorp/terraform-cdk/assets/72527044/9f00962a-8df6-4a01-8c05-7ee6339298e6">

#### `cdktf debug --json`
<img width="344" alt="Screenshot 2023-10-16 at 5 54 16 PM" src="https://github.com/hashicorp/terraform-cdk/assets/72527044/a3f0a577-a5b1-48ef-ba6b-6f108dffa52c">

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

