### PR TITLE
fix(docs): product relative links

### DIFF
--- a/packages/cdktf/lib/functions/terraform-functions.generated.ts
+++ b/packages/cdktf/lib/functions/terraform-functions.generated.ts
@@ -639,7 +639,7 @@ export class FnGenerated {
     );
   }
   /**
-   * {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).
+   * {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).
    * @param {any} value
    */
   static sensitive(value: any) {

--- a/tools/generate-function-bindings/scripts/fetch-metadata.ts
+++ b/tools/generate-function-bindings/scripts/fetch-metadata.ts
@@ -16,7 +16,21 @@ async function fetchMetadata() {
     `${TERRAFORM_BINARY_NAME} metadata functions -json`
   ).toString();
   const out = path.join(__dirname, FUNCTIONS_METADATA_FILE);
-  await fs.writeFile(out, prettier.format(json, { parser: "json" }));
+
+  const fixed = fixProductRelativeLinks(json);
+
+  await fs.writeFile(out, prettier.format(fixed, { parser: "json" }));
+}
+
+/**
+ * There are some relative links in the functions definitions that have the format
+ * /language/xy
+ * whereas the developer portal expects them to be
+ * /terraform/language/xy
+ * Until this is fixed in the terraform codebase, we need to fix this manually here.
+ */
+function fixProductRelativeLinks(content: string): string {
+  return content.replace(/\(\/language\//g, "(/terraform/language/");
 }
 
 fetchMetadata();

--- a/tools/generate-function-bindings/scripts/functions.json
+++ b/tools/generate-function-bindings/scripts/functions.json
@@ -509,7 +509,7 @@
       ]
     },
     "sensitive": {
-      "description": "`sensitive` takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).",
+      "description": "`sensitive` takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).",
       "return_type": "dynamic",
       "parameters": [
         { "name": "value", "is_nullable": true, "type": "dynamic" }

--- a/website/docs/cdktf/api-reference/csharp.mdx
+++ b/website/docs/cdktf/api-reference/csharp.mdx
@@ -25295,6 +25295,7 @@ This contains the text that Terraform will include as part of error messages whe
 using HashiCorp.Cdktf;
 
 new TestingAppConfig {
+    System.Collections.Generic.IDictionary< string, object > Context = null,
     bool EnableFutureFlags = null,
     bool FakeCdktfJsonPath = null,
     string Outdir = null,
@@ -25305,13 +25306,24 @@ new TestingAppConfig {
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                        | **Type**            | **Description**   |
-| ----------------------------------------------------------------------------------------------- | ------------------- | ----------------- |
-| <code><a href="#cdktf.TestingAppConfig.property.enableFutureFlags">EnableFutureFlags</a></code> | <code>bool</code>   | _No description._ |
-| <code><a href="#cdktf.TestingAppConfig.property.fakeCdktfJsonPath">FakeCdktfJsonPath</a></code> | <code>bool</code>   | _No description._ |
-| <code><a href="#cdktf.TestingAppConfig.property.outdir">Outdir</a></code>                       | <code>string</code> | _No description._ |
-| <code><a href="#cdktf.TestingAppConfig.property.stackTraces">StackTraces</a></code>             | <code>bool</code>   | _No description._ |
-| <code><a href="#cdktf.TestingAppConfig.property.stubVersion">StubVersion</a></code>             | <code>bool</code>   | _No description._ |
+| **Name**                                                                                        | **Type**                                                              | **Description**   |
+| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ----------------- |
+| <code><a href="#cdktf.TestingAppConfig.property.context">Context</a></code>                     | <code>System.Collections.Generic.IDictionary< string, object ></code> | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.enableFutureFlags">EnableFutureFlags</a></code> | <code>bool</code>                                                     | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.fakeCdktfJsonPath">FakeCdktfJsonPath</a></code> | <code>bool</code>                                                     | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.outdir">Outdir</a></code>                       | <code>string</code>                                                   | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.stackTraces">StackTraces</a></code>             | <code>bool</code>                                                     | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.stubVersion">StubVersion</a></code>             | <code>bool</code>                                                     | _No description._ |
+
+---
+
+##### `Context`<sup>Optional</sup> <a name="Context" id="cdktf.TestingAppConfig.property.context"></a>
+
+```csharp
+public System.Collections.Generic.IDictionary< string, object > Context { get; set; }
+```
+
+- _Type:_ System.Collections.Generic.IDictionary< string, object >
 
 ---
 
@@ -28474,7 +28486,7 @@ new Fn();
 | <code><a href="#cdktf.Fn.replace">Replace</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/replace replace} searches a given string for another given substring, and replaces each occurrence with a given replacement string.                                                                                                                                                               |
 | <code><a href="#cdktf.Fn.reverse">Reverse</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/reverse reverse} takes a sequence and produces a new sequence of the same length with all of the same elements as the given sequence but in reverse order.                                                                                                                                        |
 | <code><a href="#cdktf.Fn.rsadecrypt">Rsadecrypt</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/rsadecrypt rsadecrypt} decrypts an RSA-encrypted ciphertext, returning the corresponding cleartext.                                                                                                                                                                                               |
-| <code><a href="#cdktf.Fn.sensitive">Sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).                                            |
+| <code><a href="#cdktf.Fn.sensitive">Sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).                                  |
 | <code><a href="#cdktf.Fn.setintersection">Setintersection</a></code>   | The {@link https://developer.hashicorp.com/terraform/language/functions/setintersection setintersection} function takes multiple sets and produces a single set containing only the elements that all of the given sets have in common. In other words, it computes the [intersection](<https://en.wikipedia.org/wiki/Intersection_(set_theory)>) of the sets.        |
 | <code><a href="#cdktf.Fn.setproduct">Setproduct</a></code>             | The {@link https://developer.hashicorp.com/terraform/language/functions/setproduct setproduct} function finds all of the possible combinations of elements from all of the given sets by computing the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product).                                                                                          |
 | <code><a href="#cdktf.Fn.setsubtract">Setsubtract</a></code>           | The {@link https://developer.hashicorp.com/terraform/language/functions/setsubtract setsubtract} function returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the [relative complement](<https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement>) of the second set.  |
@@ -29746,7 +29758,7 @@ using HashiCorp.Cdktf;
 Fn.Sensitive(object Value);
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).
+{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).
 
 ###### `Value`<sup>Required</sup> <a name="Value" id="cdktf.Fn.sensitive.parameter.value"></a>
 
@@ -30804,7 +30816,7 @@ new FnGenerated();
 | <code><a href="#cdktf.FnGenerated.replace">Replace</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/replace replace} searches a given string for another given substring, and replaces each occurrence with a given replacement string.                                                                                                                                                               |
 | <code><a href="#cdktf.FnGenerated.reverse">Reverse</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/reverse reverse} takes a sequence and produces a new sequence of the same length with all of the same elements as the given sequence but in reverse order.                                                                                                                                        |
 | <code><a href="#cdktf.FnGenerated.rsadecrypt">Rsadecrypt</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/rsadecrypt rsadecrypt} decrypts an RSA-encrypted ciphertext, returning the corresponding cleartext.                                                                                                                                                                                               |
