### PR TITLE
chore(ci): check licenses of dependencies on PRs

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 comment_summary_in_pr: on-failure
 vulnerability_check: false
 license_check: true

--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,52 @@
+comment_summary_in_pr: on-failure
+vulnerability_check: false
+license_check: true
+# Source for the below is https://eng-handbook.hashicorp.services/licensing-and-dependencies/#disallowed-licenses
+deny_licenses:
+  - AGPL-1.0-only
+  - AGPL-1.0-or-later
+  - AGPL-3.0-only
+  - AGPL-3.0-or-later
+  - CC-BY-ND-1.0
+  - CC-BY-ND-2.0
+  - CC-BY-ND-2.0
+  - CC-BY-ND-3.0
+  - CC-BY-ND-3.0-DE
+  - CC-BY-ND-4.0
+  - CC-BY-SA-1.0
+  - CC-BY-SA-2.0
+  - CC-BY-SA-2.0-UK
+  - CC-BY-SA-2.1-JP
+  - CC-BY-SA-2.5
+  - CC-BY-SA-3.0
+  - CC-BY-SA-3.0-AT
+  - CC-BY-SA-3.0-DE
+  - CC-BY-SA-3.0-IGO
+  - CC-BY-SA-4.0
+  - GPL-1.0-only
+  - GPL-1.0-or-later
+  - GPL-2.0-only
+  - GPL-2.0-or-later
+  - GPL-3.0-only
+  - GPL-3.0-or-later
+  - LGPL-2.0-only
+  - LGPL-2.0-or-later
+  - LGPL-2.1-only
+  - LGPL-2.1-or-later
+  - LGPL-3.0-only
+  - LGPL-3.0-or-later
+  - NPL-1.0
+  - NPL-1.1
+  - OSL-1.0
+  - OSL-1.1
+  - OSL-2.0
+  - OSL-2.1
+  - OSL-3.0
+  - QPL-1.0
+  - QPL-1.0-INRIA-2004
+  - Sleepycat
+  # Also disallowed, but could not find license identifiers for:
+  # - BCL
+  # - qmail Terms of Distribution
+  # BUSL is also disallowed by any companies other than HashiCorp
+  # I do not know if adding BUSL here will cause problems, so skipping for now

--- a/.github/workflows/pr-dependencies.yml
+++ b/.github/workflows/pr-dependencies.yml
@@ -1,10 +1,16 @@
-name: Depcheck
+name: Dependency Review
+
 on:
   merge_group:
     types: [checks_requested]
   pull_request:
     branches:
       - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   depcheck:
     runs-on: ubuntu-latest
@@ -26,9 +32,17 @@ jobs:
             "@cdktf/commons",
             # "@cdktf/cli-core",
           ]
-
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: "Run Depcheck"
         run: |
           npx lerna exec --scope '${{ matrix.package }}' -- npx -y depcheck --ignores="@types/*,jsii,jsii-pacmak,jsii-docgen,yoga-layout-prebuilt,eslint,jest,tsc-files,typescript,esbuild,esbuild-jest,graphology-types"
+
+  license:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - name: Check dependency licenses
+        uses: actions/dependency-review-action@0c155c5e8556a497adf53f2c18edabf945ed8e70 # v4.3.2
+        with:
+          config-file: ./.github/dependency-review-config.yml


### PR DESCRIPTION
For now this is just an experiment to see how well https://github.com/actions/dependency-review-action works for license checking. No pressure to merge this anytime soon.