### PR TITLE
fix(provider-generator): use module name that does not collide commonly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.20.0 (Unreleased)
+
+**Breaking changes**
+
+### Module names / import paths changing
+
+To resolve [\#3026](https://github.com/hashicorp/terraform-cdk/issues/3026) we improved the logic for generating names for [Terraform Modules](https://developer.hashicorp.com/terraform/cdktf/concepts/modules). This makes the default module names nicer, but also leads to breaking changes for Python, C#, and Java. When updating CDKTF, please generate the new bindings with `cdktf get` after updating the CLI and update your module imports.
+
 ## 0.19.1
 
 ### feat

--- a/examples/python/aws-eks/cdktf.json
+++ b/examples/python/aws-eks/cdktf.json
@@ -9,16 +9,8 @@
     }
   ],
   "terraformModules": [
-    {
-      "name": "vpc",
-      "source": "terraform-aws-modules/vpc/aws",
-      "version": "2.77.0"
-    },
-    {
-      "name": "eks",
-      "source": "terraform-aws-modules/eks/aws",
-      "version": "~> 15.0"
-    }
+    "terraform-aws-modules/vpc/aws@5.0.0",
+    "terraform-aws-modules/rds/aws@5.0.0"
   ],
   "codeMakerOutput": "imports"
 }

--- a/examples/python/aws-eks/cdktf.json
+++ b/examples/python/aws-eks/cdktf.json
@@ -9,9 +9,16 @@
     }
   ],
   "terraformModules": [
-    "terraform-aws-modules/vpc/aws@5.0.0",
-    "terraform-aws-modules/rds/aws@5.0.0"
+    {
+      "name": "vpc",
+      "source": "terraform-aws-modules/vpc/aws",
+      "version": "2.77.0"
+    },
+    {
+      "name": "eks",
+      "source": "terraform-aws-modules/eks/aws",
+      "version": "~> 15.0"
+    }
   ],
   "codeMakerOutput": "imports"
 }
-

--- a/examples/python/aws/main.py
+++ b/examples/python/aws/main.py
@@ -3,11 +3,11 @@
 
 from constructs import Construct
 from cdktf import App, TerraformStack
+from imports.aws.iam_role import IamRole
+from imports.aws.lambda_function import LambdaFunction
 from imports.aws.provider import AwsProvider
 from imports.aws.sns_topic import SnsTopic
-from imports.terraform_aws_modules.aws import Vpc
-from imports.aws.lambda_function import LambdaFunction
-from imports.aws.iam_role import IamRole
+from imports.vpc import Vpc
 
 
 class MyStack(TerraformStack):

--- a/packages/@cdktf/commons/src/config.ts
+++ b/packages/@cdktf/commons/src/config.ts
@@ -143,7 +143,7 @@ export class TerraformModuleConstraint
       toProcess = prefixMatch[2];
     }
 