-| <code><a href="#cdktf.FnGenerated.sensitive">Sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).                                            |
+| <code><a href="#cdktf.FnGenerated.sensitive">Sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).                                  |
 | <code><a href="#cdktf.FnGenerated.setintersection">Setintersection</a></code>   | The {@link https://developer.hashicorp.com/terraform/language/functions/setintersection setintersection} function takes multiple sets and produces a single set containing only the elements that all of the given sets have in common. In other words, it computes the [intersection](<https://en.wikipedia.org/wiki/Intersection_(set_theory)>) of the sets.        |
 | <code><a href="#cdktf.FnGenerated.setproduct">Setproduct</a></code>             | The {@link https://developer.hashicorp.com/terraform/language/functions/setproduct setproduct} function finds all of the possible combinations of elements from all of the given sets by computing the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product).                                                                                          |
 | <code><a href="#cdktf.FnGenerated.setsubtract">Setsubtract</a></code>           | The {@link https://developer.hashicorp.com/terraform/language/functions/setsubtract setsubtract} function returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the [relative complement](<https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement>) of the second set.  |
@@ -32069,7 +32081,7 @@ using HashiCorp.Cdktf;
 FnGenerated.Sensitive(object Value);
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).
+{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).
 
 ###### `Value`<sup>Required</sup> <a name="Value" id="cdktf.FnGenerated.sensitive.parameter.value"></a>
 

--- a/website/docs/cdktf/api-reference/go.mdx
+++ b/website/docs/cdktf/api-reference/go.mdx
@@ -25295,6 +25295,7 @@ This contains the text that Terraform will include as part of error messages whe
 import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 &cdktf.TestingAppConfig {
+	Context: *map[string]interface{},
 	EnableFutureFlags: *bool,
 	FakeCdktfJsonPath: *bool,
 	Outdir: *string,
@@ -25305,13 +25306,24 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                        | **Type**              | **Description**   |
-| ----------------------------------------------------------------------------------------------- | --------------------- | ----------------- |
-| <code><a href="#cdktf.TestingAppConfig.property.enableFutureFlags">EnableFutureFlags</a></code> | <code>\*bool</code>   | _No description._ |
-| <code><a href="#cdktf.TestingAppConfig.property.fakeCdktfJsonPath">FakeCdktfJsonPath</a></code> | <code>\*bool</code>   | _No description._ |
-| <code><a href="#cdktf.TestingAppConfig.property.outdir">Outdir</a></code>                       | <code>\*string</code> | _No description._ |
-| <code><a href="#cdktf.TestingAppConfig.property.stackTraces">StackTraces</a></code>             | <code>\*bool</code>   | _No description._ |
-| <code><a href="#cdktf.TestingAppConfig.property.stubVersion">StubVersion</a></code>             | <code>\*bool</code>   | _No description._ |
+| **Name**                                                                                        | **Type**                              | **Description**   |
+| ----------------------------------------------------------------------------------------------- | ------------------------------------- | ----------------- |
+| <code><a href="#cdktf.TestingAppConfig.property.context">Context</a></code>                     | <code>\*map[string]interface{}</code> | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.enableFutureFlags">EnableFutureFlags</a></code> | <code>\*bool</code>                   | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.fakeCdktfJsonPath">FakeCdktfJsonPath</a></code> | <code>\*bool</code>                   | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.outdir">Outdir</a></code>                       | <code>\*string</code>                 | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.stackTraces">StackTraces</a></code>             | <code>\*bool</code>                   | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.stubVersion">StubVersion</a></code>             | <code>\*bool</code>                   | _No description._ |
+
+---
+
+##### `Context`<sup>Optional</sup> <a name="Context" id="cdktf.TestingAppConfig.property.context"></a>
+
+```go
+Context *map[string]interface{}
+```
+
+- _Type:_ \*map[string]interface{}
 
 ---
 
@@ -28476,7 +28488,7 @@ cdktf.NewFn() Fn
 | <code><a href="#cdktf.Fn.replace">Replace</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/replace replace} searches a given string for another given substring, and replaces each occurrence with a given replacement string.                                                                                                                                                               |
 | <code><a href="#cdktf.Fn.reverse">Reverse</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/reverse reverse} takes a sequence and produces a new sequence of the same length with all of the same elements as the given sequence but in reverse order.                                                                                                                                        |
 | <code><a href="#cdktf.Fn.rsadecrypt">Rsadecrypt</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/rsadecrypt rsadecrypt} decrypts an RSA-encrypted ciphertext, returning the corresponding cleartext.                                                                                                                                                                                               |
