### PR TITLE
fix: Update slack action usage for slack action v2

### DIFF
--- a/.github/workflows/cdktf-provider-docs-rollout.yml
+++ b/.github/workflows/cdktf-provider-docs-rollout.yml
@@ -57,9 +57,9 @@ jobs:
       - name: Send failures to Slack
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
+          webhook_url: ${{ secrets.REGISTRY_DOCS_FAILURE_SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
           payload: |
             {
               "run_url": "https://github.com/hashicorp/terraform-cdk/actions/runs/${{ github.run_id }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.REGISTRY_DOCS_FAILURE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/cdktf-provider-docs-rollout.yml
+++ b/.github/workflows/cdktf-provider-docs-rollout.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Send failures to Slack
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
-          webhook_url: ${{ secrets.REGISTRY_DOCS_FAILURE_SLACK_WEBHOOK_URL }}
+          webhook: ${{ secrets.REGISTRY_DOCS_FAILURE_SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger
           payload: |
             {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -362,10 +362,10 @@ jobs:
       - name: Send failures to Slack
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
+          webhook: ${{ secrets.FAILURE_SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
           payload: |
             {
               "name": "main",
               "run_url": "https://github.com/hashicorp/terraform-cdk/actions/runs/${{ github.run_id }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.FAILURE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -326,10 +326,10 @@ jobs:
       - name: Send failures to Slack
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
+          webhook: ${{ secrets.FAILURE_SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
           payload: |
             {
               "name": "next",
               "run_url": "https://github.com/hashicorp/terraform-cdk/actions/runs/${{ github.run_id }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.FAILURE_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Description

The parent [PR](https://github.com/hashicorp/terraform-cdk/pull/3795) updates the Slack Github Action to v2 which has a few breaking changes that affect us. Information on breaking changes are [here](https://github.com/slackapi/slack-github-action/releases/tag/v2.0.0). 

The actions pertain to failure reports in our [#feed-terraform-cdk](https://hashicorp.enterprise.slack.com/archives/C03N81HHDUP) channel. From investigating the integration settings, it seems like all are webhooks are of the 'workflow builder' type. For those, we have to set the `webhook-type` to `webhook-trigger`. **NOTE:** If any of our webhooks are not of that type and I was mistaken, please let me know so I can update the PR accordingly.

This PR is based on top of the parent PR's branch, so should be merged right after the parent. I'll merge that one right after this PR is approved.

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
