### PR TITLE
fix(lib): correct escaped attribute for moveTo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Since the long-term support for Node.js 16 ended on 2023-09-11, we updated our m
 ### Potential provider naming collision with instance function `moveTo` on `TerraformResource`
 
 We have added support for resource refactoring and renaming with the addition of the instance function `moveTo` on `TerraformResource`. We forsee the potential for naming collision with providers using `moveTo` as an attribute. In instances where provider bindings fail to compile due to the collision, regenerate your provider bindings and replace the provider related usage of `moveTo` to `moveToAttribute` in your configuration if applicable.
+
 ### Java: `codeMakerOutput` needs to be set to a company identifier
 
 We did not honor the `codeMakerOutput` setting in the `cdktf.json` previously, this is fixed now.

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
@@ -5,14 +5,14 @@ import { AttributeTypeModel } from "./attribute-type-model";
 export type GetterType =
   | { _type: "plain" }
   | {
-      _type: "args";
-      args: string;
-      returnType?: string;
-      returnStatement: string;
-    }
+    _type: "args";
+    args: string;
+    returnType?: string;
+    returnStatement: string;
+  }
   | {
-      _type: "stored_class";
-    };
+    _type: "stored_class";
+  };
 
 export type SetterType =
   | { _type: "none" }
@@ -50,7 +50,7 @@ export function escapeAttributeName(name: string) {
   // `importFrom` has potential for common name collision with providers
   if (name === "importFrom") return `${name}Attribute`;
   // `move` could have common name collision with providers
-  if (name === "move") return `${name}Attribute`;
+  if (name === "moveTo") return `${name}Attribute`;
   // `software` attribute can be confused with the JSII Java runtime package (see #3115)
   if (name === "software") return `${name}Attribute`;
   return name;
@@ -144,9 +144,8 @@ export class AttributeModel {
 
     return {
       _type: "set",
-      type: `${this.type.inputTypeDefinition}${
-        this.isProvider ? " | undefined" : ""
-      }`,
+      type: `${this.type.inputTypeDefinition}${this.isProvider ? " | undefined" : ""
+        }`,
     };
   }
 

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-model.ts
@@ -5,14 +5,14 @@ import { AttributeTypeModel } from "./attribute-type-model";
 export type GetterType =
   | { _type: "plain" }
   | {
-    _type: "args";
-    args: string;
-    returnType?: string;
-    returnStatement: string;
-  }
+      _type: "args";
+      args: string;
+      returnType?: string;
+      returnStatement: string;
+    }
   | {
-    _type: "stored_class";
-  };
+      _type: "stored_class";
+    };
 
 export type SetterType =
   | { _type: "none" }
@@ -144,8 +144,9 @@ export class AttributeModel {
 
     return {
       _type: "set",
-      type: `${this.type.inputTypeDefinition}${this.isProvider ? " | undefined" : ""
-        }`,
+      type: `${this.type.inputTypeDefinition}${
+        this.isProvider ? " | undefined" : ""
+      }`,
     };
   }
 


### PR DESCRIPTION
Previously had the name `move` in our list of escaped attributes, fixed it to be `moveTo` which is the current naming.