### PR TITLE
chore(docs): fix currently-404 link to built-in templates

### DIFF
--- a/website/docs/cdktf/create-and-deploy/remote-templates.mdx
+++ b/website/docs/cdktf/create-and-deploy/remote-templates.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # Remote Templates
 
-When you set up a new project via `cdktf init`, you can supply one of the [built-in templates](https://github.com/hashicorp/terraform-cdk/tree/main/packages/cdktf-cli/templates) (e.g. `typescript` or `python`) or use a custom-built remote template. Templates scaffold a new CDK for Terraform (CDKTF) project, creating the necessary directories and files.
+When you set up a new project via `cdktf init`, you can supply one of the [built-in templates](https://github.com/hashicorp/terraform-cdk/tree/main/packages/%40cdktf/cli-core/templates) (e.g. `typescript` or `python`) or use a custom-built remote template. Templates scaffold a new CDK for Terraform (CDKTF) project, creating the necessary directories and files.
 
 ## Create Remote Templates
 


### PR DESCRIPTION
### Description

The [remote templates](https://developer.hashicorp.com/terraform/cdktf/create-and-deploy/remote-templates) docs page has a [built-in templates](https://github.com/hashicorp/terraform-cdk/tree/main/packages/cdktf-cli/templates) link that's currently 404; the templates were moved in ef76955222231305d74bd9f7b3c6b79aa0e35f74. This PR updates the link to the new location of the templates.

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes
