### PR TITLE
fix(lib): respect hclOutput app config

### DIFF
--- a/packages/cdktf/lib/app.ts
+++ b/packages/cdktf/lib/app.ts
@@ -97,7 +97,7 @@ export class App extends Construct {
     const envHclOutput = process.env.SYNTH_HCL_OUTPUT;
     let hclOutput = config.hclOutput || false;
     if (envHclOutput !== undefined) {
-      hclOutput = envHclOutput === "true";
+      hclOutput = envHclOutput === "true" || envHclOutput === "1";
     }
 
     this.hclOutput = hclOutput;

--- a/packages/cdktf/lib/synthesize/synthesizer.ts
+++ b/packages/cdktf/lib/synthesize/synthesizer.ts
@@ -24,7 +24,6 @@ export class StackSynthesizer implements IStackSynthesizer {
   constructor(
     protected stack: TerraformStack,
     private continueOnErrorAnnotations = false,
-    private hclOutput = false,
   ) {}
 
   synthesize(session: ISynthesisSession) {
@@ -90,7 +89,7 @@ export class StackSynthesizer implements IStackSynthesizer {
       );
     }
 
-    if (this.hclOutput) {
+    if (manifest.hclOutput) {
       const hcl = this.stack.toHclTerraform();
       fs.writeFileSync(
         path.join(session.outdir, stackManifest.synthesizedStackPath),

--- a/packages/cdktf/lib/terraform-stack.ts
+++ b/packages/cdktf/lib/terraform-stack.ts
@@ -89,8 +89,6 @@ export class TerraformStack extends Construct {
     this.synthesizer = new StackSynthesizer(
       this,
       process.env.CDKTF_CONTINUE_SYNTH_ON_ERROR_ANNOTATIONS !== undefined,
-      process.env.SYNTH_HCL_OUTPUT === "true" ||
-        process.env.SYNTH_HCL_OUTPUT === "1",
     );
     Object.defineProperty(this, STACK_SYMBOL, { value: true });
     this.node.addValidation(new ValidateProviderPresence(this));


### PR DESCRIPTION
### Related issue

Fixes #3875

### Description

Only store and read the `hclOutput` configuration from the manifest (App class), respecting the value provided in the AppConfig, as well as the `SYNTH_HCL_OUTPUT` environment variable.

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
