### PR TITLE
fix(lib): DEP0044 in TerraformOutput

### DIFF
--- a/packages/cdktf/lib/terraform-output.ts
+++ b/packages/cdktf/lib/terraform-output.ts
@@ -5,7 +5,6 @@ import { TerraformElement } from "./terraform-element";
 import { deepMerge } from "./util";
 import { ITerraformDependable } from "./terraform-dependable";
 import { Expression } from ".";
-import { isArray } from "util";
 import { ITerraformAddressable } from "./terraform-addressable";
 import { Token } from "./tokens";
 import { Precondition } from "./terraform-conditions";
@@ -66,7 +65,7 @@ export class TerraformOutput extends TerraformElement {
     return (
       object &&
       typeof object === "object" &&
-      !isArray(object) &&
+      !Array.isArray(object) &&
       "fqn" in object
     );
   }


### PR DESCRIPTION
Don't use deprecated `util.isArray`.

Closes #3860

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes #3860

### Description

`util.isArray` is deprecated in favor of `Array.isArray`.

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
