### PR TITLE
fix: Terraform Modules relatively referencing each other with generated bindings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,2 @@
 {
-    "eslint.validate": [
-        "glimmer-ts",
-        "glimmer-js"
-    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,2 +1,6 @@
 {
+    "eslint.validate": [
+        "glimmer-ts",
+        "glimmer-js"
+    ]
 }

--- a/packages/@cdktf/cli-core/src/lib/synth-stack.ts
+++ b/packages/@cdktf/cli-core/src/lib/synth-stack.ts
@@ -120,13 +120,7 @@ might fail while synthesizing with an out of memory error.`);
     const currentContext = process.env[CONTEXT_ENV]
       ? JSON.parse(process.env.CDKTF_CONTEXT_JSON)
       : {};
-    const relativeModules = CdktfConfig.read().terraformModules.filter(
-      (mod) => {
-        return typeof mod === "string"
-          ? mod.startsWith("./") || mod.startsWith("../")
-          : mod.source.startsWith("./") || mod.source.startsWith("../");
-      }
-    );
+    const relativeModules = getRelativeTerraformModules();
 
     try {
       await shell(command, [], {
@@ -263,4 +257,20 @@ Command output on stdout:
   public static async synthErrorTelemetry(synthOrigin?: SynthOrigin) {
     await sendTelemetry("synth", { error: true, synthOrigin });
   }
+}
+
+function getRelativeTerraformModules() {
+  let cfg;
+
+  try {
+    cfg = CdktfConfig.read();
+  } catch {
+    return [];
+  }
+
+  return cfg.terraformModules.filter((mod) => {
+    return typeof mod === "string"
+      ? mod.startsWith("./") || mod.startsWith("../")
+      : mod.source.startsWith("./") || mod.source.startsWith("../");
+  });
 }

--- a/packages/@cdktf/cli-core/src/lib/synth-stack.ts
+++ b/packages/@cdktf/cli-core/src/lib/synth-stack.ts
@@ -264,7 +264,8 @@ function getRelativeTerraformModules() {
 
   try {
     cfg = CdktfConfig.read();
-  } catch {
+  } catch (e) {
+    logger.trace("Could not read cdktf.json: " + e);
     return [];
   }
 

--- a/packages/@cdktf/commons/src/config.test.ts
+++ b/packages/@cdktf/commons/src/config.test.ts
@@ -130,7 +130,7 @@ describe("parseConfig", () => {
         ],
       };
       const parsed: any = parseConfig(JSON.stringify(input));
-      expect(parsed.terraformModules[0].localSource).toMatch(
+      expect(parsed.terraformModules[0].localSourceAbsolutePath).toMatch(
         "/packages/@cdktf/commons/foo"
       );
     });
@@ -231,7 +231,7 @@ describe("parseConfig", () => {
       };
 
       const parsed: any = parseConfig(JSON.stringify(input));
-      expect(parsed.terraformModules[0].localSource).toMatch(
+      expect(parsed.terraformModules[0].localSourceAbsolutePath).toMatch(
         "/packages/@cdktf/commons/consul"
       );
 

--- a/packages/@cdktf/commons/src/config.ts
+++ b/packages/@cdktf/commons/src/config.ts
@@ -58,7 +58,7 @@ export class TerraformModuleConstraint
 {
   public readonly name: string;
   public readonly source: string;
-  public readonly localSource?: string;
+  public readonly localSourceAbsolutePath?: string;
   public readonly fqn: string;
   public readonly version?: string;
   public readonly namespace?: string;
@@ -81,7 +81,8 @@ export class TerraformModuleConstraint
 
     const localMatch = getLocalMatch(this.source);
     if (localMatch) {
-      this.localSource = `file://${path.join(process.cwd(), this.source)}`;
+      this.localSourceAbsolutePath = path.join(process.cwd(), this.source);
+      console.log("localSourceAbsolutePath", this.localSourceAbsolutePath);
     }
   }
 

--- a/packages/@cdktf/commons/src/config.ts
+++ b/packages/@cdktf/commons/src/config.ts
@@ -82,7 +82,6 @@ export class TerraformModuleConstraint
     const localMatch = getLocalMatch(this.source);
     if (localMatch) {
       this.localSourceAbsolutePath = path.join(process.cwd(), this.source);
-      console.log("localSourceAbsolutePath", this.localSourceAbsolutePath);
     }
   }
 

