### PR TITLE
feat(lib): add move workflows for specifying ids directly

### DIFF
--- a/examples/typescript/aws-move/main.ts
+++ b/examples/typescript/aws-move/main.ts
@@ -176,9 +176,59 @@ export class ComplexIteratorMoveStack extends TerraformStack {
 }
 // MOVE INTO RESOURCE USING COMPLEX ITERATOR
 
+export class MoveToIDStack extends TerraformStack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new AwsProvider(this, "aws", {
+      region: "us-west-2",
+    });
+    if (process.env.STEP_2) {
+      new S3Bucket(this, "test-bucket-move-by", {
+        bucket: "test-move-bucket-move-to-id",
+      }).moveToId("aws_s3_bucket.test-bucket-1");
+
+      new S3Bucket(this, "test-bucket-1", {
+        bucket: "test-move-bucket-move-to-id",
+      });
+    }
+    if (process.env.STEP_1) {
+      new S3Bucket(this, "test-bucket-move-by", {
+        bucket: "test-move-bucket-move-to-id",
+      });
+    }
+  }
+}
+
+export class MoveFromIDStack extends TerraformStack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new AwsProvider(this, "aws", {
+      region: "us-west-2",
+    });
+    if (process.env.STEP_2) {
+      new S3Bucket(this, "test-bucket-move-by", {
+        bucket: "test-move-bucket-move-from-id",
+      }).hasMoved();
+
+      new S3Bucket(this, "test-bucket-1", {
+        bucket: "test-move-bucket-move-from-id",
+      }).moveFromId("aws_s3_bucket.test-bucket-move-by");
+    }
+    if (process.env.STEP_1) {
+      new S3Bucket(this, "test-bucket-move-by", {
+        bucket: "test-move-bucket-move-from-id",
+      });
+    }
+  }
+}
+
 const app = new App();
-new UnNestingMoveStack(app, "un-nesting-move-stack");
-new NestingMoveStack(app, "nesting-move-stack");
-new ListIteratorMoveStack(app, "list-iterator-move-stack");
-new ComplexIteratorMoveStack(app, "complex-iterator-move-stack");
+new MoveToIDStack(app, "move-to-id-stack");
+new MoveFromIDStack(app, "move-from-id-stack");
+//new UnNestingMoveStack(app, "un-nesting-move-stack");
+//new NestingMoveStack(app, "nesting-move-stack");
+//new ListIteratorMoveStack(app, "list-iterator-move-stack");
+//new ComplexIteratorMoveStack(app, "complex-iterator-move-stack");
 app.synth();

