### PR TITLE
fix(lib): correct the concat method in TokenizedStringFragments

### DIFF
--- a/packages/cdktf/lib/tokens/string-fragments.ts
+++ b/packages/cdktf/lib/tokens/string-fragments.ts
@@ -87,7 +87,7 @@ export class TokenizedStringFragments {
   }
 
   public concat(other: TokenizedStringFragments): void {
-    this.fragments.concat(other.fragments);
+    this.fragments.push(...other.fragments);
   }
 
   /**

--- a/packages/cdktf/test/tokens/string-fragments.test.ts
+++ b/packages/cdktf/test/tokens/string-fragments.test.ts
@@ -1,0 +1,31 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { TokenizedStringFragments } from "../../lib/tokens/string-fragments";
+import { IFragmentConcatenator } from "../../lib/tokens/resolvable";
+
+describe("TokenizedStringFragments", () => {
+  test("concat method should merge fragments correctly", () => {
+    // Arrange: Create two instances with literals
+    const fragments1 = new TokenizedStringFragments();
+    fragments1.addLiteral("Hello");
+    fragments1.addLiteral(", ");
+
+    const fragments2 = new TokenizedStringFragments();
+    fragments2.addLiteral("World");
+    fragments2.addLiteral("!");
+
+    // Act: Concatenate fragments2 into fragments1
+    fragments1.concat(fragments2);
+
+    // Assert: Check the length and combined result
+    expect(fragments1.length).toBe(4); // Verify total number of fragments
+
+    const result = fragments1.join({
+      join(left: any, right: any): string {
+        return `${left}${right}`;
+      },
+    } as IFragmentConcatenator);
+
+    expect(result).toBe("Hello, World!"); // Verify merged content
+  });
+});


### PR DESCRIPTION
The `concat` method was not properly updating `this.fragments` because `Array.prototype.concat` returns a new array and does not modify the original array in place. Changed the implementation to use `this.fragments.push(...other.fragments);` to correctly merge the fragments into `this.fragments`.

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Description

I thought `concat` method in `TokenizedStringFragments` was intended to merge fragments from another instance into `this.fragments`. However, it was not functioning correctly because `Array.prototype.concat` returns a new array and does not modify the original array in place.

To fix this issue, I updated the `concat` method to use `this.fragments.push(...other.fragments);`. This modifies `this.fragments` in place and ensures that all fragments are correctly merged.

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->