### PR TITLE
feat(docs): Add note to address having the same name as new Terraform stacks feature

### DIFF
--- a/website/docs/cdktf/concepts/stacks.mdx
+++ b/website/docs/cdktf/concepts/stacks.mdx
@@ -7,6 +7,8 @@ description: >-
 
 # Stacks
 
+_Note: Stacks in CDKTF are not the same as [Terraform stacks](https://www.hashicorp.com/blog/terraform-stacks-explained), which are a configuration layer that eliminates the need to manually manage cross-configuration dependencies between Terraform modules.
+
 A stack represents a collection of infrastructure that CDK for Terraform (CDKTF) synthesizes as a dedicated Terraform configuration. Stacks allow you to separate the state management for multiple environments within an application.
 
 > **Hands-on:** Try the [Deploy Applications with CDK for Terraform](/terraform/tutorials/cdktf/cdktf-applications?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial.


### PR DESCRIPTION
Since CDKTF has a primitive called stacks and we also have an upcoming (now announced) feature that is also called "stacks" or "Terraform stacks" - I wrote a sentence with a link to point out the differences.

