### PR TITLE
chore: Use single-label runner for custom-linux-xl

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -19,10 +19,7 @@ concurrency:
 
 jobs:
   unit-test:
-    runs-on:
-      - custom
-      - linux
-      - custom-linux-xl
+    runs-on: custom-linux-xl
     container:
       image: docker.mirror.hashicorp.services/hashicorp/jsii-terraform
     env:


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->


### Description

To align with Github’s removal of [custom labels on larger runners](https://github.blog/changelog/2023-02-15-github-actions-removal-of-additional-label-option-for-github-hosted-larger-runners/), this PR is updating the labels defined in your Github Action jobs. Moving forward, only one label (the name of GH runner type)  will be needed to ensure an appropriate runner is used for your GHA job.

Please review for accuracy and merge before May 27, 2024. Thank you!

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