--- a/packages/@cdktf/provider-schema/src/provider-schema.ts
+++ b/packages/@cdktf/provider-schema/src/provider-schema.ts
@@ -215,8 +215,6 @@ export async function readModuleSchema(target: ConstructsMakerModuleTarget) {
   let moduleSchema: Record<string, ModuleSchema> = {};
 
   await withTempDir("fetchSchema", async () => {
-    console.log("readModuleSchema", target);
-
     const config: TerraformConfig = {
       terraform: {},
     };
@@ -229,11 +227,6 @@ export async function readModuleSchema(target: ConstructsMakerModuleTarget) {
     if (localSource) {
       // create relative path to module in the user project
       source = path.relative(process.cwd(), localSource);
-      console.log("localSource, relative path", source);
-
-      // one construct für alle modules (nur einmal)
-      // nur ein asset am ende mit allen local modules
-      // asset.addPath feature?
     }
 
     config.module[target.moduleKey] = { source: source };

--- a/packages/cdktf/lib/terraform-element.ts
+++ b/packages/cdktf/lib/terraform-element.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 import { ok } from "assert";
 import { Construct } from "constructs";
-import { Token } from ".";
+import { Token } from "./tokens";
 import { TerraformStack } from "./terraform-stack";
 import { ref } from "./tfExpression";
 import { unresolvedTokenInConstructId } from "./errors";

--- a/packages/cdktf/lib/terraform-module-asset.ts
+++ b/packages/cdktf/lib/terraform-module-asset.ts
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { Construct } from "constructs";
+import * as path from "path";
+import * as os from "os";
+import * as fs from "fs";
+import { TerraformStack } from "./terraform-stack";
+import { AssetType, TerraformAsset } from "./terraform-asset";
+
+const TERRAFORM_MODULE_ASSET_SYMBOL = Symbol.for("cdktf.TerraformModuleAsset");
+
+/**
+ * This Construct is being created as a singleton whenever the first
+ * TerraformModule with a local source is created in a stack.
+ *
+ * When Terraform modules depend on local modules, the local modules
+ * they depend on need to have the correct relative path to the module
+ * in the asset. This only works if all modules are in one asset.
+ *
+ * (We could theoretically detect if a module uses relative path references, but this is easier)
+ * @internal
+ */
+export class TerraformModuleAsset extends Construct {
+  private readonly relativeAssetPath: string;
+  private readonly asset: TerraformAsset;
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const relativeModules: Array<string | { source: string }> | undefined =
+      this.node.tryGetContext("cdktfRelativeModules");
+
+    if (!relativeModules) {
+      throw new Error(
+        "You are trying to use a local module with a relative path, but the cdktfRelativeModules context is not set. You either need to supply it in the Apps constructor via the context option or invoke the synthesis through the CLI. We need this information so that assets with relative paths are properly handled when used with assets, so you can also set the skipAssetCreationFromLocalModules to true on your relative modules."
+      );
+    }
+
+    const moduleSources = relativeModules.map((module) =>
+      typeof module === "string" ? module : module.source
+    );
+
+    const relativeAssetPath = findLowestCommonPath(moduleSources);
+    if (!relativeAssetPath) {
+      throw new Error(
+        "Could not find lowest common path for relative modules. This should not happen, you might be overwriting the cdktfRelativeModules value of the context with something unexpected. We expect an array of string or objects with a source attribute where the string or the source attribute reference a relative path to a module. The context can be set in the context option of the App Constructor Options."
+      );
+    }
+    this.relativeAssetPath = relativeAssetPath;
+
+    // Create a tmp dir for the asset
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "cdktf-module-asset-")
+    );
+
+    // Copy all modules into the tmp dir
+    for (const module of moduleSources) {
+      const target = path.join(tmpDir, this.relativeModulePath(module));
+      copySync(module, target);
+    }
+
+    // Create asset based on tmp dir
+    this.asset = new TerraformAsset(this, "asset", {
+      path: tmpDir,
+      type: AssetType.DIRECTORY,
+    });
+  }
+
+  public static of(construct: Construct): TerraformModuleAsset {
+    const stack = TerraformStack.of(construct);
+
+    let asset = (stack as any)[TERRAFORM_MODULE_ASSET_SYMBOL];
+    if (!asset) {
+      asset = new TerraformModuleAsset(stack, "__cdktf_module_asset");
+
+      Object.defineProperty(stack, TERRAFORM_MODULE_ASSET_SYMBOL, {
+        value: asset,
+        configurable: false,
+        enumerable: false,
+      });
+    }
+    return asset;
+  }
+
+  /**
+   * The input source is relative to cwd, but we want the value relative
+   * to the assets target, so the common path prefix
+   */
+  private relativeModulePath(source: string): string {
+    const absoluteSourcePath = path.resolve(source);
+    const absoluteAssetPath = path.resolve(this.relativeAssetPath);
+    return path.relative(absoluteAssetPath, absoluteSourcePath);
+  }
+
+  public getAssetPathForModule(source: string): string {
+    return path.join(this.asset.path, this.relativeModulePath(source));
+  }
+}
+
+/**
+ * Finds the lowest common path of all relaticve paths in the given array
+ */
+export function findLowestCommonPath(paths: string[]): string | undefined {
+  if (paths.length === 0) {
+    return undefined;
+  }
+
+  // We first need to make the paths absolute so that we can compare them
+  const absolutePaths = paths.map((p) => path.resolve(p));
+
+  // We take the first path as the base and then remove parts from the end until we find the lowest common path
+  let absolutePathPrefix = absolutePaths[0];
+  while (
+    !absolutePaths.every((p) => p.startsWith(absolutePathPrefix)) &&
+    absolutePathPrefix !== "/"
+  ) {
+    absolutePathPrefix = path.dirname(absolutePathPrefix);
+  }
+
+  return path.relative(process.cwd(), absolutePathPrefix);
+}
+
+/**
+ * Copies a file or directory recursively
+ * @param from
+ * @param to
+ */
+function copySync(from: string, to: string) {
+  if (fs.lstatSync(from).isDirectory()) {
+    fs.mkdirSync(to, { recursive: true });
+    for (const file of fs.readdirSync(from)) {
+      copySync(path.join(from, file), path.join(to, file));
+    }
+  } else {
+    fs.copyFileSync(from, to);
+  }
+}

--- a/packages/cdktf/lib/terraform-module-asset.ts
+++ b/packages/cdktf/lib/terraform-module-asset.ts
@@ -100,7 +100,7 @@ export class TerraformModuleAsset extends Construct {
   }
 
   public getAssetPathForModule(source: string): string {
-    return path.join(this.asset.path, this.relativeModulePath(source));
+    return `./${path.join(this.asset.path, this.relativeModulePath(source))}`;
   }
 }
 