-| <code><a href="#cdktf.Fn.sensitive">Sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).                                            |
+| <code><a href="#cdktf.Fn.sensitive">Sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).                                  |
 | <code><a href="#cdktf.Fn.setintersection">Setintersection</a></code>   | The {@link https://developer.hashicorp.com/terraform/language/functions/setintersection setintersection} function takes multiple sets and produces a single set containing only the elements that all of the given sets have in common. In other words, it computes the [intersection](<https://en.wikipedia.org/wiki/Intersection_(set_theory)>) of the sets.        |
 | <code><a href="#cdktf.Fn.setproduct">Setproduct</a></code>             | The {@link https://developer.hashicorp.com/terraform/language/functions/setproduct setproduct} function finds all of the possible combinations of elements from all of the given sets by computing the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product).                                                                                          |
 | <code><a href="#cdktf.Fn.setsubtract">Setsubtract</a></code>           | The {@link https://developer.hashicorp.com/terraform/language/functions/setsubtract setsubtract} function returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the [relative complement](<https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement>) of the second set.  |
@@ -29748,7 +29760,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 cdktf.Fn_Sensitive(value interface{}) interface{}
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).
+{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).
 
 ###### `value`<sup>Required</sup> <a name="value" id="cdktf.Fn.sensitive.parameter.value"></a>
 
@@ -30806,7 +30818,7 @@ cdktf.NewFnGenerated() FnGenerated
 | <code><a href="#cdktf.FnGenerated.replace">Replace</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/replace replace} searches a given string for another given substring, and replaces each occurrence with a given replacement string.                                                                                                                                                               |
 | <code><a href="#cdktf.FnGenerated.reverse">Reverse</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/reverse reverse} takes a sequence and produces a new sequence of the same length with all of the same elements as the given sequence but in reverse order.                                                                                                                                        |
 | <code><a href="#cdktf.FnGenerated.rsadecrypt">Rsadecrypt</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/rsadecrypt rsadecrypt} decrypts an RSA-encrypted ciphertext, returning the corresponding cleartext.                                                                                                                                                                                               |
-| <code><a href="#cdktf.FnGenerated.sensitive">Sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).                                            |
+| <code><a href="#cdktf.FnGenerated.sensitive">Sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).                                  |
 | <code><a href="#cdktf.FnGenerated.setintersection">Setintersection</a></code>   | The {@link https://developer.hashicorp.com/terraform/language/functions/setintersection setintersection} function takes multiple sets and produces a single set containing only the elements that all of the given sets have in common. In other words, it computes the [intersection](<https://en.wikipedia.org/wiki/Intersection_(set_theory)>) of the sets.        |
 | <code><a href="#cdktf.FnGenerated.setproduct">Setproduct</a></code>             | The {@link https://developer.hashicorp.com/terraform/language/functions/setproduct setproduct} function finds all of the possible combinations of elements from all of the given sets by computing the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product).                                                                                          |
 | <code><a href="#cdktf.FnGenerated.setsubtract">Setsubtract</a></code>           | The {@link https://developer.hashicorp.com/terraform/language/functions/setsubtract setsubtract} function returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the [relative complement](<https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement>) of the second set.  |
@@ -32071,7 +32083,7 @@ import "github.com/hashicorp/terraform-cdk-go/cdktf"
 cdktf.FnGenerated_Sensitive(value interface{}) interface{}
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).
+{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).
 
 ###### `value`<sup>Required</sup> <a name="value" id="cdktf.FnGenerated.sensitive.parameter.value"></a>
 

--- a/website/docs/cdktf/api-reference/java.mdx
+++ b/website/docs/cdktf/api-reference/java.mdx
@@ -30721,6 +30721,7 @@ This contains the text that Terraform will include as part of error messages whe
 import com.hashicorp.cdktf.TestingAppConfig;
 
 TestingAppConfig.builder()
+//  .context(java.util.Map< java.lang.String, java.lang.Object >)
 //  .enableFutureFlags(java.lang.Boolean)
 //  .fakeCdktfJsonPath(java.lang.Boolean)
 //  .outdir(java.lang.String)
@@ -30731,13 +30732,24 @@ TestingAppConfig.builder()
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                        | **Type**                       | **Description**   |
-| ----------------------------------------------------------------------------------------------- | ------------------------------ | ----------------- |
-| <code><a href="#cdktf.TestingAppConfig.property.enableFutureFlags">enableFutureFlags</a></code> | <code>java.lang.Boolean</code> | _No description._ |
-| <code><a href="#cdktf.TestingAppConfig.property.fakeCdktfJsonPath">fakeCdktfJsonPath</a></code> | <code>java.lang.Boolean</code> | _No description._ |
-| <code><a href="#cdktf.TestingAppConfig.property.outdir">outdir</a></code>                       | <code>java.lang.String</code>  | _No description._ |
-| <code><a href="#cdktf.TestingAppConfig.property.stackTraces">stackTraces</a></code>             | <code>java.lang.Boolean</code> | _No description._ |
-| <code><a href="#cdktf.TestingAppConfig.property.stubVersion">stubVersion</a></code>             | <code>java.lang.Boolean</code> | _No description._ |
+| **Name**                                                                                        | **Type**                                                         | **Description**   |
+| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ----------------- |
+| <code><a href="#cdktf.TestingAppConfig.property.context">context</a></code>                     | <code>java.util.Map< java.lang.String, java.lang.Object ></code> | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.enableFutureFlags">enableFutureFlags</a></code> | <code>java.lang.Boolean</code>                                   | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.fakeCdktfJsonPath">fakeCdktfJsonPath</a></code> | <code>java.lang.Boolean</code>                                   | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.outdir">outdir</a></code>                       | <code>java.lang.String</code>                                    | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.stackTraces">stackTraces</a></code>             | <code>java.lang.Boolean</code>                                   | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.stubVersion">stubVersion</a></code>             | <code>java.lang.Boolean</code>                                   | _No description._ |
+
+---
+
+##### `context`<sup>Optional</sup> <a name="context" id="cdktf.TestingAppConfig.property.context"></a>
+
+```java
+public java.util.Map< java.lang.String, java.lang.Object > getContext();
+```
+
+- _Type:_ java.util.Map< java.lang.String, java.lang.Object >
 
 ---
 
@@ -33900,7 +33912,7 @@ new Fn();
 | <code><a href="#cdktf.Fn.replace">replace</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/replace replace} searches a given string for another given substring, and replaces each occurrence with a given replacement string.                                                                                                                                                               |
 | <code><a href="#cdktf.Fn.reverse">reverse</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/reverse reverse} takes a sequence and produces a new sequence of the same length with all of the same elements as the given sequence but in reverse order.                                                                                                                                        |
 | <code><a href="#cdktf.Fn.rsadecrypt">rsadecrypt</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/rsadecrypt rsadecrypt} decrypts an RSA-encrypted ciphertext, returning the corresponding cleartext.                                                                                                                                                                                               |
