### PR TITLE
fix: Pass migrate-state flag through to terraform init

### DIFF
--- a/packages/@cdktf/cli-core/src/lib/cdktf-project.ts
+++ b/packages/@cdktf/cli-core/src/lib/cdktf-project.ts
@@ -407,7 +407,11 @@ export class CdktfProject {
     const stack = this.getStackExecutor(
       getSingleStack(stacks, opts?.stackName, "diff"),
     );
-    await stack.initalizeTerraform(opts.noColor, opts.skipProviderLock);
+    await stack.initalizeTerraform(
+      opts.noColor,
+      opts.skipProviderLock,
+      opts.migrateState,
+    );
 
     try {
       await stack.diff(opts);
@@ -459,6 +463,7 @@ export class CdktfProject {
     await this.initializeStacksToRunInSerial(
       opts.noColor,
       opts.skipProviderLock,
+      opts.migrateState,
     );
     while (this.stacksToRun.filter((stack) => stack.isPending).length > 0) {
       const runningStacks = this.stacksToRun.filter((stack) => stack.isRunning);
@@ -687,9 +692,10 @@ export class CdktfProject {
   private async initializeStacksToRunInSerial(
     noColor?: boolean,
     skipProviderLock?: boolean,
+    migrateState?: boolean,
   ): Promise<void> {
     for (const stack of this.stacksToRun) {
-      await stack.initalizeTerraform(noColor, skipProviderLock);
+      await stack.initalizeTerraform(noColor, skipProviderLock, migrateState);
     }
   }
 }

--- a/packages/@cdktf/cli-core/src/lib/cdktf-stack.ts
+++ b/packages/@cdktf/cli-core/src/lib/cdktf-stack.ts
@@ -253,6 +253,7 @@ export class CdktfStack {
   public async initalizeTerraform(
     noColor?: boolean,
     skipProviderLock?: boolean,
+    migrateState?: boolean,
   ) {
     const terraform = await this.terraformClient();
     const needsLockfileUpdate = skipProviderLock
@@ -263,7 +264,7 @@ export class CdktfStack {
       needsUpgrade,
       noColor: noColor ?? false,
       needsLockfileUpdate,
-      migrateState: this.options.migrateState ?? false,
+      migrateState: migrateState ?? false,
     });
     return terraform;
   }

--- a/packages/@cdktf/cli-core/src/lib/models/terraform-cli.ts
+++ b/packages/@cdktf/cli-core/src/lib/models/terraform-cli.ts
@@ -126,6 +126,9 @@ export class TerraformCli implements Terraform {
     if (opts.noColor) {
       args.push("-no-color");
     }
+    if (opts.migrateState) {
+      args.push("-migrate-state");
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     let initCanNotContinue = (_err: any) => {};
@@ -145,7 +148,11 @@ export class TerraformCli implements Terraform {
       },
       (data) => {
         stdout(data);
-        if (data.includes("Should Terraform migrate your existing state?")) {
+        if (
+          data.includes("Should Terraform migrate your existing state?") ||
+          data.includes("Do you want to copy existing state to the new backend")
+        ) {
+          // TODO: This only happens when terraform is passed the -migrate-state anyway, so this check is redundant
           if (opts.migrateState) {
             actions.writeLine("yes");
           } else {


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes #3704

### Description

This PR fixes the connection of the `--migrate-state` flag through the CLI to the terraform init invocation

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
