### PR TITLE
chore: add missing dependency on `fs-extra` to `@cdktf/hcl-tools`

### DIFF
--- a/.github/workflows/pr-depcheck.yml
+++ b/.github/workflows/pr-depcheck.yml
@@ -21,6 +21,7 @@ jobs:
             # cdktf-cli,
             "@cdktf/hcl2json",
             "@cdktf/hcl2cdk",
+            "@cdktf/hcl-tools",
             "@cdktf/provider-schema",
             "@cdktf/provider-generator",
             "@cdktf/commons",

--- a/packages/@cdktf/hcl-tools/jest.config.js
+++ b/packages/@cdktf/hcl-tools/jest.config.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+module.exports = {
+  testMatch: ['**/*.test.ts', '**/*.test.tsx'],
+  "transform": {
+    "^.+\\.tsx?$": "ts-jest"
+  },
+  moduleFileExtensions: [
+    "js",
+    "ts",
+    "tsx"
+  ],
+}

--- a/packages/@cdktf/hcl-tools/package.json
+++ b/packages/@cdktf/hcl-tools/package.json
@@ -38,6 +38,9 @@
   "bugs": {
     "url": "https://github.com/hashicorp/terraform-cdk/issues"
   },
+  "dependencies": {
+    "fs-extra": "^11.3.0"
+  },
   "devDependencies": {
     "@types/jest": "29.5.14",
     "@types/node": "^20.9.4",


### PR DESCRIPTION
### Related issue

Fixes https://github.com/hashicorp/terraform-cdk/issues/3852

### Description

Added the missing `fs-extra` dependency to `package.json` that is used here:
https://github.com/hashicorp/terraform-cdk/blob/41c1ccdbf9c9f140161d643bda424ee8595a7e48/packages/%40cdktf/hcl-tools/src/bridge.ts#L5

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes