### PR TITLE
feat(cli): support --template urls with file:// protocol

### DIFF
--- a/packages/cdktf-cli/src/bin/cmds/helper/init.ts
+++ b/packages/cdktf-cli/src/bin/cmds/helper/init.ts
@@ -542,19 +542,23 @@ async function fetchRemoteTemplate(templateUrl: string): Promise<Template> {
     );
 
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "cdktf."));
-    const tmpZipFile = path.join(tmpDir, remoteFileName);
     const zipExtractDir = path.join(tmpDir, "extracted");
 
-    logger.trace(
-      `Downloading "${remoteFileName}" to temporary directory "${tmpDir}"`
-    );
-    console.log(
-      chalkColour`Downloading "{whiteBright ${remoteFileName}}" to temporary directory`
-    );
-    await downloadFile(url.href, tmpZipFile);
-
-    console.log("Extracting zip file");
-    await extract(tmpZipFile, { dir: zipExtractDir });
+    if (url.protocol === "file:") {
+      console.log("Extracting zip file");
+      await extract(path.join(url.hostname, url.pathname), { dir: zipExtractDir });
+    } else {
+      const tmpZipFile = path.join(tmpDir, remoteFileName);
+      logger.trace(
+        `Downloading "${remoteFileName}" to temporary directory "${tmpDir}"`
+      );
+      console.log(
+        chalkColour`Downloading "{whiteBright ${remoteFileName}}" to temporary directory`
+      );
+      await downloadFile(url.href, tmpZipFile);
+      console.log("Extracting zip file");
+      await extract(tmpZipFile, { dir: zipExtractDir });
+    }
 
     // walk directory to find cdktf.json as the extracted directory contains a root directory with unknown name
     // this also allows nesting the template itself into a sub directory and having a root directory with an unrelated README

--- a/website/docs/cdktf/create-and-deploy/remote-templates.mdx
+++ b/website/docs/cdktf/create-and-deploy/remote-templates.mdx
@@ -83,3 +83,9 @@ The following example initializes a new CDKTF project with a remote template.
 ```
 $ cdktf init --template https://github.com/<user or organization>/<repo>/archive/refs/tags/v0.0.1.zip
 ```
+
+To use a local template, you can use the `file://` protocol followed by the path to your template directory:
+
+```
+$ cdktf init --template file://../path/to/your/template.zip
+```


### PR DESCRIPTION
### Related issue

Fixes #3656

### Description

Update the `--template` flag to support `file://` URIs for using local template files.

### Example

``` sh
cdktf init --template file://../my-template.zip
```

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
