### PR TITLE
chore: added index pages for each library to the docs

### DIFF
--- a/website/data/cdktf-nav-data.json
+++ b/website/data/cdktf-nav-data.json
@@ -179,6 +179,10 @@
         "title": "Typescript",
         "routes": [
           {
+            "title": "Overview",
+            "path": "api-reference/typescript"
+          },
+          {
             "title": "Classes",
             "path": "api-reference/typescript/classes"
           },
@@ -203,6 +207,10 @@
       {
         "title": "Python",
         "routes": [
+          {
+            "title": "Overview",
+            "path": "api-reference/python"
+          },
           {
             "title": "Classes",
             "path": "api-reference/python/classes"
@@ -229,6 +237,10 @@
         "title": "Java",
         "routes": [
           {
+            "title": "Overview",
+            "path": "api-reference/java"
+          },
+          {
             "title": "Classes",
             "path": "api-reference/java/classes"
           },
@@ -254,6 +266,10 @@
         "title": "C#",
         "routes": [
           {
+            "title": "Overview",
+            "path": "api-reference/csharp"
+          },
+          {
             "title": "Classes",
             "path": "api-reference/csharp/classes"
           },
@@ -278,6 +294,10 @@
       {
         "title": "Go",
         "routes": [
+          {
+            "title": "Overview",
+            "path": "api-reference/go"
+          },
           {
             "title": "Classes",
             "path": "api-reference/go/classes"

--- a/website/docs/cdktf/api-reference/csharp/index.mdx
+++ b/website/docs/cdktf/api-reference/csharp/index.mdx
@@ -1,9 +1,9 @@
 ---
 page_title: C# API resource reference overview
-description: Learn about the API resources available in the Terraform CDK library for C#.  
+description: Learn about the API resources available in the Terraform CDK library for C#.
 ---
 
-# C sharp API resource reference overview
+# C# API resource reference overview
 
 The C# API reference includes the following resources:
 

--- a/website/docs/cdktf/api-reference/csharp/index.mdx
+++ b/website/docs/cdktf/api-reference/csharp/index.mdx
@@ -1,0 +1,14 @@
+---
+page_title: C# API resource reference overview
+description: Learn about the API resources available in the Terraform CDK library for C#.  
+---
+
+# C sharp API resource reference overview
+
+The C# API reference includes the following resources:
+
+- [Classes](/terraform/cdktf/api-reference/csharp/classes)
+- [Constructs](/terraform/cdktf/api-reference/csharp/constructs)
+- [Enums](/terraform/cdktf/api-reference/csharp/enums)
+- [Protocols](/terraform/cdktf/api-reference/csharp/protocols)
+- [Structs](/terraform/cdktf/api-reference/csharp/structs)

--- a/website/docs/cdktf/api-reference/go/index.mdx
+++ b/website/docs/cdktf/api-reference/go/index.mdx
@@ -1,0 +1,14 @@
+---
+page_title: Go API resource reference overview
+description: Learn about the API resources available in the Terraform CDK library for golang.  
+---
+
+# Go API resource reference overview
+
+The Go API reference includes the following resources:
+
+- [Classes](/terraform/cdktf/api-reference/go/classes)
+- [Constructs](/terraform/cdktf/api-reference/go/constructs)
+- [Enums](/terraform/cdktf/api-reference/go/enums)
+- [Protocols](/terraform/cdktf/api-reference/go/protocols)
+- [Structs](/terraform/cdktf/api-reference/go/structs)

--- a/website/docs/cdktf/api-reference/go/index.mdx
+++ b/website/docs/cdktf/api-reference/go/index.mdx
@@ -1,6 +1,6 @@
 ---
 page_title: Go API resource reference overview
-description: Learn about the API resources available in the Terraform CDK library for golang.  
+description: Learn about the API resources available in the Terraform CDK library for golang.
 ---
 
 # Go API resource reference overview

--- a/website/docs/cdktf/api-reference/index.mdx
+++ b/website/docs/cdktf/api-reference/index.mdx
@@ -8,44 +8,10 @@ description: >-
 
 The CDK for Terraform (CDKTF) core library lets you define infrastructure resources using familiar programming languages. CDKTF translates the API into the following supported languages.
 
-## Typescript
-
-- [Classes](/terraform/cdktf/api-reference/typescript/classes)
-- [Constructs](/terraform/cdktf/api-reference/typescript/constructs)
-- [Enums](/terraform/cdktf/api-reference/typescript/enums)
-- [Protocols](/terraform/cdktf/api-reference/typescript/protocols)
-- [Structs](/terraform/cdktf/api-reference/typescript/structs)
-
-## Python
-
-- [Classes](/terraform/cdktf/api-reference/python/classes)
-- [Constructs](/terraform/cdktf/api-reference/python/constructs)
-- [Enums](/terraform/cdktf/api-reference/python/enums)
-- [Protocols](/terraform/cdktf/api-reference/python/protocols)
-- [Structs](/terraform/cdktf/api-reference/python/structs)
-
-## Java
-
-- [Classes](/terraform/cdktf/api-reference/java/classes)
-- [Constructs](/terraform/cdktf/api-reference/java/constructs)
-- [Enums](/terraform/cdktf/api-reference/java/enums)
-- [Protocols](/terraform/cdktf/api-reference/java/protocols)
-- [Structs](/terraform/cdktf/api-reference/java/structs)
-
-## CSharp
-
-- [Classes](/terraform/cdktf/api-reference/csharp/classes)
-- [Constructs](/terraform/cdktf/api-reference/csharp/constructs)
-- [Enums](/terraform/cdktf/api-reference/csharp/enums)
-- [Protocols](/terraform/cdktf/api-reference/csharp/protocols)
-- [Structs](/terraform/cdktf/api-reference/csharp/structs)
-
-## Go
-
-- [Classes](/terraform/cdktf/api-reference/go/classes)
-- [Constructs](/terraform/cdktf/api-reference/go/constructs)
-- [Enums](/terraform/cdktf/api-reference/go/enums)
-- [Protocols](/terraform/cdktf/api-reference/go/protocols)
-- [Structs](/terraform/cdktf/api-reference/go/structs)
+- [Typescript](/terraform/cdktf/api-reference/typescript)
+- [Python](/terraform/cdktf/api-reference/python)
+- [Java](/terraform/cdktf/api-reference/java)
+- [CSharp](/terraform/cdktf/api-reference/csharp)
+- [Go](/terraform/cdktf/api-reference/go)
 
 In addition to the core library, you can use [generated provider bindings](/terraform/cdktf/concepts/providers) and [Constructs](https://constructs.dev/search?q=&cdk=cdktf&offset=0) in CDKTF applications.

--- a/website/docs/cdktf/api-reference/java/index.mdx
+++ b/website/docs/cdktf/api-reference/java/index.mdx
@@ -1,0 +1,14 @@
+---
+page_title: Java API resource reference overview
+description: Learn about the API resources available in the Terraform CDK library for Java.  
+---
+
+# Java API resource reference overview
+
+The Java API reference includes the following resources:
+
+- [Classes](/terraform/cdktf/api-reference/java/classes)
+- [Constructs](/terraform/cdktf/api-reference/java/constructs)
+- [Enums](/terraform/cdktf/api-reference/java/enums)
+- [Protocols](/terraform/cdktf/api-reference/java/protocols)
+- [Structs](/terraform/cdktf/api-reference/java/structs)

--- a/website/docs/cdktf/api-reference/java/index.mdx
+++ b/website/docs/cdktf/api-reference/java/index.mdx
@@ -1,6 +1,6 @@
 ---
 page_title: Java API resource reference overview
-description: Learn about the API resources available in the Terraform CDK library for Java.  
+description: Learn about the API resources available in the Terraform CDK library for Java.
 ---
 
 # Java API resource reference overview

--- a/website/docs/cdktf/api-reference/python/index.mdx
+++ b/website/docs/cdktf/api-reference/python/index.mdx
@@ -1,6 +1,6 @@
 ---
 page_title: Python API resource reference overview
-description: Learn about the API resources available in the Terraform CDK library for Python.  
+description: Learn about the API resources available in the Terraform CDK library for Python.
 ---
 
 # Python API resource reference overview

--- a/website/docs/cdktf/api-reference/python/index.mdx
+++ b/website/docs/cdktf/api-reference/python/index.mdx
@@ -1,0 +1,14 @@
+---
+page_title: Python API resource reference overview
+description: Learn about the API resources available in the Terraform CDK library for Python.  
+---
+
+# Python API resource reference overview
+
+The Python API reference includes the following resources:
+
+- [Classes](/terraform/cdktf/api-reference/python/classes)
+- [Constructs](/terraform/cdktf/api-reference/python/constructs)
+- [Enums](/terraform/cdktf/api-reference/python/enums)
+- [Protocols](/terraform/cdktf/api-reference/python/protocols)
+- [Structs](/terraform/cdktf/api-reference/python/structs)

--- a/website/docs/cdktf/api-reference/typescript/index.mdx
+++ b/website/docs/cdktf/api-reference/typescript/index.mdx
@@ -1,6 +1,6 @@
 ---
 page_title: Typescript API resource reference overview
-description: Learn about the API resources available in the Terraform CDK library for Typescript.  
+description: Learn about the API resources available in the Terraform CDK library for Typescript.
 ---
 
 # Typescript API resource reference overview

--- a/website/docs/cdktf/api-reference/typescript/index.mdx
+++ b/website/docs/cdktf/api-reference/typescript/index.mdx
@@ -1,0 +1,14 @@
+---
+page_title: Typescript API resource reference overview
+description: Learn about the API resources available in the Terraform CDK library for Typescript.  
+---
+
+# Typescript API resource reference overview
+
+The Typescript API reference includes the following resources:
+
+- [Classes](/terraform/cdktf/api-reference/typescript/classes)
+- [Constructs](/terraform/cdktf/api-reference/typescript/constructs)
+- [Enums](/terraform/cdktf/api-reference/typescript/enums)
+- [Protocols](/terraform/cdktf/api-reference/typescript/protocols)
+- [Structs](/terraform/cdktf/api-reference/typescript/structs)


### PR DESCRIPTION
This PR is a fast follow up to PR-3668. 
This PR adds index.mdx files to each language folder in the API reference. Adding the index pages eliminates the need to add redirects as well as enforces a pattern for creating new folders.