### PR TITLE
chore: fix branch cleanup

### DIFF
--- a/.github/workflows/registry-docs-pr-based.yml
+++ b/.github/workflows/registry-docs-pr-based.yml
@@ -77,9 +77,10 @@ jobs:
           fetch-depth: 0 # complete checkout
       # Delete all branches that start with d-cdktf-docs-
       - run: |
-          BRANCHES_TO_DELETE=$(git branch -r | grep -Eo 'd-cdktf-docs-[0-9]+-[0-9]+') || (echo "no branches to clean up" && exit 0)
+          BRANCHES_TO_DELETE=$(git branch -r | grep -Eo 'origin/d-cdktf-docs-[0-9]+-[0-9]+') || (echo "no branches to clean up" && exit 0)
           for branch in $BRANCHES_TO_DELETE; do
-            git push origin --delete $branch
+            branch_without_remote=${branch#origin/}
+            git push origin --delete $branch_without_remote
           done
 
   cdktfDocsSetupBranch:


### PR DESCRIPTION
when a revert is using a part of the branch name it leads to problems in the cleanup

since the matched part is what we assume is the branch name and that one does not exist.

The origin/ should make sure that there can be no prefix, technically we should also guard against suffixes bug we'll cross that bridge when we get there