--- a/examples/typescript/aws-move/main.ts
+++ b/examples/typescript/aws-move/main.ts
@@ -227,8 +227,8 @@ export class MoveFromIDStack extends TerraformStack {
 const app = new App();
 new MoveToIDStack(app, "move-to-id-stack");
 new MoveFromIDStack(app, "move-from-id-stack");
-//new UnNestingMoveStack(app, "un-nesting-move-stack");
-//new NestingMoveStack(app, "nesting-move-stack");
-//new ListIteratorMoveStack(app, "list-iterator-move-stack");
-//new ComplexIteratorMoveStack(app, "complex-iterator-move-stack");
+new UnNestingMoveStack(app, "un-nesting-move-stack");
+new NestingMoveStack(app, "nesting-move-stack");
+new ListIteratorMoveStack(app, "list-iterator-move-stack");
+new ComplexIteratorMoveStack(app, "complex-iterator-move-stack");
 app.synth();

--- a/examples/typescript/aws-move/main.ts
+++ b/examples/typescript/aws-move/main.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { Construct, IConstruct } from "constructs";
+import { Construct } from "constructs";
 import { App, TerraformStack, TerraformIterator } from "cdktf";
 import { AwsProvider } from "./.gen/providers/aws/provider";
 import { S3Bucket } from "./.gen/providers/aws/s3-bucket";

--- a/examples/typescript/aws-move/main.ts
+++ b/examples/typescript/aws-move/main.ts
@@ -208,10 +208,6 @@ export class MoveFromIDStack extends TerraformStack {
       region: "us-west-2",
     });
     if (process.env.STEP_2) {
-      new S3Bucket(this, "test-bucket-move-by", {
-        bucket: "test-move-bucket-move-from-id",
-      }).hasMoved();
-
       new S3Bucket(this, "test-bucket-1", {
         bucket: "test-move-bucket-move-from-id",
       }).moveFromId("aws_s3_bucket.test-bucket-move-by");

--- a/examples/typescript/aws-move/main.ts
+++ b/examples/typescript/aws-move/main.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { Construct } from "constructs";
+import { Construct, IConstruct } from "constructs";
 import { App, TerraformStack, TerraformIterator } from "cdktf";
 import { AwsProvider } from "./.gen/providers/aws/provider";
 import { S3Bucket } from "./.gen/providers/aws/s3-bucket";
@@ -231,4 +231,5 @@ new UnNestingMoveStack(app, "un-nesting-move-stack");
 new NestingMoveStack(app, "nesting-move-stack");
 new ListIteratorMoveStack(app, "list-iterator-move-stack");
 new ComplexIteratorMoveStack(app, "complex-iterator-move-stack");
+
 app.synth();

--- a/packages/cdktf/lib/index.ts
+++ b/packages/cdktf/lib/index.ts
@@ -39,6 +39,6 @@ export * from "./terraform-conditions";
 export * from "./terraform-count";
 export * from "./importable-resource";
 export * from "./terraform-resource-targets";
-
+export * from "./upgrade-id-aspect";
 // required for JSII because Fn extends from it
 export * from "./functions/terraform-functions.generated";

--- a/packages/cdktf/lib/synthesize/synthesizer.ts
+++ b/packages/cdktf/lib/synthesize/synthesizer.ts
@@ -9,6 +9,7 @@ import { AnnotationMetadataEntryType, Annotations } from "../annotations";
 import { ConstructOrder, IConstruct, MetadataEntry } from "constructs";
 import { Aspects, IAspect } from "../aspect";
 import { StackAnnotation } from "../manifest";
+import { ValidateTerraformVersion } from "../validations/validate-terraform-version";
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 export class StackSynthesizer implements IStackSynthesizer {
@@ -25,6 +26,15 @@ export class StackSynthesizer implements IStackSynthesizer {
 
   synthesize(session: ISynthesisSession) {
     invokeAspects(this.stack);
+
+    if (this.stack.hasResourceMove()) {
+      this.stack.node.addValidation(
+        new ValidateTerraformVersion(
+          ">=1.5",
+          `Resource move functionality is only supported for Terraform >=1.5. Please upgrade your Terraform version.`
+        )
+      );
+    }
 
     if (!session.skipValidation) {
       this.stack.runAllValidations();

--- a/packages/cdktf/lib/terraform-resource.ts
+++ b/packages/cdktf/lib/terraform-resource.ts
@@ -335,7 +335,7 @@ export class TerraformResource
         to: ${this._movedById.to}
       }
 
-      Only one move operation can occur at a time. Remove one of the operations.
+      Only one move operation can occur plan/apply. Remove one of the operations.
       `);
     } else if (this._movedByTarget) {
       const movedBlockByTarget = this._buildMovedBlockByTarget(
@@ -400,7 +400,7 @@ export class TerraformResource
         to: ${this.terraformResourceType}.${this.friendlyUniqueId} (Resource calling the move to operation)
       }
 
-      Only one move operation can occur at a time. Remove one of the operations.
+      Only one move operation can occur per plan/apply. Remove one of the operations.
       `);
     }
     this._movedById = {
@@ -434,7 +434,7 @@ export class TerraformResource
         to: ${id}
       }
 
-      Only one move operation can occur at a time. Remove one of the operations.
+      Only one move operation can occur plan/apply. Remove one of the operations.
       `);
     }
     this._movedById = {

--- a/packages/cdktf/lib/terraform-resource.ts
+++ b/packages/cdktf/lib/terraform-resource.ts
@@ -303,7 +303,9 @@ export class TerraformResource
     );
   }
 
-  private _buildMovedBlockByTarget(movedTarget: TerraformResourceMoveByTarget) {
+  private _buildMovedBlockByTarget(
+    movedTarget: TerraformResourceMoveByTarget
+  ): { to: string; from: string } {
     const { moveTarget, index } = movedTarget;
     const resourceToMoveTo = this._getResourceTarget(moveTarget);
     if (this.terraformResourceType !== resourceToMoveTo.terraformResourceType) {
@@ -323,8 +325,7 @@ export class TerraformResource
     return { to, from };
   }
 
-  private _buildMovedBlock() {
-    let movedBlock: { to: string; from: string } | undefined;
+  private _buildMovedBlock(): { to: string; from: string } | undefined {
     if (this._movedByTarget && this._movedById) {
       throw new Error(`
       ${this.node.id} has been given two separate moved operations.
@@ -338,16 +339,27 @@ export class TerraformResource
       Only one move operation can occur per plan/apply. Remove one of the operations.
       `);
     } else if (this._movedByTarget) {
+      this.node.addValidation(
+        new ValidateTerraformVersion(
+          ">=1.5",
+          `Resource move functionality is only supported for Terraform >=1.5. Please upgrade your Terraform version.`
+        )
+      );
       const movedBlockByTarget = this._buildMovedBlockByTarget(
         this._movedByTarget
       );
-      movedBlock = { to: movedBlockByTarget.to, from: movedBlockByTarget.from };
+      return { to: movedBlockByTarget.to, from: movedBlockByTarget.from };
     } else if (this._movedById) {
-      movedBlock = { to: this._movedById.to, from: this._movedById.from };
+      this.node.addValidation(
+        new ValidateTerraformVersion(
+          ">=1.5",
+          `Resource move functionality is only supported for Terraform >=1.5. Please upgrade your Terraform version.`
+        )
+      );
+      return { to: this._movedById.to, from: this._movedById.from };
     } else {
-      movedBlock = undefined;
+      return undefined;
     }
-    return movedBlock;
   }
 
   /**
@@ -366,12 +378,6 @@ export class TerraformResource
     }
     this._movedByTarget = { moveTarget, index };
     this._hasMoved = true;
-    this.node.addValidation(
-      new ValidateTerraformVersion(
-        ">=1.5",
-        `Resource move functionality is only supported for Terraform >=1.5. Please upgrade your Terraform version.`
-      )
-    );
   }
 
   /**
@@ -408,12 +414,6 @@ export class TerraformResource
       from: `${this.terraformResourceType}.${this.friendlyUniqueId}`,
     };
     this._hasMoved = true;
-    this.node.addValidation(
-      new ValidateTerraformVersion(
-        ">=1.5",
-        `Resource move functionality is only supported for Terraform >=1.5. Please upgrade your Terraform version.`
-      )
-    );
   }
 
   /**
@@ -441,24 +441,5 @@ export class TerraformResource
       to: `${this.terraformResourceType}.${this.friendlyUniqueId}`,
       from: id,
     };
-    this.node.addValidation(
-      new ValidateTerraformVersion(
-        ">=1.5",
-        `Resource move functionality is only supported for Terraform >=1.5. Please upgrade your Terraform version.`
-      )
-    );
-  }
-
-  /**
-   * Marks this resource as moved. Required to be present on a resource being moved from.
-   */
-  public hasMoved() {
-    this._hasMoved = true;
-    this.node.addValidation(
-      new ValidateTerraformVersion(
-        ">=1.5",
-        `Resource move functionality is only supported for Terraform >=1.5. Please upgrade your Terraform version.`
-      )
-    );
   }
 }

--- a/packages/cdktf/lib/terraform-resource.ts
+++ b/packages/cdktf/lib/terraform-resource.ts
@@ -386,6 +386,22 @@ export class TerraformResource
    * @param id Full id of resource to move to
    */
   public moveToId(id: string) {
+    if (this._movedById) {
+      throw new Error(`
+      ${this.node.id} has been given two separate moved operations.
+
+      {
+        from: ${this._movedById.from}
+        to: ${this._movedById.to}
+      }
+      {
+        from: ${id}
+        to: ${this.terraformResourceType}.${this.friendlyUniqueId} (Resource calling the move to operation)
+      }
+
+      Only one move operation can occur at a time. Remove one of the operations.
+      `);
+    }
     this._movedById = {
       to: id,
       from: `${this.terraformResourceType}.${this.friendlyUniqueId}`,
@@ -404,6 +420,22 @@ export class TerraformResource
    * @param id Full id of resource being moved from
    */
   public moveFromId(id: string) {
+    if (this._movedById) {
+      throw new Error(`
+      ${this.node.id} has been given two separate moved operations.
+
+      {
+        from: ${this._movedById.from}
+        to: ${this._movedById.to}
+      }
+      {
+        from: ${this.terraformResourceType}.${this.friendlyUniqueId} (Resource calling the move from operation)
+        to: ${id}
+      }
+
+      Only one move operation can occur at a time. Remove one of the operations.
+      `);
+    }
     this._movedById = {
       to: `${this.terraformResourceType}.${this.friendlyUniqueId}`,
       from: id,

--- a/packages/cdktf/lib/terraform-resource.ts
+++ b/packages/cdktf/lib/terraform-resource.ts
@@ -137,6 +137,10 @@ export class TerraformResource
     );
   }
 
+  public hasResourceMove() {
+    return this._movedById || this._movedByTarget;
+  }
+
   public getStringAttribute(terraformAttribute: string) {
     return Token.asString(this.interpolationForAttribute(terraformAttribute));
   }
@@ -339,23 +343,11 @@ export class TerraformResource
       Only one move operation can occur per plan/apply. Remove one of the operations.
       `);
     } else if (this._movedByTarget) {
-      this.node.addValidation(
-        new ValidateTerraformVersion(
-          ">=1.5",
-          `Resource move functionality is only supported for Terraform >=1.5. Please upgrade your Terraform version.`
-        )
-      );
       const movedBlockByTarget = this._buildMovedBlockByTarget(
         this._movedByTarget
       );
       return { to: movedBlockByTarget.to, from: movedBlockByTarget.from };
     } else if (this._movedById) {
-      this.node.addValidation(
-        new ValidateTerraformVersion(
-          ">=1.5",
-          `Resource move functionality is only supported for Terraform >=1.5. Please upgrade your Terraform version.`
-        )
-      );
       return { to: this._movedById.to, from: this._movedById.from };
     } else {
       return undefined;

--- a/packages/cdktf/lib/terraform-resource.ts
+++ b/packages/cdktf/lib/terraform-resource.ts
@@ -264,11 +264,12 @@ export class TerraformResource
             [this.terraformResourceType]: [this.friendlyUniqueId],
           }
         : undefined,