--- a/packages/cdktf/lib/terraform-module-asset.ts
+++ b/packages/cdktf/lib/terraform-module-asset.ts
@@ -124,7 +124,8 @@ export function findLowestCommonPath(paths: string[]): string | undefined {
     absolutePathPrefix = path.dirname(absolutePathPrefix);
   }
 
-  return path.relative(process.cwd(), absolutePathPrefix);
+  const relativePath = path.relative(process.cwd(), absolutePathPrefix);
+  return relativePath === "" ? "." : relativePath;
 }
 
 /**

--- a/packages/cdktf/lib/terraform-module-asset.ts
+++ b/packages/cdktf/lib/terraform-module-asset.ts
@@ -34,7 +34,7 @@ export class TerraformModuleAsset extends Construct {
 
     if (!relativeModules) {
       throw new Error(
-        "You are trying to use a local module with a relative path, but the cdktfRelativeModules context is not set. You either need to supply it in the Apps constructor via the context option or invoke the synthesis through the CLI. We need this information so that assets with relative paths are properly handled when used with assets, so you can also set the skipAssetCreationFromLocalModules to true on your relative modules."
+        "You are trying to use a local module with a relative path, but the cdktfRelativeModules context is not set. It is expected to be an array of strings containing the relative paths to. You either need to supply it in the Apps constructor via the context option or invoke the synthesis through the CLI. We need this information so that assets with relative paths are properly handled when used with assets, so you can also set the skipAssetCreationFromLocalModules to true on your relative modules."
       );
     }
 

--- a/packages/cdktf/lib/terraform-module-asset.ts
+++ b/packages/cdktf/lib/terraform-module-asset.ts
@@ -9,6 +9,7 @@ import * as os from "os";
 import * as fs from "fs";
 import { TerraformStack } from "./terraform-stack";
 import { AssetType, TerraformAsset } from "./terraform-asset";
+import { hashPath } from "./private/fs";
 
 const TERRAFORM_MODULE_ASSET_SYMBOL = Symbol.for("cdktf.TerraformModuleAsset");
 
@@ -31,6 +32,9 @@ export class TerraformModuleAsset extends Construct {
 
     const relativeModules: Array<string | { source: string }> | undefined =
       this.node.tryGetContext("cdktfRelativeModules");
+    const staticModuleAssetHash: string | undefined = this.node.tryGetContext(
+      "cdktfStaticModuleAssetHash"
+    );
 
     if (!relativeModules) {
       throw new Error(
@@ -65,6 +69,7 @@ export class TerraformModuleAsset extends Construct {
     this.asset = new TerraformAsset(this, "asset", {
       path: tmpDir,
       type: AssetType.DIRECTORY,
+      assetHash: staticModuleAssetHash ?? hashPath(relativeAssetPath),
     });
   }
 

--- a/packages/cdktf/lib/terraform-module-asset.ts
+++ b/packages/cdktf/lib/terraform-module-asset.ts
@@ -38,7 +38,7 @@ export class TerraformModuleAsset extends Construct {
 
     if (!relativeModules) {
       throw new Error(
-        "You are trying to use a local module with a relative path, but the cdktfRelativeModules context is not set. It is expected to be an array of strings containing the relative paths to. You either need to supply it in the Apps constructor via the context option or invoke the synthesis through the CLI. We need this information so that assets with relative paths are properly handled when used with assets, so you can also set the skipAssetCreationFromLocalModules to true on your relative modules."
+        "You are trying to use a local module with a relative path, but the cdktfRelativeModules context is not set. It is expected to be an array of strings containing the relative paths to the relative modules your app is using. You either need to supply it in the Apps constructor via the context option or invoke the synthesis through the CLI. We need this information so that assets with relative paths are properly handled when used with assets, so you can also set the skipAssetCreationFromLocalModules to true on your relative modules."
       );
     }
 

--- a/packages/cdktf/lib/terraform-module.ts
+++ b/packages/cdktf/lib/terraform-module.ts
@@ -7,7 +7,6 @@ import { deepMerge } from "./util";
 import { ITerraformDependable } from "./terraform-dependable";
 import { Token } from "./tokens";
 import { ref, dependable } from "./tfExpression";
-import { TerraformAsset } from "./terraform-asset";
 import { ITerraformIterator } from "./terraform-iterator";
 import { modulesWithSameAlias } from "./errors";
 import { TerraformModuleAsset } from "./terraform-module-asset";

--- a/packages/cdktf/lib/terraform-module.ts
+++ b/packages/cdktf/lib/terraform-module.ts
@@ -10,6 +10,7 @@ import { ref, dependable } from "./tfExpression";
 import { TerraformAsset } from "./terraform-asset";
 import { ITerraformIterator } from "./terraform-iterator";
 import { modulesWithSameAlias } from "./errors";
+import { TerraformModuleAsset } from "./terraform-module-asset";
 
 export interface TerraformModuleUserConfig {
   readonly providers?: (TerraformProvider | TerraformModuleProvider)[];
@@ -47,12 +48,10 @@ export abstract class TerraformModule
 
     if (!options.skipAssetCreationFromLocalModules) {
       if (options.source.startsWith("./") || options.source.startsWith("../")) {
-        // Create an asset for the local module for better TFC support
-        const asset = new TerraformAsset(scope, `local-module-${id}`, {
-          path: options.source,
-        });
-        // Despite being a relative path already, further indicate it as such for Terraform handling
-        this.source = `./${asset.path}`;
+        // Create an asset or reuse existing "singleton asset" for the local module for better TFC support
+        this.source = TerraformModuleAsset.of(scope).getAssetPathForModule(
+          options.source
+        );
       }
     }
 

--- a/packages/cdktf/lib/testing/index.ts
+++ b/packages/cdktf/lib/testing/index.ts
@@ -78,6 +78,7 @@ export class Testing {
 
   public static fakeCdktfJsonPath(app: App): App {
     app.node.setContext("cdktfJsonPath", `${process.cwd()}/cdktf.json`);
+    app.node.setContext("cdktfRelativeModules", []);
     return app;
   }
 

--- a/packages/cdktf/lib/testing/index.ts
+++ b/packages/cdktf/lib/testing/index.ts
@@ -27,6 +27,7 @@ export interface TestingAppConfig {
   readonly stubVersion?: boolean;
   readonly enableFutureFlags?: boolean;
   readonly fakeCdktfJsonPath?: boolean;
+  readonly context?: { [key: string]: any };
 }
 
 const DefaultTestingAppConfig: TestingAppConfig = {
@@ -55,6 +56,7 @@ export class Testing {
     const app = new App({
       outdir: appConfig.outdir,
       stackTraces: appConfig.stackTraces,
+      context: options.context,
     });
 
     if (appConfig.stubVersion) {
@@ -78,7 +80,7 @@ export class Testing {
 
   public static fakeCdktfJsonPath(app: App): App {
     app.node.setContext("cdktfJsonPath", `${process.cwd()}/cdktf.json`);
-    app.node.setContext("cdktfRelativeModules", []);
+    app.node.setContext("cdktfRelativeModules", ["./"]);
     return app;
   }
 

--- a/packages/cdktf/lib/tfExpression.ts
+++ b/packages/cdktf/lib/tfExpression.ts
@@ -3,7 +3,7 @@
 import { IResolvable, IResolveContext } from "./tokens/resolvable";
 import { Intrinsic } from "./tokens/private/intrinsic";
 import { Tokenization, Token } from "./tokens/token";
-import { App } from ".";
+import { App } from "./app";
 import { TerraformStack } from "./terraform-stack";
 import { ITerraformDependable } from "./terraform-dependable";
 import { Construct } from "constructs";

--- a/packages/cdktf/test/__snapshots__/module.test.ts.snap
+++ b/packages/cdktf/test/__snapshots__/module.test.ts.snap
@@ -4,7 +4,7 @@ exports[`depends on 1`] = `
 "{
   "module": {
     "test_1": {
-      "source": "./assets/local-module-test_1/EF2B4CE432B6BA0BE6788E2EB57445E5"
+      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     },
     "test_2": {
       "depends_on": [

--- a/packages/cdktf/test/__snapshots__/module.test.ts.snap
+++ b/packages/cdktf/test/__snapshots__/module.test.ts.snap
@@ -4,7 +4,7 @@ exports[`depends on 1`] = `
 "{
   "module": {
     "test_1": {
-      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
+      "source": "./assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     },
     "test_2": {
       "depends_on": [

--- a/packages/cdktf/test/__snapshots__/terraform-hcl-module.test.ts.snap
+++ b/packages/cdktf/test/__snapshots__/terraform-hcl-module.test.ts.snap
@@ -7,7 +7,7 @@ exports[`add provider 1`] = `
       "providers": {
         "test": "test.provider1"
       },
-      "source": "./assets/local-module-test/EF2B4CE432B6BA0BE6788E2EB57445E5"
+      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     }
   },
   "provider": {
@@ -42,7 +42,7 @@ exports[`complex providers 1`] = `
         "test.dst": "test.provider2",
         "test.src": "test.provider1"
       },
-      "source": "./assets/local-module-test/EF2B4CE432B6BA0BE6788E2EB57445E5"
+      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     }
   },
   "provider": {
@@ -71,7 +71,7 @@ exports[`depend on module 1`] = `
 "{
   "module": {
     "test": {
-      "source": "./assets/local-module-test/EF2B4CE432B6BA0BE6788E2EB57445E5"
+      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     }
   },
   "provider": {
@@ -104,13 +104,13 @@ exports[`depend on other module 1`] = `
 "{
   "module": {
     "test_1": {
-      "source": "./assets/local-module-test_1/EF2B4CE432B6BA0BE6788E2EB57445E5"
+      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     },
     "test_2": {
       "depends_on": [
         "module.test_1"
       ],
-      "source": "./assets/local-module-test_2/EF2B4CE432B6BA0BE6788E2EB57445E5"
+      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     }
   }
 }"
@@ -120,7 +120,7 @@ exports[`minimal configuration 1`] = `
 "{
   "module": {
     "test": {
-      "source": "./assets/local-module-test/EF2B4CE432B6BA0BE6788E2EB57445E5"
+      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     }
   }
 }"
@@ -134,7 +134,7 @@ exports[`multiple providers 1`] = `
         "differentType": "differentType",
         "test": "test"
       },
-      "source": "./assets/local-module-test/EF2B4CE432B6BA0BE6788E2EB57445E5"
+      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     }
   },
   "provider": {
@@ -172,7 +172,7 @@ exports[`pass variables 1`] = `
         "id1",
         "id2"
       ],
-      "source": "./assets/local-module-test/EF2B4CE432B6BA0BE6788E2EB57445E5"
+      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     }
   }
 }"
@@ -182,7 +182,7 @@ exports[`reference module 1`] = `
 "{
   "module": {
     "test": {
-      "source": "./assets/local-module-test/EF2B4CE432B6BA0BE6788E2EB57445E5"
+      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     }
   },
   "provider": {
@@ -212,7 +212,7 @@ exports[`reference module list 1`] = `
 "{
   "module": {
     "test": {
-      "source": "./assets/local-module-test/EF2B4CE432B6BA0BE6788E2EB57445E5"
+      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     }
   },
   "provider": {
@@ -244,7 +244,7 @@ exports[`set variable 1`] = `
   "module": {
     "test": {
       "param1": "value1",
-      "source": "./assets/local-module-test/EF2B4CE432B6BA0BE6788E2EB57445E5"
+      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     }
   }
 }"
@@ -257,7 +257,7 @@ exports[`simple provider 1`] = `
       "providers": {
         "test": "test.provider1"
       },
-      "source": "./assets/local-module-test/EF2B4CE432B6BA0BE6788E2EB57445E5"
+      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     }
   },
   "provider": {

--- a/packages/cdktf/test/__snapshots__/terraform-hcl-module.test.ts.snap
+++ b/packages/cdktf/test/__snapshots__/terraform-hcl-module.test.ts.snap
@@ -7,7 +7,7 @@ exports[`add provider 1`] = `
       "providers": {
         "test": "test.provider1"
       },
-      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
+      "source": "./assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     }
   },
   "provider": {
@@ -42,7 +42,7 @@ exports[`complex providers 1`] = `
         "test.dst": "test.provider2",
         "test.src": "test.provider1"
       },
-      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
+      "source": "./assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     }
   },
   "provider": {
@@ -71,7 +71,7 @@ exports[`depend on module 1`] = `
 "{
   "module": {
     "test": {
-      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
+      "source": "./assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     }
   },
   "provider": {
@@ -104,13 +104,13 @@ exports[`depend on other module 1`] = `
 "{
   "module": {
     "test_1": {
-      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
+      "source": "./assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     },
     "test_2": {
       "depends_on": [
         "module.test_1"
       ],
-      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
+      "source": "./assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     }
   }
 }"
@@ -120,7 +120,7 @@ exports[`minimal configuration 1`] = `
 "{
   "module": {
     "test": {
-      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
+      "source": "./assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     }
   }
 }"
@@ -134,7 +134,7 @@ exports[`multiple providers 1`] = `
         "differentType": "differentType",
         "test": "test"
       },
-      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
+      "source": "./assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     }
   },
   "provider": {
@@ -172,7 +172,7 @@ exports[`pass variables 1`] = `
         "id1",
         "id2"
       ],
-      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
+      "source": "./assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     }
   }
 }"
@@ -182,7 +182,7 @@ exports[`reference module 1`] = `
 "{
   "module": {
     "test": {
-      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
+      "source": "./assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     }
   },
   "provider": {
@@ -212,7 +212,7 @@ exports[`reference module list 1`] = `
 "{
   "module": {
     "test": {
-      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
+      "source": "./assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     }
   },
   "provider": {
@@ -244,7 +244,7 @@ exports[`set variable 1`] = `
   "module": {
     "test": {
       "param1": "value1",
-      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
+      "source": "./assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     }
   }
 }"
@@ -257,7 +257,7 @@ exports[`simple provider 1`] = `
       "providers": {
         "test": "test.provider1"
       },
-      "source": "assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
+      "source": "./assets/__cdktf_module_asset_26CE565C/hash/test/fixtures/hcl-module"
     }
   },
   "provider": {

--- a/packages/cdktf/test/assets.test.ts
+++ b/packages/cdktf/test/assets.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 import { App, TerraformHclModule, TerraformStack, Testing } from "../lib";
 import * as path from "path";
+import { TerraformModuleAsset } from "../lib/terraform-module-asset";
 
 describe("createAssetsFromLocalModules", () => {
   test("remote source without skipAssetCreationFromLocalModules", () => {
@@ -74,13 +75,14 @@ describe("createAssetsFromLocalModules", () => {
 
   test("local source without skipAssetCreationFromLocalModules", () => {
     const localSource = "../";
-    const assetRegex =
-      /^.\/assets\/local-module-moduleOptionsNotExists\/[a-zA-z\d]+$/;
 
     const app = Testing.stubVersion(
       new App({
         stackTraces: false,
-        context: { cdktfJsonPath: path.resolve(__dirname, "fixtures/app") },
+        context: {
+          cdktfJsonPath: path.resolve(__dirname, "fixtures/app"),
+          cdktfRelativeModules: [localSource],
+        },
       })
     );
     const stack = new TerraformStack(app, "MyStack");
@@ -93,18 +95,23 @@ describe("createAssetsFromLocalModules", () => {
       }
     );
 
-    expect(moduleOptionsNotExists.source).toMatch(assetRegex);
+    const terraformModuleAssetSource =
+      TerraformModuleAsset.of(stack).getAssetPathForModule(localSource);
+
+    expect(moduleOptionsNotExists.source).toEqual(terraformModuleAssetSource);
   });
 
   test("local source with skipAssetCreationFromLocalModules set to false", () => {
     const localSource = "../";
-    const assetRegex =
-      /^.\/assets\/local-module-moduleOptionsTrue\/[a-zA-z\d]+$/;
+    const cdktfJsonPath = path.resolve(__dirname, "fixtures/app");
 
     const app = Testing.stubVersion(
       new App({
         stackTraces: false,
-        context: { cdktfJsonPath: path.resolve(__dirname, "fixtures/app") },
+        context: {
+          cdktfJsonPath,
+          cdktfRelativeModules: [localSource],
+        },
       })
     );
     const stack = new TerraformStack(app, "MyStack");
@@ -118,7 +125,10 @@ describe("createAssetsFromLocalModules", () => {
       }
     );
 
-    expect(moduleOptionsTrue.source).toMatch(assetRegex);
+    const terraformModuleAssetSource =
+      TerraformModuleAsset.of(stack).getAssetPathForModule(localSource);
+
+    expect(moduleOptionsTrue.source).toEqual(terraformModuleAssetSource);
   });
 
   test("local source with skipAssetCreationFromLocalModules set to true", () => {

--- a/packages/cdktf/test/module.test.ts
+++ b/packages/cdktf/test/module.test.ts
@@ -4,7 +4,10 @@ import { Testing, TerraformStack, TerraformHclModule } from "../lib";
 import { TestModule, TestProvider } from "./helper";
 
 test("minimal configuration", () => {
-  const app = Testing.app({ fakeCdktfJsonPath: true });
+  const app = Testing.app({
+    fakeCdktfJsonPath: true,
+    context: { cdktfStaticModuleAssetHash: "hash" },
+  });
   const stack = new TerraformStack(app, "test");
 
   new TestModule(stack, "test", {
@@ -14,7 +17,10 @@ test("minimal configuration", () => {
 });
 
 test("simple provider", () => {
-  const app = Testing.app({ fakeCdktfJsonPath: true });
+  const app = Testing.app({
+    fakeCdktfJsonPath: true,
+    context: { cdktfStaticModuleAssetHash: "hash" },
+  });
   const stack = new TerraformStack(app, "test");
 
   const provider = new TestProvider(stack, "provider", {
@@ -30,7 +36,10 @@ test("simple provider", () => {
 });
 
 test("depends on", () => {
-  const app = Testing.app({ fakeCdktfJsonPath: true });
+  const app = Testing.app({
+    fakeCdktfJsonPath: true,
+    context: { cdktfStaticModuleAssetHash: "hash" },
+  });
   const stack = new TerraformStack(app, "test");
 
   const module1 = new TerraformHclModule(stack, "test_1", {

--- a/packages/cdktf/test/terraform-hcl-module.test.ts
+++ b/packages/cdktf/test/terraform-hcl-module.test.ts
@@ -1,10 +1,17 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import { Testing, TerraformStack, TerraformHclModule } from "../lib";
+import { Testing, TerraformStack, TerraformHclModule, App } from "../lib";
 import { TestProvider, TestResource } from "./helper";
 
+function getApp(): App {
+  return Testing.app({
+    fakeCdktfJsonPath: true,
+    context: { cdktfStaticModuleAssetHash: "hash" },
+  });
+}
+
 test("minimal configuration", () => {
-  const app = Testing.app({ fakeCdktfJsonPath: true });
+  const app = getApp();
   const stack = new TerraformStack(app, "test");
 
   new TerraformHclModule(stack, "test", {
@@ -14,7 +21,7 @@ test("minimal configuration", () => {
 });
 
 test("pass variables", () => {
-  const app = Testing.app({ fakeCdktfJsonPath: true });
+  const app = getApp();
   const stack = new TerraformStack(app, "test");
 
   new TerraformHclModule(stack, "test", {
@@ -29,7 +36,7 @@ test("pass variables", () => {
 });
 
 test("simple provider", () => {
-  const app = Testing.app({ fakeCdktfJsonPath: true });
+  const app = getApp();
   const stack = new TerraformStack(app, "test");
 
   const provider = new TestProvider(stack, "provider", {
@@ -45,7 +52,7 @@ test("simple provider", () => {
 });
 
 test("multiple providers", () => {
-  const app = Testing.app({ fakeCdktfJsonPath: true });
+  const app = getApp();
   const stack = new TerraformStack(app, "test");
 
   const provider1 = new TestProvider(stack, "provider1", {
@@ -65,7 +72,7 @@ test("multiple providers", () => {
 });
 
 test("multiple providers can't have the same module alias", () => {
-  const app = Testing.app({ fakeCdktfJsonPath: true });
+  const app = getApp();
   const stack = new TerraformStack(app, "test");
 
   const provider1 = new TestProvider(stack, "provider1", {
@@ -91,7 +98,7 @@ test("multiple providers can't have the same module alias", () => {
 });
 
 test("complex providers", () => {
-  const app = Testing.app({ fakeCdktfJsonPath: true });
+  const app = getApp();
   const stack = new TerraformStack(app, "test");
 
   const provider1 = new TestProvider(stack, "provider1", {
@@ -120,7 +127,7 @@ test("complex providers", () => {
 });
 
 test("reference module", () => {
-  const app = Testing.app({ fakeCdktfJsonPath: true });
+  const app = getApp();
   const stack = new TerraformStack(app, "test");
   new TestProvider(stack, "provider", {});
 
@@ -135,7 +142,7 @@ test("reference module", () => {
 });
 
 test("reference module list", () => {
-  const app = Testing.app({ fakeCdktfJsonPath: true });
+  const app = getApp();
   const stack = new TerraformStack(app, "test");
   new TestProvider(stack, "provider", {});
 
@@ -152,7 +159,7 @@ test("reference module list", () => {
 });
 
 test("set variable", () => {
-  const app = Testing.app({ fakeCdktfJsonPath: true });
+  const app = getApp();
   const stack = new TerraformStack(app, "test");
 
   const module = new TerraformHclModule(stack, "test", {
@@ -164,7 +171,7 @@ test("set variable", () => {
 });
 
 test("add provider", () => {
-  const app = Testing.app({ fakeCdktfJsonPath: true });
+  const app = getApp();
   const stack = new TerraformStack(app, "test");
 
   const module = new TerraformHclModule(stack, "test", {
@@ -180,7 +187,7 @@ test("add provider", () => {
 });
 
 test("depend on module", () => {
-  const app = Testing.app({ fakeCdktfJsonPath: true });
+  const app = getApp();
   const stack = new TerraformStack(app, "test");
   new TestProvider(stack, "provider", {});
 
@@ -196,7 +203,7 @@ test("depend on module", () => {
 });
 
 test("depend on other module", () => {
-  const app = Testing.app({ fakeCdktfJsonPath: true });
+  const app = getApp();
   const stack = new TerraformStack(app, "test");
 
   const module1 = new TerraformHclModule(stack, "test_1", {

--- a/packages/cdktf/test/terraform-module-asset.test.ts
+++ b/packages/cdktf/test/terraform-module-asset.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 import { findLowestCommonPath } from "../lib/terraform-module-asset";
 
 describe("TerraformModuleAsset", () => {

--- a/packages/cdktf/test/terraform-module-asset.test.ts
+++ b/packages/cdktf/test/terraform-module-asset.test.ts
@@ -1,0 +1,15 @@
+import { findLowestCommonPath } from "../lib/terraform-module-asset";
+
+describe("TerraformModuleAsset", () => {
+  describe("findLowestCommonPath", () => {
+    it.each([
+      { paths: ["./foo/bar", "./foo/baz", "./foo"], expected: "./foo/" },
+      { paths: ["../fuzz", "./foo/baz", "./foo/"], expected: "../" },
+    ])(
+      "should find the lowest common path",
+      ({ paths, expected }: { paths: string[]; expected: string }) => {
+        expect(findLowestCommonPath(paths)).toEqual(expected);
+      }
+    );
+  });
+});

--- a/packages/cdktf/test/terraform-module-asset.test.ts
+++ b/packages/cdktf/test/terraform-module-asset.test.ts
@@ -8,11 +8,19 @@ import { findLowestCommonPath } from "../lib/terraform-module-asset";
 describe("TerraformModuleAsset", () => {
   describe("findLowestCommonPath", () => {
     it.each([
-      { paths: ["./foo/bar", "./foo/baz", "./foo"], expected: "./foo/" },
-      { paths: ["../fuzz", "./foo/baz", "./foo/"], expected: "../" },
+      { paths: [], expected: undefined },
+      { paths: ["./"], expected: "." },
+      { paths: ["./foo/bar", "./foo/baz", "./foo"], expected: "foo" },
+      { paths: ["../fuzz", "./foo/baz", "./foo/"], expected: ".." },
     ])(
-      "should find the lowest common path",
-      ({ paths, expected }: { paths: string[]; expected: string }) => {
+      "should find the lowest common path for $paths expecting $expected",
+      ({
+        paths,
+        expected,
+      }: {
+        paths: string[];
+        expected: string | undefined;
+      }) => {
         expect(findLowestCommonPath(paths)).toEqual(expected);
       }
     );

--- a/test/test-helper.ts
+++ b/test/test-helper.ts
@@ -296,10 +296,16 @@ export class TestDriver {
   /**
    * runs terraform init and terraform validate in the output directory for the given stack name
    * @param stack the name of the stack to validate
+   * @param baseDirectory an optional base directory for the cdktf project
    * @returns the stdout of terraform validate
    */
