### PR TITLE
chore(ci): use Dependabot to keep GitHub Actions updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    labels:
+      - dependencies
+      - security
+    groups:
+      github-actions-breaking:
+        update-types:
+          - major
+      github-actions-backward-compatible:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Now that TSCCR has gone away, Security's recommendation is that we go back to using Dependabot to keep all GitHub Actions updated.