### PR TITLE
docs(constructs.mdx)

### DIFF
--- a/website/docs/cdktf/concepts/constructs.mdx
+++ b/website/docs/cdktf/concepts/constructs.mdx
@@ -37,11 +37,10 @@ class TaggedS3Bucket extends S3Bucket {
   constructor(scope: Construct, name: string, config: S3BucketConfig) {
     super(scope, name, config);
 
-    this.tagsInput = {
-      ...this.tagsInput,
+    Object.assign(this.tagsInput, {
       owner: "my-team",
       purpose: "storage",
-    };
+    });
   }
 }
 


### PR DESCRIPTION

# I changed the example.

In TaggedS3Bucket example this documents re-assigne value into this.tagsInput with spread operator like this.

```
this.tagsInput = {
     ...this.tagsInput,
     owner: "my-team",
     purpose: "storage",
};
```

I changed to

```
Object.assign(this.tagsInput, {
    owner: "my-team",
    purpose: "storage"
});
```

# What’s the difference?
When use … `AKA spread operator` is a kind of duplicate mechanism
And usually use for `dont want impact to original value.`

When using Object.assign it’s just extend the original object

In this document example …this.tagsInput is used for assing itself.
which means `generate new object and assign to original object`
It’s working but not best practice.


# If you change to Object.assign approach (my offer)
1. There are tiny performance difference
2. And who read this documents they instintly understand ‘oh this guy extends object’


I love Terraform, and I wish Terraform document offer best practice
Thank you.