-  async validate(stack: string) {
-    const cwd = path.join(this.workingDirectory, "cdktf.out", "stacks", stack);
+  async validate(stack: string, baseDirectory?: string) {
+    const cwd = path.join(
+      baseDirectory || this.workingDirectory,
+      "cdktf.out",
+      "stacks",
+      stack
+    );
     await this.exec("terraform", ["init"], cwd);
     const res = await this.exec("terraform", ["validate"], cwd);
     return res.stdout;

--- a/test/typescript/modules-relative-paths/README.md
+++ b/test/typescript/modules-relative-paths/README.md
@@ -1,0 +1,1 @@
+This is a reproduction case for https://github.com/hashicorp/terraform-cdk/issues/2460

--- a/test/typescript/modules-relative-paths/cdktf-project/cdktf.json
+++ b/test/typescript/modules-relative-paths/cdktf-project/cdktf.json
@@ -1,0 +1,16 @@
+{
+  "language": "typescript",
+  "app": "npx ts-node main.ts",
+  "terraformProviders": [],
+  "terraformModules": [
+    {
+      "name": "constants",
+      "source": "../terraform-modules/constants"
+    },
+    {
+      "name": "register",
+      "source": "../terraform-modules/register"
+    }
+  ],
+  "context": {}
+}

--- a/test/typescript/modules-relative-paths/cdktf-project/main.ts
+++ b/test/typescript/modules-relative-paths/cdktf-project/main.ts
@@ -1,0 +1,16 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { Construct } from "constructs";
+import { App, TerraformStack, Testing, LocalBackend } from "cdktf";
+
+export class HelloTerra extends TerraformStack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    // TODO: put code here
+  }
+}
+
+const app = Testing.stubVersion(new App({ stackTraces: false }));
+new HelloTerra(app, "modules-relative-paths");
+app.synth();

