### PR TITLE
fix(cli): Corrected formatting for java provider dependencies

### DIFF
--- a/packages/@cdktf/cli-core/src/lib/dependencies/dependency-manager.ts
+++ b/packages/@cdktf/cli-core/src/lib/dependencies/dependency-manager.ts
@@ -413,7 +413,7 @@ export class DependencyManager {
         /github.com\/(?:cdktf|hashicorp)\/cdktf-provider-(.+)-go\//i,
       [Language.TYPESCRIPT]: /(.+)/i,
       [Language.CSHARP]: /HashiCorp\.Cdktf\.Providers\.(.+)/i,
-      [Language.JAVA]: /com\.hashicorp:cdktf-provider-(.+)/i,
+      [Language.JAVA]: /cdktf-provider-(.+)/i,
       [Language.PYTHON]: /cdktf-cdktf-provider-(.+)/i,
     };
     const regex = regexes[this.targetLanguage];

--- a/packages/@cdktf/cli-core/src/lib/dependencies/dependency-manager.ts
+++ b/packages/@cdktf/cli-core/src/lib/dependencies/dependency-manager.ts
@@ -392,7 +392,7 @@ export class DependencyManager {
       case Language.CSHARP: // e.g. HashiCorp.Cdktf.Providers.Opentelekomcloud
         return `HashiCorp.Cdktf.Providers.` + toPascalCase(providerName);
       case Language.JAVA: // e.g. com.hashicorp.opentelekomcloud
-        return `com.hashicorp.cdktf-provider-${providerName}`;
+        return `com.hashicorp:cdktf-provider-${providerName}`;
       case Language.PYTHON: // e.g. cdktf-cdktf-provider-opentelekomcloud
         return `cdktf-cdktf-provider-${providerName}`;
       default:
@@ -413,7 +413,7 @@ export class DependencyManager {
         /github.com\/(?:cdktf|hashicorp)\/cdktf-provider-(.+)-go\//i,
       [Language.TYPESCRIPT]: /(.+)/i,
       [Language.CSHARP]: /HashiCorp\.Cdktf\.Providers\.(.+)/i,
-      [Language.JAVA]: /com\.hashicorp\.cdktf-provider-(.+)/i,
+      [Language.JAVA]: /com\.hashicorp:cdktf-provider-(.+)/i,
       [Language.PYTHON]: /cdktf-cdktf-provider-(.+)/i,
     };
     const regex = regexes[this.targetLanguage];

--- a/packages/@cdktf/cli-core/src/lib/dependencies/package-manager.ts
+++ b/packages/@cdktf/cli-core/src/lib/dependencies/package-manager.ts
@@ -672,7 +672,11 @@ class GradlePackageManager extends JavaPackageManager {
       buildGradleLines.splice(existingDependency, 1);
     }
 
-    const newPackageDependency = `\timplementation '${packageName}:${packageVersion}'`;
+    const packageNameElements = packageName.split(".");
+    const packageNameProvider = packageNameElements.pop();
+    const groupName = packageNameElements.join(".");
+
+    const newPackageDependency = `\timplementation '${groupName}:${packageNameProvider}:${packageVersion}'`;
     buildGradleLines.splice(dependencyBlockStart + 1, 0, newPackageDependency);
 
     await fs.writeFile(buildGradlePath, buildGradleLines.join("\n"));

--- a/packages/@cdktf/cli-core/src/lib/dependencies/package-manager.ts
+++ b/packages/@cdktf/cli-core/src/lib/dependencies/package-manager.ts
@@ -517,7 +517,7 @@ abstract class JavaPackageManager extends PackageManager {
     logger.debug(`Checking if ${packageName}@${packageVersion} is available`);
 
     const parts = packageName.split(":");
-    if (parts.length !== 2) {
+    if (parts.length !== 3) {
       throw Errors.Internal(
         `Expected package name to be in format "group.artifact", e.g. "com.hashicorp:cdktf-provider-google", got: ${packageName}`
       );
@@ -676,7 +676,7 @@ class GradlePackageManager extends JavaPackageManager {
     const packageNameProvider = packageNameElements.pop();
     const groupName = packageNameElements.join(".");
 
-    const newPackageDependency = `\timplementation '${groupName}:${packageNameProvider}:${packageVersion}'`;
+    const newPackageDependency = `\timplementation '${groupName}.${packageNameProvider}:${packageVersion}'`;
     buildGradleLines.splice(dependencyBlockStart + 1, 0, newPackageDependency);
 
     await fs.writeFile(buildGradlePath, buildGradleLines.join("\n"));
@@ -699,7 +699,7 @@ class GradlePackageManager extends JavaPackageManager {
         return dep.name.includes("cdktf-provider-");
       })
       .map((dep) => ({ name: dep!.name, version: dep!.version }));
-
+    console.log("dependency list: ", dependencyList);
     return dependencyList;
   }
 }

--- a/packages/@cdktf/cli-core/src/lib/dependencies/package-manager.ts
+++ b/packages/@cdktf/cli-core/src/lib/dependencies/package-manager.ts
@@ -516,15 +516,15 @@ abstract class JavaPackageManager extends PackageManager {
   ): Promise<boolean> {
     logger.debug(`Checking if ${packageName}@${packageVersion} is available`);
 
-    const parts = packageName.split(".");
-    if (parts.length !== 3) {
+    const parts = packageName.split(":");
+    if (parts.length !== 2) {
       throw Errors.Internal(
-        `Expected package name to be in format "group.artifact", e.g. "com.hashicorp.cdktf-provider-google", got: ${packageName}`
+        `Expected package name to be in format "group.artifact", e.g. "com.hashicorp:cdktf-provider-google", got: ${packageName}`
       );
     }
 
     const packageIdentifier = parts.pop();
-    const groupId = parts.join(".");
+    const groupId = parts.pop();
 
     const url = `https://search.maven.org/solrsearch/select?q=g:${groupId}+AND+a:${packageIdentifier}+AND+v:${packageVersion}&rows=5&wt=json`;
     logger.debug(

--- a/packages/@cdktf/cli-core/src/lib/dependencies/package-manager.ts
+++ b/packages/@cdktf/cli-core/src/lib/dependencies/package-manager.ts
@@ -517,7 +517,7 @@ abstract class JavaPackageManager extends PackageManager {
     logger.debug(`Checking if ${packageName}@${packageVersion} is available`);
 
     const parts = packageName.split(":");
-    if (parts.length !== 3) {
+    if (parts.length !== 2) {
       throw Errors.Internal(
         `Expected package name to be in format "group.artifact", e.g. "com.hashicorp:cdktf-provider-google", got: ${packageName}`
       );

--- a/test/java/provider-list-command/test.ts
+++ b/test/java/provider-list-command/test.ts
@@ -34,6 +34,8 @@ describe("provider list command", () => {
     test("with json output", async () => {
       const res = await driver.exec("cdktf", ["provider", "list", "--json"]);
 
+      console.log(res);
+
       const output = JSON.parse(res.stdout);
 
       expect(output).toHaveProperty("local");

--- a/test/java/provider-list-command/test.ts
+++ b/test/java/provider-list-command/test.ts
@@ -51,7 +51,7 @@ describe("provider list command", () => {
 
       expect(output.prebuilt[0]).toEqual(
         expect.objectContaining({
-          packageName: "com.hashicorp.cdktf-provider-random",
+          packageName: "com.hashicorp:cdktf-provider-random",
           packageVersion: "0.2.55",
           providerName: "random",
           providerVersion: "3.1.3",

--- a/test/run-against-dist
+++ b/test/run-against-dist
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -euox pipefail
 
 scriptdir=$(cd $(dirname $0) && pwd)
 


### PR DESCRIPTION
### Description

Provider add in java was previously using an incorrect format for the dependencies it added.

#### Before

`com.hashicorp.cdktf-provider-random:11.0.0`

#### After

`com.hashicorp:cdktf-provider-random:11.0.0`
