### PR TITLE
feat(lib): Add support for the built-in Terraform data resource

### DIFF
--- a/packages/@cdktf/hcl2cdk/lib/index.ts
+++ b/packages/@cdktf/hcl2cdk/lib/index.ts
@@ -349,6 +349,7 @@ You can read more about this at https://cdk.tf/variables`
   // We add a comment if there are providers with missing schema information
   const providersLackingSchema = Object.keys(providerRequirements).filter(
     (providerName) =>
+      providerName !== "terraform" &&
       !Object.keys(providerSchema.provider_schemas || {}).some((schemaName) =>
         schemaName.endsWith(providerName)
       )

--- a/packages/@cdktf/hcl2cdk/lib/provider.ts
+++ b/packages/@cdktf/hcl2cdk/lib/provider.ts
@@ -21,6 +21,7 @@ export function getProviderRequirements(plan: Plan) {
   const explicitProviders = Object.keys(plan.provider || {});
   const implicitProviders = Object.keys({ ...plan.resource, ...plan.data })
     .filter((type) => type !== "terraform_remote_state")
+    .filter((type) => type !== "terraform_data")
     .map((type) => type.split("_")[0]);
 
   const providerRequirements = Array.from(

--- a/packages/@cdktf/hcl2cdk/lib/variables.ts
+++ b/packages/@cdktf/hcl2cdk/lib/variables.ts
@@ -115,6 +115,14 @@ export function constructAst(
     return t.identifier("TerraformVariable");
   }
 
+  if (type === "terraform.data") {
+    scope.importables.push({
+      constructName: "DataResource",
+      provider: "cdktf",
+    });
+    return t.identifier("DataResource");
+  }
+
   // resources or data sources
   if (!type.includes("./") && type.includes(".")) {
     const parts = type.split(".");

--- a/packages/@cdktf/hcl2cdk/test/__snapshots__/resources.test.ts.snap
+++ b/packages/@cdktf/hcl2cdk/test/__snapshots__/resources.test.ts.snap
@@ -79,8 +79,6 @@ import { TerraformVariable, DataResource, TerraformStack } from "cdktf";
 class MyConvertedCode extends TerraformStack {
   constructor(scope: Construct, name: string) {
     super(scope, name);
-    /*The following providers are missing schema information and might need manual adjustments to synthesize correctly: terraform.
-    For a more precise conversion please use the --provider flag in convert.*/
     /*Terraform Variables are not always the best fit for getting inputs in the context of Terraform CDK.
     You can read more about this at https://cdk.tf/variables*/
     const revision = new TerraformVariable(this, "revision", {

--- a/packages/@cdktf/hcl2cdk/test/__snapshots__/resources.test.ts.snap
+++ b/packages/@cdktf/hcl2cdk/test/__snapshots__/resources.test.ts.snap
@@ -73,6 +73,27 @@ class MyConvertedCode extends TerraformStack {
 "
 `;
 
+exports[`resources built-in data resource snapshot typescript 1`] = `
+"import { Construct } from "constructs";
+import { TerraformVariable, DataResource, TerraformStack } from "cdktf";
+class MyConvertedCode extends TerraformStack {
+  constructor(scope: Construct, name: string) {
+    super(scope, name);
+    /*The following providers are missing schema information and might need manual adjustments to synthesize correctly: terraform.
+    For a more precise conversion please use the --provider flag in convert.*/
+    /*Terraform Variables are not always the best fit for getting inputs in the context of Terraform CDK.
+    You can read more about this at https://cdk.tf/variables*/
+    const revision = new TerraformVariable(this, "revision", {
+      default: 1,
+    });
+    new DataResource(this, "replacement", {
+      input: revision.value,
+    });
+  }
+}
+"
+`;
+
 exports[`resources complex resource snapshot typescript 1`] = `
 "import { Construct } from "constructs";
 import { TerraformStack } from "cdktf";

--- a/packages/@cdktf/hcl2cdk/test/resources.test.ts
+++ b/packages/@cdktf/hcl2cdk/test/resources.test.ts
@@ -529,4 +529,23 @@ describe("resources", () => {
       resources: ["aws_ecs_task_definition"],
     }
   );
+
+  testCase.test(
+    "built-in data resource",
+    `
+    variable "revision" {
+      default = 1
+    }
+
+    resource "terraform_data" "replacement" {
+      input = var.revision
+    }
+  `,
+    [],
+    Snapshot.yes,
+    Synth.yes,
+    {
+      resources: ["terraform_data"],
+    }
+  );
 });

--- a/packages/cdktf/lib/index.ts
+++ b/packages/cdktf/lib/index.ts
@@ -40,5 +40,6 @@ export * from "./terraform-count";
 export * from "./importable-resource";
 export * from "./terraform-resource-targets";
 export * from "./upgrade-id-aspect";
+export * from "./terraform-data-resource";
 // required for JSII because Fn extends from it
 export * from "./functions/terraform-functions.generated";

--- a/packages/cdktf/lib/terraform-data-resource.ts
+++ b/packages/cdktf/lib/terraform-data-resource.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 import { Construct } from "constructs";
 import * as cdktf from "cdktf";
 import { ValidateTerraformVersion } from "./validations/validate-terraform-version";

--- a/packages/cdktf/lib/terraform-data-resource.ts
+++ b/packages/cdktf/lib/terraform-data-resource.ts
@@ -1,0 +1,162 @@
+import { Construct } from "constructs";
+import * as cdktf from "cdktf";
+import { ValidateTerraformVersion } from "./validations/validate-terraform-version";
+
+export interface DataConfig extends cdktf.TerraformMetaArguments {
+  /**
+   * (Optional) A value which will be stored in the instance state, and reflected in the output attribute after apply.
+   * https://developer.hashicorp.com/terraform/language/resources/terraform-data#input
+   */
+  readonly input?: { [key: string]: any };
+  /**
+   * (Optional) A value which is stored in the instance state, and will force replacement when the value changes.
+   * https://developer.hashicorp.com/terraform/language/resources/terraform-data#triggers_replace
+   */
+  readonly triggersReplace?: { [key: string]: any };
+}
+
+/**
+ * The DataResource implements the standard resource lifecycle, but does not directly take any other actions. You can use the DataResource resource without requiring or configuring a provider.
+ *
+ * The DataResource resource is useful for storing values which need to follow a manage resource lifecycle, and for triggering provisioners when there is no other logical managed resource in which to place them.
+ *
+ * It requires Terraform 1.4 or later.
+ *
+ * It is also possible to generate these bindings by adding "terraform.io/builtin/terraform" to the "terraformProviders" key in your cdktf.json file and running "cdktf get".
+ *
+ * https://developer.hashicorp.com/terraform/language/resources/terraform-data
+ */
+export class DataResource extends cdktf.TerraformResource {
+  // =================
+  // STATIC PROPERTIES
+  // =================
+  public static readonly tfResourceType = "terraform_data";
+
+  // ==============
+  // STATIC Methods
+  // ==============
+  /**
+   * Generates CDKTF code for importing a Data resource upon running "cdktf plan <stack-name>"
+   * @param scope The scope in which to define this construct
+   * @param importToId The construct id used in the generated config for the Data to import
+   * @param importFromId The id of the existing Data that should be imported. Refer to the {@link https://terraform.io/providers/builtin/terraform/latest/docs/resources/data#import import section} in the documentation of this resource for the id to use
+   * @param provider? Optional instance of the provider where the Data to import is found
+   */
+  public static generateConfigForImport(
+    scope: Construct,
+    importToId: string,
+    importFromId: string,
+    provider?: cdktf.TerraformProvider
+  ) {
+    return new cdktf.ImportableResource(scope, importToId, {
+      terraformResourceType: "terraform_data",
+      importId: importFromId,
+      provider,
+    });
+  }
+
+  // ===========
+  // INITIALIZER
+  // ===========
+
+  /**
+   * Create a new TerraformData Resource.
+   *
+   * The DataResource resource is useful for storing values which need to follow a manage resource lifecycle, and for triggering provisioners when there is no other logical managed resource in which to place them.
+   *
+   * @param scope The scope in which to define this construct
+   * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
+   * @param options DataConfig = {}
+   */
+  public constructor(scope: Construct, id: string, config: DataConfig = {}) {
+    super(scope, id, {
+      terraformResourceType: "terraform_data",
+      terraformGeneratorMetadata: {
+        providerName: "terraform",
+      },
+      provider: config.provider,
+      dependsOn: config.dependsOn,
+      count: config.count,
+      lifecycle: config.lifecycle,
+      provisioners: config.provisioners,
+      connection: config.connection,
+      forEach: config.forEach,
+    });
+    this._input = config.input;
+    this._triggersReplace = config.triggersReplace;
+    this.node.addValidation(
+      new ValidateTerraformVersion(
+        ">=1.4",
+        `The built-in Terraform data resource is only supported for Terraform >=1.4. Please upgrade your Terraform version.`
+      )
+    );
+  }
+
+  // ==========
+  // ATTRIBUTES
+  // ==========
+
+  // id - computed: true, optional: false, required: false
+  public get id() {
+    return this.getStringAttribute("id");
+  }
+
+  // input - computed: false, optional: true, required: false
+  private _input?: { [key: string]: any };
+  public get input() {
+    return this.getAnyMapAttribute("input");
+  }
+  /**
+   * (Optional) A value which will be stored in the instance state, and reflected in the output attribute after apply.
+   * https://developer.hashicorp.com/terraform/language/resources/terraform-data#input
+   */
+  public set input(value: { [key: string]: any }) {
+    this._input = value;
+  }
+  public resetInput() {
+    this._input = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get inputInput() {
+    return this._input;
+  }
+
+  // output - computed: true, optional: false, required: false
+  private _output = new cdktf.AnyMap(this, "output");
+  public get output() {
+    return this._output;
+  }
+
+  // triggers_replace - computed: false, optional: true, required: false
+  private _triggersReplace?: { [key: string]: any };
+  public get triggersReplace() {
+    return this.getAnyMapAttribute("triggers_replace");
+  }
+  /**
+   * (Optional) A value which is stored in the instance state, and will force replacement when the value changes.
+   * https://developer.hashicorp.com/terraform/language/resources/terraform-data#triggers_replace
+   */
+  public set triggersReplace(value: { [key: string]: any }) {
+    this._triggersReplace = value;
+  }
+  public resetTriggersReplace() {
+    this._triggersReplace = undefined;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get triggersReplaceInput() {
+    return this._triggersReplace;
+  }
+
+  // =========
+  // SYNTHESIS
+  // =========
+
+  protected synthesizeAttributes(): { [name: string]: any } {
+    return {
+      input: cdktf.hashMapper(cdktf.anyToTerraform)(this._input),
+      triggers_replace: cdktf.hashMapper(cdktf.anyToTerraform)(
+        this._triggersReplace
+      ),
+    };
+  }
+}

--- a/packages/cdktf/lib/terraform-data-resource.ts
+++ b/packages/cdktf/lib/terraform-data-resource.ts
@@ -4,10 +4,17 @@
  */
 
 import { Construct } from "constructs";
-import * as cdktf from "cdktf";
 import { ValidateTerraformVersion } from "./validations/validate-terraform-version";
+import {
+  TerraformMetaArguments,
+  TerraformResource,
+} from "./terraform-resource";
+import { TerraformProvider } from "./terraform-provider";
+import { ImportableResource } from "./importable-resource";
+import { AnyMap } from "./complex-computed-list";
+import { anyToTerraform, hashMapper } from "./runtime";
 
-export interface DataConfig extends cdktf.TerraformMetaArguments {
+export interface DataConfig extends TerraformMetaArguments {
   /**
    * (Optional) A value which will be stored in the instance state, and reflected in the output attribute after apply.
    * https://developer.hashicorp.com/terraform/language/resources/terraform-data#input
@@ -31,7 +38,7 @@ export interface DataConfig extends cdktf.TerraformMetaArguments {
  *
  * https://developer.hashicorp.com/terraform/language/resources/terraform-data
  */
-export class DataResource extends cdktf.TerraformResource {
+export class DataResource extends TerraformResource {
   // =================
   // STATIC PROPERTIES
   // =================
@@ -51,9 +58,9 @@ export class DataResource extends cdktf.TerraformResource {
     scope: Construct,
     importToId: string,
     importFromId: string,
-    provider?: cdktf.TerraformProvider
+    provider?: TerraformProvider
   ) {
-    return new cdktf.ImportableResource(scope, importToId, {
+    return new ImportableResource(scope, importToId, {
       terraformResourceType: "terraform_data",
       importId: importFromId,
       provider,
@@ -127,7 +134,7 @@ export class DataResource extends cdktf.TerraformResource {
   }
 
   // output - computed: true, optional: false, required: false
-  private _output = new cdktf.AnyMap(this, "output");
+  private _output = new AnyMap(this, "output");
   public get output() {
     return this._output;
   }
@@ -158,10 +165,8 @@ export class DataResource extends cdktf.TerraformResource {
 
   protected synthesizeAttributes(): { [name: string]: any } {
     return {
-      input: cdktf.hashMapper(cdktf.anyToTerraform)(this._input),
-      triggers_replace: cdktf.hashMapper(cdktf.anyToTerraform)(
-        this._triggersReplace
-      ),
+      input: hashMapper(anyToTerraform)(this._input),
+      triggers_replace: hashMapper(anyToTerraform)(this._triggersReplace),
     };
   }
 }

--- a/packages/cdktf/lib/validations/validate-provider-presence.ts
+++ b/packages/cdktf/lib/validations/validate-provider-presence.ts
@@ -1,6 +1,6 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import { IConstruct, IValidation, Node } from "constructs";
+import { IConstruct, IValidation } from "constructs";
 import { TerraformProvider } from "../terraform-provider";
 import { TerraformResource } from "../terraform-resource";
 import { TerraformDataSource } from "../terraform-data-source";
@@ -33,7 +33,10 @@ export class ValidateProviderPresence implements IValidation {
       TerraformResource.isTerraformResource(node) ||
       TerraformDataSource.isTerraformDataSource(node)
     ) {
-      if (node.terraformGeneratorMetadata) {
+      if (
+        node.terraformGeneratorMetadata &&
+        node.terraformGeneratorMetadata.providerName !== "terraform"
+      ) {
         this.providerNames.add(node.terraformGeneratorMetadata.providerName);
       }
     }
@@ -42,7 +45,7 @@ export class ValidateProviderPresence implements IValidation {
       this.foundProviders.push(node);
     }
 
-    for (const child of Node.of(node).children) {
+    for (const child of node.node.children) {
       this.check(child);
     }
   }

--- a/packages/cdktf/test/terraform-data-resource.test.ts
+++ b/packages/cdktf/test/terraform-data-resource.test.ts
@@ -1,0 +1,34 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { Testing, TerraformStack } from "../lib";
+import { ref } from "../lib/tfExpression";
+import { DataResource } from "../lib/terraform-data-resource";
+
+test("built-in Terraform data resource", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+
+  new DataResource(stack, "test-data", {
+    input: ref("var.input"),
+    triggersReplace: [ref("var.triggersReplace1"), ref("var.triggersReplace2")],
+  });
+
+  // Note: the triggers_replace attribute is defined as dynamic in the schema,
+  // which is treated as an object by the CDKTF provider generation and therefore
+  // renders the array as a map instead.
+  expect(Testing.synth(stack)).toMatchInlineSnapshot(`
+    "{
+      "resource": {
+        "terraform_data": {
+          "test-data": {
+            "input": "\${var.input}",
+            "triggers_replace": {
+              "0": "\${var.triggersReplace1}",
+              "1": "\${var.triggersReplace2}"
+            }
+          }
+        }
+      }
+    }"
+  `);
+});

--- a/website/docs/cdktf/concepts/resources.mdx
+++ b/website/docs/cdktf/concepts/resources.mdx
@@ -1165,6 +1165,10 @@ securitygroup.NewSecurityGroup(stack, jsii.String("security2"), &securitygroup.S
 
 ## Special Cases
 
+### Built-in `terraform_data` resource
+
+There is a special resource built into Terraform itself. It is called [`terraform_data`](/terraform/language/resources/terraform-data) and implements the standard resource lifecycle, but does not directly take any other actions. In CDKTF it is exposed as the `TerraformData` class and you can import it directly from the `cdktf` package.
+
 ### Large Resource Configurations
 
 A few individual Terraform Resources have very deeply nested schemas with a lot of attributes. This blows up the config classes and slows down the code generation for languages besides Typescript. To work around this we sometimes limit the depth of the config classes and use `any` on deeper level, some attributes we directly expose as `any` on the top level config class.

--- a/website/docs/cdktf/concepts/resources.mdx
+++ b/website/docs/cdktf/concepts/resources.mdx
@@ -1167,7 +1167,7 @@ securitygroup.NewSecurityGroup(stack, jsii.String("security2"), &securitygroup.S
 
 ### Built-in `terraform_data` resource
 
-There is a special resource built into Terraform itself. It is called [`terraform_data`](/terraform/language/resources/terraform-data) and implements the standard resource lifecycle, but does not directly take any other actions. In CDKTF it is exposed as the `TerraformData` class and you can import it directly from the `cdktf` package.
+The [`terraform_data`](/terraform/language/resources/terraform-data) resource implements the standard resource lifecycle but does not directly perform any other actions. In CDKTF, the resource is exposed as the `TerraformData` class and you can import it directly from the `cdktf` package.
 
 ### Large Resource Configurations
 


### PR DESCRIPTION
The code is based on the output of our provider-generation as that requires only a simple (import related) special handling in convert

Closes #3142

## Todos

- [x] Add convert support for Terraform Data Resource (requires adjusting the import)
- [x] Docs?
