### PR TITLE
fix: explicitly listen on ipv4 address for verdaccio due to Github runner image regression

### DIFF
--- a/test/verdaccio.yaml
+++ b/test/verdaccio.yaml
@@ -81,3 +81,6 @@ logs:
 server:
   keepAliveTimeout: 0
   max_body_size: 100mb
+
+listen:
+  - 0.0.0.0:4873


### PR DESCRIPTION
Configure Verdaccio to explicitly listen on IPv4 as there's some problem in the latest Github Runner Image with `localhost` and IPv4 / IPv6.