### PR TITLE
chore: Add web presence ability to approve PRs to website files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@
 # Education likes to get notifications if changes happen to docs.
 # We need to include the CDKTF team as well to ensure Education
 # members are not the only ones notified.
-website/docs/ @hashicorp/cdktf @hashicorp/team-docs-packer-and-terraform
+website/ @hashicorp/cdktf @hashicorp/team-docs-packer-and-terraform @hashicorp/web-presence
 
 # No codeowners for these files, as they are generated.
 # This way, Education does not get notified if only these files changed.


### PR DESCRIPTION

I'm trying to standardize who can approve PRs to docs across all our code repos. Please let me know if you have any feedback! 

### Related issue

Fixes # <!-- INSERT ISSUE NUMBER -->

### Description

In plain English, describe your approach to addressing the issue linked above. For example, if you made a particular design decision, let us know why you chose this path instead of another solution.

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
