### PR TITLE
chore: Use locally built bindings for ts provider doc example

### DIFF
--- a/examples/typescript/documentation/cdktf.json
+++ b/examples/typescript/documentation/cdktf.json
@@ -7,7 +7,6 @@
     "random@~> 3.5",
     "dnsimple/dnsimple@~> 1.3",
     "integrations/github@~> 5.42"
-
   ],
   "terraformModules": [
     "terraform-aws-modules/vpc/aws@~> 5.2",

--- a/examples/typescript/documentation/providers.ts
+++ b/examples/typescript/documentation/providers.ts
@@ -3,13 +3,13 @@
 // DOCS_BLOCK_START:providers-import,providers-import-classes
 import { Construct } from "constructs";
 import { TerraformStack, TerraformVariable, Token } from "cdktf";
-import { AwsProvider } from "@cdktf/provider-aws/lib/aws-provider";
-import { Instance } from "@cdktf/provider-aws/lib/instance";
+import { AwsProvider } from "./.gen/providers/aws/provider";
+import { Instance } from "./.gen/providers/aws/instance";
 // DOCS_BLOCK_END:providers-import,providers-import-classes
 
 // DOCS_BLOCK_START:providers-import-classes
-import { DnsimpleProvider } from "@cdktf/provider-dnsimple/lib/provider";
-import { ZoneRecord } from "@cdktf/provider-dnsimple/lib/zone-record";
+import { DnsimpleProvider } from "./.gen/providers/dnsimple/provider";
+import { ZoneRecord } from "./.gen/providers/dnsimple/zone-record";
 // DOCS_BLOCK_END:providers-import-classes
 
 // DOCS_BLOCK_START:providers-import,providers-import-classes

--- a/website/docs/cdktf/concepts/providers.mdx
+++ b/website/docs/cdktf/concepts/providers.mdx
@@ -60,8 +60,8 @@ This TypeScript example project has a `main.ts` file that defines AWS resources.
 ```ts
 import { Construct } from "constructs";
 import { TerraformStack, TerraformVariable, Token } from "cdktf";
-import { AwsProvider } from "@cdktf/provider-aws/lib/aws-provider";
-import { Instance } from "@cdktf/provider-aws/lib/instance";
+import { AwsProvider } from "./.gen/providers/aws/provider";
+import { Instance } from "./.gen/providers/aws/instance";
 
 export class ProvidersStack extends TerraformStack {
   constructor(scope: Construct, id: string) {
@@ -243,10 +243,10 @@ Import and use the generated classes in your application. The following example 
 ```ts
 import { Construct } from "constructs";
 import { TerraformStack, TerraformVariable, Token } from "cdktf";
-import { AwsProvider } from "@cdktf/provider-aws/lib/aws-provider";
-import { Instance } from "@cdktf/provider-aws/lib/instance";
-import { DnsimpleProvider } from "@cdktf/provider-dnsimple/lib/provider";
-import { ZoneRecord } from "@cdktf/provider-dnsimple/lib/zone-record";
+import { AwsProvider } from "./.gen/providers/aws/provider";
+import { Instance } from "./.gen/providers/aws/instance";
+import { DnsimpleProvider } from "./.gen/providers/dnsimple/provider";
+import { ZoneRecord } from "./.gen/providers/dnsimple/zone-record";
 
 export class ProvidersStack extends TerraformStack {
   constructor(scope: Construct, id: string) {


### PR DESCRIPTION
### Related issue

Fixes #2575

### Description

Typescript example in `providers.mdx` now uses locally build bindings in it's imports to align with documentation wording.
