### PR TITLE
chore: Throw error when variables are used within backend configuration

### DIFF
--- a/packages/cdktf/lib/terraform-backend.ts
+++ b/packages/cdktf/lib/terraform-backend.ts
@@ -37,29 +37,95 @@ export abstract class TerraformBackend extends TerraformElement {
   ): TerraformRemoteState;
 
   public toHclTerraform(): any {
+    const backendConfig = deepMerge(
+      this.synthesizeHclAttributes(),
+      this.rawOverrides
+    );
+
+    const variables = this.detectVariables(backendConfig);
+
+    if (variables.length > 0) {
+      throw new Error(
+        [
+          "Terraform does not support interpolated values within backends.",
+          "Interpolations found in the following configuration backend attributes:",
+          ...variables.map((v) => `\t${this.constructor.name}: "${v}"`),
+        ].join("\n")
+      );
+    }
     return {
       terraform: {
         backend: {
-          [this.name]: deepMerge(
-            this.synthesizeHclAttributes(),
-            this.rawOverrides
-          ),
+          [this.name]: backendConfig,
         },
       },
     };
+  }
+
+  private detectVariables(obj: any, parentKey?: string): string[] {
+    const hasVariableRegex = /var\.(\w+)/g;
+
+    if (typeof obj === "string") {
+      const matches = hasVariableRegex.test(obj);
+      if (matches) {
+        if (parentKey) {
+          return [parentKey];
+        }
+      }
+
+      return [];
+    } else if (typeof obj === "object") {
+      // References
+      if (obj.value && typeof obj.value === "string") {
+        return this.detectVariables(obj.value, parentKey);
+      }
+
+      const foundKeys = Object.keys(obj).filter((key) => {
+        return (
+          this.detectVariables(
+            obj[key],
+            parentKey ? `${parentKey}.${key}` : key
+          ).length > 0
+        );
+      });
+
+      return foundKeys.flat(0);
+    } else if (Array.isArray(obj)) {
+      const foundIndices = obj.filter((v, i) =>
+        this.detectVariables(v, `${parentKey}[${i}]`)
+      );
+
+      return foundIndices.flat(0);
+    } else {
+      return [];
+    }
   }
 
   /**
    * Adds this resource to the terraform JSON output.
    */
   public toTerraform(): any {
+    const backendConfig = deepMerge(
+      this.synthesizeAttributes(),
+      this.rawOverrides
+    );
+
+    const variables = this.detectVariables(backendConfig);
+
+    if (variables.length > 0) {
+      throw new Error(
+        [
+          "Terraform does not support interpolated values within backends.",
+          "Interpolations found in the following configuration backend attributes:",
+          ...variables.map((v) => `\t${this.constructor.name}: "${v}"`),
+        ].join("\n")
+      );
+    }
+
     return {
       terraform: {
         backend: {
-          [this.name]: deepMerge(
-            this.synthesizeAttributes(),
-            this.rawOverrides
-          ),
+          [this.name]: backendConfig,
         },
       },
     };

--- a/packages/cdktf/lib/terraform-backend.ts
+++ b/packages/cdktf/lib/terraform-backend.ts
@@ -4,6 +4,7 @@ import { Construct } from "constructs";
 import { TerraformRemoteState } from "./terraform-remote-state";
 import { TerraformElement } from "./terraform-element";
 import { deepMerge } from "./util";
+import { Annotations } from "./annotations";
 
 const BACKEND_SYMBOL = Symbol.for("cdktf/TerraformBackend");
 
@@ -45,7 +46,7 @@ export abstract class TerraformBackend extends TerraformElement {
     const variables = this.detectVariables(backendConfig);
 
     if (variables.length > 0) {
-      throw new Error(
+      Annotations.of(this).addError(
         [
           "Terraform does not support interpolated values within backends.",
           "Interpolations found in the following configuration backend attributes:",
@@ -53,6 +54,7 @@ export abstract class TerraformBackend extends TerraformElement {
         ].join("\n")
       );
     }
+
     return {
       terraform: {
         backend: {
@@ -113,7 +115,7 @@ export abstract class TerraformBackend extends TerraformElement {
     const variables = this.detectVariables(backendConfig);
 
     if (variables.length > 0) {
-      throw new Error(
+      Annotations.of(this).addError(
         [
           "Terraform does not support interpolated values within backends.",
           "Interpolations found in the following configuration backend attributes:",


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes https://github.com/hashicorp/terraform-cdk/issues/2535

### Description

Terraform doesn't support variables within backends, but CDKTF doesn't prevent users from going this route. With this PR, we try to detect variable usage within the backend, and will throw an error when encountered.

Note: The proper way of using credentials etc within backends is outlined [here](https://github.com/hashicorp/terraform-cdk/issues/2535), but supporting that within the CDKTF CLI would need more work.