### PR TITLE
fix: punycode deprecation warning

### DIFF
--- a/packages/@cdktf/commons/package.json
+++ b/packages/@cdktf/commons/package.json
@@ -44,15 +44,16 @@
     "cross-spawn": "7.0.6",
     "follow-redirects": "1.15.9",
     "fs-extra": "11.2.0",
-    "is-valid-domain": "0.1.6",
     "log4js": "6.9.1",
     "strip-ansi": "6.0.1",
-    "uuid": "9.0.1"
+    "uuid": "9.0.1",
+    "validator": "13.12.0"
   },
   "devDependencies": {
     "@types/follow-redirects": "1.14.4",
     "@types/fs-extra": "11.0.4",
     "@types/uuid": "9.0.8",
+    "@types/validator": "13.12.2",
     "@typescript-eslint/eslint-plugin": "4.33.0",
     "@typescript-eslint/parser": "4.33.0",
     "eslint-config-prettier": "8.10.0",

--- a/packages/@cdktf/commons/src/terraform-module.test.ts
+++ b/packages/@cdktf/commons/src/terraform-module.test.ts
@@ -1,0 +1,25 @@
+import { isRegistryModule } from "./terraform-module";
+
+describe("terraform-module", () => {
+  describe.each`
+    source                                                        | expected
+    ${"hashicorp/consul/aws"}                                     | ${true}
+    ${"hashicorp/consul/aws//foo"}                                | ${false}
+    ${"./consul"}                                                 | ${false}
+    ${"git@github.com:hashicorp/example.git"}                     | ${false}
+    ${"github.com/hashicorp/example"}                             | ${false}
+    ${"github.com/hashicorp/terraform-cidr-subnets"}              | ${false}
+    ${"bitbucket.org/hashicorp/terraform-consul-aws"}             | ${false}
+    ${"foo/var/baz/qux"}                                          | ${false}
+    ${"foo.com/var/baz"}                                          | ${true}
+    ${".foo.com/var/baz"}                                         | ${false}
+    ${"f-o-o.com/var/baz"}                                        | ${true}
+    ${"foo.com/var/baz/canz"}                                     | ${true}
+    ${"example.com/awesomecorp/network/happycloud//examples/foo"} | ${false}
+    ${"www.googleapis.com/storage/v1/BUCKET_NAME/PATH_TO_MODULE"} | ${false}
+  `("isRegistryModule($source)", ({ source, expected }) => {
+    it(`expects ${expected}`, () => {
+      expect(isRegistryModule(source)).toBe(expected);
+    });
+  });
+});

--- a/packages/@cdktf/commons/src/terraform-module.ts
+++ b/packages/@cdktf/commons/src/terraform-module.ts
@@ -1,6 +1,6 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import isValidDomain from "is-valid-domain";
+import { isFQDN } from "validator";
 
 // Logic from https://github.com/hashicorp/terraform/blob/e09b831f6ee35d37b11b8dcccd3a6d6f6db5e5ff/internal/addrs/module_source.go#L198
 export function isRegistryModule(source: string) {
@@ -15,7 +15,7 @@ export function isRegistryModule(source: string) {
     return false;
   }
 
-  if (parts.length === 4 && !isValidDomain(parts[0])) {
+  if (parts.length === 4 && !isFQDN(parts[0])) {
     return false;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2405,6 +2405,11 @@
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.8.tgz#7545ba4fc3c003d6c756f651f3bf163d8f0f29ba"
   integrity sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==
 
+"@types/validator@13.12.2":
+  version "13.12.2"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.12.2.tgz#760329e756e18a4aab82fc502b51ebdfebbe49f5"
+  integrity sha512-6SlHBzUW8Jhf3liqrGGXyTJSIFe4nqlJ5A5KaMZ2l/vbM3Wh3KSybots/wfWVzNLK4D1NZluDlSQIbIEPx6oyA==
+
 "@types/wrap-ansi@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz#18b97a972f94f60a679fd5c796d96421b9abb9fd"
@@ -6929,13 +6934,6 @@ is-upper-case@^2.0.2:
   integrity sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==
   dependencies:
     tslib "^2.0.3"
-
-is-valid-domain@0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/is-valid-domain/-/is-valid-domain-0.1.6.tgz#3c85469d2938f170c8f82ce6e52df8ad9fca8105"
-  integrity sha512-ZKtq737eFkZr71At8NxOFcP9O1K89gW3DkdrGMpp1upr/ueWjj+Weh4l9AI4rN0Gt8W2M1w7jrG2b/Yv83Ljpg==
-  dependencies:
-    punycode "^2.1.1"
 
 is-weakmap@^2.0.2:
   version "2.0.2"
@@ -12229,6 +12227,11 @@ validate-npm-package-name@^5.0.0:
   integrity sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==
   dependencies:
     builtins "^5.0.0"
+
+validator@13.12.0:
+  version "13.12.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.12.0.tgz#7d78e76ba85504da3fee4fd1922b385914d4b35f"
+  integrity sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### Related issue

Fixes #3640

### Description

[is-valid-domain](https://www.npmjs.com/package/is-valid-domain) package is bringing deprecated node's (not userland) punycode as a dependency which has long been deprecated and, starting with node v21, changed to a runtime deprecation, causing the below:

```log
0.20.7
(node:529691) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

Given it's been more then 2 years since the package has been last updated, and [its source archived by the owner](https://github.com/miguelmota/is-valid-domain), replacing it by the more stable and stablished [validator](https://www.npmjs.com/package/validator).

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