-| <code><a href="#cdktf.Fn.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).                                            |
+| <code><a href="#cdktf.Fn.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).                                  |
 | <code><a href="#cdktf.Fn.setintersection">setintersection</a></code>   | The {@link https://developer.hashicorp.com/terraform/language/functions/setintersection setintersection} function takes multiple sets and produces a single set containing only the elements that all of the given sets have in common. In other words, it computes the [intersection](<https://en.wikipedia.org/wiki/Intersection_(set_theory)>) of the sets.        |
 | <code><a href="#cdktf.Fn.setproduct">setproduct</a></code>             | The {@link https://developer.hashicorp.com/terraform/language/functions/setproduct setproduct} function finds all of the possible combinations of elements from all of the given sets by computing the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product).                                                                                          |
 | <code><a href="#cdktf.Fn.setsubtract">setsubtract</a></code>           | The {@link https://developer.hashicorp.com/terraform/language/functions/setsubtract setsubtract} function returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the [relative complement](<https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement>) of the second set.  |
@@ -35172,7 +35184,7 @@ import com.hashicorp.cdktf.Fn;
 Fn.sensitive(java.lang.Object value)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).
+{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).
 
 ###### `value`<sup>Required</sup> <a name="value" id="cdktf.Fn.sensitive.parameter.value"></a>
 
@@ -36230,7 +36242,7 @@ new FnGenerated();
 | <code><a href="#cdktf.FnGenerated.replace">replace</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/replace replace} searches a given string for another given substring, and replaces each occurrence with a given replacement string.                                                                                                                                                               |
 | <code><a href="#cdktf.FnGenerated.reverse">reverse</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/reverse reverse} takes a sequence and produces a new sequence of the same length with all of the same elements as the given sequence but in reverse order.                                                                                                                                        |
 | <code><a href="#cdktf.FnGenerated.rsadecrypt">rsadecrypt</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/rsadecrypt rsadecrypt} decrypts an RSA-encrypted ciphertext, returning the corresponding cleartext.                                                                                                                                                                                               |
