### PR TITLE
chore: manifest.json should have stable json

### DIFF
--- a/packages/@cdktf/cli-core/src/test/lib/cdktf-project.test.ts
+++ b/packages/@cdktf/cli-core/src/test/lib/cdktf-project.test.ts
@@ -161,7 +161,7 @@ describe("CdktfProject", () => {
       });
 
       return expect(cdktfProject.diff()).rejects.toMatchInlineSnapshot(
-        `[Error: Usage Error: Found more than one stack, please specify a target stack. Run cdktf diff <stack> with one of these stacks: first, second, third, fourth, fifth ]`
+        `[Error: Usage Error: Found more than one stack, please specify a target stack. Run cdktf diff <stack> with one of these stacks: fifth, first, fourth, second, third ]`
       );
     });
   });

--- a/packages/cdktf/lib/manifest.ts
+++ b/packages/cdktf/lib/manifest.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import * as fs from "fs";
 import { TerraformStack } from "./terraform-stack";
 import { AnnotationMetadataEntryType } from "./annotations";
+import stringify = require("json-stable-stringify");
 
 export interface StackAnnotation {
   readonly constructPath: string;
@@ -87,7 +88,7 @@ export class Manifest implements IManifest {
   public writeToFile() {
     fs.writeFileSync(
       path.join(this.outdir, Manifest.fileName),
-      JSON.stringify(this.buildManifest(), undefined, 2)
+      stringify(this.buildManifest(), { space: 2 })
     );
   }
 }

--- a/packages/cdktf/test/manifest.test.ts
+++ b/packages/cdktf/test/manifest.test.ts
@@ -53,18 +53,20 @@ test("write manifest", () => {
   expect(fs.readFileSync(path.join(outdir, Manifest.fileName)).toString())
     .toMatchInlineSnapshot(`
     "{
-      "version": "0.0.0",
       "stacks": {
         "this-is-a-stack": {
-          "name": "this-is-a-stack",
+          "annotations": [
+          ],
           "constructPath": "this-is-a-stack",
-          "workingDirectory": "stacks/this-is-a-stack",
-          "synthesizedStackPath": "stacks/this-is-a-stack/cdk.tf.json",
+          "dependencies": [
+          ],
+          "name": "this-is-a-stack",
           "stackMetadataPath": "stacks/this-is-a-stack/metadata.json",
-          "annotations": [],
-          "dependencies": []
+          "synthesizedStackPath": "stacks/this-is-a-stack/cdk.tf.json",
+          "workingDirectory": "stacks/this-is-a-stack"
         }
-      }
+      },
+      "version": "0.0.0"
     }"
   `);
 });
@@ -88,14 +90,8 @@ describe("manifest annotations", () => {
     expect(fs.readFileSync(path.join(outdir, Manifest.fileName)).toString())
       .toMatchInlineSnapshot(`
       "{
-        "version": "stubbed",
         "stacks": {
           "this-is-a-stack": {
-            "name": "this-is-a-stack",
-            "constructPath": "this-is-a-stack",
-            "workingDirectory": "stacks/this-is-a-stack",
-            "synthesizedStackPath": "stacks/this-is-a-stack/cdk.tf.json",
-            "stackMetadataPath": "stacks/this-is-a-stack/metadata.json",
             "annotations": [
               {
                 "constructPath": "this-is-a-stack",
@@ -113,9 +109,16 @@ describe("manifest annotations", () => {
                 "message": "an error"
               }
             ],
-            "dependencies": []
+            "constructPath": "this-is-a-stack",
+            "dependencies": [
+            ],
+            "name": "this-is-a-stack",
+            "stackMetadataPath": "stacks/this-is-a-stack/metadata.json",
+            "synthesizedStackPath": "stacks/this-is-a-stack/cdk.tf.json",
+            "workingDirectory": "stacks/this-is-a-stack"
           }
-        }
+        },
+        "version": "stubbed"
       }"
     `);
   });

--- a/test/python/cross-stack-references/test.ts
+++ b/test/python/cross-stack-references/test.ts
@@ -20,62 +20,68 @@ describe("python cross stack references", () => {
   onPosixWithoutHcl("synth generates JSON on POSIX", () => {
     expect(driver.manifest()).toMatchInlineSnapshot(`
       "{
-        "version": "stubbed",
         "stacks": {
-          "source": {
-            "name": "source",
-            "constructPath": "source",
-            "workingDirectory": "stacks/source",
-            "synthesizedStackPath": "stacks/source/cdk.tf.json",
-            "stackMetadataPath": "stacks/source/metadata.json",
-            "annotations": [],
-            "dependencies": []
-          },
-          "passthrough": {
-            "name": "passthrough",
-            "constructPath": "passthrough",
-            "workingDirectory": "stacks/passthrough",
-            "synthesizedStackPath": "stacks/passthrough/cdk.tf.json",
-            "stackMetadataPath": "stacks/passthrough/metadata.json",
-            "annotations": [],
-            "dependencies": [
-              "source"
-            ]
-          },
-          "sink": {
-            "name": "sink",
-            "constructPath": "sink",
-            "workingDirectory": "stacks/sink",
-            "synthesizedStackPath": "stacks/sink/cdk.tf.json",
-            "stackMetadataPath": "stacks/sink/metadata.json",
-            "annotations": [],
-            "dependencies": [
-              "source"
-            ]
-          },
           "fns": {
-            "name": "fns",
+            "annotations": [
+            ],
             "constructPath": "fns",
-            "workingDirectory": "stacks/fns",
-            "synthesizedStackPath": "stacks/fns/cdk.tf.json",
-            "stackMetadataPath": "stacks/fns/metadata.json",
-            "annotations": [],
             "dependencies": [
               "source"
-            ]
+            ],
+            "name": "fns",
+            "stackMetadataPath": "stacks/fns/metadata.json",
+            "synthesizedStackPath": "stacks/fns/cdk.tf.json",
+            "workingDirectory": "stacks/fns"
           },
           "functionOutput": {
-            "name": "functionOutput",
+            "annotations": [
+            ],
             "constructPath": "functionOutput",
-            "workingDirectory": "stacks/functionOutput",
-            "synthesizedStackPath": "stacks/functionOutput/cdk.tf.json",
-            "stackMetadataPath": "stacks/functionOutput/metadata.json",
-            "annotations": [],
             "dependencies": [
               "source"
-            ]
+            ],
+            "name": "functionOutput",
+            "stackMetadataPath": "stacks/functionOutput/metadata.json",
+            "synthesizedStackPath": "stacks/functionOutput/cdk.tf.json",
+            "workingDirectory": "stacks/functionOutput"
+          },
+          "passthrough": {
+            "annotations": [
+            ],
+            "constructPath": "passthrough",
+            "dependencies": [
+              "source"
+            ],
+            "name": "passthrough",
+            "stackMetadataPath": "stacks/passthrough/metadata.json",
+            "synthesizedStackPath": "stacks/passthrough/cdk.tf.json",
+            "workingDirectory": "stacks/passthrough"
+          },
+          "sink": {
+            "annotations": [
+            ],
+            "constructPath": "sink",
+            "dependencies": [
+              "source"
+            ],
+            "name": "sink",
+            "stackMetadataPath": "stacks/sink/metadata.json",
+            "synthesizedStackPath": "stacks/sink/cdk.tf.json",
+            "workingDirectory": "stacks/sink"
+          },
+          "source": {
+            "annotations": [
+            ],
+            "constructPath": "source",
+            "dependencies": [
+            ],
+            "name": "source",
+            "stackMetadataPath": "stacks/source/metadata.json",
+            "synthesizedStackPath": "stacks/source/cdk.tf.json",
+            "workingDirectory": "stacks/source"
           }
-        }
+        },
+        "version": "stubbed"
       }"
     `);
   });
@@ -83,62 +89,68 @@ describe("python cross stack references", () => {
   onPosixWithHcl("synth generates HCL on POSIX", () => {
     expect(driver.manifest()).toMatchInlineSnapshot(`
       "{
-        "version": "stubbed",
         "stacks": {
-          "source": {
-            "name": "source",
-            "constructPath": "source",
-            "workingDirectory": "stacks/source",
-            "synthesizedStackPath": "stacks/source/cdk.tf",
-            "stackMetadataPath": "stacks/source/metadata.json",
-            "annotations": [],
-            "dependencies": []
-          },
-          "passthrough": {
-            "name": "passthrough",
-            "constructPath": "passthrough",
-            "workingDirectory": "stacks/passthrough",
-            "synthesizedStackPath": "stacks/passthrough/cdk.tf",
-            "stackMetadataPath": "stacks/passthrough/metadata.json",
-            "annotations": [],
-            "dependencies": [
-              "source"
-            ]
-          },
-          "sink": {
-            "name": "sink",
-            "constructPath": "sink",
-            "workingDirectory": "stacks/sink",
-            "synthesizedStackPath": "stacks/sink/cdk.tf",
-            "stackMetadataPath": "stacks/sink/metadata.json",
-            "annotations": [],
-            "dependencies": [
-              "source"
-            ]
-          },
           "fns": {
-            "name": "fns",
+            "annotations": [
+            ],
             "constructPath": "fns",
-            "workingDirectory": "stacks/fns",
-            "synthesizedStackPath": "stacks/fns/cdk.tf",
-            "stackMetadataPath": "stacks/fns/metadata.json",
-            "annotations": [],
             "dependencies": [
               "source"
-            ]
+            ],
+            "name": "fns",
+            "stackMetadataPath": "stacks/fns/metadata.json",
+            "synthesizedStackPath": "stacks/fns/cdk.tf",
+            "workingDirectory": "stacks/fns"
           },
           "functionOutput": {
-            "name": "functionOutput",
+            "annotations": [
+            ],
             "constructPath": "functionOutput",
-            "workingDirectory": "stacks/functionOutput",
-            "synthesizedStackPath": "stacks/functionOutput/cdk.tf",
-            "stackMetadataPath": "stacks/functionOutput/metadata.json",
-            "annotations": [],
             "dependencies": [
               "source"
-            ]
+            ],
+            "name": "functionOutput",
+            "stackMetadataPath": "stacks/functionOutput/metadata.json",
+            "synthesizedStackPath": "stacks/functionOutput/cdk.tf",
+            "workingDirectory": "stacks/functionOutput"
+          },
+          "passthrough": {
+            "annotations": [
+            ],
+            "constructPath": "passthrough",
+            "dependencies": [
+              "source"
+            ],
+            "name": "passthrough",
+            "stackMetadataPath": "stacks/passthrough/metadata.json",
+            "synthesizedStackPath": "stacks/passthrough/cdk.tf",
+            "workingDirectory": "stacks/passthrough"
+          },
+          "sink": {
+            "annotations": [
+            ],
+            "constructPath": "sink",
+            "dependencies": [
+              "source"
+            ],
+            "name": "sink",
+            "stackMetadataPath": "stacks/sink/metadata.json",
+            "synthesizedStackPath": "stacks/sink/cdk.tf",
+            "workingDirectory": "stacks/sink"
+          },
+          "source": {
+            "annotations": [
+            ],
+            "constructPath": "source",
+            "dependencies": [
+            ],
+            "name": "source",
+            "stackMetadataPath": "stacks/source/metadata.json",
+            "synthesizedStackPath": "stacks/source/cdk.tf",
+            "workingDirectory": "stacks/source"
           }
-        }
+        },
+        "version": "stubbed"
       }"
     `);
   });
@@ -146,57 +158,68 @@ describe("python cross stack references", () => {
   onWindowsWithoutHcl("synth generates JSON on Windows", () => {
     expect(driver.manifest()).toMatchInlineSnapshot(`
       "{
-        "version": "stubbed",
         "stacks": {
-          "source": {
-            "name": "source",
-            "constructPath": "source",
-            "workingDirectory": "stacks\\\\source",
-            "synthesizedStackPath": "stacks\\\\source\\\\cdk.tf.json",
-            "annotations": [],
-            "dependencies": []
-          },
-          "passthrough": {
-            "name": "passthrough",
-            "constructPath": "passthrough",
-            "workingDirectory": "stacks\\\\passthrough",
-            "synthesizedStackPath": "stacks\\\\passthrough\\\\cdk.tf.json",
-            "annotations": [],
-            "dependencies": [
-              "source"
-            ]
-          },
-          "sink": {
-            "name": "sink",
-            "constructPath": "sink",
-            "workingDirectory": "stacks\\\\sink",
-            "synthesizedStackPath": "stacks\\\\sink\\\\cdk.tf.json",
-            "annotations": [],
-            "dependencies": [
-              "source"
-            ]
-          },
           "fns": {
-            "name": "fns",
+            "annotations": [
+            ],
             "constructPath": "fns",
-            "workingDirectory": "stacks\\\\fns",
-            "synthesizedStackPath": "stacks\\\\fns\\\\cdk.tf.json",
-            "annotations": [],
             "dependencies": [
               "source"
-            ]
+            ],
+            "name": "fns",
+            "stackMetadataPath": "stacks\\\\fns\\\\metadata.json",
+            "synthesizedStackPath": "stacks\\\\fns\\\\cdk.tf.json",
+            "workingDirectory": "stacks\\\\fns"
           },
           "functionOutput": {
-            "name": "functionOutput",
+            "annotations": [
+            ],
             "constructPath": "functionOutput",
-            "workingDirectory": "stacks\\\\functionOutput",
-            "synthesizedStackPath": "stacks\\\\functionOutput\\\\cdk.tf.json",
-            "annotations": [],
             "dependencies": [
               "source"
-            ]
+            ],
+            "name": "functionOutput",
+            "stackMetadataPath": "stacks\\\\functionOutput\\\\metadata.json",
+            "synthesizedStackPath": "stacks\\\\functionOutput\\\\cdk.tf.json",
+            "workingDirectory": "stacks\\\\functionOutput"
+          },
+          "passthrough": {
+            "annotations": [
+            ],
+            "constructPath": "passthrough",
+            "dependencies": [
+              "source"
+            ],
+            "name": "passthrough",
+            "stackMetadataPath": "stacks\\\\passthrough\\\\metadata.json",
+            "synthesizedStackPath": "stacks\\\\passthrough\\\\cdk.tf.json",
+            "workingDirectory": "stacks\\\\passthrough"
+          },
+          "sink": {
+            "annotations": [
+            ],
+            "constructPath": "sink",
+            "dependencies": [
+              "source"
+            ],
+            "name": "sink",
+            "stackMetadataPath": "stacks\\\\sink\\\\metadata.json",
+            "synthesizedStackPath": "stacks\\\\sink\\\\cdk.tf.json",
+            "workingDirectory": "stacks\\\\sink"
+          },
+          "source": {
+            "annotations": [
+            ],
+            "constructPath": "source",
+            "dependencies": [
+            ],
+            "name": "source",
+            "stackMetadataPath": "stacks\\\\source\\\\metadata.json",
+            "synthesizedStackPath": "stacks\\\\source\\\\cdk.tf.json",
+            "workingDirectory": "stacks\\\\source"
           }
-        }
+        },
+        "version": "stubbed"
       }"
     `);
   });
@@ -204,57 +227,68 @@ describe("python cross stack references", () => {
   onWindowsWithHcl("synth generates HCL on Windows", () => {
     expect(driver.manifest()).toMatchInlineSnapshot(`
       "{
-        "version": "stubbed",
         "stacks": {
-          "source": {
-            "name": "source",
-            "constructPath": "source",
-            "workingDirectory": "stacks\\\\source",
-            "synthesizedStackPath": "stacks\\\\source\\\\cdk.tf",
-            "annotations": [],
-            "dependencies": []
-          },
-          "passthrough": {
-            "name": "passthrough",
-            "constructPath": "passthrough",
-            "workingDirectory": "stacks\\\\passthrough",
-            "synthesizedStackPath": "stacks\\\\passthrough\\\\cdk.tf",
-            "annotations": [],
-            "dependencies": [
-              "source"
-            ]
-          },
-          "sink": {
-            "name": "sink",
-            "constructPath": "sink",
-            "workingDirectory": "stacks\\\\sink",
-            "synthesizedStackPath": "stacks\\\\sink\\\\cdk.tf",
-            "annotations": [],
-            "dependencies": [
-              "source"
-            ]
-          },
           "fns": {
-            "name": "fns",
+            "annotations": [
+            ],
             "constructPath": "fns",
-            "workingDirectory": "stacks\\\\fns",
-            "synthesizedStackPath": "stacks\\\\fns\\\\cdk.tf",
-            "annotations": [],
             "dependencies": [
               "source"
-            ]
+            ],
+            "name": "fns",
+            "stackMetadataPath": "stacks\\\\fns\\\\metadata.json",
+            "synthesizedStackPath": "stacks\\\\fns\\\\cdk.tf",
+            "workingDirectory": "stacks\\\\fns"
           },
           "functionOutput": {
-            "name": "functionOutput",
+            "annotations": [
+            ],
             "constructPath": "functionOutput",
-            "workingDirectory": "stacks\\\\functionOutput",
-            "synthesizedStackPath": "stacks\\\\functionOutput\\\\cdk.tf",
-            "annotations": [],
             "dependencies": [
               "source"
-            ]
+            ],
+            "name": "functionOutput",
+            "stackMetadataPath": "stacks\\\\functionOutput\\\\metadata.json",
+            "synthesizedStackPath": "stacks\\\\functionOutput\\\\cdk.tf",
+            "workingDirectory": "stacks\\\\functionOutput"
+          },
+          "passthrough": {
+            "annotations": [
+            ],
+            "constructPath": "passthrough",
+            "dependencies": [
+              "source"
+            ],
+            "name": "passthrough",
+            "stackMetadataPath": "stacks\\\\passthrough\\\\metadata.json",
+            "synthesizedStackPath": "stacks\\\\passthrough\\\\cdk.tf",
+            "workingDirectory": "stacks\\\\passthrough"
+          },
+          "sink": {
+            "annotations": [
+            ],
+            "constructPath": "sink",
+            "dependencies": [
+              "source"
+            ],
+            "name": "sink",
+            "stackMetadataPath": "stacks\\\\sink\\\\metadata.json",
+            "synthesizedStackPath": "stacks\\\\sink\\\\cdk.tf",
+            "workingDirectory": "stacks\\\\sink"
+          },
+          "source": {
+            "annotations": [
+            ],
+            "constructPath": "source",
+            "dependencies": [
+            ],
+            "name": "source",
+            "stackMetadataPath": "stacks\\\\source\\\\metadata.json",
+            "synthesizedStackPath": "stacks\\\\source\\\\cdk.tf",
+            "workingDirectory": "stacks\\\\source"
           }
-        }
+        },
+        "version": "stubbed"
       }"
     `);
   });

--- a/test/typescript/cross-stack-references/test.ts
+++ b/test/typescript/cross-stack-references/test.ts
@@ -20,102 +20,114 @@ describe("cross stack references", () => {
   onPosixWithoutHcl("synth generates JSON on POSIX", () => {
     expect(driver.manifest()).toMatchInlineSnapshot(`
       "{
-        "version": "stubbed",
         "stacks": {
-          "origin": {
-            "name": "origin",
-            "constructPath": "origin",
-            "workingDirectory": "stacks/origin",
-            "synthesizedStackPath": "stacks/origin/cdk.tf.json",
-            "stackMetadataPath": "stacks/origin/metadata.json",
-            "annotations": [],
-            "dependencies": []
-          },
-          "passthrough": {
-            "name": "passthrough",
-            "constructPath": "passthrough",
-            "workingDirectory": "stacks/passthrough",
-            "synthesizedStackPath": "stacks/passthrough/cdk.tf.json",
-            "stackMetadataPath": "stacks/passthrough/metadata.json",
-            "annotations": [],
-            "dependencies": [
-              "origin"
-            ]
-          },
-          "sink": {
-            "name": "sink",
-            "constructPath": "sink",
-            "workingDirectory": "stacks/sink",
-            "synthesizedStackPath": "stacks/sink/cdk.tf.json",
-            "stackMetadataPath": "stacks/sink/metadata.json",
-            "annotations": [],
-            "dependencies": [
-              "origin"
-            ]
-          },
           "fns": {
-            "name": "fns",
+            "annotations": [
+            ],
             "constructPath": "fns",
-            "workingDirectory": "stacks/fns",
-            "synthesizedStackPath": "stacks/fns/cdk.tf.json",
-            "stackMetadataPath": "stacks/fns/metadata.json",
-            "annotations": [],
             "dependencies": [
               "origin"
-            ]
+            ],
+            "name": "fns",
+            "stackMetadataPath": "stacks/fns/metadata.json",
+            "synthesizedStackPath": "stacks/fns/cdk.tf.json",
+            "workingDirectory": "stacks/fns"
           },
           "functionOutput": {
-            "name": "functionOutput",
+            "annotations": [
+            ],
             "constructPath": "functionOutput",
-            "workingDirectory": "stacks/functionOutput",
-            "synthesizedStackPath": "stacks/functionOutput/cdk.tf.json",
+            "dependencies": [
+              "origin"
+            ],
+            "name": "functionOutput",
             "stackMetadataPath": "stacks/functionOutput/metadata.json",
-            "annotations": [],
-            "dependencies": [
-              "origin"
-            ]
-          },
-          "pinnedFns": {
-            "name": "pinnedFns",
-            "constructPath": "pinnedFns",
-            "workingDirectory": "stacks/pinnedFns",
-            "synthesizedStackPath": "stacks/pinnedFns/cdk.tf.json",
-            "stackMetadataPath": "stacks/pinnedFns/metadata.json",
-            "annotations": [],
-            "dependencies": [
-              "origin"
-            ]
+            "synthesizedStackPath": "stacks/functionOutput/cdk.tf.json",
+            "workingDirectory": "stacks/functionOutput"
           },
           "functionOutputPinned": {
-            "name": "functionOutputPinned",
+            "annotations": [
+            ],
             "constructPath": "functionOutputPinned",
-            "workingDirectory": "stacks/functionOutputPinned",
-            "synthesizedStackPath": "stacks/functionOutputPinned/cdk.tf.json",
-            "stackMetadataPath": "stacks/functionOutputPinned/metadata.json",
-            "annotations": [],
             "dependencies": [
               "pinnedFns"
-            ]
+            ],
+            "name": "functionOutputPinned",
+            "stackMetadataPath": "stacks/functionOutputPinned/metadata.json",
+            "synthesizedStackPath": "stacks/functionOutputPinned/cdk.tf.json",
+            "workingDirectory": "stacks/functionOutputPinned"
+          },
+          "origin": {
+            "annotations": [
+            ],
+            "constructPath": "origin",
+            "dependencies": [
+            ],
+            "name": "origin",
+            "stackMetadataPath": "stacks/origin/metadata.json",
+            "synthesizedStackPath": "stacks/origin/cdk.tf.json",
+            "workingDirectory": "stacks/origin"
+          },
+          "passthrough": {
+            "annotations": [
+            ],
+            "constructPath": "passthrough",
+            "dependencies": [
+              "origin"
+            ],
+            "name": "passthrough",
+            "stackMetadataPath": "stacks/passthrough/metadata.json",
+            "synthesizedStackPath": "stacks/passthrough/cdk.tf.json",
+            "workingDirectory": "stacks/passthrough"
+          },
+          "pinnedFns": {
+            "annotations": [
+            ],
+            "constructPath": "pinnedFns",
+            "dependencies": [
+              "origin"
+            ],
+            "name": "pinnedFns",
+            "stackMetadataPath": "stacks/pinnedFns/metadata.json",
+            "synthesizedStackPath": "stacks/pinnedFns/cdk.tf.json",
+            "workingDirectory": "stacks/pinnedFns"
           },
           "secondOrigin": {
-            "name": "secondOrigin",
+            "annotations": [
+            ],
             "constructPath": "secondOrigin",
-            "workingDirectory": "stacks/secondOrigin",
-            "synthesizedStackPath": "stacks/secondOrigin/cdk.tf.json",
+            "dependencies": [
+            ],
+            "name": "secondOrigin",
             "stackMetadataPath": "stacks/secondOrigin/metadata.json",
-            "annotations": [],
-            "dependencies": []
+            "synthesizedStackPath": "stacks/secondOrigin/cdk.tf.json",
+            "workingDirectory": "stacks/secondOrigin"
+          },
+          "sink": {
+            "annotations": [
+            ],
+            "constructPath": "sink",
+            "dependencies": [
+              "origin"
+            ],
+            "name": "sink",
+            "stackMetadataPath": "stacks/sink/metadata.json",
+            "synthesizedStackPath": "stacks/sink/cdk.tf.json",
+            "workingDirectory": "stacks/sink"
           },
           "switchedStack": {
-            "name": "switchedStack",
+            "annotations": [
+            ],
             "constructPath": "switchedStack",
-            "workingDirectory": "stacks/switchedStack",
-            "synthesizedStackPath": "stacks/switchedStack/cdk.tf.json",
+            "dependencies": [
+            ],
+            "name": "switchedStack",
             "stackMetadataPath": "stacks/switchedStack/metadata.json",
-            "annotations": [],
-            "dependencies": []
+            "synthesizedStackPath": "stacks/switchedStack/cdk.tf.json",
+            "workingDirectory": "stacks/switchedStack"
           }
-        }
+        },
+        "version": "stubbed"
       }"
     `);
   });
@@ -123,102 +135,114 @@ describe("cross stack references", () => {
   onPosixWithHcl("synth generates HCL on POSIX", () => {
     expect(driver.manifest()).toMatchInlineSnapshot(`
       "{
-        "version": "stubbed",
         "stacks": {
-          "origin": {
-            "name": "origin",
-            "constructPath": "origin",
-            "workingDirectory": "stacks/origin",
-            "synthesizedStackPath": "stacks/origin/cdk.tf",
-            "stackMetadataPath": "stacks/origin/metadata.json",
-            "annotations": [],
-            "dependencies": []
-          },
-          "passthrough": {
-            "name": "passthrough",
-            "constructPath": "passthrough",
-            "workingDirectory": "stacks/passthrough",
-            "synthesizedStackPath": "stacks/passthrough/cdk.tf",
-            "stackMetadataPath": "stacks/passthrough/metadata.json",
-            "annotations": [],
-            "dependencies": [
-              "origin"
-            ]
-          },
-          "sink": {
-            "name": "sink",
-            "constructPath": "sink",
-            "workingDirectory": "stacks/sink",
-            "synthesizedStackPath": "stacks/sink/cdk.tf",
-            "stackMetadataPath": "stacks/sink/metadata.json",
-            "annotations": [],
-            "dependencies": [
-              "origin"
-            ]
-          },
           "fns": {
-            "name": "fns",
+            "annotations": [
+            ],
             "constructPath": "fns",
-            "workingDirectory": "stacks/fns",
-            "synthesizedStackPath": "stacks/fns/cdk.tf",
-            "stackMetadataPath": "stacks/fns/metadata.json",
-            "annotations": [],
             "dependencies": [
               "origin"
-            ]
+            ],
+            "name": "fns",
+            "stackMetadataPath": "stacks/fns/metadata.json",
+            "synthesizedStackPath": "stacks/fns/cdk.tf",
+            "workingDirectory": "stacks/fns"
           },
           "functionOutput": {
-            "name": "functionOutput",
+            "annotations": [
+            ],
             "constructPath": "functionOutput",
-            "workingDirectory": "stacks/functionOutput",
-            "synthesizedStackPath": "stacks/functionOutput/cdk.tf",
+            "dependencies": [
+              "origin"
+            ],
+            "name": "functionOutput",
             "stackMetadataPath": "stacks/functionOutput/metadata.json",
-            "annotations": [],
-            "dependencies": [
-              "origin"
-            ]
-          },
-          "pinnedFns": {
-            "name": "pinnedFns",
-            "constructPath": "pinnedFns",
-            "workingDirectory": "stacks/pinnedFns",
-            "synthesizedStackPath": "stacks/pinnedFns/cdk.tf",
-            "stackMetadataPath": "stacks/pinnedFns/metadata.json",
-            "annotations": [],
-            "dependencies": [
-              "origin"
-            ]
+            "synthesizedStackPath": "stacks/functionOutput/cdk.tf",
+            "workingDirectory": "stacks/functionOutput"
           },
           "functionOutputPinned": {
-            "name": "functionOutputPinned",
+            "annotations": [
+            ],
             "constructPath": "functionOutputPinned",
-            "workingDirectory": "stacks/functionOutputPinned",
-            "synthesizedStackPath": "stacks/functionOutputPinned/cdk.tf",
-            "stackMetadataPath": "stacks/functionOutputPinned/metadata.json",
-            "annotations": [],
             "dependencies": [
               "pinnedFns"
-            ]
+            ],
+            "name": "functionOutputPinned",
+            "stackMetadataPath": "stacks/functionOutputPinned/metadata.json",
+            "synthesizedStackPath": "stacks/functionOutputPinned/cdk.tf",
+            "workingDirectory": "stacks/functionOutputPinned"
+          },
+          "origin": {
+            "annotations": [
+            ],
+            "constructPath": "origin",
+            "dependencies": [
+            ],
+            "name": "origin",
+            "stackMetadataPath": "stacks/origin/metadata.json",
+            "synthesizedStackPath": "stacks/origin/cdk.tf",
+            "workingDirectory": "stacks/origin"
+          },
+          "passthrough": {
+            "annotations": [
+            ],
+            "constructPath": "passthrough",
+            "dependencies": [
+              "origin"
+            ],
+            "name": "passthrough",
+            "stackMetadataPath": "stacks/passthrough/metadata.json",
+            "synthesizedStackPath": "stacks/passthrough/cdk.tf",
+            "workingDirectory": "stacks/passthrough"
+          },
+          "pinnedFns": {
+            "annotations": [
+            ],
+            "constructPath": "pinnedFns",
+            "dependencies": [
+              "origin"
+            ],
+            "name": "pinnedFns",
+            "stackMetadataPath": "stacks/pinnedFns/metadata.json",
+            "synthesizedStackPath": "stacks/pinnedFns/cdk.tf",
+            "workingDirectory": "stacks/pinnedFns"
           },
           "secondOrigin": {
-            "name": "secondOrigin",
+            "annotations": [
+            ],
             "constructPath": "secondOrigin",
-            "workingDirectory": "stacks/secondOrigin",
-            "synthesizedStackPath": "stacks/secondOrigin/cdk.tf",
+            "dependencies": [
+            ],
+            "name": "secondOrigin",
             "stackMetadataPath": "stacks/secondOrigin/metadata.json",
-            "annotations": [],
-            "dependencies": []
+            "synthesizedStackPath": "stacks/secondOrigin/cdk.tf",
+            "workingDirectory": "stacks/secondOrigin"
+          },
+          "sink": {
+            "annotations": [
+            ],
+            "constructPath": "sink",
+            "dependencies": [
+              "origin"
+            ],
+            "name": "sink",
+            "stackMetadataPath": "stacks/sink/metadata.json",
+            "synthesizedStackPath": "stacks/sink/cdk.tf",
+            "workingDirectory": "stacks/sink"
           },
           "switchedStack": {
-            "name": "switchedStack",
+            "annotations": [
+            ],
             "constructPath": "switchedStack",
-            "workingDirectory": "stacks/switchedStack",
-            "synthesizedStackPath": "stacks/switchedStack/cdk.tf",
+            "dependencies": [
+            ],
+            "name": "switchedStack",
             "stackMetadataPath": "stacks/switchedStack/metadata.json",
-            "annotations": [],
-            "dependencies": []
+            "synthesizedStackPath": "stacks/switchedStack/cdk.tf",
+            "workingDirectory": "stacks/switchedStack"
           }
-        }
+        },
+        "version": "stubbed"
       }"
     `);
   });
@@ -226,93 +250,114 @@ describe("cross stack references", () => {
   onWindowsWithoutHcl("synth generates JSON on Windows", () => {
     expect(driver.manifest()).toMatchInlineSnapshot(`
       "{
-        "version": "stubbed",
         "stacks": {
-          "origin": {
-            "name": "origin",
-            "constructPath": "origin",
-            "workingDirectory": "stacks\\\\origin",
-            "synthesizedStackPath": "stacks\\\\origin\\\\cdk.tf.json",
-            "annotations": [],
-            "dependencies": []
-          },
-          "passthrough": {
-            "name": "passthrough",
-            "constructPath": "passthrough",
-            "workingDirectory": "stacks\\\\passthrough",
-            "synthesizedStackPath": "stacks\\\\passthrough\\\\cdk.tf.json",
-            "annotations": [],
-            "dependencies": [
-              "origin"
-            ]
-          },
-          "sink": {
-            "name": "sink",
-            "constructPath": "sink",
-            "workingDirectory": "stacks\\\\sink",
-            "synthesizedStackPath": "stacks\\\\sink\\\\cdk.tf.json",
-            "annotations": [],
-            "dependencies": [
-              "origin"
-            ]
-          },
           "fns": {
-            "name": "fns",
+            "annotations": [
+            ],
             "constructPath": "fns",
-            "workingDirectory": "stacks\\\\fns",
-            "synthesizedStackPath": "stacks\\\\fns\\\\cdk.tf.json",
-            "annotations": [],
             "dependencies": [
               "origin"
-            ]
+            ],
+            "name": "fns",
+            "stackMetadataPath": "stacks\\\\fns\\\\metadata.json",
+            "synthesizedStackPath": "stacks\\\\fns\\\\cdk.tf.json",
+            "workingDirectory": "stacks\\\\fns"
           },
           "functionOutput": {
-            "name": "functionOutput",
+            "annotations": [
+            ],
             "constructPath": "functionOutput",
-            "workingDirectory": "stacks\\\\functionOutput",
+            "dependencies": [
+              "origin"
+            ],
+            "name": "functionOutput",
+            "stackMetadataPath": "stacks\\\\functionOutput\\\\metadata.json",
             "synthesizedStackPath": "stacks\\\\functionOutput\\\\cdk.tf.json",
-            "annotations": [],
-            "dependencies": [
-              "origin"
-            ]
-          },
-          "pinnedFns": {
-            "name": "pinnedFns",
-            "constructPath": "pinnedFns",
-            "workingDirectory": "stacks\\\\pinnedFns",
-            "synthesizedStackPath": "stacks\\\\pinnedFns\\\\cdk.tf.json",
-            "annotations": [],
-            "dependencies": [
-              "origin"
-            ]
+            "workingDirectory": "stacks\\\\functionOutput"
           },
           "functionOutputPinned": {
-            "name": "functionOutputPinned",
+            "annotations": [
+            ],
             "constructPath": "functionOutputPinned",
-            "workingDirectory": "stacks\\\\functionOutputPinned",
-            "synthesizedStackPath": "stacks\\\\functionOutputPinned\\\\cdk.tf.json",
-            "annotations": [],
             "dependencies": [
               "pinnedFns"
-            ]
+            ],
+            "name": "functionOutputPinned",
+            "stackMetadataPath": "stacks\\\\functionOutputPinned\\\\metadata.json",
+            "synthesizedStackPath": "stacks\\\\functionOutputPinned\\\\cdk.tf.json",
+            "workingDirectory": "stacks\\\\functionOutputPinned"
+          },
+          "origin": {
+            "annotations": [
+            ],
+            "constructPath": "origin",
+            "dependencies": [
+            ],
+            "name": "origin",
+            "stackMetadataPath": "stacks\\\\origin\\\\metadata.json",
+            "synthesizedStackPath": "stacks\\\\origin\\\\cdk.tf.json",
+            "workingDirectory": "stacks\\\\origin"
+          },
+          "passthrough": {
+            "annotations": [
+            ],
+            "constructPath": "passthrough",
+            "dependencies": [
+              "origin"
+            ],
+            "name": "passthrough",
+            "stackMetadataPath": "stacks\\\\passthrough\\\\metadata.json",
+            "synthesizedStackPath": "stacks\\\\passthrough\\\\cdk.tf.json",
+            "workingDirectory": "stacks\\\\passthrough"
+          },
+          "pinnedFns": {
+            "annotations": [
+            ],
+            "constructPath": "pinnedFns",
+            "dependencies": [
+              "origin"
+            ],
+            "name": "pinnedFns",
+            "stackMetadataPath": "stacks\\\\pinnedFns\\\\metadata.json",
+            "synthesizedStackPath": "stacks\\\\pinnedFns\\\\cdk.tf.json",
+            "workingDirectory": "stacks\\\\pinnedFns"
           },
           "secondOrigin": {
-            "name": "secondOrigin",
+            "annotations": [
+            ],
             "constructPath": "secondOrigin",
-            "workingDirectory": "stacks\\\\secondOrigin",
+            "dependencies": [
+            ],
+            "name": "secondOrigin",
+            "stackMetadataPath": "stacks\\\\secondOrigin\\\\metadata.json",
             "synthesizedStackPath": "stacks\\\\secondOrigin\\\\cdk.tf.json",
-            "annotations": [],
-            "dependencies": []
+            "workingDirectory": "stacks\\\\secondOrigin"
+          },
+          "sink": {
+            "annotations": [
+            ],
+            "constructPath": "sink",
+            "dependencies": [
+              "origin"
+            ],
+            "name": "sink",
+            "stackMetadataPath": "stacks\\\\sink\\\\metadata.json",
+            "synthesizedStackPath": "stacks\\\\sink\\\\cdk.tf.json",
+            "workingDirectory": "stacks\\\\sink"
           },
           "switchedStack": {
-            "name": "switchedStack",
+            "annotations": [
+            ],
             "constructPath": "switchedStack",
-            "workingDirectory": "stacks\\\\switchedStack",
+            "dependencies": [
+            ],
+            "name": "switchedStack",
+            "stackMetadataPath": "stacks\\\\switchedStack\\\\metadata.json",
             "synthesizedStackPath": "stacks\\\\switchedStack\\\\cdk.tf.json",
-            "annotations": [],
-            "dependencies": []
+            "workingDirectory": "stacks\\\\switchedStack"
           }
-        }
+        },
+        "version": "stubbed"
       }"
     `);
   });
@@ -320,93 +365,114 @@ describe("cross stack references", () => {
   onWindowsWithHcl("synth generates HCL on Windows", () => {
     expect(driver.manifest()).toMatchInlineSnapshot(`
       "{
-        "version": "stubbed",
         "stacks": {
-          "origin": {
-            "name": "origin",
-            "constructPath": "origin",
-            "workingDirectory": "stacks\\\\origin",
-            "synthesizedStackPath": "stacks\\\\origin\\\\cdk.tf",
-            "annotations": [],
-            "dependencies": []
-          },
-          "passthrough": {
-            "name": "passthrough",
-            "constructPath": "passthrough",
-            "workingDirectory": "stacks\\\\passthrough",
-            "synthesizedStackPath": "stacks\\\\passthrough\\\\cdk.tf",
-            "annotations": [],
-            "dependencies": [
-              "origin"
-            ]
-          },
-          "sink": {
-            "name": "sink",
-            "constructPath": "sink",
-            "workingDirectory": "stacks\\\\sink",
-            "synthesizedStackPath": "stacks\\\\sink\\\\cdk.tf",
-            "annotations": [],
-            "dependencies": [
-              "origin"
-            ]
-          },
           "fns": {
-            "name": "fns",
+            "annotations": [
+            ],
             "constructPath": "fns",
-            "workingDirectory": "stacks\\\\fns",
-            "synthesizedStackPath": "stacks\\\\fns\\\\cdk.tf",
-            "annotations": [],
             "dependencies": [
               "origin"
-            ]
+            ],
+            "name": "fns",
+            "stackMetadataPath": "stacks\\\\fns\\\\metadata.json",
+            "synthesizedStackPath": "stacks\\\\fns\\\\cdk.tf",
+            "workingDirectory": "stacks\\\\fns"
           },
           "functionOutput": {
-            "name": "functionOutput",
+            "annotations": [
+            ],
             "constructPath": "functionOutput",
-            "workingDirectory": "stacks\\\\functionOutput",
+            "dependencies": [
+              "origin"
+            ],
+            "name": "functionOutput",
+            "stackMetadataPath": "stacks\\\\functionOutput\\\\metadata.json",
             "synthesizedStackPath": "stacks\\\\functionOutput\\\\cdk.tf",
-            "annotations": [],
-            "dependencies": [
-              "origin"
-            ]
-          },
-          "pinnedFns": {
-            "name": "pinnedFns",
-            "constructPath": "pinnedFns",
-            "workingDirectory": "stacks\\\\pinnedFns",
-            "synthesizedStackPath": "stacks\\\\pinnedFns\\\\cdk.tf",
-            "annotations": [],
-            "dependencies": [
-              "origin"
-            ]
+            "workingDirectory": "stacks\\\\functionOutput"
           },
           "functionOutputPinned": {
-            "name": "functionOutputPinned",
+            "annotations": [
+            ],
             "constructPath": "functionOutputPinned",
-            "workingDirectory": "stacks\\\\functionOutputPinned",
-            "synthesizedStackPath": "stacks\\\\functionOutputPinned\\\\cdk.tf",
-            "annotations": [],
             "dependencies": [
               "pinnedFns"
-            ]
+            ],
+            "name": "functionOutputPinned",
+            "stackMetadataPath": "stacks\\\\functionOutputPinned\\\\metadata.json",
+            "synthesizedStackPath": "stacks\\\\functionOutputPinned\\\\cdk.tf",
+            "workingDirectory": "stacks\\\\functionOutputPinned"
+          },
+          "origin": {
+            "annotations": [
+            ],
+            "constructPath": "origin",
+            "dependencies": [
+            ],
+            "name": "origin",
+            "stackMetadataPath": "stacks\\\\origin\\\\metadata.json",
+            "synthesizedStackPath": "stacks\\\\origin\\\\cdk.tf",
+            "workingDirectory": "stacks\\\\origin"
+          },
+          "passthrough": {
+            "annotations": [
+            ],
+            "constructPath": "passthrough",
+            "dependencies": [
+              "origin"
+            ],
+            "name": "passthrough",
+            "stackMetadataPath": "stacks\\\\passthrough\\\\metadata.json",
+            "synthesizedStackPath": "stacks\\\\passthrough\\\\cdk.tf",
+            "workingDirectory": "stacks\\\\passthrough"
+          },
+          "pinnedFns": {
+            "annotations": [
+            ],
+            "constructPath": "pinnedFns",
+            "dependencies": [
+              "origin"
+            ],
+            "name": "pinnedFns",
+            "stackMetadataPath": "stacks\\\\pinnedFns\\\\metadata.json",
+            "synthesizedStackPath": "stacks\\\\pinnedFns\\\\cdk.tf",
+            "workingDirectory": "stacks\\\\pinnedFns"
           },
           "secondOrigin": {
-            "name": "secondOrigin",
+            "annotations": [
+            ],
             "constructPath": "secondOrigin",
-            "workingDirectory": "stacks\\\\secondOrigin",
+            "dependencies": [
+            ],
+            "name": "secondOrigin",
+            "stackMetadataPath": "stacks\\\\secondOrigin\\\\metadata.json",
             "synthesizedStackPath": "stacks\\\\secondOrigin\\\\cdk.tf",
-            "annotations": [],
-            "dependencies": []
+            "workingDirectory": "stacks\\\\secondOrigin"
+          },
+          "sink": {
+            "annotations": [
+            ],
+            "constructPath": "sink",
+            "dependencies": [
+              "origin"
+            ],
+            "name": "sink",
+            "stackMetadataPath": "stacks\\\\sink\\\\metadata.json",
+            "synthesizedStackPath": "stacks\\\\sink\\\\cdk.tf",
+            "workingDirectory": "stacks\\\\sink"
           },
           "switchedStack": {
-            "name": "switchedStack",
+            "annotations": [
+            ],
             "constructPath": "switchedStack",
-            "workingDirectory": "stacks\\\\switchedStack",
+            "dependencies": [
+            ],
+            "name": "switchedStack",
+            "stackMetadataPath": "stacks\\\\switchedStack\\\\metadata.json",
             "synthesizedStackPath": "stacks\\\\switchedStack\\\\cdk.tf",
-            "annotations": [],
-            "dependencies": []
+            "workingDirectory": "stacks\\\\switchedStack"
           }
-        }
+        },
+        "version": "stubbed"
       }"
     `);
   });
@@ -485,210 +551,233 @@ describe("cross stack references", () => {
         await driver.deploy(["secondOrigin", "switchedStack"]);
 
         expect(driver.manifest()).toMatchInlineSnapshot(`
-        "{
-          "version": "stubbed",
-          "stacks": {
-            "origin": {
-              "name": "origin",
-              "constructPath": "origin",
-              "workingDirectory": "stacks/origin",
-              "synthesizedStackPath": "stacks/origin/cdk.tf.json",
-              "stackMetadataPath": "stacks/origin/metadata.json",
-              "annotations": [],
-              "dependencies": []
+          "{
+            "stacks": {
+              "fns": {
+                "annotations": [
+                ],
+                "constructPath": "fns",
+                "dependencies": [
+                  "origin"
+                ],
+                "name": "fns",
+                "stackMetadataPath": "stacks/fns/metadata.json",
+                "synthesizedStackPath": "stacks/fns/cdk.tf.json",
+                "workingDirectory": "stacks/fns"
+              },
+              "functionOutput": {
+                "annotations": [
+                ],
+                "constructPath": "functionOutput",
+                "dependencies": [
+                  "origin"
+                ],
+                "name": "functionOutput",
+                "stackMetadataPath": "stacks/functionOutput/metadata.json",
+                "synthesizedStackPath": "stacks/functionOutput/cdk.tf.json",
+                "workingDirectory": "stacks/functionOutput"
+              },
+              "functionOutputPinned": {
+                "annotations": [
+                ],
+                "constructPath": "functionOutputPinned",
+                "dependencies": [
+                  "pinnedFns"
+                ],
+                "name": "functionOutputPinned",
+                "stackMetadataPath": "stacks/functionOutputPinned/metadata.json",
+                "synthesizedStackPath": "stacks/functionOutputPinned/cdk.tf.json",
+                "workingDirectory": "stacks/functionOutputPinned"
+              },
+              "origin": {
+                "annotations": [
+                ],
+                "constructPath": "origin",
+                "dependencies": [
+                ],
+                "name": "origin",
+                "stackMetadataPath": "stacks/origin/metadata.json",
+                "synthesizedStackPath": "stacks/origin/cdk.tf.json",
+                "workingDirectory": "stacks/origin"
+              },
+              "passthrough": {
+                "annotations": [
+                ],
+                "constructPath": "passthrough",
+                "dependencies": [
+                  "origin"
+                ],
+                "name": "passthrough",
+                "stackMetadataPath": "stacks/passthrough/metadata.json",
+                "synthesizedStackPath": "stacks/passthrough/cdk.tf.json",
+                "workingDirectory": "stacks/passthrough"
+              },
+              "pinnedFns": {
+                "annotations": [
+                ],
+                "constructPath": "pinnedFns",
+                "dependencies": [
+                  "origin"
+                ],
+                "name": "pinnedFns",
+                "stackMetadataPath": "stacks/pinnedFns/metadata.json",
+                "synthesizedStackPath": "stacks/pinnedFns/cdk.tf.json",
+                "workingDirectory": "stacks/pinnedFns"
+              },
+              "secondOrigin": {
+                "annotations": [
+                ],
+                "constructPath": "secondOrigin",
+                "dependencies": [
+                ],
+                "name": "secondOrigin",
+                "stackMetadataPath": "stacks/secondOrigin/metadata.json",
+                "synthesizedStackPath": "stacks/secondOrigin/cdk.tf.json",
+                "workingDirectory": "stacks/secondOrigin"
+              },
+              "sink": {
+                "annotations": [
+                ],
+                "constructPath": "sink",
+                "dependencies": [
+                  "origin"
+                ],
+                "name": "sink",
+                "stackMetadataPath": "stacks/sink/metadata.json",
+                "synthesizedStackPath": "stacks/sink/cdk.tf.json",
+                "workingDirectory": "stacks/sink"
+              },
+              "switchedStack": {
+                "annotations": [
+                ],
+                "constructPath": "switchedStack",
+                "dependencies": [
+                  "secondOrigin"
+                ],
+                "name": "switchedStack",
+                "stackMetadataPath": "stacks/switchedStack/metadata.json",
+                "synthesizedStackPath": "stacks/switchedStack/cdk.tf.json",
+                "workingDirectory": "stacks/switchedStack"
+              }
             },
-            "passthrough": {
-              "name": "passthrough",
-              "constructPath": "passthrough",
-              "workingDirectory": "stacks/passthrough",
-              "synthesizedStackPath": "stacks/passthrough/cdk.tf.json",
-              "stackMetadataPath": "stacks/passthrough/metadata.json",
-              "annotations": [],
-              "dependencies": [
-                "origin"
-              ]
-            },
-            "sink": {
-              "name": "sink",
-              "constructPath": "sink",
-              "workingDirectory": "stacks/sink",
-              "synthesizedStackPath": "stacks/sink/cdk.tf.json",
-              "stackMetadataPath": "stacks/sink/metadata.json",
-              "annotations": [],
-              "dependencies": [
-                "origin"
-              ]
-            },
-            "fns": {
-              "name": "fns",
-              "constructPath": "fns",
-              "workingDirectory": "stacks/fns",
-              "synthesizedStackPath": "stacks/fns/cdk.tf.json",
-              "stackMetadataPath": "stacks/fns/metadata.json",
-              "annotations": [],
-              "dependencies": [
-                "origin"
-              ]
-            },
-            "functionOutput": {
-              "name": "functionOutput",
-              "constructPath": "functionOutput",
-              "workingDirectory": "stacks/functionOutput",
-              "synthesizedStackPath": "stacks/functionOutput/cdk.tf.json",
-              "stackMetadataPath": "stacks/functionOutput/metadata.json",
-              "annotations": [],
-              "dependencies": [
-                "origin"
-              ]
-            },
-            "pinnedFns": {
-              "name": "pinnedFns",
-              "constructPath": "pinnedFns",
-              "workingDirectory": "stacks/pinnedFns",
-              "synthesizedStackPath": "stacks/pinnedFns/cdk.tf.json",
-              "stackMetadataPath": "stacks/pinnedFns/metadata.json",
-              "annotations": [],
-              "dependencies": [
-                "origin"
-              ]
-            },
-            "functionOutputPinned": {
-              "name": "functionOutputPinned",
-              "constructPath": "functionOutputPinned",
-              "workingDirectory": "stacks/functionOutputPinned",
-              "synthesizedStackPath": "stacks/functionOutputPinned/cdk.tf.json",
-              "stackMetadataPath": "stacks/functionOutputPinned/metadata.json",
-              "annotations": [],
-              "dependencies": [
-                "pinnedFns"
-              ]
-            },
-            "secondOrigin": {
-              "name": "secondOrigin",
-              "constructPath": "secondOrigin",
-              "workingDirectory": "stacks/secondOrigin",
-              "synthesizedStackPath": "stacks/secondOrigin/cdk.tf.json",
-              "stackMetadataPath": "stacks/secondOrigin/metadata.json",
-              "annotations": [],
-              "dependencies": []
-            },
-            "switchedStack": {
-              "name": "switchedStack",
-              "constructPath": "switchedStack",
-              "workingDirectory": "stacks/switchedStack",
-              "synthesizedStackPath": "stacks/switchedStack/cdk.tf.json",
-              "stackMetadataPath": "stacks/switchedStack/metadata.json",
-              "annotations": [],
-              "dependencies": [
-                "secondOrigin"
-              ]
-            }
-          }
-        }"
-      `);
+            "version": "stubbed"
+          }"
+        `);
 
         driver.setEnv("SWITCH_STACK", undefined);
         await driver.deploy(["secondOrigin", "switchedStack"]);
         expect(driver.manifest()).toMatchInlineSnapshot(`
-        "{
-          "version": "stubbed",
-          "stacks": {
-            "origin": {
-              "name": "origin",
-              "constructPath": "origin",
-              "workingDirectory": "stacks/origin",
-              "synthesizedStackPath": "stacks/origin/cdk.tf.json",
-              "stackMetadataPath": "stacks/origin/metadata.json",
-              "annotations": [],
-              "dependencies": []
+          "{
+            "stacks": {
+              "fns": {
+                "annotations": [
+                ],
+                "constructPath": "fns",
+                "dependencies": [
+                  "origin"
+                ],
+                "name": "fns",
+                "stackMetadataPath": "stacks/fns/metadata.json",
+                "synthesizedStackPath": "stacks/fns/cdk.tf.json",
+                "workingDirectory": "stacks/fns"
+              },
+              "functionOutput": {
+                "annotations": [
+                ],
+                "constructPath": "functionOutput",
+                "dependencies": [
+                  "origin"
+                ],
+                "name": "functionOutput",
+                "stackMetadataPath": "stacks/functionOutput/metadata.json",
+                "synthesizedStackPath": "stacks/functionOutput/cdk.tf.json",
+                "workingDirectory": "stacks/functionOutput"
+              },
+              "functionOutputPinned": {
+                "annotations": [
+                ],
+                "constructPath": "functionOutputPinned",
+                "dependencies": [
+                  "pinnedFns"
+                ],
+                "name": "functionOutputPinned",
+                "stackMetadataPath": "stacks/functionOutputPinned/metadata.json",
+                "synthesizedStackPath": "stacks/functionOutputPinned/cdk.tf.json",
+                "workingDirectory": "stacks/functionOutputPinned"
+              },
+              "origin": {
+                "annotations": [
+                ],
+                "constructPath": "origin",
+                "dependencies": [
+                ],
+                "name": "origin",
+                "stackMetadataPath": "stacks/origin/metadata.json",
+                "synthesizedStackPath": "stacks/origin/cdk.tf.json",
+                "workingDirectory": "stacks/origin"
+              },
+              "passthrough": {
+                "annotations": [
+                ],
+                "constructPath": "passthrough",
+                "dependencies": [
+                  "origin"
+                ],
+                "name": "passthrough",
+                "stackMetadataPath": "stacks/passthrough/metadata.json",
+                "synthesizedStackPath": "stacks/passthrough/cdk.tf.json",
+                "workingDirectory": "stacks/passthrough"
+              },
+              "pinnedFns": {
+                "annotations": [
+                ],
+                "constructPath": "pinnedFns",
+                "dependencies": [
+                  "origin"
+                ],
+                "name": "pinnedFns",
+                "stackMetadataPath": "stacks/pinnedFns/metadata.json",
+                "synthesizedStackPath": "stacks/pinnedFns/cdk.tf.json",
+                "workingDirectory": "stacks/pinnedFns"
+              },
+              "secondOrigin": {
+                "annotations": [
+                ],
+                "constructPath": "secondOrigin",
+                "dependencies": [
+                ],
+                "name": "secondOrigin",
+                "stackMetadataPath": "stacks/secondOrigin/metadata.json",
+                "synthesizedStackPath": "stacks/secondOrigin/cdk.tf.json",
+                "workingDirectory": "stacks/secondOrigin"
+              },
+              "sink": {
+                "annotations": [
+                ],
+                "constructPath": "sink",
+                "dependencies": [
+                  "origin"
+                ],
+                "name": "sink",
+                "stackMetadataPath": "stacks/sink/metadata.json",
+                "synthesizedStackPath": "stacks/sink/cdk.tf.json",
+                "workingDirectory": "stacks/sink"
+              },
+              "switchedStack": {
+                "annotations": [
+                ],
+                "constructPath": "switchedStack",
+                "dependencies": [
+                ],
+                "name": "switchedStack",
+                "stackMetadataPath": "stacks/switchedStack/metadata.json",
+                "synthesizedStackPath": "stacks/switchedStack/cdk.tf.json",
+                "workingDirectory": "stacks/switchedStack"
+              }
             },
-            "passthrough": {
-              "name": "passthrough",
-              "constructPath": "passthrough",
-              "workingDirectory": "stacks/passthrough",
-              "synthesizedStackPath": "stacks/passthrough/cdk.tf.json",
-              "stackMetadataPath": "stacks/passthrough/metadata.json",
-              "annotations": [],
-              "dependencies": [
-                "origin"
-              ]
-            },
-            "sink": {
-              "name": "sink",
-              "constructPath": "sink",
-              "workingDirectory": "stacks/sink",
-              "synthesizedStackPath": "stacks/sink/cdk.tf.json",
-              "stackMetadataPath": "stacks/sink/metadata.json",
-              "annotations": [],
-              "dependencies": [
-                "origin"
-              ]
-            },
-            "fns": {
-              "name": "fns",
-              "constructPath": "fns",
-              "workingDirectory": "stacks/fns",
-              "synthesizedStackPath": "stacks/fns/cdk.tf.json",
-              "stackMetadataPath": "stacks/fns/metadata.json",
-              "annotations": [],
-              "dependencies": [
-                "origin"
-              ]
-            },
-            "functionOutput": {
-              "name": "functionOutput",
-              "constructPath": "functionOutput",
-              "workingDirectory": "stacks/functionOutput",
-              "synthesizedStackPath": "stacks/functionOutput/cdk.tf.json",
-              "stackMetadataPath": "stacks/functionOutput/metadata.json",
-              "annotations": [],
-              "dependencies": [
-                "origin"
-              ]
-            },
-            "pinnedFns": {
-              "name": "pinnedFns",
-              "constructPath": "pinnedFns",
-              "workingDirectory": "stacks/pinnedFns",
-              "synthesizedStackPath": "stacks/pinnedFns/cdk.tf.json",
-              "stackMetadataPath": "stacks/pinnedFns/metadata.json",
-              "annotations": [],
-              "dependencies": [
-                "origin"
-              ]
-            },
-            "functionOutputPinned": {
-              "name": "functionOutputPinned",
-              "constructPath": "functionOutputPinned",
-              "workingDirectory": "stacks/functionOutputPinned",
-              "synthesizedStackPath": "stacks/functionOutputPinned/cdk.tf.json",
-              "stackMetadataPath": "stacks/functionOutputPinned/metadata.json",
-              "annotations": [],
-              "dependencies": [
-                "pinnedFns"
-              ]
-            },
-            "secondOrigin": {
-              "name": "secondOrigin",
-              "constructPath": "secondOrigin",
-              "workingDirectory": "stacks/secondOrigin",
-              "synthesizedStackPath": "stacks/secondOrigin/cdk.tf.json",
-              "stackMetadataPath": "stacks/secondOrigin/metadata.json",
-              "annotations": [],
-              "dependencies": []
-            },
-            "switchedStack": {
-              "name": "switchedStack",
-              "constructPath": "switchedStack",
-              "workingDirectory": "stacks/switchedStack",
-              "synthesizedStackPath": "stacks/switchedStack/cdk.tf.json",
-              "stackMetadataPath": "stacks/switchedStack/metadata.json",
-              "annotations": [],
-              "dependencies": []
-            }
-          }
-        }"
-      `);
+            "version": "stubbed"
+          }"
+        `);
       }
     );
 
@@ -698,97 +787,118 @@ describe("cross stack references", () => {
         driver.setEnv("SWITCH_STACK", "on");
         console.log(driver.workingDirectory);
         await driver.deploy(["secondOrigin", "switchedStack"]);
+
         expect(driver.manifest()).toMatchInlineSnapshot(`
           "{
-            "version": "stubbed",
             "stacks": {
-              "origin": {
-                "name": "origin",
-                "constructPath": "origin",
-                "workingDirectory": "stacks\\\\origin",
-                "synthesizedStackPath": "stacks\\\\origin\\\\cdk.tf.json",
-                "annotations": [],
-                "dependencies": []
-              },
-              "passthrough": {
-                "name": "passthrough",
-                "constructPath": "passthrough",
-                "workingDirectory": "stacks\\\\passthrough",
-                "synthesizedStackPath": "stacks\\\\passthrough\\\\cdk.tf.json",
-                "annotations": [],
-                "dependencies": [
-                  "origin"
-                ]
-              },
-              "sink": {
-                "name": "sink",
-                "constructPath": "sink",
-                "workingDirectory": "stacks\\\\sink",
-                "synthesizedStackPath": "stacks\\\\sink\\\\cdk.tf.json",
-                "annotations": [],
-                "dependencies": [
-                  "origin"
-                ]
-              },
               "fns": {
-                "name": "fns",
+                "annotations": [
+                ],
                 "constructPath": "fns",
-                "workingDirectory": "stacks\\\\fns",
-                "synthesizedStackPath": "stacks\\\\fns\\\\cdk.tf.json",
-                "annotations": [],
                 "dependencies": [
                   "origin"
-                ]
+                ],
+                "name": "fns",
+                "stackMetadataPath": "stacks\\\\fns\\\\metadata.json",
+                "synthesizedStackPath": "stacks\\\\fns\\\\cdk.tf.json",
+                "workingDirectory": "stacks\\\\fns"
               },
               "functionOutput": {
-                "name": "functionOutput",
+                "annotations": [
+                ],
                 "constructPath": "functionOutput",
-                "workingDirectory": "stacks\\\\functionOutput",
+                "dependencies": [
+                  "origin"
+                ],
+                "name": "functionOutput",
+                "stackMetadataPath": "stacks\\\\functionOutput\\\\metadata.json",
                 "synthesizedStackPath": "stacks\\\\functionOutput\\\\cdk.tf.json",
-                "annotations": [],
-                "dependencies": [
-                  "origin"
-                ]
-              },
-              "pinnedFns": {
-                "name": "pinnedFns",
-                "constructPath": "pinnedFns",
-                "workingDirectory": "stacks\\\\pinnedFns",
-                "synthesizedStackPath": "stacks\\\\pinnedFns\\\\cdk.tf.json",
-                "annotations": [],
-                "dependencies": [
-                  "origin"
-                ]
+                "workingDirectory": "stacks\\\\functionOutput"
               },
               "functionOutputPinned": {
-                "name": "functionOutputPinned",
+                "annotations": [
+                ],
                 "constructPath": "functionOutputPinned",
-                "workingDirectory": "stacks\\\\functionOutputPinned",
-                "synthesizedStackPath": "stacks\\\\functionOutputPinned\\\\cdk.tf.json",
-                "annotations": [],
                 "dependencies": [
                   "pinnedFns"
-                ]
+                ],
+                "name": "functionOutputPinned",
+                "stackMetadataPath": "stacks\\\\functionOutputPinned\\\\metadata.json",
+                "synthesizedStackPath": "stacks\\\\functionOutputPinned\\\\cdk.tf.json",
+                "workingDirectory": "stacks\\\\functionOutputPinned"
+              },
+              "origin": {
+                "annotations": [
+                ],
+                "constructPath": "origin",
+                "dependencies": [
+                ],
+                "name": "origin",
+                "stackMetadataPath": "stacks\\\\origin\\\\metadata.json",
+                "synthesizedStackPath": "stacks\\\\origin\\\\cdk.tf.json",
+                "workingDirectory": "stacks\\\\origin"
+              },
+              "passthrough": {
+                "annotations": [
+                ],
+                "constructPath": "passthrough",
+                "dependencies": [
+                  "origin"
+                ],
+                "name": "passthrough",
+                "stackMetadataPath": "stacks\\\\passthrough\\\\metadata.json",
+                "synthesizedStackPath": "stacks\\\\passthrough\\\\cdk.tf.json",
+                "workingDirectory": "stacks\\\\passthrough"
+              },
+              "pinnedFns": {
+                "annotations": [
+                ],
+                "constructPath": "pinnedFns",
+                "dependencies": [
+                  "origin"
+                ],
+                "name": "pinnedFns",
+                "stackMetadataPath": "stacks\\\\pinnedFns\\\\metadata.json",
+                "synthesizedStackPath": "stacks\\\\pinnedFns\\\\cdk.tf.json",
+                "workingDirectory": "stacks\\\\pinnedFns"
               },
               "secondOrigin": {
-                "name": "secondOrigin",
+                "annotations": [
+                ],
                 "constructPath": "secondOrigin",
-                "workingDirectory": "stacks\\\\secondOrigin",
+                "dependencies": [
+                ],
+                "name": "secondOrigin",
+                "stackMetadataPath": "stacks\\\\secondOrigin\\\\metadata.json",
                 "synthesizedStackPath": "stacks\\\\secondOrigin\\\\cdk.tf.json",
-                "annotations": [],
-                "dependencies": []
+                "workingDirectory": "stacks\\\\secondOrigin"
+              },
+              "sink": {
+                "annotations": [
+                ],
+                "constructPath": "sink",
+                "dependencies": [
+                  "origin"
+                ],
+                "name": "sink",
+                "stackMetadataPath": "stacks\\\\sink\\\\metadata.json",
+                "synthesizedStackPath": "stacks\\\\sink\\\\cdk.tf.json",
+                "workingDirectory": "stacks\\\\sink"
               },
               "switchedStack": {
-                "name": "switchedStack",
+                "annotations": [
+                ],
                 "constructPath": "switchedStack",
-                "workingDirectory": "stacks\\\\switchedStack",
-                "synthesizedStackPath": "stacks\\\\switchedStack\\\\cdk.tf.json",
-                "annotations": [],
                 "dependencies": [
                   "secondOrigin"
-                ]
+                ],
+                "name": "switchedStack",
+                "stackMetadataPath": "stacks\\\\switchedStack\\\\metadata.json",
+                "synthesizedStackPath": "stacks\\\\switchedStack\\\\cdk.tf.json",
+                "workingDirectory": "stacks\\\\switchedStack"
               }
-            }
+            },
+            "version": "stubbed"
           }"
         `);
 
@@ -796,93 +906,114 @@ describe("cross stack references", () => {
         await driver.deploy(["secondOrigin", "switchedStack"]);
         expect(driver.manifest()).toMatchInlineSnapshot(`
           "{
-            "version": "stubbed",
             "stacks": {
-              "origin": {
-                "name": "origin",
-                "constructPath": "origin",
-                "workingDirectory": "stacks\\\\origin",
-                "synthesizedStackPath": "stacks\\\\origin\\\\cdk.tf.json",
-                "annotations": [],
-                "dependencies": []
-              },
-              "passthrough": {
-                "name": "passthrough",
-                "constructPath": "passthrough",
-                "workingDirectory": "stacks\\\\passthrough",
-                "synthesizedStackPath": "stacks\\\\passthrough\\\\cdk.tf.json",
-                "annotations": [],
-                "dependencies": [
-                  "origin"
-                ]
-              },
-              "sink": {
-                "name": "sink",
-                "constructPath": "sink",
-                "workingDirectory": "stacks\\\\sink",
-                "synthesizedStackPath": "stacks\\\\sink\\\\cdk.tf.json",
-                "annotations": [],
-                "dependencies": [
-                  "origin"
-                ]
-              },
               "fns": {
-                "name": "fns",
+                "annotations": [
+                ],
                 "constructPath": "fns",
-                "workingDirectory": "stacks\\\\fns",
-                "synthesizedStackPath": "stacks\\\\fns\\\\cdk.tf.json",
-                "annotations": [],
                 "dependencies": [
                   "origin"
-                ]
+                ],
+                "name": "fns",
+                "stackMetadataPath": "stacks\\\\fns\\\\metadata.json",
+                "synthesizedStackPath": "stacks\\\\fns\\\\cdk.tf.json",
+                "workingDirectory": "stacks\\\\fns"
               },
               "functionOutput": {
-                "name": "functionOutput",
+                "annotations": [
+                ],
                 "constructPath": "functionOutput",
-                "workingDirectory": "stacks\\\\functionOutput",
+                "dependencies": [
+                  "origin"
+                ],
+                "name": "functionOutput",
+                "stackMetadataPath": "stacks\\\\functionOutput\\\\metadata.json",
                 "synthesizedStackPath": "stacks\\\\functionOutput\\\\cdk.tf.json",
-                "annotations": [],
-                "dependencies": [
-                  "origin"
-                ]
-              },
-              "pinnedFns": {
-                "name": "pinnedFns",
-                "constructPath": "pinnedFns",
-                "workingDirectory": "stacks\\\\pinnedFns",
-                "synthesizedStackPath": "stacks\\\\pinnedFns\\\\cdk.tf.json",
-                "annotations": [],
-                "dependencies": [
-                  "origin"
-                ]
+                "workingDirectory": "stacks\\\\functionOutput"
               },
               "functionOutputPinned": {
-                "name": "functionOutputPinned",
+                "annotations": [
+                ],
                 "constructPath": "functionOutputPinned",
-                "workingDirectory": "stacks\\\\functionOutputPinned",
-                "synthesizedStackPath": "stacks\\\\functionOutputPinned\\\\cdk.tf.json",
-                "annotations": [],
                 "dependencies": [
                   "pinnedFns"
-                ]
+                ],
+                "name": "functionOutputPinned",
+                "stackMetadataPath": "stacks\\\\functionOutputPinned\\\\metadata.json",
+                "synthesizedStackPath": "stacks\\\\functionOutputPinned\\\\cdk.tf.json",
+                "workingDirectory": "stacks\\\\functionOutputPinned"
+              },
+              "origin": {
+                "annotations": [
+                ],
+                "constructPath": "origin",
+                "dependencies": [
+                ],
+                "name": "origin",
+                "stackMetadataPath": "stacks\\\\origin\\\\metadata.json",
+                "synthesizedStackPath": "stacks\\\\origin\\\\cdk.tf.json",
+                "workingDirectory": "stacks\\\\origin"
+              },
+              "passthrough": {
+                "annotations": [
+                ],
+                "constructPath": "passthrough",
+                "dependencies": [
+                  "origin"
+                ],
+                "name": "passthrough",
+                "stackMetadataPath": "stacks\\\\passthrough\\\\metadata.json",
+                "synthesizedStackPath": "stacks\\\\passthrough\\\\cdk.tf.json",
+                "workingDirectory": "stacks\\\\passthrough"
+              },
+              "pinnedFns": {
+                "annotations": [
+                ],
+                "constructPath": "pinnedFns",
+                "dependencies": [
+                  "origin"
+                ],
+                "name": "pinnedFns",
+                "stackMetadataPath": "stacks\\\\pinnedFns\\\\metadata.json",
+                "synthesizedStackPath": "stacks\\\\pinnedFns\\\\cdk.tf.json",
+                "workingDirectory": "stacks\\\\pinnedFns"
               },
               "secondOrigin": {
-                "name": "secondOrigin",
+                "annotations": [
+                ],
                 "constructPath": "secondOrigin",
-                "workingDirectory": "stacks\\\\secondOrigin",
+                "dependencies": [
+                ],
+                "name": "secondOrigin",
+                "stackMetadataPath": "stacks\\\\secondOrigin\\\\metadata.json",
                 "synthesizedStackPath": "stacks\\\\secondOrigin\\\\cdk.tf.json",
-                "annotations": [],
-                "dependencies": []
+                "workingDirectory": "stacks\\\\secondOrigin"
+              },
+              "sink": {
+                "annotations": [
+                ],
+                "constructPath": "sink",
+                "dependencies": [
+                  "origin"
+                ],
+                "name": "sink",
+                "stackMetadataPath": "stacks\\\\sink\\\\metadata.json",
+                "synthesizedStackPath": "stacks\\\\sink\\\\cdk.tf.json",
+                "workingDirectory": "stacks\\\\sink"
               },
               "switchedStack": {
-                "name": "switchedStack",
+                "annotations": [
+                ],
                 "constructPath": "switchedStack",
-                "workingDirectory": "stacks\\\\switchedStack",
+                "dependencies": [
+                ],
+                "name": "switchedStack",
+                "stackMetadataPath": "stacks\\\\switchedStack\\\\metadata.json",
                 "synthesizedStackPath": "stacks\\\\switchedStack\\\\cdk.tf.json",
-                "annotations": [],
-                "dependencies": []
+                "workingDirectory": "stacks\\\\switchedStack"
               }
-            }
+            },
+            "version": "stubbed"
           }"
         `);
       }


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Description

Ensure that the `manifest.json` file has stable output. Removes instances where test snapshots fail when no content has changed, but `JSON.stringify` shuffles object attribute order. Suggested by #3561

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
