### PR TITLE
chore: Ensure build succeeds if go version 1.24 is used

### DIFF
--- a/packages/@cdktf/hcl-tools/prebuild.sh
+++ b/packages/@cdktf/hcl-tools/prebuild.sh
@@ -11,12 +11,13 @@ if [[ -z "${GOROOT-}" ]]; then
   exit 1
 fi
 
-if [ ! -f "$GOROOT/misc/wasm/wasm_exec.js" ]
-then
-    echo "File $GOROOT/misc/wasm/wasm_exec.js does not exist!"
-    exit 1
+WASM_EXEC_PATH="${GOROOT}/misc/wasm/wasm_exec.js"
+
+# After Go version 1.24, the wasm_exec is in the lib/wasm directory instead
+if [[ ! -f "${WASM_EXEC_PATH}" ]]; then
+    WASM_EXEC_PATH="${GOROOT}/lib/wasm/wasm_exec.js"
 fi
 
-cp "$GOROOT/misc/wasm/wasm_exec.js" ./wasm/wasm_exec.js
+cp "$WASM_EXEC_PATH" ./wasm/wasm_exec.js
 
 echo "Copied build system wasm_exec.js file to wasm/ directory."


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Description

As of [this commit](https://github.com/golang/go/commit/6781ff226d8d2f9b49a61eaa8de40be68fea7037#diff-90549dbceb7c1434dc14b1218c6f76f89173d157b96269ce26d867b1005268cb), Go changes the location of the wasm_exec.js file. This PR updates our build script to be resilient to this change. 

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
