### PR TITLE
fix(cli): Fix version range matching for 0.x version ranges with the ~> operator

### DIFF
--- a/packages/@cdktf/cli-core/src/lib/dependencies/version-constraints.ts
+++ b/packages/@cdktf/cli-core/src/lib/dependencies/version-constraints.ts
@@ -48,15 +48,25 @@ export function versionMatchesConstraint(
       case "~>": {
         // allows rightmost version component to increment
 
+        const parts = parsed.version.split(".");
+        const minorSpecified = parts.length === 2;
+        const majorIsZero = parts[0] === "0";
+
         // ~>2.0 which allows 2.1 and 2.1.1 needs special handling as
         // npm semver handles "~" differently for ~2.0 than for ~2 or ~2.1.0
         // So we need to use "^" (e.g. ^2.0) for this case
         // see: https://github.com/npm/node-semver/issues/11
-        const allowMinorAndPatchOnly = parsed.version.split(".").length === 2;
+        const allowMinorAndPatchOnly = minorSpecified;
 
-        const range = allowMinorAndPatchOnly
+        let range = allowMinorAndPatchOnly
           ? `^${parsed.version}`
           : `~${parsed.version}`;
+
+        // versions below 1.0 are treated a bit differently in NPM than in Terraform
+        // meaning that NPMs ^0.4 doesn't allow 0.55 while TFs ~>0.4 allows 0.55
+        if (majorIsZero && minorSpecified) {
+          range = `>=${parsed.version} <1.0.0`;
+        }
 
         return semver.satisfies(version, range);
       }

--- a/packages/@cdktf/cli-core/src/test/lib/dependencies/version-constraints.test.ts
+++ b/packages/@cdktf/cli-core/src/test/lib/dependencies/version-constraints.test.ts
@@ -138,6 +138,19 @@ describe("version constraints", () => {
         { constraint: "~>4", version: "4.2.5", matches: true },
         { constraint: "~>4", version: "5", matches: false },
 
+        // ~> operator with 0.x
+        { constraint: "~>0.4", version: "0.4", matches: true },
+        { constraint: "~>0.4", version: "0.3", matches: false },
+        { constraint: "~>0.4", version: "0.4.1", matches: true },
+        { constraint: "~>0.4", version: "0.55", matches: true },
+        { constraint: "~>0.4", version: "1.0", matches: false },
+        { constraint: "~>0.4", version: "2.0", matches: false },
+        { constraint: "~>0.0.3", version: "0.0.3", matches: true },
+        { constraint: "~>0.0.3", version: "0.0.2", matches: false },
+        { constraint: "~>0.0.3", version: "0.0.55", matches: true },
+        { constraint: "~>0.0.3", version: "1.0", matches: false },
+        { constraint: "~>0.0.3", version: "2.0", matches: false },
+
         // whitespace is ignored
         { constraint: " = 4.0 ", version: "  4   ", matches: true },
 


### PR DESCRIPTION
Versions below `1.0` are treated a bit differently in NPM than in Terraform meaning that NPMs `^0.4` doesn't allow `0.55` while TFs `~>0.4` allows `0.55`.

This PR ensures that `~>0.4` matches `0.55`.