### PR TITLE
fix(lib): Print a warning with manual steps to move a module when UpgradeIds aspect encounters modules

### DIFF
--- a/packages/cdktf/lib/upgrade-id-aspect.ts
+++ b/packages/cdktf/lib/upgrade-id-aspect.ts
@@ -1,7 +1,12 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
 
-import { TerraformElement, TerraformResource } from ".";
+import {
+  Annotations,
+  TerraformElement,
+  TerraformModule,
+  TerraformResource,
+} from ".";
 import { IAspect } from "./aspect";
 import { IConstruct, Node } from "constructs";
 import * as crypto from "crypto";
@@ -165,6 +170,14 @@ export class MigrateIds implements IAspect {
     if (node instanceof TerraformResource) {
       const oldId = allocateLogicalIdOldVersion(node);
       node.moveFromId(`${node.terraformResourceType}.${oldId}`);
+    }
+    // eslint-disable-next-line no-instanceof/no-instanceof
+    if (node instanceof TerraformModule) {
+      const oldId = allocateLogicalIdOldVersion(node);
+      Annotations.of(node)
+        .addWarning(`Found module with new id ${node.friendlyUniqueId}. Moving this module requires a manual state migration.
+If this module has not been moved yet, run "terraform state mv module.${oldId} module.${node.friendlyUniqueId}" to migrate the existing state to its new id.
+Refer to the following page for more information: https://developer.hashicorp.com/terraform/cdktf/examples-and-guides/refactoring#moving-or-renaming-modules`);
     }
   }
 }

--- a/packages/cdktf/lib/upgrade-id-aspect.ts
+++ b/packages/cdktf/lib/upgrade-id-aspect.ts
@@ -3,14 +3,17 @@
 
 import {
   Annotations,
+  App,
   TerraformElement,
   TerraformModule,
   TerraformResource,
+  TerraformStack,
 } from ".";
 import { IAspect } from "./aspect";
 import { IConstruct, Node } from "constructs";
 import * as crypto from "crypto";
 import { cannotCalcIdForEmptySetOfComponents } from "./errors";
+import * as path from "path";
 
 /**
  * We have to copy this from the old CDKTF version for now, so that we can
@@ -174,9 +177,15 @@ export class MigrateIds implements IAspect {
     // eslint-disable-next-line no-instanceof/no-instanceof
     if (node instanceof TerraformModule) {
       const oldId = allocateLogicalIdOldVersion(node);
+      const appManifest = App.of(node).manifest;
+      const stackManifest = appManifest.forStack(TerraformStack.of(node));
+      const stackOutdir = path.join(
+        appManifest.outdir,
+        stackManifest.workingDirectory
+      );
       Annotations.of(node)
         .addWarning(`Found module with new id ${node.friendlyUniqueId}. Moving this module requires a manual state migration.
-If this module has not been moved yet, run "terraform state mv module.${oldId} module.${node.friendlyUniqueId}" to migrate the existing state to its new id.
+If this module has not been moved yet, run "terraform state mv module.${oldId} module.${node.friendlyUniqueId}" in the output directory "${stackOutdir}" to migrate the existing state to its new id.
 Refer to the following page for more information: https://developer.hashicorp.com/terraform/cdktf/examples-and-guides/refactoring#moving-or-renaming-modules`);
     }
   }

--- a/packages/cdktf/test/upgrade-id-aspect.test.ts
+++ b/packages/cdktf/test/upgrade-id-aspect.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 import { App, Aspects, MigrateIds, TerraformStack, Testing } from "../lib";
 import { TestModule } from "./helper";
 

--- a/packages/cdktf/test/upgrade-id-aspect.test.ts
+++ b/packages/cdktf/test/upgrade-id-aspect.test.ts
@@ -1,0 +1,24 @@
+import { App, Aspects, MigrateIds, TerraformStack, Testing } from "../lib";
+import { TestModule } from "./helper";
+
+describe("MigrateIds", () => {
+  it("should add warning annoations for modules", () => {
+    const app = Testing.stubVersion(new App({ stackTraces: false }));
+    const stack = new TerraformStack(app, "staging");
+    new TestModule(stack, "vpc", {
+      moduleParameter: "moduleValue",
+    });
+    Aspects.of(stack).add(new MigrateIds());
+    app.synth();
+
+    expect(app.manifest.forStack(stack).annotations).toEqual([
+      {
+        constructPath: "staging/vpc",
+        level: "@cdktf/warn",
+        message: `Found module with new id vpc. Moving this module requires a manual state migration.
+If this module has not been moved yet, run "terraform state mv module.staging_vpc_C4EA2553 module.vpc" in the output directory "cdktf.out/stacks/staging" to migrate the existing state to its new id.
+Refer to the following page for more information: https://developer.hashicorp.com/terraform/cdktf/examples-and-guides/refactoring#moving-or-renaming-modules`,
+      },
+    ]);
+  });
+});

--- a/website/docs/cdktf/examples-and-guides/refactoring.mdx
+++ b/website/docs/cdktf/examples-and-guides/refactoring.mdx
@@ -184,6 +184,17 @@ new S3Bucket(this, "bucket-moved", {
 new NestedConstruct(this, "nested-construct", {});
 ```
 
+## Moving or renaming modules
+
+To change the id of a module without losing its state use the `terraform state mv` command. This command needs to be run in the output directory of the stack that contains the module. Commonly this is `cdktf.out/stacks/<stack-name>`. The command takes two arguments, the first is the current id of the module, the second is the new id of the module.
+
+```shell-session
+$ cd cdktf.out/stacks/refactoring-example
+$ terraform state mv module.my-module module.my-new-module
+```
+
+For further details on the `terraform state mv` command refer to the [Terraform documentation](/terraform/cli/commands/state/mv).
+
 ## Moving Resources From One Stack To Another
 
 You may want to move a resource from one stack to another, like the following example aws `S3Bucket` resource.


### PR DESCRIPTION
CDKTF does not support moved blocks for modules at this point, hence it requires manual work
