### PR TITLE
chore: use activated virtual env in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,13 @@ ARG DEFAULT_TERRAFORM_VERSION
 ARG AVAILABLE_TERRAFORM_VERSIONS
 
 
-RUN apt-get update -y && apt-get install -y unzip jq build-essential time python3-venv wget pipenv
-RUN curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python3
+RUN apt-get update -y && apt-get install -y unzip jq build-essential time python3-venv wget
+# Install and activate python virtualenv
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+# Install pipenv
+RUN pip install pipenv
 RUN npm install -g @sentry/cli --unsafe-perm
 # From the official gradle Dockerfile (https://github.com/keeganwitt/docker-gradle/blob/2ba84220e311de7a55f3731509dd772a885b86f8/jdk8/Dockerfile)
 ENV GRADLE_HOME /opt/gradle


### PR DESCRIPTION
the main python installation is marked as system-wide and causes installs to fail