-| <code><a href="#cdktf.FnGenerated.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).                                            |
+| <code><a href="#cdktf.FnGenerated.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).                                  |
 | <code><a href="#cdktf.FnGenerated.setintersection">setintersection</a></code>   | The {@link https://developer.hashicorp.com/terraform/language/functions/setintersection setintersection} function takes multiple sets and produces a single set containing only the elements that all of the given sets have in common. In other words, it computes the [intersection](<https://en.wikipedia.org/wiki/Intersection_(set_theory)>) of the sets.        |
 | <code><a href="#cdktf.FnGenerated.setproduct">setproduct</a></code>             | The {@link https://developer.hashicorp.com/terraform/language/functions/setproduct setproduct} function finds all of the possible combinations of elements from all of the given sets by computing the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product).                                                                                          |
 | <code><a href="#cdktf.FnGenerated.setsubtract">setsubtract</a></code>           | The {@link https://developer.hashicorp.com/terraform/language/functions/setsubtract setsubtract} function returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the [relative complement](<https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement>) of the second set.  |
@@ -37495,7 +37507,7 @@ import com.hashicorp.cdktf.FnGenerated;
 FnGenerated.sensitive(java.lang.Object value)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).
+{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).
 
 ###### `value`<sup>Required</sup> <a name="value" id="cdktf.FnGenerated.sensitive.parameter.value"></a>
 
@@ -39283,18 +39295,18 @@ public java.lang.String getFqn();
 ```java
 import com.hashicorp.cdktf.MapTerraformIterator;
 
-new MapTerraformIterator(StringMap OR NumberMap OR BooleanMap OR AnyMap OR ComplexMap OR java.util.Map< java.lang.String, java.lang.Object > OR java.util.Map< java.lang.String, java.lang.String > OR java.util.Map< java.lang.String, java.lang.Number > map);
+new MapTerraformIterator(AnyMap OR StringMap OR NumberMap OR BooleanMap OR ComplexMap OR java.util.Map< java.lang.String, java.lang.Object > OR java.util.Map< java.lang.String, java.lang.String > OR java.util.Map< java.lang.String, java.lang.Number > map);
 ```
 
 | **Name**                                                                             | **Type**                                                                                                                                                                                                                                                                                                                                                                                                 | **Description**   |
 | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| <code><a href="#cdktf.MapTerraformIterator.Initializer.parameter.map">map</a></code> | <code><a href="#cdktf.StringMap">StringMap</a> OR <a href="#cdktf.NumberMap">NumberMap</a> OR <a href="#cdktf.BooleanMap">BooleanMap</a> OR <a href="#cdktf.AnyMap">AnyMap</a> OR <a href="#cdktf.ComplexMap">ComplexMap</a> OR java.util.Map< java.lang.String, java.lang.Object > OR java.util.Map< java.lang.String, java.lang.String > OR java.util.Map< java.lang.String, java.lang.Number ></code> | _No description._ |
+| <code><a href="#cdktf.MapTerraformIterator.Initializer.parameter.map">map</a></code> | <code><a href="#cdktf.AnyMap">AnyMap</a> OR <a href="#cdktf.StringMap">StringMap</a> OR <a href="#cdktf.NumberMap">NumberMap</a> OR <a href="#cdktf.BooleanMap">BooleanMap</a> OR <a href="#cdktf.ComplexMap">ComplexMap</a> OR java.util.Map< java.lang.String, java.lang.Object > OR java.util.Map< java.lang.String, java.lang.String > OR java.util.Map< java.lang.String, java.lang.Number ></code> | _No description._ |
 
 ---
 
 ##### `map`<sup>Required</sup> <a name="map" id="cdktf.MapTerraformIterator.Initializer.parameter.map"></a>
 
-- _Type:_ <a href="#cdktf.StringMap">StringMap</a> OR <a href="#cdktf.NumberMap">NumberMap</a> OR <a href="#cdktf.BooleanMap">BooleanMap</a> OR <a href="#cdktf.AnyMap">AnyMap</a> OR <a href="#cdktf.ComplexMap">ComplexMap</a> OR java.util.Map< java.lang.String, java.lang.Object > OR java.util.Map< java.lang.String, java.lang.String > OR java.util.Map< java.lang.String, java.lang.Number >
+- _Type:_ <a href="#cdktf.AnyMap">AnyMap</a> OR <a href="#cdktf.StringMap">StringMap</a> OR <a href="#cdktf.NumberMap">NumberMap</a> OR <a href="#cdktf.BooleanMap">BooleanMap</a> OR <a href="#cdktf.ComplexMap">ComplexMap</a> OR java.util.Map< java.lang.String, java.lang.Object > OR java.util.Map< java.lang.String, java.lang.String > OR java.util.Map< java.lang.String, java.lang.Number >
 
 ---
 

--- a/website/docs/cdktf/api-reference/python.mdx
+++ b/website/docs/cdktf/api-reference/python.mdx
@@ -31596,6 +31596,7 @@ This contains the text that Terraform will include as part of error messages whe
 import cdktf
 
 cdktf.TestingAppConfig(
+  context: typing.Mapping[typing.Any] = None,
   enable_future_flags: bool = None,
   fake_cdktf_json_path: bool = None,
   outdir: str = None,
@@ -31606,13 +31607,24 @@ cdktf.TestingAppConfig(
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                           | **Type**          | **Description**   |
-| -------------------------------------------------------------------------------------------------- | ----------------- | ----------------- |
-| <code><a href="#cdktf.TestingAppConfig.property.enableFutureFlags">enable_future_flags</a></code>  | <code>bool</code> | _No description._ |
-| <code><a href="#cdktf.TestingAppConfig.property.fakeCdktfJsonPath">fake_cdktf_json_path</a></code> | <code>bool</code> | _No description._ |
-| <code><a href="#cdktf.TestingAppConfig.property.outdir">outdir</a></code>                          | <code>str</code>  | _No description._ |
-| <code><a href="#cdktf.TestingAppConfig.property.stackTraces">stack_traces</a></code>               | <code>bool</code> | _No description._ |
-| <code><a href="#cdktf.TestingAppConfig.property.stubVersion">stub_version</a></code>               | <code>bool</code> | _No description._ |
+| **Name**                                                                                           | **Type**                                | **Description**   |
+| -------------------------------------------------------------------------------------------------- | --------------------------------------- | ----------------- |
+| <code><a href="#cdktf.TestingAppConfig.property.context">context</a></code>                        | <code>typing.Mapping[typing.Any]</code> | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.enableFutureFlags">enable_future_flags</a></code>  | <code>bool</code>                       | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.fakeCdktfJsonPath">fake_cdktf_json_path</a></code> | <code>bool</code>                       | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.outdir">outdir</a></code>                          | <code>str</code>                        | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.stackTraces">stack_traces</a></code>               | <code>bool</code>                       | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.stubVersion">stub_version</a></code>               | <code>bool</code>                       | _No description._ |
+
+---
+
+##### `context`<sup>Optional</sup> <a name="context" id="cdktf.TestingAppConfig.property.context"></a>
+
+```python
+context: typing.Mapping[typing.Any]
+```
+
+- _Type:_ typing.Mapping[typing.Any]
 
 ---
 
@@ -35004,7 +35016,7 @@ cdktf.Fn()
 | <code><a href="#cdktf.Fn.replace">replace</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/replace replace} searches a given string for another given substring, and replaces each occurrence with a given replacement string.                                                                                                                                                               |
 | <code><a href="#cdktf.Fn.reverse">reverse</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/reverse reverse} takes a sequence and produces a new sequence of the same length with all of the same elements as the given sequence but in reverse order.                                                                                                                                        |
 | <code><a href="#cdktf.Fn.rsadecrypt">rsadecrypt</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/rsadecrypt rsadecrypt} decrypts an RSA-encrypted ciphertext, returning the corresponding cleartext.                                                                                                                                                                                               |
-| <code><a href="#cdktf.Fn.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).                                            |
+| <code><a href="#cdktf.Fn.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).                                  |
 | <code><a href="#cdktf.Fn.setintersection">setintersection</a></code>   | The {@link https://developer.hashicorp.com/terraform/language/functions/setintersection setintersection} function takes multiple sets and produces a single set containing only the elements that all of the given sets have in common. In other words, it computes the [intersection](<https://en.wikipedia.org/wiki/Intersection_(set_theory)>) of the sets.        |
 | <code><a href="#cdktf.Fn.setproduct">setproduct</a></code>             | The {@link https://developer.hashicorp.com/terraform/language/functions/setproduct setproduct} function finds all of the possible combinations of elements from all of the given sets by computing the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product).                                                                                          |
 | <code><a href="#cdktf.Fn.setsubtract">setsubtract</a></code>           | The {@link https://developer.hashicorp.com/terraform/language/functions/setsubtract setsubtract} function returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the [relative complement](<https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement>) of the second set.  |
@@ -36434,7 +36446,7 @@ cdktf.Fn.sensitive(
 )
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).
+{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).
 
 ###### `value`<sup>Required</sup> <a name="value" id="cdktf.Fn.sensitive.parameter.value"></a>
 
@@ -37617,7 +37629,7 @@ cdktf.FnGenerated()
 | <code><a href="#cdktf.FnGenerated.replace">replace</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/replace replace} searches a given string for another given substring, and replaces each occurrence with a given replacement string.                                                                                                                                                               |
 | <code><a href="#cdktf.FnGenerated.reverse">reverse</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/reverse reverse} takes a sequence and produces a new sequence of the same length with all of the same elements as the given sequence but in reverse order.                                                                                                                                        |
 | <code><a href="#cdktf.FnGenerated.rsadecrypt">rsadecrypt</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/rsadecrypt rsadecrypt} decrypts an RSA-encrypted ciphertext, returning the corresponding cleartext.                                                                                                                                                                                               |
