### PR TITLE
chore: update-project-board-issue calls different repo

### DIFF
--- a/.github/workflows/update-project-board-issue.yml
+++ b/.github/workflows/update-project-board-issue.yml
@@ -29,4 +29,4 @@ jobs:
           ISSUE: ${{ inputs.issue || github.event.issue.number }}
         run: |
           sleep 5
-          gh workflow run update-project-board-issue.yml -R hashicorp/terraform-cdk-team -f issue=$ISSUE -f repository=terraform-cdk
+          gh workflow run update-project-board-issue.yml -R hashicorp/update-project-board -f issue=$ISSUE -f repository=terraform-cdk -f project=125


### PR DESCRIPTION
Late last year I decided that the `update-project-board` script is better off living in its own repo after all, and I got it all set up except I kept forgetting to actually update this script to point to the new place.

Feel free to wait to merge this until Monday, no rush.
