### PR TITLE
fix(docs): Italics broken

### DIFF
--- a/website/docs/cdktf/concepts/stacks.mdx
+++ b/website/docs/cdktf/concepts/stacks.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # Stacks
 
-\_Note: Stacks in CDKTF are not the same as [Terraform stacks](https://www.hashicorp.com/blog/terraform-stacks-explained), which are a configuration layer that eliminates the need to manually manage cross-configuration dependencies between Terraform modules.
+_Note: Stacks in CDKTF are not the same as [Terraform stacks](https://www.hashicorp.com/blog/terraform-stacks-explained), which are a configuration layer that eliminates the need to manually manage cross-configuration dependencies between Terraform modules._
 
 A stack represents a collection of infrastructure that CDK for Terraform (CDKTF) synthesizes as a dedicated Terraform configuration. Stacks allow you to separate the state management for multiple environments within an application.
 

--- a/website/docs/cdktf/concepts/stacks.mdx
+++ b/website/docs/cdktf/concepts/stacks.mdx
@@ -7,10 +7,9 @@ description: >-
 
 # Stacks
 
-> **Note**: CDKTF stacks differ from [Terraform stacks](https://www.hashicorp.com/blog/terraform-stacks-explained). Terraform stacks are a configuration layer that simplifies provisioning and managing resources at scale by controlling cross-configuration dependencies between Terraform modules.
-
 A stack represents a collection of infrastructure that CDK for Terraform (CDKTF) synthesizes as a dedicated Terraform configuration. Stacks allow you to separate the state management for multiple environments within an application.
 
+> **Note**: Stacks in CDKTF are different from the Terraform stacks concept announced at HashiConf 2023. Terraform stacks are a configuration layer that simplifies provisioning and managing resources at scale by controlling cross-configuration dependencies between Terraform modules. Refer to [Terraform stacks, explained](https://www.hashicorp.com/blog/terraform-stacks-explained) in the HashiCorp blog for additional information.
 > **Hands-on:** Try the [Deploy Applications with CDK for Terraform](/terraform/tutorials/cdktf/cdktf-applications?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial.
 
 ## Scope

--- a/website/docs/cdktf/concepts/stacks.mdx
+++ b/website/docs/cdktf/concepts/stacks.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # Stacks
 
-_Note: Stacks in CDKTF are not the same as [Terraform stacks](https://www.hashicorp.com/blog/terraform-stacks-explained), which are a configuration layer that eliminates the need to manually manage cross-configuration dependencies between Terraform modules._
+> **Note**: CDKTF stacks differ from [Terraform stacks](https://www.hashicorp.com/blog/terraform-stacks-explained). Terraform stacks are a configuration layer that simplifies provisioning and managing resources at scale by controlling cross-configuration dependencies between Terraform modules.
 
 A stack represents a collection of infrastructure that CDK for Terraform (CDKTF) synthesizes as a dedicated Terraform configuration. Stacks allow you to separate the state management for multiple environments within an application.
 


### PR DESCRIPTION
The italics on this 'Note:' at the beginning of the page is broken.