-| <code><a href="#cdktf.FnGenerated.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).                                            |
+| <code><a href="#cdktf.FnGenerated.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).                                  |
 | <code><a href="#cdktf.FnGenerated.setintersection">setintersection</a></code>   | The {@link https://developer.hashicorp.com/terraform/language/functions/setintersection setintersection} function takes multiple sets and produces a single set containing only the elements that all of the given sets have in common. In other words, it computes the [intersection](<https://en.wikipedia.org/wiki/Intersection_(set_theory)>) of the sets.        |
 | <code><a href="#cdktf.FnGenerated.setproduct">setproduct</a></code>             | The {@link https://developer.hashicorp.com/terraform/language/functions/setproduct setproduct} function finds all of the possible combinations of elements from all of the given sets by computing the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product).                                                                                          |
 | <code><a href="#cdktf.FnGenerated.setsubtract">setsubtract</a></code>           | The {@link https://developer.hashicorp.com/terraform/language/functions/setsubtract setsubtract} function returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the [relative complement](<https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement>) of the second set.  |
@@ -39040,7 +39052,7 @@ cdktf.FnGenerated.sensitive(
 )
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).
+{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).
 
 ###### `value`<sup>Required</sup> <a name="value" id="cdktf.FnGenerated.sensitive.parameter.value"></a>
 
@@ -41026,19 +41038,19 @@ fqn: str
 import cdktf
 
 cdktf.MapTerraformIterator(
-  map: typing.Union[StringMap, NumberMap, BooleanMap, AnyMap, ComplexMap, typing.Mapping[typing.Any], typing.Mapping[str], typing.Mapping[typing.Union[int, float]]]
+  map: typing.Union[AnyMap, StringMap, NumberMap, BooleanMap, ComplexMap, typing.Mapping[typing.Any], typing.Mapping[str], typing.Mapping[typing.Union[int, float]]]
 )
 ```
 
 | **Name**                                                                             | **Type**                                                                                                                                                                                                                                                                                                                             | **Description**   |
 | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------- |
-| <code><a href="#cdktf.MapTerraformIterator.Initializer.parameter.map">map</a></code> | <code>typing.Union[<a href="#cdktf.StringMap">StringMap</a>, <a href="#cdktf.NumberMap">NumberMap</a>, <a href="#cdktf.BooleanMap">BooleanMap</a>, <a href="#cdktf.AnyMap">AnyMap</a>, <a href="#cdktf.ComplexMap">ComplexMap</a>, typing.Mapping[typing.Any], typing.Mapping[str], typing.Mapping[typing.Union[int, float]]]</code> | _No description._ |
+| <code><a href="#cdktf.MapTerraformIterator.Initializer.parameter.map">map</a></code> | <code>typing.Union[<a href="#cdktf.AnyMap">AnyMap</a>, <a href="#cdktf.StringMap">StringMap</a>, <a href="#cdktf.NumberMap">NumberMap</a>, <a href="#cdktf.BooleanMap">BooleanMap</a>, <a href="#cdktf.ComplexMap">ComplexMap</a>, typing.Mapping[typing.Any], typing.Mapping[str], typing.Mapping[typing.Union[int, float]]]</code> | _No description._ |
 
 ---
 
 ##### `map`<sup>Required</sup> <a name="map" id="cdktf.MapTerraformIterator.Initializer.parameter.map"></a>
 
-- _Type:_ typing.Union[<a href="#cdktf.StringMap">StringMap</a>, <a href="#cdktf.NumberMap">NumberMap</a>, <a href="#cdktf.BooleanMap">BooleanMap</a>, <a href="#cdktf.AnyMap">AnyMap</a>, <a href="#cdktf.ComplexMap">ComplexMap</a>, typing.Mapping[typing.Any], typing.Mapping[str], typing.Mapping[typing.Union[int, float]]]
+- _Type:_ typing.Union[<a href="#cdktf.AnyMap">AnyMap</a>, <a href="#cdktf.StringMap">StringMap</a>, <a href="#cdktf.NumberMap">NumberMap</a>, <a href="#cdktf.BooleanMap">BooleanMap</a>, <a href="#cdktf.ComplexMap">ComplexMap</a>, typing.Mapping[typing.Any], typing.Mapping[str], typing.Mapping[typing.Union[int, float]]]
 
 ---
 
@@ -44688,6 +44700,7 @@ cdktf.Testing()
 import cdktf
 
 cdktf.Testing.app(
+  context: typing.Mapping[typing.Any] = None,
   enable_future_flags: bool = None,
   fake_cdktf_json_path: bool = None,
   outdir: str = None,
@@ -44697,6 +44710,12 @@ cdktf.Testing.app(
 ```
 
 Returns an app for testing with the following properties: - Output directory is a temp dir.
+
+###### `context`<sup>Optional</sup> <a name="context" id="cdktf.Testing.app.parameter.context"></a>
+
+- _Type:_ typing.Mapping[typing.Any]
+
+---
 
 ###### `enable_future_flags`<sup>Optional</sup> <a name="enable_future_flags" id="cdktf.Testing.app.parameter.enableFutureFlags"></a>
 

--- a/website/docs/cdktf/api-reference/typescript.mdx
+++ b/website/docs/cdktf/api-reference/typescript.mdx
@@ -24590,13 +24590,24 @@ const testingAppConfig: TestingAppConfig = { ... }
 
 #### Properties <a name="Properties" id="Properties"></a>
 
-| **Name**                                                                                        | **Type**             | **Description**   |
-| ----------------------------------------------------------------------------------------------- | -------------------- | ----------------- |
-| <code><a href="#cdktf.TestingAppConfig.property.enableFutureFlags">enableFutureFlags</a></code> | <code>boolean</code> | _No description._ |
-| <code><a href="#cdktf.TestingAppConfig.property.fakeCdktfJsonPath">fakeCdktfJsonPath</a></code> | <code>boolean</code> | _No description._ |
-| <code><a href="#cdktf.TestingAppConfig.property.outdir">outdir</a></code>                       | <code>string</code>  | _No description._ |
-| <code><a href="#cdktf.TestingAppConfig.property.stackTraces">stackTraces</a></code>             | <code>boolean</code> | _No description._ |
-| <code><a href="#cdktf.TestingAppConfig.property.stubVersion">stubVersion</a></code>             | <code>boolean</code> | _No description._ |
+| **Name**                                                                                        | **Type**                            | **Description**   |
+| ----------------------------------------------------------------------------------------------- | ----------------------------------- | ----------------- |
+| <code><a href="#cdktf.TestingAppConfig.property.context">context</a></code>                     | <code>{[ key: string ]: any}</code> | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.enableFutureFlags">enableFutureFlags</a></code> | <code>boolean</code>                | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.fakeCdktfJsonPath">fakeCdktfJsonPath</a></code> | <code>boolean</code>                | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.outdir">outdir</a></code>                       | <code>string</code>                 | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.stackTraces">stackTraces</a></code>             | <code>boolean</code>                | _No description._ |
+| <code><a href="#cdktf.TestingAppConfig.property.stubVersion">stubVersion</a></code>             | <code>boolean</code>                | _No description._ |
+
+---
+
+##### `context`<sup>Optional</sup> <a name="context" id="cdktf.TestingAppConfig.property.context"></a>
+
+```typescript
+public readonly context: {[ key: string ]: any};
+```
+
+- _Type:_ {[ key: string ]: any}
 
 ---
 
@@ -27749,7 +27760,7 @@ new Fn();
 | <code><a href="#cdktf.Fn.replace">replace</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/replace replace} searches a given string for another given substring, and replaces each occurrence with a given replacement string.                                                                                                                                                               |
 | <code><a href="#cdktf.Fn.reverse">reverse</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/reverse reverse} takes a sequence and produces a new sequence of the same length with all of the same elements as the given sequence but in reverse order.                                                                                                                                        |
 | <code><a href="#cdktf.Fn.rsadecrypt">rsadecrypt</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/rsadecrypt rsadecrypt} decrypts an RSA-encrypted ciphertext, returning the corresponding cleartext.                                                                                                                                                                                               |
