### PR TITLE
fix: Stop escaping quotes within HEREDOC

### DIFF
--- a/packages/cdktf/lib/hcl/render.ts
+++ b/packages/cdktf/lib/hcl/render.ts
@@ -44,7 +44,7 @@ function renderString(str: string): string {
 
   if (lines.length === 1) return `"${escapeQuotes(str)}"`;
 
-  return `<<EOF\n${lines.map((s) => escapeQuotes(s)).join("\n")}\nEOF`;
+  return `<<EOF\n${lines.map((s) => s).join("\n")}\nEOF`;
 }
 
 /**


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes #3716 
### Description

This was an oversight in the HCL rendering that we kept escaping quotes within HEREDOCs

### Checklist

- [ ] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
