### PR TITLE
fix(provider-generator): provided name does not need to match name in source

### DIFF
--- a/packages/@cdktf/provider-generator/lib/__tests__/provider.test.ts
+++ b/packages/@cdktf/provider-generator/lib/__tests__/provider.test.ts
@@ -42,6 +42,29 @@ function directorySnapshot(root: string) {
   return output;
 }
 
+function resourceTypesPresentInSnapshot(
+  snapshot: SynthOutput,
+  providerNameInPath: string
+) {
+  const resources: string[] = [];
+  const files = Object.keys(snapshot);
+  for (const file of files) {
+    const match = file.match(
+      `/providers\/${providerNameInPath}\/(.*?)\/index\.ts/`
+    );
+    // avoids any not resources from being pushed
+    if (
+      match &&
+      !match[1].includes("/") &&
+      !match[1].includes("data-") &&
+      !match[1].includes("provider")
+    ) {
+      resources.push(match[1]);
+    }
+  }
+  return resources;
+}
+
 describe("Provider", () => {
   it("generates a provider", async () => {
     const constraint = new TerraformProviderConstraint(
@@ -76,20 +99,9 @@ describe("Provider", () => {
         await maker.generate([constraint]);
         const snapshot = directorySnapshot(workdir);
 
-        const terraformResourceTypesPresent: string[] = [];
-        const files = Object.keys(snapshot);
-        for (const file of files) {
-          const match = file.match(/providers\/datadog\/(.*?)\/index\.ts/);
-          // avoids any not resources from being pushed
-          if (
-            match &&
-            !match[1].includes("/") &&
-            !match[1].includes("data-") &&
-            !match[1].includes("provider")
-          ) {
-            terraformResourceTypesPresent.push(match[1]);
-          }
-        }
+        const terraformResourceTypesPresent: string[] =
+          resourceTypesPresentInSnapshot(snapshot, "datadog");
+
         terraformResourceTypesPresent.forEach((resource) => {
           let terraformResourceType = resource.replace(/-/g, "_");
           if (!terraformResourceType.includes("datadog")) {
@@ -104,4 +116,33 @@ describe("Provider", () => {
         });
       });
     }, 600_000);
+  it("has name in constraint that does not match resolved name in fqpn", async () => {
+    const constraint = new TerraformProviderConstraint({
+      name: "dockerr",
+      source: "registry.terraform.io/kreuzwerker/docker",
+      version: "3.0.2",
+    });
+    return await mkdtemp(async (workdir) => {
+      const jsiiPath = path.join(workdir, ".jsii");
+      const maker = new ConstructsMaker(
+        {
+          codeMakerOutput: workdir,
+          outputJsii: jsiiPath,
+          targetLanguage: Language.TYPESCRIPT,
+        },
+        process.env.CDKTF_EXPERIMENTAL_PROVIDER_SCHEMA_CACHE_PATH
+      );
+      await maker.generate([constraint]);
+      const snapshot = directorySnapshot(workdir);
+
+      const terraformResourceTypesPresent: string[] =
+        resourceTypesPresentInSnapshot(snapshot, "dockerr");
+
+      terraformResourceTypesPresent.forEach((resource) => {
+        expect(
+          snapshot[`providers/dockerr/${resource}/index.ts`]
+        ).toBeDefined();
+      });
+    });
+  }, 600_000);
 });

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/provider.test.ts
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/provider.test.ts
@@ -47,3 +47,5 @@ test("generate provider with only block_types", async () => {
   );
   expect(output).toMatchSnapshot();
 });
+
+test("name in constraint does not match resolved name in fqpn", () => {});

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/provider.test.ts
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/provider.test.ts
@@ -47,5 +47,3 @@ test("generate provider with only block_types", async () => {
   );
   expect(output).toMatchSnapshot();
 });
-
-test("name in constraint does not match resolved name in fqpn", () => {});

--- a/packages/@cdktf/provider-generator/lib/get/generator/provider-generator.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/provider-generator.ts
@@ -107,7 +107,7 @@ export class TerraformProviderGenerator {
 
   public buildResourceModels(
     fqpn: FQPN,
-    providerName?: ProviderName
+    constraint?: ConstructsMakerTarget
   ): ResourceModel[] {
     const provider = this.schema.provider_schemas?.[fqpn];
     if (!provider) {
@@ -116,13 +116,7 @@ export class TerraformProviderGenerator {
 
     const resources = Object.entries(provider.resource_schemas || {}).map(
       ([type, resource]) =>
-        this.resourceParser.parse(
-          fqpn,
-          type,
-          resource,
-          "resource",
-          providerName ? providerName : parseFQPN(fqpn).name
-        )
+        this.resourceParser.parse(fqpn, type, resource, "resource", constraint)
     );
 
     const dataSources = Object.entries(provider.data_source_schemas || {}).map(
@@ -132,7 +126,7 @@ export class TerraformProviderGenerator {
           `data_${type}`,
           resource,
           "data_source",
-          providerName ? providerName : parseFQPN(fqpn).name
+          constraint
         )
     );
 
@@ -161,7 +155,7 @@ export class TerraformProviderGenerator {
     }
 
     const files: string[] = [];
-    this.buildResourceModels(fqpn, name).forEach((resourceModel) => {
+    this.buildResourceModels(fqpn, constraint).forEach((resourceModel) => {
       if (constraint) {
         resourceModel.providerVersionConstraint = constraint.version;
         resourceModel.terraformProviderSource = constraint.source;
@@ -182,7 +176,7 @@ export class TerraformProviderGenerator {
         `provider`,
         provider.provider,
         "provider",
-        name
+        constraint
       );
       if (constraint) {
         providerResource.providerVersionConstraint = constraint.version;

--- a/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
@@ -129,7 +129,9 @@ class Parser {
   ): ResourceModel {
     let baseName = type;
 
-    const providerNameFromConstraint = constraint?.name as ProviderName;
+    const providerNameFromConstraint = constraint
+      ? (constraint.name as ProviderName)
+      : undefined;
     const providerNameFromFQPN = parseFQPN(fqpn).name;
 
     if (baseName.startsWith(`${providerNameFromFQPN}_`)) {

--- a/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/resource-parser.ts
@@ -7,11 +7,12 @@ import {
   AttributeType,
   Block,
   BlockType,
+  ConstructsMakerTarget,
   isAttributeNestedType,
   isNestedTypeAttribute,
   Schema,
 } from "@cdktf/commons";
-import { ProviderName, FQPN } from "@cdktf/provider-schema";
+import { ProviderName, FQPN, parseFQPN } from "@cdktf/provider-schema";
 import {
   ResourceModel,
   AttributeTypeModel,
@@ -124,12 +125,20 @@ class Parser {
     type: string,
     schema: Schema,
     terraformSchemaType: string,
-    providerName: ProviderName
+    constraint?: ConstructsMakerTarget
   ): ResourceModel {
     let baseName = type;
-    if (baseName.startsWith(`${providerName}_`)) {
-      baseName = baseName.substr(providerName.length + 1);
+
+    const providerNameFromConstraint = constraint?.name as ProviderName;
+    const providerNameFromFQPN = parseFQPN(fqpn).name;
+
+    if (baseName.startsWith(`${providerNameFromFQPN}_`)) {
+      baseName = baseName.substr(providerNameFromFQPN.length + 1);
     }
+
+    const providerName = providerNameFromConstraint
+      ? providerNameFromConstraint
+      : providerNameFromFQPN;
 
     const isProvider = terraformSchemaType === "provider";
     if (isProvider) {
@@ -665,7 +674,7 @@ export class ResourceParser {
     type: string,
     schema: Schema,
     terraformType: string,
-    providerName: ProviderName
+    constraint?: ConstructsMakerTarget
   ): ResourceModel {
     if (this.resources[type]) {
       return this.resources[type];
@@ -677,7 +686,7 @@ export class ResourceParser {
       type,
       schema,
       terraformType,
-      providerName
+      constraint
     );
     this.resources[type] = resource;
     return resource;


### PR DESCRIPTION
### Related issue

Fixes #2730

### Description

Allows for a provided name in a provider constraint (i.e. within`terraformProviders` of`cdktf.json`) to differ from the name found in source. The provided name is then used as the namespace for the folder containing the provider in `.gen`.

#### Example

In `cdktf.json`
```json
...
"terraformProviders": [
    {
      "name": "dockerr",
      "source": "registry.terraform.io/kreuzwerker/docker"
    }
  ],
...
```

Generated provider in `.gen` 

![Screenshot 2024-01-02 at 12 09 45 PM](https://github.com/hashicorp/terraform-cdk/assets/72527044/cc3017ed-7481-49dd-826b-726e5cb998bb)




