### PR TITLE
chore: Improve locals output - Group all locals into one locals block

### DIFF
--- a/packages/cdktf/lib/hcl/render.ts
+++ b/packages/cdktf/lib/hcl/render.ts
@@ -376,15 +376,23 @@ ${renderAttributes(outputAttributes)}
  *
  */
 export function renderLocals(locals: any) {
-  const localName = Object.keys(locals)[0];
-  const localAttributes = locals[localName];
+  if (!locals) {
+    return "";
+  }
 
-  if (localAttributes.value === undefined) {
+  const localNames = Object.keys(locals);
+
+  if (localNames.length === 0) {
     return "";
   }
 
   return `locals {
-    ${localName} = ${renderFuzzyJsonExpression(localAttributes.value)}
+    ${localNames
+      .map((name: string) => {
+        const value = renderFuzzyJsonExpression(locals[name].value);
+        return `${name} = ${value}`;
+      })
+      .join("\n")}
 }`;
 }
 

--- a/packages/cdktf/lib/hcl/render.ts
+++ b/packages/cdktf/lib/hcl/render.ts
@@ -388,6 +388,7 @@ export function renderLocals(locals: any) {
 
   return `locals {
     ${localNames
+      .filter((name) => !!locals[name].value)
       .map((name: string) => {
         const value = renderFuzzyJsonExpression(locals[name].value);
         return `${name} = ${value}`;

--- a/packages/cdktf/test/json-to-hcl.test.ts
+++ b/packages/cdktf/test/json-to-hcl.test.ts
@@ -28,7 +28,9 @@ test("string local", async () => {
 
   const hcl = Testing.synthHcl(stack);
   expect(hcl).toMatchInlineSnapshot(`
-    "locals {
+    "
+
+    locals {
         greeting = "Hello, \${var.name}"
     }"
   `);
@@ -43,7 +45,9 @@ test("multiple locals", async () => {
 
   const hcl = Testing.synthHcl(stack);
   expect(hcl).toMatchInlineSnapshot(`
-    "locals {
+    "
+
+    locals {
         greeting = "Hello, \${var.name}"
     greeting-2 = "Hello, \${var.name}"
     }"

--- a/packages/cdktf/test/json-to-hcl.test.ts
+++ b/packages/cdktf/test/json-to-hcl.test.ts
@@ -28,10 +28,24 @@ test("string local", async () => {
 
   const hcl = Testing.synthHcl(stack);
   expect(hcl).toMatchInlineSnapshot(`
-    "
-
-    locals {
+    "locals {
         greeting = "Hello, \${var.name}"
+    }"
+  `);
+});
+
+test("multiple locals", async () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+
+  new TerraformLocal(stack, "greeting", "Hello, ${var.name}");
+  new TerraformLocal(stack, "greeting-2", "Hello, ${var.name}");
+
+  const hcl = Testing.synthHcl(stack);
+  expect(hcl).toMatchInlineSnapshot(`
+    "locals {
+        greeting = "Hello, \${var.name}"
+    greeting-2 = "Hello, \${var.name}"
     }"
   `);
 });


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Description
The existing HCL output converted each Terraform local in a separate `locals` block, which is not ideal. While this is a purely cosmetic change that doesn't really impact the HCL synth correctness, it makes the synthed output easier to read, and closer to how practitioners would expect it to be.