### PR TITLE
fix: #3630 Slightly improve HCL rendering for skipped attributes

### DIFF
--- a/packages/cdktf/lib/hcl/render.ts
+++ b/packages/cdktf/lib/hcl/render.ts
@@ -671,6 +671,25 @@ ${renderAttributes(value)}
         if (classType === "number" || classType === "boolean") {
           return `${name} = ${value}`;
         }
+
+        // Not sure why we're here, but there's either a bug in the provider
+        // or we have skipped the attribute to reduce the size of our provider
+        // In either case, we should try to not output [object Object] here
+        // and try a best approximation. Though, it would not work for
+        // blocks
+        if (typeof value === "object") {
+          return `
+# Warning: The following attribute is of an unexpected type. Either there's a problem with the provider
+# or CDKTF has chosen to skip generating a detailed type for this because it increases the size of the provider library significantly. 
+# Please check if this resource is included in our skip list: 
+# https://github.com/hashicorp/terraform-cdk/blob/main/packages/%40cdktf/provider-generator/lib/get/generator/skipped-attributes.ts
+# and if not, please check with the provider authors to see if the provider schema is accurate.
+# 
+# We understand this is not ideal, so we suggest using JSON synthesis instead of HCL synthesis for this particular case.
+
+${name} = ${renderFuzzyJsonExpression(value)}
+`;
+        }
       }
 
       if (type === "any") {


### PR DESCRIPTION

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes #3630 (Partially)

### Description

This is a side-effect of our effort to reduce provider size from blowing up. We use a skip list to ignore a very small number of attributes that are known to bloat the size of the provider significantly.

This doesn't cause a problem for our JSON synthesis, since it doesn't care too much about types, but the HCL synthesis is more sensitive.

This commit, while not fixing the problem, will do two things. First, it tries its best to output the attribute contents, and secondly, lets the user know this is a problem and one that they might want to fix either manually, or just use JSON output

It is important to note that this **does not** solve the issue completely, as the HCL output will probably not be usable directly without modification, but this is a best effort solution that leaves the developer in a slightly better state with more context. Until we get to a solution where skipping attributes is not needed, this will be the best solution.

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
