### PR TITLE
Fix(cli): A bug when opening browser using CLI hangs the shell process forever

### DIFF
--- a/packages/cdktf-cli/src/bin/cmds/helper/terraform-login.ts
+++ b/packages/cdktf-cli/src/bin/cmds/helper/terraform-login.ts
@@ -72,7 +72,7 @@ the following file for use by subsequent Terraform commands:
     try {
       await open.default(this.terraformLoginURL, {
         allowNonzeroExitCode: true,
-        wait: true,
+        wait: false, // Should remain false. Otherwise, it waits for the app (browser) to exit/quit, not just the window.
       });
     } catch (e) {
       logger.debug(

--- a/packages/cdktf-cli/src/test/cmds/init.test.ts
+++ b/packages/cdktf-cli/src/test/cmds/init.test.ts
@@ -35,4 +35,29 @@ describe("init command", () => {
       expect(result.stdout).not.toContain(`Detected Terraform Cloud token.`);
     });
   }, 30_000);
+
+  it("opens up the browser and waits for the token input", async () => {
+    await mkdtemp(async (cwd) => {
+      const input = "Y\n";
+      const result = await execa(
+        cdktfBin,
+        [
+          "init",
+          "--template=go",
+          "--from-terraform-project=false",
+          "--enable-crash-reporting=false",
+        ],
+        {
+          stdio: "pipe",
+          cwd,
+          input,
+        }
+      );
+      expect(result.stderr).toEqual("");
+      expect(result.stdout).toContain(
+        `opening webpage using your browser.`
+      );
+      expect(result.stdout).not.toContain(`Token for app.terraform.io`);
+    });
+  }, 30_000);
 });


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes #3470 

### Description

When we request an API token from terraform cloud (during `cdktf login` or `cdktf init`...) we do a sys call to open the browser. This sys call opens a new tab using the default browser defined by the OS. We pass an option when making this syscall called `{... wait: true}`. Based on the docs, this option will wait/block the standard input until the user exits/quits the browser. Not just the tab, the browser process. This is not user friendly, nor required in my opinion. As a result, when the browser opens and we copy the newly generated token then proceed to paste it in the terminal, there is no standard input to paste it in, the process is blocked.

What I did was simply remove this wait=true option since there is no need to wait for the browser to quit/exit in order to paste our token.

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
