### PR TITLE
fix(release): Don't validate single commit for semanticity

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -47,7 +47,7 @@ jobs:
           # will suggest using that commit message instead of the PR title for the
           # merge commit, and it's easy to commit this by mistake. Enable this option
           # to also validate the commit message for one commit PRs.
-          validateSingleCommit: true
+          validateSingleCommit: false
 
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}" does not match the required format.


### PR DESCRIPTION
This usually fails for commits by tools that don't adhere to our requirements as the commit message is concerned. For example PRs like this one: https://github.com/hashicorp/terraform-cdk/pull/3714 As our changelog generation script only uses PR titles to begin with, we don't need this safeguard to lint single commit PRs on their commits as well.