-      moved: this._movedByTarget
-        ? {
-            [this.terraformResourceType]: [this.friendlyUniqueId],
-          }
-        : undefined,
+      moved:
+        this._movedByTarget || this._movedById
+          ? {
+              [this.terraformResourceType]: [this.friendlyUniqueId],
+            }
+          : undefined,
     };
   }
 

--- a/packages/cdktf/lib/terraform-resource.ts
+++ b/packages/cdktf/lib/terraform-resource.ts
@@ -335,7 +335,7 @@ export class TerraformResource
         to: ${this._movedById.to}
       }
 
-      Only one move operation can occur plan/apply. Remove one of the operations.
+      Only one move operation can occur per plan/apply. Remove one of the operations.
       `);
     } else if (this._movedByTarget) {
       const movedBlockByTarget = this._buildMovedBlockByTarget(
@@ -384,7 +384,7 @@ export class TerraformResource
 
   /**
    * Moves this resource to the resource corresponding to "id"
-   * @param id Full id of resource to move to
+   * @param id Full id of resource to move to, e.g. "aws_s3_bucket.example"
    */
   public moveToId(id: string) {
     if (this._movedById) {
@@ -418,7 +418,7 @@ export class TerraformResource
 
   /**
    * Move the resource corresponding to "id" to this resource. Note that the resource being moved from must be marked as moved using it's instance function.
-   * @param id Full id of resource being moved from
+   * @param id Full id of resource being moved from, e.g. "aws_s3_bucket.example"
    */
   public moveFromId(id: string) {
     if (this._movedById) {

--- a/packages/cdktf/lib/terraform-stack.ts
+++ b/packages/cdktf/lib/terraform-stack.ts
@@ -19,6 +19,7 @@ import { ValidateProviderPresence } from "./validations";
 import { App } from "./app";
 import { TerraformBackend } from "./terraform-backend";
 import { TerraformResourceTargets } from "./terraform-resource-targets";
+import { TerraformResource } from "./terraform-resource";
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 type StackIdentifier = string;
@@ -327,6 +328,15 @@ export class TerraformStack extends Construct {
         `Validation failed with the following errors:\n  ${errorList}`
       );
     }
+  }
+
+  public hasResourceMove(): boolean {
+    return terraformElements(this).some((e) => {
+      if (TerraformResource.isTerraformResource(e) && e.hasResourceMove()) {
+        return true;
+      }
+      return false;
+    });
   }
 }
 

--- a/packages/cdktf/lib/upgrade-id-aspect.ts
+++ b/packages/cdktf/lib/upgrade-id-aspect.ts
@@ -158,7 +158,7 @@ function allocateLogicalIdOldVersion(
 }
 
 /**
- * For migrating past 0.17 where id generation changed
+ * For migrating past 0.17 where the feature flag for the old id generation logic was removed after being deprecated since 0.15
  */
 export class MigrateIdsAspect implements IAspect {
   visit(node: IConstruct) {

--- a/packages/cdktf/lib/upgrade-id-aspect.ts
+++ b/packages/cdktf/lib/upgrade-id-aspect.ts
@@ -160,7 +160,7 @@ function allocateLogicalIdOldVersion(
 /**
  * For migrating past 0.17 where the feature flag for the old id generation logic was removed after being deprecated since 0.15
  */
-export class MigrateIdsAspect implements IAspect {
+export class MigrateIds implements IAspect {
   visit(node: IConstruct) {
     // eslint-disable-next-line no-instanceof/no-instanceof
     if (node instanceof TerraformResource) {

--- a/packages/cdktf/lib/upgrade-id-aspect.ts
+++ b/packages/cdktf/lib/upgrade-id-aspect.ts
@@ -1,0 +1,171 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+
+import { TerraformElement, TerraformResource } from ".";
+import { IAspect } from "./aspect";
+import { IConstruct, Node } from "constructs";
+import * as crypto from "crypto";
+
+/**
+ * We have to copy this from the old CDKTF version for now, so that we can
+ * calculate the old logical IDs for now and for later for the migration.
+ */
+
+/**
+ * Resources with this ID are hidden from humans
+ *
+ * They do not appear in the human-readable part of the logical ID,
+ * but they are included in the hash calculation.
+ */
+const HIDDEN_FROM_HUMAN_ID = "Resource";
+
+/**
+ * Resources with this ID are complete hidden from the logical ID calculation.
+ */
+const HIDDEN_ID = "Default";
+
+const PATH_SEP = "/";
+const UNIQUE_SEP = "_";
+
+const HASH_LEN = 8;
+const MAX_HUMAN_LEN = 240; // max ID len is 255
+const MAX_ID_LEN = 255;
+
+/**
+ * Calculates a unique ID for a set of textual components.
+ *
+ * This is done by calculating a hash on the full path and using it as a suffix
+ * of a length-limited "human" rendition of the path components.
+ *
+ * @param components The path components
+ * @returns a unique alpha-numeric identifier with a maximum length of 255
+ */
+function makeUniqueIdOldVersion(components: string[], allowSepChars: boolean) {
+  components = components.filter((x) => x !== HIDDEN_ID);
+
+  if (components.length === 0) {
+    throw new Error(
+      "Unable to calculate a unique id for an empty set of components"
+    );
+  }
+
+  // top-level resources will simply use the `name` as-is in order to support
+  // transparent migration of cloudformation templates to the CDK without the
+  // need to rename all resources.
+  if (components.length === 1) {
+    // we filter out non-alpha characters but that is actually a bad idea
+    // because it could create conflicts ("A-B" and "AB" will render the same
+    // logical ID). sadly, changing it in the 1.x version line is impossible
+    // because it will be a breaking change. we should consider for v2.0.
+    // https://github.com/aws/aws-cdk/issues/6421
+    const candidate = removeDisallowedCharacters(components[0], allowSepChars);
+
+    // if our candidate is short enough, use it as is. otherwise, fall back to
+    // the normal mode.
+    if (candidate.length <= MAX_ID_LEN) {
+      return candidate;
+    }
+  }
+
+  const hash = pathHash(components);
+  const human = removeDupes(components)
+    .filter((x) => x !== HIDDEN_FROM_HUMAN_ID)
+    .map((s) => removeDisallowedCharacters(s, allowSepChars))
+    .join(UNIQUE_SEP)
+    .slice(0, MAX_HUMAN_LEN);
+
+  return human + UNIQUE_SEP + hash;
+}
+
+/**
+ * Take a hash of the given path.
+ *
+ * The hash is limited in size.
+ */
+function pathHash(path: string[]): string {
+  const md5 = crypto
+    .createHash("md5")
+    .update(path.join(PATH_SEP))
+    .digest("hex");
+  return md5.slice(0, HASH_LEN).toUpperCase();
+}
+
+/**
+ *
+ * @param s
+ * @param allowSepChars
+ * @returns
+ */
+function removeDisallowedCharacters(s: string, allowSepChars: boolean) {
+  if (allowSepChars) {
+    return removeNonAlphanumericSep(s);
+  } else {
+    return removeNonAlphanumeric(s);
+  }
+}
+
+/**
+ * Removes all non-alphanumeric characters in a string.
+ */
+function removeNonAlphanumeric(s: string) {
+  return s.replace(/[^A-Za-z0-9]/g, "");
+}
+
+/**
+ *
+ * @param s
+ * @returns
+ */
+function removeNonAlphanumericSep(s: string) {
+  return s.replace(/[^A-Za-z0-9_-]/g, "");
+}
+
+/**
+ * Remove duplicate "terms" from the path list
+ *
+ * If the previous path component name ends with this component name, skip the
+ * current component.
+ */
+function removeDupes(path: string[]): string[] {
+  const ret = new Array<string>();
+
+  for (const component of path) {
+    if (ret.length === 0 || !ret[ret.length - 1].endsWith(component)) {
+      ret.push(component);
+    }
+  }
+
+  return ret;
+}
+
+/**
+ *
+ * @param tfElement
+ * @returns
+ */
+function allocateLogicalIdOldVersion(
+  tfElement: TerraformElement | Node
+): string {
+  const node = TerraformElement.isTerraformElement(tfElement)
+    ? tfElement.node
+    : tfElement;
+
+  // This is the previous behavior, which we want for now.
+  const stackIndex = 0;
+
+  const components = node.scopes.slice(stackIndex + 1).map((c) => c.node.id);
+  return components.length > 0 ? makeUniqueIdOldVersion(components, false) : "";
+}
+
+/**
+ * For migrating past 0.17 where id generation changed
+ */
+export class MigrateIdsAspect implements IAspect {
+  visit(node: IConstruct) {
+    // eslint-disable-next-line no-instanceof/no-instanceof
+    if (node instanceof TerraformResource) {
+      const oldId = allocateLogicalIdOldVersion(node);
+      node.moveFromId(`${node.terraformResourceType}.${oldId}`);
+    }
+  }
+}

--- a/packages/cdktf/test/resource.test.ts
+++ b/packages/cdktf/test/resource.test.ts
@@ -624,7 +624,7 @@ it("moves correctly when target set after call to moveTo", () => {
   );
 });
 
-it.only("override logical ID - before moveTo", () => {
+it("override logical ID - before moveTo", () => {
   const app = Testing.app();
   const stack = new TerraformStack(app, "test");
   new TestProvider(stack, "provider", {});
@@ -666,7 +666,7 @@ it.only("override logical ID - before moveTo", () => {
   );
 });
 
-it.only("override logical ID - before addTarget", () => {
+it("override logical ID - before addTarget", () => {
   const app = Testing.app();
   const stack = new TerraformStack(app, "test");
   new TestProvider(stack, "provider", {});

--- a/packages/cdktf/test/resource.test.ts
+++ b/packages/cdktf/test/resource.test.ts
@@ -653,53 +653,17 @@ it.only("override logical ID - before moveTo", () => {
   });
 
   const synthedStack = JSON.parse(Testing.synth(stack));
-  console.log(synthedStack);
-  expect(synthedStack).toMatchInlineSnapshot(`
-    {
-      "moved": [
-        {
-          "from": "test_resource.old_logical_id",
-          "to": "test_resource.construct_nested-construct_simple_2C3755B0",
-        },
-      ],
-      "provider": {
-        "test": [
-          {},
-        ],
-      },
-      "resource": {
-        "test_resource": {
-          "construct_nested-construct_simple_2C3755B0": {
-            "name": "foo",
-            "provisioner": [
-              {
-                "local-exec": {
-                  "command": "echo 'hello' > world.txt",
-                },
-              },
-              {
-                "local-exec": {
-                  "command": "echo 'hello' > world1.txt",
-                },
-              },
-              {
-                "local-exec": {
-                  "command": "echo 'hello' > world2.txt",
-                },
-              },
-            ],
-          },
-        },
-      },
-      "terraform": {
-        "required_providers": {
-          "test": {
-            "version": "~> 2.0",
-          },
-        },
-      },
-    }
-  `);
+  expect(synthedStack.moved[0].from).toEqual("test_resource.old_logical_id");
+  expect(synthedStack.moved[0].to).toEqual(
+    "test_resource.construct_nested-construct_simple_2C3755B0"
+  );
+  expect(Object.keys(synthedStack.resource.test_resource)).toContain(
+    "construct_nested-construct_simple_2C3755B0"
+  );
+  // Must not include old resource being moved from
+  expect(Object.keys(synthedStack.resource.test_resource)).not.toContain(
+    "old_logical_id"
+  );
 });
 
 it.only("override logical ID - before addTarget", () => {
@@ -732,50 +696,13 @@ it.only("override logical ID - before addTarget", () => {
   resource.moveFromId("test_resource.simple");
 
   const synthedStack = JSON.parse(Testing.synth(stack));
-  expect(synthedStack).toMatchInlineSnapshot(`
-    {
-      "moved": [
-        {
-          "from": "test_resource.simple",
-          "to": "test_resource.old_logical_id",
-        },
-      ],
-      "provider": {
-        "test": [
-          {},
-        ],
-      },
-      "resource": {
-        "test_resource": {
-          "old_logical_id": {
-            "name": "foo",
-            "provisioner": [
-              {
-                "local-exec": {
-                  "command": "echo 'hello' > world.txt",
-                },
-              },
-              {
-                "local-exec": {
-                  "command": "echo 'hello' > world1.txt",
-                },
-              },
-              {
-                "local-exec": {
-                  "command": "echo 'hello' > world2.txt",
-                },
-              },
-            ],
-          },
-        },
-      },
-      "terraform": {
-        "required_providers": {
-          "test": {
-            "version": "~> 2.0",
-          },
-        },
-      },
-    }
-  `);
+  expect(synthedStack.moved[0].from).toEqual("test_resource.simple");
+  expect(synthedStack.moved[0].to).toEqual("test_resource.old_logical_id");
+  expect(Object.keys(synthedStack.resource.test_resource)).toContain(
+    "old_logical_id"
+  );
+  // Must not include old resource being moved from
+  expect(Object.keys(synthedStack.resource.test_resource)).not.toContain(
+    "simple"
+  );
 });

--- a/packages/cdktf/test/resource.test.ts
+++ b/packages/cdktf/test/resource.test.ts
@@ -624,7 +624,7 @@ it("moves correctly when target set after call to moveTo", () => {
   );
 });
 
-it("override logical ID - before moveTo", () => {
+it("override logical ID - before move to id", () => {
   const app = Testing.app();
   const stack = new TerraformStack(app, "test");
   new TestProvider(stack, "provider", {});
@@ -666,22 +666,13 @@ it("override logical ID - before moveTo", () => {
   );
 });
 
-it("override logical ID - before addTarget", () => {
+it("override logical ID - before move from id", () => {
   const app = Testing.app();
   const stack = new TerraformStack(app, "test");
   new TestProvider(stack, "provider", {});
 
   const construct = new Construct(stack, "construct");
   const nestedContruct = new Construct(construct, "nested-construct");
-
-  new TestResource(stack, "simple", {
-    name: "foo",
-    provisioners: [
-      { type: "local-exec", command: "echo 'hello' > world.txt" },
-      { type: "local-exec", command: "echo 'hello' > world1.txt" },
-      { type: "local-exec", command: "echo 'hello' > world2.txt" },
-    ],
-  }).hasMoved();
 
   const resource = new TestResource(nestedContruct, "simple", {
     name: "foo",

--- a/website/docs/cdktf/examples-and-guides/refactoring.mdx
+++ b/website/docs/cdktf/examples-and-guides/refactoring.mdx
@@ -160,27 +160,28 @@ new S3Bucket(this, "bucket-new", {
 #### Move From
 
 ```typescript
