### PR TITLE
feat(cli): add support for local templates

### DIFF
--- a/packages/cdktf-cli/src/bin/cmds/helper/init.ts
+++ b/packages/cdktf-cli/src/bin/cmds/helper/init.ts
@@ -519,15 +519,22 @@ async function getTemplate(
     }
   }
 
-  // treat as remote url
-  if (!templates.includes(templateName)) {
-    return fetchRemoteTemplate(templateName);
-  } else {
+  if (templates.includes(templateName)) {
     return {
       Name: templateName,
       Path: path.join(templatesDir, templateName),
     };
   }
+  if (
+    templateName.startsWith("http://") ||
+    templateName.startsWith("https://")
+  ) {
+    return fetchRemoteTemplate(templateName);
+  }
+  return {
+    Name: path.basename(templateName),
+    Path: templateName,
+  };
 }
 
 async function fetchRemoteTemplate(templateUrl: string): Promise<Template> {

--- a/packages/cdktf-cli/src/bin/cmds/init.ts
+++ b/packages/cdktf-cli/src/bin/cmds/init.ts
@@ -16,7 +16,7 @@ class Command extends BaseCommand {
       .showHelpOnFail(true)
       .option("template", {
         type: "string",
-        desc: `The template to be used to create a new project. Either URL to zip file or one of the built-in templates.`,
+        desc: `The template to be used to create a new project. Either URL to zip file, one of the built-in templates, or a local directory.`,
       })
       .option("project-name", {
         type: "string",

--- a/test/typescript/init-local-template/cdktf.json
+++ b/test/typescript/init-local-template/cdktf.json
@@ -1,0 +1,8 @@
+{
+  "language": "typescript",
+  "app": "npx ts-node main.ts",
+  "terraformProviders": [
+    "null@ ~> 3.1.0"
+  ],
+  "context": {}
+}

--- a/test/typescript/init-local-template/test.ts
+++ b/test/typescript/init-local-template/test.ts
@@ -1,0 +1,36 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { TestDriver } from "../../test-helper";
+const fs = require("fs").promises;
+const path = require("path");
+
+describe("local templates", () => {
+  test("can init", async () => {
+    const driver = new TestDriver(__dirname);
+    driver.switchToTempDir();
+    const templateDir = path.resolve(
+      __dirname,
+      "..",
+      "..",
+      "..",
+      "packages/@cdktf/cli-core/templates/typescript"
+    );
+    await driver.init(templateDir);
+    const files = await fs.readdir(driver.workingDirectory);
+    expect(files).toEqual(
+      expect.arrayContaining([
+        ".gen",
+        ".gitignore",
+        ".npmrc",
+        "cdktf.json",
+        "help",
+        "jest.config.js",
+        "main.ts",
+        "package.json",
+        "setup.js",
+        "tsconfig.json",
+        "__tests__",
+      ])
+    );
+  });
+});


### PR DESCRIPTION
### Related issue

Fixes #3656

### Description

Allow passing local directory as `--template` parameter.

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
