### PR TITLE
chore: Fix a small documentation typo

### DIFF
--- a/website/docs/cdktf/test/debugging.mdx
+++ b/website/docs/cdktf/test/debugging.mdx
@@ -34,7 +34,7 @@ When you encounter an execution-time issue, we recommend first examining the syn
 
 We recommend keeping CDKTF CLI and the CDKTF library on the same version. A newer library version might expect the CLI to pass additional or different data to your CDKTF application. A newer CLI version might generate provider bindings in `cdktf get` that rely on functionality that the older library does not support.
 
-To check whether the versions align, run `cdktf debug`. The following example output shows a case where the `cdktf-cli` version (0.11.0) is newer than the `cdtf` version (0.10.0).
+To check whether the versions align, run `cdktf debug`. The following example output shows a case where the `cdktf-cli` version (0.11.0) is newer than the `cdktf` version (0.10.0).
 
 ```
 language: typescript


### PR DESCRIPTION
This threw me for about five seconds when I was reading the documentation. I'm pretty sure this is what was meant.

I went over the checklist and I don't think any of it applies since this is not a code change.