### PR TITLE
fix(provider-generator): Skip `statement` block for `rule` block in `aws_wafv2_web_acl` and `aws_wafv2_rule_group` resources

### DIFF
--- a/examples/typescript/aws-cloudfront-proxy/main.ts
+++ b/examples/typescript/aws-cloudfront-proxy/main.ts
@@ -50,18 +50,18 @@ class MyStack extends TerraformStack {
             sampledRequestsEnabled: true,
           },
           statement: {
-            managedRuleGroupStatement: {
+            managed_rule_group_statement: {
               name: "managed-rule-example",
-              vendorName: "AWS",
-              excludedRule: [
+              vendor_name: "AWS",
+              excluded_rule: [
                 {
                   name: "SizeRestrictions_QUERYSTRING",
                 },
                 { name: "SQLInjection_QUERYSTRING" },
               ],
-              scopeDownStatement: {
-                geoMatchStatement: {
-                  countryCodes: ["US"],
+              scope_down_statement: {
+                geo_match_statement: {
+                  country_codes: ["US"],
                 },
               },
             },

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/export-sharding.test.ts
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/export-sharding.test.ts
@@ -25,19 +25,22 @@ test("shard exports across multiple files to avoid generating files with more th
   await code.save(workdir);
 
   const output = fs.readFileSync(
-    path.join(workdir, "providers/aws/wafv2-web-acl/index.ts"),
+    path.join(workdir, "providers/test/wafv2-web-acl/index.ts"),
     "utf-8"
   );
   expect(output).toMatchSnapshot(`wafv2-web-acl-resource`);
 
   const outputStructsIndex = fs.readFileSync(
-    path.join(workdir, "providers/aws/wafv2-web-acl/index-structs/index.ts"),
+    path.join(workdir, "providers/test/wafv2-web-acl/index-structs/index.ts"),
     "utf-8"
   );
   expect(outputStructsIndex).toMatchSnapshot(`structs-index`);
 
   const outputStructs0 = fs.readFileSync(
-    path.join(workdir, "providers/aws/wafv2-web-acl/index-structs/structs0.ts"),
+    path.join(
+      workdir,
+      "providers/test/wafv2-web-acl/index-structs/structs0.ts"
+    ),
     "utf-8"
   );
   expect(outputStructs0).toMatchSnapshot(`structs0`);
@@ -45,7 +48,7 @@ test("shard exports across multiple files to avoid generating files with more th
   const outputStructs400 = fs.readFileSync(
     path.join(
       workdir,
-      "providers/aws/wafv2-web-acl/index-structs/structs400.ts"
+      "providers/test/wafv2-web-acl/index-structs/structs400.ts"
     ),
     "utf-8"
   );
@@ -54,7 +57,7 @@ test("shard exports across multiple files to avoid generating files with more th
   const outputStructs800 = fs.readFileSync(
     path.join(
       workdir,
-      "providers/aws/wafv2-web-acl/index-structs/structs800.ts"
+      "providers/test/wafv2-web-acl/index-structs/structs800.ts"
     ),
     "utf-8"
   );
@@ -63,7 +66,7 @@ test("shard exports across multiple files to avoid generating files with more th
   const outputStructs1200 = fs.readFileSync(
     path.join(
       workdir,
-      "providers/aws/wafv2-web-acl/index-structs/structs1200.ts"
+      "providers/test/wafv2-web-acl/index-structs/structs1200.ts"
     ),
     "utf-8"
   );
@@ -72,7 +75,7 @@ test("shard exports across multiple files to avoid generating files with more th
   const outputStructs1600 = fs.readFileSync(
     path.join(
       workdir,
-      "providers/aws/wafv2-web-acl/index-structs/structs1600.ts"
+      "providers/test/wafv2-web-acl/index-structs/structs1600.ts"
     ),
     "utf-8"
   );
@@ -81,7 +84,7 @@ test("shard exports across multiple files to avoid generating files with more th
   const outputStructs2000 = fs.readFileSync(
     path.join(
       workdir,
-      "providers/aws/wafv2-web-acl/index-structs/structs2000.ts"
+      "providers/test/wafv2-web-acl/index-structs/structs2000.ts"
     ),
     "utf-8"
   );
@@ -90,7 +93,7 @@ test("shard exports across multiple files to avoid generating files with more th
   const outputStructs2400 = fs.readFileSync(
     path.join(
       workdir,
-      "providers/aws/wafv2-web-acl/index-structs/structs2400.ts"
+      "providers/test/wafv2-web-acl/index-structs/structs2400.ts"
     ),
     "utf-8"
   );
@@ -99,7 +102,7 @@ test("shard exports across multiple files to avoid generating files with more th
   const outputStructs2800 = fs.readFileSync(
     path.join(
       workdir,
-      "providers/aws/wafv2-web-acl/index-structs/structs2800.ts"
+      "providers/test/wafv2-web-acl/index-structs/structs2800.ts"
     ),
     "utf-8"
   );
@@ -108,7 +111,7 @@ test("shard exports across multiple files to avoid generating files with more th
   const outputStructs3200 = fs.readFileSync(
     path.join(
       workdir,
-      "providers/aws/wafv2-web-acl/index-structs/structs3200.ts"
+      "providers/test/wafv2-web-acl/index-structs/structs3200.ts"
     ),
     "utf-8"
   );
@@ -117,7 +120,7 @@ test("shard exports across multiple files to avoid generating files with more th
   const outputStructs3600 = fs.readFileSync(
     path.join(
       workdir,
-      "providers/aws/wafv2-web-acl/index-structs/structs3600.ts"
+      "providers/test/wafv2-web-acl/index-structs/structs3600.ts"
     ),
     "utf-8"
   );

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/aws_wafv2_web_acl.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/aws_wafv2_web_acl.test.fixture.json
@@ -1,8 +1,8 @@
 {
   "provider_schemas": {
-    "registry.terraform.io/hashicorp/aws": {
+    "registry.terraform.io/hashicorp/test": {
       "resource_schemas": {
-        "aws_wafv2_web_acl": {
+        "test_wafv2_web_acl": {
           "version": 0,
           "block": {
             "attributes": {

--- a/packages/@cdktf/provider-generator/lib/get/generator/skipped-attributes.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/skipped-attributes.ts
@@ -11,6 +11,8 @@ const SKIPPED_ATTRIBUTES: string[] = [
   "aws.quicksight_template.definition",
   "aws.quicksight_dashboard.definition",
   "aws.quicksight_analysis.definition",
+  "aws.wafv2_web_acl.wafv2_web_acl_rule.statement",
+  "aws.wafv2_rule_group.wafv2_rule_group_rule.statement",
 ];
 
 /**

--- a/test/typescript/synth-app/__snapshots__/test.ts.snap
+++ b/test/typescript/synth-app/__snapshots__/test.ts.snap
@@ -75,46 +75,6 @@ output "instance-http-endpoint" {
 
 output "tf-env-var-output" {
   value = "no-value-found"
-}
-resource "aws_wafv2_web_acl" "wafv2" {
-  name  = "managed-rule-example"
-  scope = "REGIONAL"
-  default_action {
-    allow {
-
-    }
-  }
-  rule {
-    name     = "managed-rule-example"
-    priority = 1
-    override_action {
-      count {
-
-      }
-    }
-    statement {
-      managed_rule_group_statement {
-        name        = "managed-rule-example"
-        vendor_name = "AWS"
-        excluded_rule {
-          name = "SizeRestrictions_QUERYSTRING"
-        }
-        excluded_rule {
-          name = "SQLInjection_QUERYSTRING"
-        }
-      }
-    }
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "managed-rule-example"
-      sampled_requests_enabled   = true
-    }
-  }
-  visibility_config {
-    cloudwatch_metrics_enabled = true
-    metric_name                = "managed-rule-example"
-    sampled_requests_enabled   = true
-  }
 }"
 `;
 
@@ -225,54 +185,6 @@ exports[`full integration test synth synth generates JSON 1`] = `
           "create_before_destroy": true
         },
         "provider": "aws"
-      }
-    },
-    "aws_wafv2_web_acl": {
-      "wafv2": {
-        "//": {
-          "metadata": {
-            "path": "hello-terra/wafv2",
-            "uniqueId": "wafv2"
-          }
-        },
-        "default_action": {
-          "allow": {}
-        },
-        "name": "managed-rule-example",
-        "rule": [
-          {
-            "name": "managed-rule-example",
-            "override_action": {
-              "count": {}
-            },
-            "priority": 1,
-            "statement": {
-              "managed_rule_group_statement": {
-                "excluded_rule": [
-                  {
-                    "name": "SizeRestrictions_QUERYSTRING"
-                  },
-                  {
-                    "name": "SQLInjection_QUERYSTRING"
-                  }
-                ],
-                "name": "managed-rule-example",
-                "vendor_name": "AWS"
-              }
-            },
-            "visibility_config": {
-              "cloudwatch_metrics_enabled": true,
-              "metric_name": "managed-rule-example",
-              "sampled_requests_enabled": true
-            }
-          }
-        ],
-        "scope": "REGIONAL",
-        "visibility_config": {
-          "cloudwatch_metrics_enabled": true,
-          "metric_name": "managed-rule-example",
-          "sampled_requests_enabled": true
-        }
       }
     }
   },

--- a/test/typescript/synth-app/main.ts
+++ b/test/typescript/synth-app/main.ts
@@ -110,10 +110,10 @@ export class HelloTerra extends TerraformStack {
             sampledRequestsEnabled: true,
           },
           statement: {
-            managedRuleGroupStatement: {
+            managed_rule_group_statement: {
               name: "managed-rule-example",
-              vendorName: "AWS",
-              excludedRule: [
+              vendor_name: "AWS",
+              excluded_rule: [
                 {
                   name: "SizeRestrictions_QUERYSTRING",
                 },

--- a/test/typescript/synth-app/main.ts
+++ b/test/typescript/synth-app/main.ts
@@ -11,7 +11,6 @@ import {
 } from "cdktf";
 import { provider, snsTopic } from "./.gen/providers/aws";
 import { Instance } from "./.gen/providers/aws/instance";
-import { Wafv2WebAcl } from "./.gen/providers/aws/wafv2-web-acl";
 
 export class HelloTerra extends TerraformStack {
   constructor(scope: Construct, id: string) {
@@ -84,45 +83,6 @@ export class HelloTerra extends TerraformStack {
           name: "test",
         },
       },
-    });
-
-    new Wafv2WebAcl(this, "wafv2", {
-      defaultAction: {
-        allow: {},
-      },
-      name: "managed-rule-example",
-      scope: "REGIONAL",
-      visibilityConfig: {
-        cloudwatchMetricsEnabled: true,
-        metricName: "managed-rule-example",
-        sampledRequestsEnabled: true,
-      },
-      rule: [
-        {
-          name: "managed-rule-example",
-          priority: 1,
-          overrideAction: {
-            count: {},
-          },
-          visibilityConfig: {
-            cloudwatchMetricsEnabled: true,
-            metricName: "managed-rule-example",
-            sampledRequestsEnabled: true,
-          },
-          statement: {
-            managed_rule_group_statement: {
-              name: "managed-rule-example",
-              vendor_name: "AWS",
-              excluded_rule: [
-                {
-                  name: "SizeRestrictions_QUERYSTRING",
-                },
-                { name: "SQLInjection_QUERYSTRING" },
-              ],
-            },
-          },
-        },
-      ],
     });
   }
 }


### PR DESCRIPTION
This is a breaking change for users of these properties in these resources. It is necessary to bring down the size of the generated Go code though and also has an effect on all other languages.

For Go it shrinks the size of the generated code for the AWS provider from 648MB to 357MB. Previously the two resources accounted for 187MB (web acl) and 103MB (rule group) of the total size

Our resource docs already state that some attributes are skipped which includes mentions of the web acl resources (even though they weren't affected in the past)

Resolves #3358