-new S3Bucket(this, "bucket-moved", {
-  bucket: "move-bucket",
-}).hasMoved();
+// Old resource
+// new S3Bucket(this, "bucket-moved", {
+//   bucket: "move-bucket",
+// });
 
 new S3Bucket(this, "bucket-new", {
   bucket: "move-bucket",
 }).moveFromId("aws_s3_bucket.bucket-moved");
 ```
 
-Note that in moving from a specified resource address, the resource being moved from must be marked as moved.
+Note that in moving from a specified resource address, the original resource being moved from must be removed.
 
 #### Nested Constructs
 
-Resource addresses in the context of nested constructs will not simply be the specified id given to the resource. When dealing with moving resources by their address to/from nested constructs, run `cdktf synth` and refer to `cdktf.out/stacks/<stack name>/cdk.tf.json` to find the exact address to move to/from.
+Resource addresses in the context of nested constructs will not simply be the specified id given to the resource. When dealing with moving resources by their address to/from nested constructs, run `cdktf synth` and refer to `cdktf.out/stacks/'your stack name'` to find the exact address to move to/from.
 
 ```typescript
 new S3Bucket(this, "bucket-moved", {
   bucket: "bucket-moved",
 }).moveToId("aws_s3_bucket.nested-construct_bucket-new_5A0C9225"); // moving to S3Bucket "bucket-new" in NestedConstruct "nested-construct"
 
