### PR TITLE
fix: Map keys not being quoted when they are not valid identifiers

### DIFF
--- a/packages/cdktf/lib/hcl/render.ts
+++ b/packages/cdktf/lib/hcl/render.ts
@@ -16,11 +16,7 @@ function escapeQuotes(str: string): string {
 }
 
 function wrapIdentifierInQuotesIfNeeded(key: string): string {
-  return /^(?:\d|[\-])/.test(key)
-    ? `"${key}"`
-    : /[^A-Za-z0-9_\-]/.test(key)
-    ? `"${key}"`
-    : key;
+  return /(^\d)|[^A-Za-z0-9_\-]/.test(key) ? `"${key}"` : key;
 }
 
 /**

--- a/packages/cdktf/lib/hcl/render.ts
+++ b/packages/cdktf/lib/hcl/render.ts
@@ -15,6 +15,14 @@ function escapeQuotes(str: string): string {
   return str.replace(/(?<!\\)"/g, '\\"');
 }
 
+function wrapKeyInQuotesIfNeeded(key: string): string {
+  return /^(?:\d|[\-])/.test(key)
+    ? `"${key}"`
+    : /[^A-Za-z0-9_\-]/.test(key)
+    ? `"${key}"`
+    : key;
+}
+
 /**
  *
  */
@@ -163,7 +171,11 @@ export function renderMap(map: any): string {
   }
   return `{
 ${Object.entries(map)
-  .map(([k, v]) => `${k} = ${renderMapValue(v)}`)
+  .map(([k, v]) => {
+    const wrappedKey = wrapKeyInQuotesIfNeeded(k);
+
+    return `${wrappedKey} = ${renderMapValue(v)}`;
+  })
   .join("\n")}
 }`;
 }

--- a/packages/cdktf/lib/hcl/render.ts
+++ b/packages/cdktf/lib/hcl/render.ts
@@ -15,8 +15,11 @@ function escapeQuotes(str: string): string {
   return str.replace(/(?<!\\)"/g, '\\"');
 }
 
+/**
+ *
+ */
 function wrapIdentifierInQuotesIfNeeded(key: string): string {
-  return /(^\d)|[^A-Za-z0-9_\-]/.test(key) ? `"${key}"` : key;
+  return /(^\d)|[^A-Za-z0-9_-]/.test(key) ? `"${key}"` : key;
 }
 
 /**

--- a/packages/cdktf/lib/hcl/render.ts
+++ b/packages/cdktf/lib/hcl/render.ts
@@ -15,7 +15,7 @@ function escapeQuotes(str: string): string {
   return str.replace(/(?<!\\)"/g, '\\"');
 }
 
-function wrapKeyInQuotesIfNeeded(key: string): string {
+function wrapIdentifierInQuotesIfNeeded(key: string): string {
   return /^(?:\d|[\-])/.test(key)
     ? `"${key}"`
     : /[^A-Za-z0-9_\-]/.test(key)
@@ -172,7 +172,7 @@ export function renderMap(map: any): string {
   return `{
 ${Object.entries(map)
   .map(([k, v]) => {
-    const wrappedKey = wrapKeyInQuotesIfNeeded(k);
+    const wrappedKey = wrapIdentifierInQuotesIfNeeded(k);
 
     return `${wrappedKey} = ${renderMapValue(v)}`;
   })
@@ -494,7 +494,8 @@ function renderFuzzyJsonObject(jsonObject: any): string {
   return [
     "{",
     ...Object.entries(jsonObject).map(([name, value]) => {
-      return `${name} = ${renderFuzzyJsonExpression(value)}`;
+      const wrappedKey = wrapIdentifierInQuotesIfNeeded(name);
+      return `${wrappedKey} = ${renderFuzzyJsonExpression(value)}`;
     }),
     "}",
   ].join("\n");

--- a/packages/cdktf/test/json-to-hcl.test.ts
+++ b/packages/cdktf/test/json-to-hcl.test.ts
@@ -316,6 +316,43 @@ describe("output", () => {
     `);
   });
 
+  test("map keys with invalid identifier chars", async () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, "test");
+
+    new TestProvider(stack, "provider", {});
+
+    new TestResource(stack, "weird-long-running-resource", {
+      name: "foo",
+      tags: {
+        "foo:bar": "baz",
+        simple: "true",
+      },
+    });
+
+    expect(Testing.synthHcl(stack)).toMatchInlineSnapshot(`
+      "terraform {
+      required_providers {
+        test = {
+      version = "~> 2.0"
+      }
+      }
+
+
+      }
+
+      provider "test" {
+      }
+      resource "test_resource" "weird-long-running-resource" {
+      name = "foo"
+      tags = {
+      "foo:bar" = "baz"
+      simple = "true"
+      }
+      }"
+    `);
+  });
+
   test("dependent output", async () => {
     const app = Testing.app();
     const stack = new TerraformStack(app, "test");

--- a/packages/cdktf/test/json-to-hcl.test.ts
+++ b/packages/cdktf/test/json-to-hcl.test.ts
@@ -54,6 +54,26 @@ test("multiple locals", async () => {
   `);
 });
 
+test("string local with quoted name", async () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+
+  new TerraformLocal(stack, "greeting", {
+    "hip : ho": "Hello, ${var.name}",
+  });
+
+  const hcl = Testing.synthHcl(stack);
+  expect(hcl).toMatchInlineSnapshot(`
+    "
+
+    locals {
+        greeting = {
+    "hip : ho" = "Hello, \${var.name}"
+    }
+    }"
+  `);
+});
+
 test("with provider alias", async () => {
   const app = Testing.app();
   const stack = new TerraformStack(app, "test");


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes #3459

### Description

Terraform expects keys of maps to be [valid identifiers](https://developer.hashicorp.com/terraform/language/syntax/configuration#identifiers), and the HCL synth was not ensuring that before. This PR tries to detect areas where quoting is required to ensure valid HCL is output. 