--- a/test/typescript/modules-relative-paths/cdktf-project/main.ts
+++ b/test/typescript/modules-relative-paths/cdktf-project/main.ts
@@ -1,13 +1,16 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
 import { Construct } from "constructs";
-import { App, TerraformStack, Testing, LocalBackend } from "cdktf";
+import { App, TerraformStack, Testing } from "cdktf";
+import { Constants } from './.gen/modules/constants';
+import { Register } from './.gen/modules/register';
 
 export class HelloTerra extends TerraformStack {
   constructor(scope: Construct, id: string) {
     super(scope, id);
 
-    // TODO: put code here
+    new Constants(this, "constants", {});
+    new Register(this, "register", {});
   }
 }
 

--- a/test/typescript/modules-relative-paths/cdktf-project/main.ts
+++ b/test/typescript/modules-relative-paths/cdktf-project/main.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MPL-2.0
 import { Construct } from "constructs";
 import { App, TerraformStack, Testing } from "cdktf";
-import { Constants } from './.gen/modules/constants';
-import { Register } from './.gen/modules/register';
+import { Constants } from "./.gen/modules/constants";
+import { Register } from "./.gen/modules/register";
 
 export class HelloTerra extends TerraformStack {
   constructor(scope: Construct, id: string) {

--- a/test/typescript/modules-relative-paths/terraform-modules/constants/main.tf
+++ b/test/typescript/modules-relative-paths/terraform-modules/constants/main.tf
@@ -1,0 +1,3 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+

--- a/test/typescript/modules-relative-paths/terraform-modules/register/main.tf
+++ b/test/typescript/modules-relative-paths/terraform-modules/register/main.tf
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 module "constants" {
   source = "../constants"
 }

--- a/test/typescript/modules-relative-paths/terraform-modules/register/main.tf
+++ b/test/typescript/modules-relative-paths/terraform-modules/register/main.tf
@@ -1,0 +1,3 @@
+module "constants" {
+  source = "../constants"
+}

--- a/test/typescript/modules-relative-paths/test.ts
+++ b/test/typescript/modules-relative-paths/test.ts
@@ -1,0 +1,39 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { TestDriver } from "../../test-helper";
+import * as fs from "fs-extra";
+import * as path from "path";
+
+describe("modules with relative paths", () => {
+  let driver: TestDriver;
+
+  beforeAll(async () => {
+    driver = new TestDriver(__dirname);
+    driver.switchToTempDir();
+
+    // run in a subdir
+    fs.mkdirSync("cdktf-project");
+    process.chdir(path.join(driver.workingDirectory, "cdktf-project"));
+    await driver.init("typescript");
+    process.chdir(driver.workingDirectory);
+    driver.copyFiles("cdktf-project/main.ts", "cdktf-project/cdktf.json");
+
+    // copy modules
+    fs.copySync(
+      path.join(__dirname, "terraform-modules"),
+      path.join(driver.workingDirectory, "terraform-modules")
+    );
+
+    // generate bindings
+    process.chdir(path.join(driver.workingDirectory, "cdktf-project"));
+    await driver.get();
+  });
+
+  it("should be valid Terraform", async () => {
+    await driver.synth();
+    await driver.validate(
+      "modules-relative-paths",
+      path.join(driver.workingDirectory, "cdktf-project")
+    );
+  }, 120_000);
+});

--- a/test/typescript/modules-relative-paths/test.ts
+++ b/test/typescript/modules-relative-paths/test.ts
@@ -24,6 +24,8 @@ describe("modules with relative paths", () => {
       path.join(driver.workingDirectory, "terraform-modules")
     );
 
+    console.log("working directory", driver.workingDirectory);
+
     // generate bindings
     process.chdir(path.join(driver.workingDirectory, "cdktf-project"));
     await driver.get();

--- a/test/typescript/modules/test.ts
+++ b/test/typescript/modules/test.ts
@@ -65,7 +65,7 @@ describe("full integration test", () => {
               "test",
               "sets"
             ],
-            "source": "./assets/local-module-local-module/1A068C39166AE65C43D174678BD00022"
+            "source": "./assets/__cdktf_module_asset_26CE565C/1A068C39166AE65C43D174678BD00022"
           }
         },
         "terraform": {

--- a/website/docs/cdktf/concepts/modules.mdx
+++ b/website/docs/cdktf/concepts/modules.mdx
@@ -221,6 +221,7 @@ For local modules, use the object format.
 ```
 
 For performance reasons, we don't automatically generate bindings for submodules. To generate bindings for submodules, specify the module source as `terraform-aws-modules/vpc/aws//submodules/vpc-endpoints`, where after the `//` is the path to the submodule in the modules repository. Refer to [the Terraform source specification](/terraform/language/modules/sources) for more details.
+When you are using local modules that reference other local modules you need to add all referenced modules to the `terraformModules` array.
 
 ### Generate Module Bindings
 


### PR DESCRIPTION
When multiple local terraform modules are mentioned in the `cdktf.json` and they rely on one-another locally with relative paths the previous implementation destroyed the structure of their relative paths. This implementation uses a single asset for all terraform modules, leading to correct relative paths.

Closes #2460
