### PR TITLE
fix: issue where archive was being closed before the file finished writing causing corrupt TerraformAssets

### DIFF
--- a/packages/cdktf/lib/private/fs.ts
+++ b/packages/cdktf/lib/private/fs.ts
@@ -74,7 +74,7 @@ async function runArchive(src: string, dest: string) {
     archive.on("error", (err: Error) => {
       reject(err);
     });
-    archive.on("close", () => {
+    output.on("close", () => {
       resolve();
     });
 


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes #3858 

### Description

I'm not sure why this only showed up once we upgraded the version of `archiver` in the last release, but intuitively this should've always been a problem. Was led to this by @DarkAtra's comment ❤️ .

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