-new NestedConstruct(this, "nested-construct"); // contains the moved S3 bucket resource with the id "bucket-new"
+new NestedConstruct(this, "nested-construct", {});
 ```
 
 ## Moving Resources From One Stack To Another

--- a/website/docs/cdktf/examples-and-guides/refactoring.mdx
+++ b/website/docs/cdktf/examples-and-guides/refactoring.mdx
@@ -173,14 +173,14 @@ Note that in moving from a specified resource address, the resource being moved 
 
 #### Nested Constructs
 
-Resource addresses in the context of nested constructs will not simply be the specified id given to the resource. When dealing with moving resources by their address to/from nested constructs, run `cdktf synth` and refer to `cdktf.out/stacks/'your stack name'` to find the exact address to move to/from.
+Resource addresses in the context of nested constructs will not simply be the specified id given to the resource. When dealing with moving resources by their address to/from nested constructs, run `cdktf synth` and refer to `cdktf.out/stacks/<stack name>/cdk.tf.json` to find the exact address to move to/from.
 
 ```typescript
 new S3Bucket(this, "bucket-moved", {
   bucket: "bucket-moved",
 }).moveToId("aws_s3_bucket.nested-construct_bucket-new_5A0C9225"); // moving to S3Bucket "bucket-new" in NestedConstruct "nested-construct"
 
