### PR TITLE
fix pipenv build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,8 @@ ARG DEFAULT_TERRAFORM_VERSION
 ARG AVAILABLE_TERRAFORM_VERSIONS
 
 
-RUN apt-get update -y && apt-get install -y unzip jq build-essential time python3-venv wget
+RUN apt-get update -y && apt-get install -y unzip jq build-essential time python3-venv wget pipenv
 RUN curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python3
-RUN pip install pipenv
 RUN npm install -g @sentry/cli --unsafe-perm
 # From the official gradle Dockerfile (https://github.com/keeganwitt/docker-gradle/blob/2ba84220e311de7a55f3731509dd772a885b86f8/jdk8/Dockerfile)
 ENV GRADLE_HOME /opt/gradle


### PR DESCRIPTION
Docker build had a problem: https://github.com/hashicorp/terraform-cdk/actions/runs/7387708978/job/20096990663

```
#7 [4/7] RUN pip install pipenv
#7 0.338 error: externally-managed-environment
#7 0.338 
#7 0.338 × This environment is externally managed
#7 0.338 ╰─> To install Python packages system-wide, try apt install
#7 0.338     python3-xyz, where xyz is the package you are trying to
#7 0.338     install.
#7 0.338     
#7 0.338     If you wish to install a non-Debian-packaged Python package,
#7 0.338     create a virtual environment using python3 -m venv path/to/venv.
#7 0.338     Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
#7 0.338     sure you have python3-full installed.
#7 0.338     
#7 0.338     If you wish to install a non-Debian packaged Python application,
#7 0.338     it may be easiest to use pipx install xyz, which will manage a
#7 0.338     virtual environment for you. Make sure you have pipx installed.
#7 0.338     
#7 0.338     See /usr/share/doc/python3.11/README.venv for more information.
#7 0.338 
#7 0.338 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
#7 0.338 hint: See PEP 668 for the detailed specification.
```