### PR TITLE
fix(devcontainer): ensure devcontainer can be used

### DIFF
--- a/packages/@cdktf/hcl-tools/build-go.sh
+++ b/packages/@cdktf/hcl-tools/build-go.sh
@@ -13,7 +13,7 @@ export GOWORK=off
 echo "Running go get.."
 GOOS=js GOARCH=wasm go get .
 echo "Running go build.."
-GOOS=js GOARCH=wasm go build -ldflags="-s -w" -o main.wasm
+GOOS=js GOARCH=wasm go build -ldflags="-s -w" -buildvcs=false -o main.wasm
 echo "Zipping wasm build.."
 gzip -9 -v -c main.wasm > main.wasm.gz
 echo "Done."

--- a/packages/@cdktf/hcl2json/build-go.sh
+++ b/packages/@cdktf/hcl2json/build-go.sh
@@ -13,7 +13,7 @@ export GOWORK=off
 echo "Running go get.."
 GOOS=js GOARCH=wasm go get .
 echo "Running go build.."
-GOOS=js GOARCH=wasm go build -ldflags="-s -w" -o main.wasm
+GOOS=js GOARCH=wasm go build -ldflags="-s -w" -buildvcs=false -o main.wasm
 echo "Zipping wasm build.."
 gzip -9 -v -c main.wasm > main.wasm.gz
 echo "Done."


### PR DESCRIPTION
without prior knowledge on if version control information should've been included in builds in the past: go tries to embed version control information by default since 1.18 (https://tip.golang.org/doc/go1.18), which fails during the devcontainer build. therefore, disable it.

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes # <!-- INSERT ISSUE NUMBER -->

### Description

In plain English, describe your approach to addressing the issue linked above. For example, if you made a particular design decision, let us know why you chose this path instead of another solution.

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
