### PR TITLE
fix: Sort stacks in generated manifest.json file

### DIFF
--- a/packages/cdktf/lib/manifest.ts
+++ b/packages/cdktf/lib/manifest.ts
@@ -85,9 +85,21 @@ export class Manifest implements IManifest {
   }
 
   public writeToFile() {
+    const replacer = (key, value) => {
+      if (key === "stacks") {
+        return Object.keys(value)
+          .sort()
+          .reduce((sorted, key) => {
+            sorted[key] = value[key];
+            return sorted 
+          }, {});
+        }
+      return value;
+    }
+
     fs.writeFileSync(
       path.join(this.outdir, Manifest.fileName),
-      JSON.stringify(this.buildManifest(), undefined, 2)
+      JSON.stringify(this.buildManifest(), replacer, 2)
     );
   }
 }


### PR DESCRIPTION
### Description

The sorting of the stacks in the `metadata.json` file generated by `cdktf synth` seems to be random between runs. This makes writing snapshot tests a bit cumbersome.