### PR TITLE
fix: Properly skip certain unit tests when TF version < 1.6

### DIFF
--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/module-generator.test.ts
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/module-generator.test.ts
@@ -13,7 +13,7 @@ const onTf1_6AndNewer = (
   fn: () => Promise<void>,
   timeout?: number
 ) => {
-  const output = execSync("terraform version -json");
+  const output = execSync("$TERRAFORM_BINARY_NAME version -json");
 
   if (!output) {
     throw new Error("Could not determine Terraform version");


### PR DESCRIPTION
### Description

Fixes the CI issue where provider generator unit tests running Terraform 1.5.5 fail. 

Problem was that we were not invoking the Terraform binary directly when checking the version (the output of which is used to properly skip tests that require `> 1.6`)– instead we were just using `terraform version -json`. This incorrectly picked up the default `1.6.5`. 
