### PR TITLE
feat(provider-generator): support renaming provider names in order to allow using two providers sharing the same name at the same time

### DIFF
--- a/packages/@cdktf/provider-generator/lib/get/generator/models/resource-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/resource-model.ts
@@ -37,6 +37,11 @@ export class ResourceModel {
   public providerVersionConstraint?: string;
   public providerVersion?: string;
   public terraformProviderSource?: string;
+  /*
+   * usually same as provider, but can be overridden if user picks a different name
+   * to be able to use two providers with the same name
+   */
+  public terraformProviderName: string;
   public fileName: string;
   public attributes: AttributeModel[];
   public schema: Schema;
@@ -56,6 +61,7 @@ export class ResourceModel {
     this.schema = options.schema;
     this.fqpn = options.fqpn;
     this.provider = parseFQPN(options.fqpn).name;
+    this.terraformProviderName = this.provider;
     this.fileName = options.fileName;
     this._structs = options.structs;
     this.terraformSchemaType = options.terraformSchemaType;
@@ -118,7 +124,7 @@ export class ResourceModel {
 
   public get terraformResourceType(): string {
     return this.isProvider
-      ? this.provider
+      ? this.terraformProviderName
       : this.isDataSource
       ? this.terraformType.replace(/^data_/, "")
       : this.terraformType;

--- a/packages/@cdktf/provider-generator/lib/get/generator/provider-generator.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/provider-generator.ts
@@ -26,18 +26,60 @@ const isMatching = (
 ): boolean => {
   if (target.isModule) return false;
 
+  console.log("isMatching", { target, terraformSchemaName });
+
   const elements = terraformSchemaName.split("/");
 
   if (elements.length === 1) {
     return target.source === terraformSchemaName;
   } else {
-    const [hostname, scope, provider] = elements;
+    const [hostname, namespace, provider] = elements;
 
-    if (!hostname || !scope || !provider) {
+    if (!hostname || !namespace || !provider) {
       throw new Error(`can't handle ${terraformSchemaName}`);
     }
 
-    return target.name === provider || target.source === terraformSchemaName;
+    console.log("target.name", target.name);
+    console.log("terraformSchemaName", terraformSchemaName);
+
+    // If target.source is set, try to match it
+    if (target.source) {
+      const targetSource = {
+        // defaults
+        hostname: "registry.terraform.io",
+        namespace: "hashicorp",
+        name: "",
+      };
+      const targetElements = target.source.split("/");
+      switch (targetElements.length) {
+        case 1: // only name set
+          targetSource.name = targetElements[0].toLowerCase();
+          break;
+        case 2: // namespace and name set
+          targetSource.namespace = targetElements[0].toLowerCase();
+          targetSource.name = targetElements[1].toLowerCase();
+          break;
+        case 3: // hostname, namespace and name set
+          targetSource.hostname = targetElements[0].toLowerCase();
+          targetSource.namespace = targetElements[1].toLowerCase();
+          targetSource.name = targetElements[2].toLowerCase();
+          break;
+        default:
+          throw new Error(
+            `can't handle ${target.source}. Expected string with 1, 2 or 3 elements separated by '/'`
+          );
+      }
+
+      return (
+        targetSource.hostname === hostname &&
+        targetSource.namespace === namespace &&
+        targetSource.name === provider
+      );
+    }
+
+    // Else, try to match target.name to the provider name
+
+    return target.name === provider;
   }
 };
 
@@ -181,6 +223,7 @@ export class TerraformProviderGenerator {
       if (constraint) {
         providerResource.providerVersionConstraint = constraint.version;
         providerResource.terraformProviderSource = constraint.source;
+        providerResource.terraformProviderName = constraint.name;
       }
       providerResource.providerVersion = providerVersion;
       files.push(this.emitResource(providerResource));

--- a/packages/@cdktf/provider-generator/lib/get/generator/provider-generator.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/provider-generator.ts
@@ -39,9 +39,6 @@ const isMatching = (
       throw new Error(`can't handle ${terraformSchemaName}`);
     }
 
-    console.log("target.name", target.name);
-    console.log("terraformSchemaName", terraformSchemaName);
-
     // If target.source is set, try to match it
     if (target.source) {
       const targetSource = {

--- a/test/typescript/renamed-providers/cdktf.json
+++ b/test/typescript/renamed-providers/cdktf.json
@@ -1,0 +1,19 @@
+{
+  "language": "typescript",
+  "app": "npx ts-node main.ts",
+  "terraformProviders": [
+    {
+      "name": "bitbucket",
+      "namespace": "Runelab",
+      "version": "2.1.0",
+      "source": "Runelab/bitbucket"
+    },
+    {
+      "name": "abitbucket",
+      "namespace": "aeirola",
+      "version": "2.0.2",
+      "source": "aeirola/bitbucket"
+    }
+  ],
+  "context": {}
+}

--- a/test/typescript/renamed-providers/main.ts
+++ b/test/typescript/renamed-providers/main.ts
@@ -1,0 +1,40 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { Construct } from "constructs";
+import { App, LocalBackend, TerraformStack, Testing } from "cdktf";
+
+import * as bitbucket from "./.gen/providers/bitbucket";
+import * as abitbucket from "./.gen/providers/abitbucket";
+
+class RenamedProvidersStack extends TerraformStack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+    // required for stable snapshots during testing
+    new LocalBackend(this, {
+      path: "terraform.tfstate",
+    });
+
+    new bitbucket.provider.BitbucketProvider(this, "bitbucket", {
+      username: "foo",
+      password: "bar",
+    });
+    new bitbucket.repository.Repository(this, "test-repo", {
+      name: "test",
+      owner: "foo",
+    });
+
+    const abb = new abitbucket.provider.AbitbucketProvider(this, "abitbucket", {
+      username: "foo",
+      password: "bar",
+    });
+    new abitbucket.repository.Repository(this, "test-repo2", {
+      name: "test2",
+      owner: "foo",
+      provider: abb, // needs to be passed explicitly
+    });
+  }
+}
+
+const app = Testing.stubVersion(new App({}));
+new RenamedProvidersStack(app, "renamed-providers");
+app.synth();

--- a/test/typescript/renamed-providers/test.ts
+++ b/test/typescript/renamed-providers/test.ts
@@ -1,0 +1,128 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { TestDriver, onlyHcl, onlyJson } from "../../test-helper";
+
+describe("renamed providers", () => {
+  let driver: TestDriver;
+
+  beforeAll(async () => {
+    driver = new TestDriver(__dirname);
+    await driver.setupTypescriptProject();
+    await driver.synth();
+  });
+
+  onlyJson("synthesizes correct JSON", () => {
+    const out = driver.synthesizedStackContentsRaw("renamed-providers");
+    expect(out).toMatchInlineSnapshot(`
+      "{
+        "//": {
+          "metadata": {
+            "backend": "local",
+            "stackName": "renamed-providers",
+            "version": "stubbed"
+          },
+          "outputs": {
+          }
+        },
+        "provider": {
+          "abitbucket": [
+            {
+              "password": "bar",
+              "username": "foo"
+            }
+          ],
+          "bitbucket": [
+            {
+              "password": "bar",
+              "username": "foo"
+            }
+          ]
+        },
+        "resource": {
+          "bitbucket_repository": {
+            "test-repo": {
+              "//": {
+                "metadata": {
+                  "path": "renamed-providers/test-repo",
+                  "uniqueId": "test-repo"
+                }
+              },
+              "name": "test",
+              "owner": "foo"
+            },
+            "test-repo2": {
+              "//": {
+                "metadata": {
+                  "path": "renamed-providers/test-repo2",
+                  "uniqueId": "test-repo2"
+                }
+              },
+              "name": "test2",
+              "owner": "foo",
+              "provider": "abitbucket"
+            }
+          }
+        },
+        "terraform": {
+          "backend": {
+            "local": {
+              "path": "terraform.tfstate"
+            }
+          },
+          "required_providers": {
+            "abitbucket": {
+              "source": "aeirola/bitbucket",
+              "version": "2.0.2"
+            },
+            "bitbucket": {
+              "source": "Runelab/bitbucket",
+              "version": "2.1.0"
+            }
+          }
+        }
+      }"
+    `);
+  });
+
+  onlyHcl("synthesizes correct HCL", () => {
+    const out = driver.synthesizedStackContentsRaw("renamed-providers");
+    expect(out).toMatchInlineSnapshot(`
+      "terraform {
+        required_providers {
+          bitbucket = {
+            version = "2.1.0"
+            source  = "Runelab/bitbucket"
+          }
+          abitbucket = {
+            version = "2.0.2"
+            source  = "aeirola/bitbucket"
+          }
+        }
+        backend "local" {
+          path = "terraform.tfstate"
+        }
+
+
+      }
+
+      provider "bitbucket" {
+        password = "bar"
+        username = "foo"
+      }
+      resource "bitbucket_repository" "test-repo" {
+        name  = "test"
+        owner = "foo"
+      }
+
+      provider "abitbucket" {
+        password = "bar"
+        username = "foo"
+      }
+      resource "bitbucket_repository" "test-repo2" {
+        name     = "test2"
+        owner    = "foo"
+        provider = "abitbucket"
+      }"
+    `);
+  });
+});


### PR DESCRIPTION
Adds support for the Terraform feature described here: https://developer.hashicorp.com/terraform/language/providers/requirements#handling-local-name-conflicts

Resolves #1258

### Open items
- [x] add test case for JSON and HCL output when using two providers with the same name