### PR TITLE
fix(cli): Support Kotlin Build Scripts in Gradle Project and Cdktf Version Detection

### DIFF
--- a/packages/@cdktf/commons/src/gradle.ts
+++ b/packages/@cdktf/commons/src/gradle.ts
@@ -9,7 +9,7 @@ import { logger } from "./logging";
 import { exec } from "./util";
 
 export function isGradleProject(workingDirectory: string): boolean {
-  const buildGradlePath = path.join(workingDirectory, "build.gradle");
+  const buildGradlePath = path.join(workingDirectory, "build.gradle" || "build.gradle.kts");
 
   try {
     fs.accessSync(buildGradlePath, fs.constants.R_OK | fs.constants.W_OK);
@@ -151,7 +151,7 @@ export async function getGradlePackageVersion(packageName: string) {
 }
 
 export async function getGradlePackageVersionFromBuild(packageName: string) {
-  const buildGradlePath = path.join(process.cwd(), "build.gradle");
+  const buildGradlePath = path.join(process.cwd(), "build.gradle" || "build.gradle.kts");
   const buildGradleContents = await fs.readFile(buildGradlePath, "utf-8");
   const buildLines = buildGradleContents.split(/\r\n|\r|\n/);
 

--- a/packages/@cdktf/commons/src/gradle.ts
+++ b/packages/@cdktf/commons/src/gradle.ts
@@ -9,7 +9,10 @@ import { logger } from "./logging";
 import { exec } from "./util";
 
 export function isGradleProject(workingDirectory: string): boolean {
-  const buildGradlePath = path.join(workingDirectory, "build.gradle" || "build.gradle.kts");
+  const buildGradlePath = path.join(
+    workingDirectory,
+    "build.gradle" || "build.gradle.kts"
+  );
 
   try {
     fs.accessSync(buildGradlePath, fs.constants.R_OK | fs.constants.W_OK);
@@ -151,7 +154,10 @@ export async function getGradlePackageVersion(packageName: string) {
 }
 
 export async function getGradlePackageVersionFromBuild(packageName: string) {
-  const buildGradlePath = path.join(process.cwd(), "build.gradle" || "build.gradle.kts");
+  const buildGradlePath = path.join(
+    process.cwd(),
+    "build.gradle" || "build.gradle.kts"
+  );
   const buildGradleContents = await fs.readFile(buildGradlePath, "utf-8");
   const buildLines = buildGradleContents.split(/\r\n|\r|\n/);
 


### PR DESCRIPTION
### Related issue

Fixes # 3759

### Description

Support Kotlin build scripts for Gradle by enumerating `build.gradle.kts` in `isGradleProject` and `getGradlePackageVersionFromBuild` functions.

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