-| <code><a href="#cdktf.Fn.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).                                            |
+| <code><a href="#cdktf.Fn.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).                                  |
 | <code><a href="#cdktf.Fn.setintersection">setintersection</a></code>   | The {@link https://developer.hashicorp.com/terraform/language/functions/setintersection setintersection} function takes multiple sets and produces a single set containing only the elements that all of the given sets have in common. In other words, it computes the [intersection](<https://en.wikipedia.org/wiki/Intersection_(set_theory)>) of the sets.        |
 | <code><a href="#cdktf.Fn.setproduct">setproduct</a></code>             | The {@link https://developer.hashicorp.com/terraform/language/functions/setproduct setproduct} function finds all of the possible combinations of elements from all of the given sets by computing the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product).                                                                                          |
 | <code><a href="#cdktf.Fn.setsubtract">setsubtract</a></code>           | The {@link https://developer.hashicorp.com/terraform/language/functions/setsubtract setsubtract} function returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the [relative complement](<https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement>) of the second set.  |
@@ -29021,7 +29032,7 @@ import { Fn } from 'cdktf'
 Fn.sensitive(value: any)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).
+{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).
 
 ###### `value`<sup>Required</sup> <a name="value" id="cdktf.Fn.sensitive.parameter.value"></a>
 
@@ -30079,7 +30090,7 @@ new FnGenerated();
 | <code><a href="#cdktf.FnGenerated.replace">replace</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/replace replace} searches a given string for another given substring, and replaces each occurrence with a given replacement string.                                                                                                                                                               |
 | <code><a href="#cdktf.FnGenerated.reverse">reverse</a></code>                   | {@link https://developer.hashicorp.com/terraform/language/functions/reverse reverse} takes a sequence and produces a new sequence of the same length with all of the same elements as the given sequence but in reverse order.                                                                                                                                        |
 | <code><a href="#cdktf.FnGenerated.rsadecrypt">rsadecrypt</a></code>             | {@link https://developer.hashicorp.com/terraform/language/functions/rsadecrypt rsadecrypt} decrypts an RSA-encrypted ciphertext, returning the corresponding cleartext.                                                                                                                                                                                               |
-| <code><a href="#cdktf.FnGenerated.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).                                            |
+| <code><a href="#cdktf.FnGenerated.sensitive">sensitive</a></code>               | {@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).                                  |
 | <code><a href="#cdktf.FnGenerated.setintersection">setintersection</a></code>   | The {@link https://developer.hashicorp.com/terraform/language/functions/setintersection setintersection} function takes multiple sets and produces a single set containing only the elements that all of the given sets have in common. In other words, it computes the [intersection](<https://en.wikipedia.org/wiki/Intersection_(set_theory)>) of the sets.        |
 | <code><a href="#cdktf.FnGenerated.setproduct">setproduct</a></code>             | The {@link https://developer.hashicorp.com/terraform/language/functions/setproduct setproduct} function finds all of the possible combinations of elements from all of the given sets by computing the [Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product).                                                                                          |
 | <code><a href="#cdktf.FnGenerated.setsubtract">setsubtract</a></code>           | The {@link https://developer.hashicorp.com/terraform/language/functions/setsubtract setsubtract} function returns a new set containing the elements from the first set that are not present in the second set. In other words, it computes the [relative complement](<https://en.wikipedia.org/wiki/Complement_(set_theory)#Relative_complement>) of the second set.  |
@@ -31344,7 +31355,7 @@ import { FnGenerated } from 'cdktf'
 FnGenerated.sensitive(value: any)
 ```
 
-{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/language/values/variables#suppressing-values-in-cli-output).
+{@link https://developer.hashicorp.com/terraform/language/functions/sensitive sensitive} takes any value and returns a copy of it marked so that Terraform will treat it as sensitive, with the same meaning and behavior as for [sensitive input variables](/terraform/language/values/variables#suppressing-values-in-cli-output).
 
 ###### `value`<sup>Required</sup> <a name="value" id="cdktf.FnGenerated.sensitive.parameter.value"></a>
 
@@ -33134,18 +33145,18 @@ public readonly fqn: string;
 ```typescript
 import { MapTerraformIterator } from 'cdktf'
 
-new MapTerraformIterator(map: StringMap | NumberMap | BooleanMap | AnyMap | ComplexMap | {[ key: string ]: any} | {[ key: string ]: string} | {[ key: string ]: number})
+new MapTerraformIterator(map: AnyMap | StringMap | NumberMap | BooleanMap | ComplexMap | {[ key: string ]: any} | {[ key: string ]: string} | {[ key: string ]: number})
 ```
 
 | **Name**                                                                             | **Type**                                                                                                                                                                                                                                                                                                                | **Description**   |
 | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| <code><a href="#cdktf.MapTerraformIterator.Initializer.parameter.map">map</a></code> | <code><a href="#cdktf.StringMap">StringMap</a> \| <a href="#cdktf.NumberMap">NumberMap</a> \| <a href="#cdktf.BooleanMap">BooleanMap</a> \| <a href="#cdktf.AnyMap">AnyMap</a> \| <a href="#cdktf.ComplexMap">ComplexMap</a> \| {[ key: string ]: any} \| {[ key: string ]: string} \| {[ key: string ]: number}</code> | _No description._ |
+| <code><a href="#cdktf.MapTerraformIterator.Initializer.parameter.map">map</a></code> | <code><a href="#cdktf.AnyMap">AnyMap</a> \| <a href="#cdktf.StringMap">StringMap</a> \| <a href="#cdktf.NumberMap">NumberMap</a> \| <a href="#cdktf.BooleanMap">BooleanMap</a> \| <a href="#cdktf.ComplexMap">ComplexMap</a> \| {[ key: string ]: any} \| {[ key: string ]: string} \| {[ key: string ]: number}</code> | _No description._ |
 
 ---
 
 ##### `map`<sup>Required</sup> <a name="map" id="cdktf.MapTerraformIterator.Initializer.parameter.map"></a>
 
-- _Type:_ <a href="#cdktf.StringMap">StringMap</a> | <a href="#cdktf.NumberMap">NumberMap</a> | <a href="#cdktf.BooleanMap">BooleanMap</a> | <a href="#cdktf.AnyMap">AnyMap</a> | <a href="#cdktf.ComplexMap">ComplexMap</a> | {[ key: string ]: any} | {[ key: string ]: string} | {[ key: string ]: number}
+- _Type:_ <a href="#cdktf.AnyMap">AnyMap</a> | <a href="#cdktf.StringMap">StringMap</a> | <a href="#cdktf.NumberMap">NumberMap</a> | <a href="#cdktf.BooleanMap">BooleanMap</a> | <a href="#cdktf.ComplexMap">ComplexMap</a> | {[ key: string ]: any} | {[ key: string ]: string} | {[ key: string ]: number}
 
 ---
 


### PR DESCRIPTION
Closes #2816

- fix(docs): Add override to ensure function bindings docs don't have relative links without the terraform product prefix in them
- fix(docs): update API docs
