### PR TITLE
feat(lib): add the `remove` function to `TerraformResource`

### DIFF
--- a/packages/cdktf/lib/errors.ts
+++ b/packages/cdktf/lib/errors.ts
@@ -90,6 +90,34 @@ export const modulesWithSameAlias = (alias: string) =>
 Each provider must have a unique alias when passing multiple providers of the same type to modules.
   `);
 
+export const cannotRemoveMovedResource = (resourceId: string) =>
+  new Error(
+    `Cannot remove the resource "${resourceId}" because it has already been marked for a move operation.
+
+A resource cannot be moved and removed at the same time. Please ensure the resource is not moved before attempting to remove it.`,
+  );
+
+export const cannotMoveRemovedResource = (resourceId: string) =>
+  new Error(
+    `Cannot move the resource "${resourceId}" because it has already been marked for removal.
+
+A resource cannot be moved and removed at the same time. Please ensure the resource is not removed before attempting to move it.`,
+  );
+
+export const cannotRemoveImportedResource = (resourceId: string) =>
+  new Error(
+    `Cannot remove the resource "${resourceId}" because it has already been marked for import.
+
+A resource cannot be imported and removed at the same time. Please ensure the resource is not imported before attempting to remove it.`,
+  );
+
+export const cannotImportRemovedResource = (resourceId: string) =>
+  new Error(
+    `Cannot import the resource "${resourceId}" because it has already been marked for removal.
+
+A resource cannot be imported and removed at the same time. Please ensure the resource is not removed before attempting to import it.`,
+  );
+
 export const moveTargetAlreadySet = (
   target: string,
   friendlyUniqueId: string | undefined,

--- a/packages/cdktf/lib/hcl/render.ts
+++ b/packages/cdktf/lib/hcl/render.ts
@@ -463,6 +463,23 @@ ${renderAttributes(importBlock)}
 /**
  *
  */
+export function renderRemoved(removed: any) {
+  const removedBlocks = removed.map((removedBlock: any) => {
+    const { provisioner, ...otherAttrs } = removedBlock;
+    const hcl = [`removed {`];
+    const attrs = renderAttributes(otherAttrs);
+    if (attrs) hcl.push(attrs);
+    if (provisioner) hcl.push(renderProvisionerBlock(provisioner));
+    hcl.push("}");
+    return hcl.join("\n");
+  });
+
+  return removedBlocks.join("\n");
+}
+
+/**
+ *
+ */
 export function renderTerraform(terraform: any) {
   const blockAttributes = ["required_providers", "backend", "cloud"];
   const requiredProviders = `required_providers {

--- a/packages/cdktf/lib/terraform-provisioner.ts
+++ b/packages/cdktf/lib/terraform-provisioner.ts
@@ -346,6 +346,47 @@ export interface RemoteExecProvisioner {
 }
 
 /**
+ * A removed block specific local-exec provisioner invokes a local executable after a resource is destroyed.
+ * This invokes a process on the machine running Terraform, not on the resource.
+ *
+ * See {@link https://developer.hashicorp.com/terraform/language/resources/provisioners/local-exec local-exec}
+ */
+export interface RemovedBlockLocalExecProvisioner {
+  readonly type: "local-exec";
+  /**
+   * This is the command to execute.
+   * It can be provided as a relative path to the current working directory or as an absolute path.
+   * It is evaluated in a shell, and can use environment variables or Terraform variables.
+   */
+  readonly command: string;
+  /**
+   * If provided, specifies the working directory where command will be executed.
+   * It can be provided as a relative path to the current working directory or as an absolute path.
+   * The directory must exist.
+   */
+  readonly workingDir?: string;
+  /**
+   * If provided, this is a list of interpreter arguments used to execute the command.
+   * The first argument is the interpreter itself.
+   * It can be provided as a relative path to the current working directory or as an absolute path
+   * The remaining arguments are appended prior to the command.
+   * This allows building command lines of the form "/bin/bash", "-c", "echo foo".
+   * If interpreter is unspecified, sensible defaults will be chosen based on the system OS.
+   */
+  readonly interpreter?: string[];
+  /**
+   *  A record of key value pairs representing the environment of the executed command.
+   * It inherits the current process environment.
+   */
+  readonly environment?: Record<string, string>;
+  /**
+   * Specifies when Terraform will execute the command.
+   * For example, when = destroy specifies that the provisioner will run when the associated resource is destroyed
+   */
+  readonly when: "destroy";
+}
+
+/**
  * Expressions in connection blocks cannot refer to their parent resource by name.
  * References create dependencies, and referring to a resource by name within its own block would create a dependency cycle.
  * Instead, expressions can use the self object, which represents the connection's parent resource and has all of that resource's attributes.

--- a/packages/cdktf/lib/terraform-resource.ts
+++ b/packages/cdktf/lib/terraform-resource.ts
@@ -446,6 +446,7 @@ export class TerraformResource
               [this.terraformResourceType]: [this.friendlyUniqueId],
             }
           : undefined,
+      // TODO: its was unclear to me if how removed should interact with `toMetadata`
       removed: this._removed
         ? {
             [this.terraformResourceType]: [this.friendlyUniqueId],

--- a/packages/cdktf/lib/terraform-stack.ts
+++ b/packages/cdktf/lib/terraform-stack.ts
@@ -32,6 +32,7 @@ import {
   renderVariable,
   renderImport,
   cleanForMetadata,
+  renderRemoved,
 } from "./hcl/render";
 import {
   noStackForConstruct,
@@ -303,6 +304,10 @@ export class TerraformStack extends Construct {
 
         if (frag.import) {
           res = [res, renderImport(frag.import)].join("\n\n");
+        }
+
+        if (frag.removed) {
+          res = [res, renderRemoved(frag.removed)].join("\n\n");
         }
 
         if (frag.locals) {


### PR DESCRIPTION
Adds support within the `TerraformResource` for the [removed block](https://developer.hashicorp.com/terraform/language/resources/syntax#removing-resources.)

### Related issue

Fixes https://github.com/hashicorp/terraform-cdk/issues/3638

### Description

#### Key Changes
- Introduced a `_removed` private field on `TerraformResource` to track removed state.
- Updated `toTerraform`, `toHclTerraform`, and `toMetadata` to support the removed block when applicable.
- Added a new `remove(...)` method to define removed resources, including optional lifecycle and provisioner support.
- Introduced a new `RemovedBlockLocalExecProvisioner` interface, as JSII does not support the `Omit` type against `LocalExecProvisioner`, to make the API clearer and reduce developer confusion.
- Added compatibility checks to prevent calling `remove()` in combination with `importFrom` or any `moveXX()` methods, since these operations are mutually exclusive in Terraform’s configuration model.
- Added versions checks for the `remove` functionality (`1.7) and the `provisioner` block (`1.9`)
- Added HCL rendering support via `renderRemoved`

#### Rationale
- Keeping a dedicated `_removed` field aligns with the patterns used for import and move, making the codebase more consistent and easier to reason about.
- Using a distinct provisioner type for `removed` blocks improves the developer experience by avoiding misuse of the `when` property and surfacing clearer validation (as opposed to a value check and throw).
- Enforcing mutual exclusivity via runtime checks ensures predictable behaviour and avoids subtle bugs where `toTerraform()` would silently ignore conflicting operations.

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