-    // strip off any protocl
+    // strip off any protocol
     const protocolMatch = toProcess.match(/^([a-zA-Z]*):\/\/(.*)/);
     if (protocolMatch) {
       toProcess = protocolMatch[2];

--- a/packages/@cdktf/commons/src/construct-maker-target.test.ts
+++ b/packages/@cdktf/commons/src/construct-maker-target.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { Language, TerraformModuleConstraint } from "./config";
+import { ConstructsMakerModuleTarget } from "./construct-maker-target";
+
+describe("ConstructsMakerModuleTarget", () => {
+  describe.each([
+    {
+      fqn: "cloudposse/label/null",
+      names: {
+        [Language.TYPESCRIPT]: "cloudposse.null",
+        [Language.PYTHON]: "cloudposse.label.null",
+        [Language.JAVA]: "cloudposse.label.null",
+        [Language.CSHARP]: "cloudposse.label.null",
+        [Language.GO]: "label",
+      },
+    },
+    {
+      fqn: "terraform-google-modules/project-factory/google",
+      names: {
+        [Language.TYPESCRIPT]: "terraform_google_modules.google",
+        [Language.PYTHON]: "terraform_google_modules.project_factory.google",
+        [Language.JAVA]: "terraform_google_modules.project_factory.google",
+        [Language.CSHARP]: "terraform_google_modules.project_factory.google",
+        [Language.GO]: "project_factory",
+      },
+    },
+    {
+      fqn: "terraform-aws-modules/vpc/aws@5.0.0",
+      names: {
+        [Language.TYPESCRIPT]: "terraform_aws_modules.aws",
+        [Language.PYTHON]: "terraform_aws_modules.vpc.aws",
+        [Language.JAVA]: "terraform_aws_modules.vpc.aws",
+        [Language.CSHARP]: "terraform_aws_modules.vpc.aws",
+        [Language.GO]: "vpc",
+      },
+    },
+    {
+      fqn: "terraform-aws-modules/eks/aws//modules/self-managed-node-group",
+      names: {
+        [Language.TYPESCRIPT]: "terraform_aws_modules.aws.eks.modules",
+        [Language.PYTHON]:
+          "terraform_aws_modules.eks.aws.modules.self_managed_node_group",
+        [Language.JAVA]:
+          "terraform_aws_modules.eks.aws.modules.self_managed_node_group",
+        [Language.CSHARP]:
+          "terraform_aws_modules.eks.aws.modules.self_managed_node_group",
+        [Language.GO]: "self_managed_node_group",
+      },
+    },
+    {
+      fqn: {
+        name: "my-local-module",
+        source: "./path/to/local/terraform/module",
+      },
+      names: {
+        [Language.TYPESCRIPT]: "my-local-module",
+        [Language.PYTHON]: "my_local_module",
+        [Language.JAVA]: "my_local_module",
+        [Language.CSHARP]: "my_local_module",
+        [Language.GO]: "my_local_module",
+      },
+    },
+  ])("#srcMakName %#", ({ fqn, names }) => {
+    it.each(Object.entries(names))(
+      `expect name for ${JSON.stringify(fqn)} in %s to be %s`,
+      (language, name) => {
+        const constraint = new TerraformModuleConstraint(fqn as any);
+        const target = new ConstructsMakerModuleTarget(
+          constraint,
+          language as Language
+        );
+        expect(target.srcMakName).toBe(name);
+      }
+    );
+  });
+});

--- a/packages/@cdktf/commons/src/construct-maker-target.ts
+++ b/packages/@cdktf/commons/src/construct-maker-target.ts
@@ -87,6 +87,7 @@ export class ConstructsMakerModuleTarget extends ConstructsMakerTarget {
       case Language.JAVA:
       case Language.CSHARP:
       case Language.PYTHON:
+        return this.simplifiedFqn;
       default:
         return this.simplifiedName;
     }
@@ -109,6 +110,10 @@ export class ConstructsMakerModuleTarget extends ConstructsMakerTarget {
     return (
       this.namespace?.replace(/\//gi, ".").replace(/-/gi, "_") ?? this.name
     );
+  }
+
+  protected get simplifiedFqn(): string {
+    return this.fqn.replace(/\//gi, ".").replace(/-/gi, "_");
   }
 }
 


### PR DESCRIPTION
Closes #3026

## Summary

We use the fqn in a sanitized version now instead of the namespace, leading to less likely collissions in python, c#, and java. For go and typescript we leave the same logic.

## Example

Let's assume the `cdktf.json`

```jsonc
{
 // ...
 "terraformModules": [
        {
            "name": "eks",
            "source": "terraform-aws-modules/eks/aws",
            "version": "~> 16.0"
        },
        "terraform-aws-modules/vpc/aws@5.0.0",
        "terraform-aws-modules/rds/aws@5.0.0",
        "cloudposse/label/null",
        "terraform-google-modules/project-factory/google",
        "terraform-aws-modules/eks/aws//modules/self-managed-node-group"
    ]
}
```

### Typescript

```
.gen/modules/
├── cloudposse
│   └── null
│       └── label.ts
├── terraform-aws-modules
│   └── aws
│       ├── eks
│       │   └── modules
│       │       └── self-managed-node-group.ts
│       ├── rds.ts
│       └── vpc.ts
└── terraform-google-modules
    └── google
        └── project-factory.ts
```

### Python

```
imports/
├── constraints.json
├── label
│   ├── __init__.py
│   ├── _jsii
│   │   ├── __init__.py
│   │   └── label@0.0.0.jsii.tgz
│   └── py.typed
├── project_factory
│   ├── __init__.py
│   ├── _jsii
│   │   ├── __init__.py
│   │   └── project-factory@0.0.0.jsii.tgz
│   └── py.typed
├── self_managed_node_group
│   ├── __init__.py
│   ├── _jsii
│   │   ├── __init__.py
│   │   └── self-managed-node-group@0.0.0.jsii.tgz
│   └── py.typed
├── versions.json
└── vpc
    ├── __init__.py
    ├── _jsii
    │   ├── __init__.py
    │   └── vpc@0.0.0.jsii.tgz
    └── py.typed
```

### C#

```
.gen/
├── constraints.json
├── label
│   ├── AssemblyInfo.cs
│   ├── label
│   │   ├── ILabelConfig.cs
│   │   ├── Internal
│   │   │   └── DependencyResolution
│   │   │       └── Anchor.cs
│   │   ├── Label.cs
│   │   └── LabelConfig.cs
│   ├── label-0.0.0.tgz
│   └── label.csproj
├── project_factory
│   ├── AssemblyInfo.cs
│   ├── project-factory-0.0.0.tgz
│   ├── project_factory
│   │   ├── IProjectFactoryConfig.cs
│   │   ├── Internal
│   │   │   └── DependencyResolution
│   │   │       └── Anchor.cs
│   │   ├── ProjectFactory.cs
│   │   └── ProjectFactoryConfig.cs
│   └── project_factory.csproj
├── rds
│   ├── AssemblyInfo.cs
│   ├── rds
│   │   ├── IRdsConfig.cs
│   │   ├── Internal
│   │   │   └── DependencyResolution
│   │   │       └── Anchor.cs
│   │   ├── Rds.cs
│   │   └── RdsConfig.cs
│   ├── rds-0.0.0.tgz
│   └── rds.csproj
├── self_managed_node_group
│   ├── AssemblyInfo.cs
│   ├── self-managed-node-group-0.0.0.tgz
│   ├── self_managed_node_group
│   │   ├── ISelfManagedNodeGroupConfig.cs
│   │   ├── Internal
│   │   │   └── DependencyResolution
│   │   │       └── Anchor.cs
│   │   ├── SelfManagedNodeGroup.cs
│   │   └── SelfManagedNodeGroupConfig.cs
│   └── self_managed_node_group.csproj
├── versions.json
└── vpc
    ├── AssemblyInfo.cs
    ├── vpc
    │   ├── IVpcConfig.cs
    │   ├── Internal
    │   │   └── DependencyResolution
    │   │       └── Anchor.cs
    │   ├── Vpc.cs
    │   └── VpcConfig.cs
    ├── vpc-0.0.0.tgz
    └── vpc.csproj
```

### Java

```
src/main/java/imports/
├── label
│   ├── $Module.java
│   ├── Label.java
│   └── LabelConfig.java
├── project_factory
│   ├── $Module.java
│   ├── ProjectFactory.java
│   └── ProjectFactoryConfig.java
├── rds
│   ├── $Module.java
│   ├── Rds.java
│   └── RdsConfig.java
├── self_managed_node_group
│   ├── $Module.java
│   ├── SelfManagedNodeGroup.java
│   └── SelfManagedNodeGroupConfig.java
└── vpc
    ├── $Module.java
    ├── Vpc.java
    └── VpcConfig.java
```

### Go

```
generated/
├── cloudposse
│   └── null
│       └── label
│           ├── Label.go
│           ├── LabelConfig.go
│           ├── Label__checks.go
│           ├── Label__no_checks.go
│           ├── internal
│           │   └── types.go
│           ├── jsii
│           │   ├── jsii.go
│           │   └── label-0.0.0.tgz
│           ├── main.go
│           └── version
├── constraints.json
├── eks
│   ├── Eks.go
│   ├── EksConfig.go
│   ├── Eks__checks.go
│   ├── Eks__no_checks.go
│   ├── internal
│   │   └── types.go
│   ├── jsii
│   │   ├── eks-0.0.0.tgz
│   │   └── jsii.go
│   ├── main.go
│   └── version
├── terraform-aws-modules
│   └── aws
│       ├── eks
│       │   └── modules
│       │       └── self_managed_node_group
│       │           ├── SelfManagedNodeGroup.go
│       │           ├── SelfManagedNodeGroupConfig.go
│       │           ├── SelfManagedNodeGroup__checks.go
│       │           ├── SelfManagedNodeGroup__no_checks.go
│       │           ├── internal
│       │           │   └── types.go
│       │           ├── jsii
│       │           │   ├── jsii.go
│       │           │   └── self-managed-node-group-0.0.0.tgz
│       │           ├── main.go
│       │           └── version
│       ├── rds
│       │   ├── Rds.go
│       │   ├── RdsConfig.go
│       │   ├── Rds__checks.go
│       │   ├── Rds__no_checks.go
│       │   ├── internal
│       │   │   └── types.go
│       │   ├── jsii
│       │   │   ├── jsii.go
│       │   │   └── rds-0.0.0.tgz
│       │   ├── main.go
│       │   └── version
│       └── vpc
│           ├── Vpc.go
│           ├── VpcConfig.go
│           ├── Vpc__checks.go
│           ├── Vpc__no_checks.go
│           ├── internal
│           │   └── types.go
│           ├── jsii
│           │   ├── jsii.go
│           │   └── vpc-0.0.0.tgz
│           ├── main.go
│           └── version
├── terraform-google-modules
│   └── google
│       └── project_factory
│           ├── ProjectFactory.go
│           ├── ProjectFactoryConfig.go
│           ├── ProjectFactory__checks.go
│           ├── ProjectFactory__no_checks.go
│           ├── internal
│           │   └── types.go
│           ├── jsii
│           │   ├── jsii.go
│           │   └── project-factory-0.0.0.tgz
│           ├── main.go
│           └── version
└── versions.json
```



