### PR TITLE
fix: Use an additional results step to ensure dynamic matrix jobs can…

### DIFF
--- a/.github/workflows/examples-pr.yml
+++ b/.github/workflows/examples-pr.yml
@@ -22,7 +22,7 @@ jobs:
   results:
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    name: Example Integration Tests Result
+    name: Result
     needs: [examples]
     steps:
       - run: exit 1

--- a/.github/workflows/examples-pr.yml
+++ b/.github/workflows/examples-pr.yml
@@ -19,3 +19,15 @@ jobs:
     with:
       concurrency_group_prefix: pr
     secrets: inherit
+  results:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Example Integration Tests Result
+    needs: [examples]
+    steps:
+      - run: exit 1
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+          }}

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -22,7 +22,7 @@ jobs:
   results:
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    name: Integration Tests Result
+    name: Result
     needs: [integration_test]
     steps:
       - run: exit 1

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -19,3 +19,15 @@ jobs:
     with:
       concurrency_group_prefix: pr
     secrets: inherit
+  results:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Integration Tests Result
+    needs: [integration_test]
+    steps:
+      - run: exit 1
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+          }}

--- a/.github/workflows/pr-provider-integration.yml
+++ b/.github/workflows/pr-provider-integration.yml
@@ -19,3 +19,15 @@ jobs:
     with:
       concurrency_group_prefix: pr
     secrets: inherit
+  results:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Example Integration Tests Result
+    needs: [provider_integration_test]
+    steps:
+      - run: exit 1
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+          }}

--- a/.github/workflows/pr-provider-integration.yml
+++ b/.github/workflows/pr-provider-integration.yml
@@ -22,7 +22,7 @@ jobs:
   results:
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    name: Example Integration Tests Result
+    name: Result
     needs: [provider_integration_test]
     steps:
       - run: exit 1

--- a/.github/workflows/pr-unit.yml
+++ b/.github/workflows/pr-unit.yml
@@ -138,7 +138,7 @@ jobs:
   results:
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    name: Unit Tests Result
+    name: Result
     needs: [all_unit_tests]
     steps:
       - run: exit 1

--- a/.github/workflows/pr-unit.yml
+++ b/.github/workflows/pr-unit.yml
@@ -134,3 +134,16 @@ jobs:
       package: "cdktf"
       terraform_version: ${{ matrix.terraform_version }}
     secrets: inherit
+
+  results:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Unit Tests Result
+    needs: [all_unit_tests]
+    steps:
+      - run: exit 1
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+          }}


### PR DESCRIPTION
… be used

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Description

Branch protections, RuleSets and so on within Github don't seem to work that well with dynamic (matrix based) jobs, so following the suggestions of https://github.com/orgs/community/discussions/26822 to see if we can use them.