-new NestedConstruct(this, "nested-construct", {});
+new NestedConstruct(this, "nested-construct"); // contains the moved S3 bucket resource with the id "bucket-new"
 ```
 
 ## Moving Resources From One Stack To Another

--- a/website/docs/cdktf/examples-and-guides/refactoring.mdx
+++ b/website/docs/cdktf/examples-and-guides/refactoring.mdx
@@ -56,7 +56,7 @@ refactoring-example    # aws_s3_bucket.new-bucket (new-bucket) will be created
 
 Terraform plans to destroy the old bucket and create a new one to replace it. The replacement can be harmful if there is already state in the resource, such as files in the bucket or data in the database.
 
-To avoid the recreation of the resource, use the `moveTo` function.
+To avoid this recreation behavior, use one of the move instance functions (`moveTo`, `moveToId`, `moveFromId`) available on the resource.
 
 ```typescript
 import { Construct } from "constructs";
@@ -140,6 +140,48 @@ new S3Bucket(this, "moved-bucket", {
 ```
 
 This allows you to efficiently integrate existing resources into a `foreach` composition without destroying the existing deployed resource.
+
+### Move By Resource Address
+
+In instances where the move target workflow does not easily fit your use case, resource moves can be performed by directly specifying the full resource address to be moved to/from.
+
+#### Move To
+
+```typescript
+new S3Bucket(this, "bucket-moved", {
+  bucket: "move-bucket",
+}).moveToId("aws_s3_bucket.bucket-new");
+
+new S3Bucket(this, "bucket-new", {
+  bucket: "move-bucket",
+});
+```
+
+#### Move From
+
+```typescript
+new S3Bucket(this, "bucket-moved", {
+  bucket: "move-bucket",
+}).hasMoved();
+
+new S3Bucket(this, "bucket-new", {
+  bucket: "move-bucket",
+}).moveFromId("aws_s3_bucket.bucket-moved");
+```
+
+Note that in moving from a specified resource address, the resource being moved from must be marked as moved.
+
+#### Nested Constructs
+
+Resource addresses in the context of nested constructs will not simply be the specified id given to the resource. When dealing with moving resources by their address to/from nested constructs, run `cdktf synth` and refer to `cdktf.out/stacks/'your stack name'` to find the exact address to move to/from.
+
+```typescript
+new S3Bucket(this, "bucket-moved", {
+  bucket: "bucket-moved",
+}).moveToId("aws_s3_bucket.nested-construct_bucket-new_5A0C9225"); // moving to S3Bucket "bucket-new" in NestedConstruct "nested-construct"
+
+new NestedConstruct(this, "nested-construct", {});
+```
 
 ## Moving Resources From One Stack To Another
 

--- a/website/docs/cdktf/release/upgrade-guide-v0-17.mdx
+++ b/website/docs/cdktf/release/upgrade-guide-v0-17.mdx
@@ -8,6 +8,8 @@ description: >-
 
 0.17 is focused around fixing issues with the [AWS Quicksight](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_template) resources. We also removed the deprecated feature flags that were used to enable potentially breaking changes in previous releases.
 
+If you encounter breaking changes from the removal of these feature flags, use the `MigrateIds` `Aspect` at the root of your affected stacks to migrate resources to use the current form of id generation without their recreation.
+
 ## AWS Quicksight
 
 A few individual Terraform Resources have very deeply nested schemas with a lot of attributes. This blows up the config classes and slows down the code generation for languages besides TypeScript. To work around this we sometimes limit the depth of the config classes and use `any` on deeper levels, and we directly expose some attributes as `any` on the top level config class.

--- a/website/docs/cdktf/release/upgrade-guide-v0-17.mdx
+++ b/website/docs/cdktf/release/upgrade-guide-v0-17.mdx
@@ -16,7 +16,7 @@ A few individual Terraform Resources have very deeply nested schemas with a lot 
 
 - `aws_quicksight_template.definition`, `aws_quicksight_dashboard.definition`, and `aws_quicksight_analysis.definition` are set to `any`
 
-This means when configuring these attributes you need to pass in the configuration as objects and with snake case keys. Alternatively you can also use the [escape hatch](concepts/resources#escape-hatch).
+This means when configuring these attributes you need to pass in the configuration as objects and with snake case keys. Alternatively you can also use the [escape hatch](/terraform/cdktf/concepts/resources#escape-hatch).
 
 ### Removal: The feature flags that go into the `context` field of the `cdktf.json` file were removed
 


### PR DESCRIPTION
## Description

Adds a alternative workflow for performing resource moves by specifying resource ids directly. 

The original workflow for resource moves didn't have (as of writing this) any bugs per say, yet some of the tradeoffs made in it's design made certain use cases quite difficult. As such, I made resource instance functions where the id to move to/from can be directly specified. Provides a better experience compared to using escape hatches, while avoiding potentially unhelpful abstraction in the targeting system.

In particular we saw in [migrating the repository manager to use our new id generation](https://github.com/cdktf/cdktf-repository-manager/pull/233) that using the target system was incredibly cumbersome. In response to this use case, I've created an Aspect that will automatically perform the resource moves between the old id generation and the new for ease of upgrading past 0.17.

### Resource Instance Function Additions

#### `moveToId(id: string)`

Moves the resource it is called upon to the resource corresponding to `id`

```typescript
new S3Bucket(this, "test-bucket-moved", {
  bucket: "test-move-bucket-move-to-id",
}).moveToId("aws_s3_bucket.test-bucket-moved-to");

new S3Bucket(this, "test-bucket-moved-to", {
  bucket: "test-move-bucket-move-to-id",
});
```

#### `moveFromId(id: string)`

Move the resource corresponding to `id` to the resource it is called upon. Note that the resource being moved from must be marked as moved using the instance function `.hasMoved()`.

```typescript
new S3Bucket(this, "test-bucket-moved-from", {
  bucket: "test-move-bucket-move-from-id",
}).hasMoved();
new S3Bucket(this, "test-bucket", {
  bucket: "test-move-bucket-move-from-id",
}).moveFromId("aws_s3_bucket.test-bucket-moved-from");
```

## Id Migration Aspect

```typescript
/**
 * For migrating past 0.17 where id generation changed
 */
export class MigrateIdsAspect implements IAspect {
  visit(node: IConstruct) {
    // eslint-disable-next-line no-instanceof/no-instanceof
    if (node instanceof TerraformResource) {
      const oldId = allocateLogicalIdOldVersion(node);
      node.moveFromId(`${node.terraformResourceType}.${oldId}`);
    }
  }
}
```

Added an Aspect (`MigrateIdsAspect`) to the lib that migrates ids from prev 0.17 to post 0.17 when the feature flag was removed. Uses the old logic for Id generation to resolve the original resource address and calls `moveFromId` with that old address. 

Should solve our issue in the repository manager quite nicely as well as any users in the same situation of upgrading their CDKTF version.

### A screenshot of the new Aspect in action

<img width="1486" alt="Screenshot 2023-11-14 at 9 30 23 AM" src="https://github.com/hashicorp/terraform-cdk/assets/72527044/55053b28-7c1d-4fd7-b2f5-4f6b1ab6f95a">
