### PR TITLE
chore: increase version of cdktf-registry-docs used

### DIFF
--- a/.github/workflows/cdktf-provider-docs-rollout.yml
+++ b/.github/workflows/cdktf-provider-docs-rollout.yml
@@ -47,7 +47,7 @@ jobs:
       languages: "typescript,python"
       parallelFileConversions: 1
       maxRunners: 1
-      cdktfRegistryDocsVersion: "1.21.0"
+      cdktfRegistryDocsVersion: "1.26.0"
 
   reportFailureToSlack:
     needs: cdktfDocs

--- a/.github/workflows/registry-docs-pr-based.yml
+++ b/.github/workflows/registry-docs-pr-based.yml
@@ -53,7 +53,7 @@ on:
       cdktfRegistryDocsVersion:
         description: "Version of cdktf-registry-docs to use"
         required: false
-        default: "1.21.0"
+        default: "1.26.0"
         type: string
     secrets:
       GH_PR_TOKEN:
@@ -119,7 +119,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
         with:
-          node-version: "18.x"
+          node-version: "20.x"
 
       - name: Install cdktf-registry-docs
         run: npm install -g cdktf-registry-docs@${{ inputs.cdktfRegistryDocsVersion }}
@@ -164,7 +164,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
         with:
-          node-version: "18.x"
+          node-version: "20.x"
 
       - name: Install cdktf-registry-docs
         run: npm install -g cdktf-registry-docs@${{ inputs.cdktfRegistryDocsVersion }}


### PR DESCRIPTION
I noticed the other day that the Registry docs were being built off of CDKTF 0.20.1 when 0.20.8 is out. When trying to figure out why there's such a discrepancy, I realized it's because of this.

I don't know if we've fixed or changed anything about `convert` that would change the actual docs output, but it's worth keeping this updated in case there have been improvements.