### PR TITLE
fix(cli): Handle overlapping resource names in augmented logs

### DIFF
--- a/packages/@cdktf/cli-core/src/lib/execution-logs.ts
+++ b/packages/@cdktf/cli-core/src/lib/execution-logs.ts
@@ -20,6 +20,14 @@ type TFJson = {
   resource: TfResourceType;
 };
 
+// escapes any special charaters used in regex
+const escapeRegexSpecialChars = (str: string) =>
+  str.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
+
+// uses word boundary to match the whole of the tfIdentifer
+const lineHasExactMatch = (line: string, tfIdentifier: string) =>
+  new RegExp(`\\b${escapeRegexSpecialChars(tfIdentifier)}\\b`).test(line);
+
 export function createEnhanceLogMessage(
   stack: SynthesizedStack
 ): (message: string) => string | undefined {
@@ -57,7 +65,7 @@ export function createEnhanceLogMessage(
       .split("\n")
       .map((line) => {
         const matchingEntry = Object.entries(pathMapping).find(
-          ([tfIdentifier]) => line.includes(tfIdentifier)
+          ([tfIdentifier]) => lineHasExactMatch(line, tfIdentifier)
         );
         if (!matchingEntry) {
           return line;

--- a/packages/@cdktf/cli-core/src/test/lib/execution-logs.test.ts
+++ b/packages/@cdktf/cli-core/src/test/lib/execution-logs.test.ts
@@ -58,4 +58,62 @@ describe("enhanceLogs", () => {
       `"This is a message where some_thing.different (ThisConstruct) is used"`
     );
   });
+  it("properly matches to the resource when names overlap", () => {
+    expect(
+      createEnhanceLogMessage({
+        name: "demo",
+        content: JSON.stringify({
+          "//": {
+            metadata: {
+              backend: "local",
+              stackName: "demo",
+              version: "0.0.0",
+            },
+            outputs: {},
+          },
+          provider: {
+            null: [{}],
+          },
+          resource: {
+            null_resource: {
+              null_resource: {
+                "//": {
+                  metadata: {
+                    path: "demo/null_resource",
+                    uniqueId: "null_resource",
+                  },
+                },
+              },
+              null_resource2: {
+                "//": {
+                  metadata: {
+                    path: "demo/null_resource2",
+                    uniqueId: "null_resource2",
+                  },
+                },
+              },
+            },
+          },
+          terraform: {
+            backend: {
+              local: {
+                path: "path",
+              },
+            },
+            required_providers: {
+              null: {
+                source: "hashicorp/null",
+                version: "3.2.2",
+              },
+            },
+          },
+        }),
+      } as SynthesizedStack)(
+        "This is a message where null_resource.null_resource is used \n This is a message where null_resource.null_resource2 is used"
+      )
+    ).toMatchInlineSnapshot(`
+    "This is a message where null_resource.null_resource (null_resource) is used 
+     This is a message where null_resource.null_resource2 (null_resource2) is used"
+  `);
+  });
 });


### PR DESCRIPTION
### Related issue

Fixes #2331

## Description

Fixes the issue where our augmented logs match to the wrong resource when there are resource ids that overlap. Such as two resources named `null_resource` and `null_resource2` respectively. This was occurring previously since we just checked if a line included the resource id, which led to situation where `null_resource` would be mapped to `null_resource2`.

### The Fix

Introduced stricter matching where we check each line for the presence of the whole resource id rather than just a subset.

#### Before

![](https://user-images.githubusercontent.com/1112056/203332472-71e68430-44c5-4011-8ab7-2a681bbce746.png)

#### After

![Screenshot 2023-12-07 at 2 23 14 PM](https://github.com/hashicorp/terraform-cdk/assets/72527044/ea7b6f16-68f3-418e-a46c-ac6774921fc0)

