### PR TITLE
feat(lib): add StringMapMap class

### DIFF
--- a/go.work
+++ b/go.work
@@ -9,5 +9,5 @@ use (
 	./examples/go/google-cloudrun
 	./examples/go/scaleway
 	./examples/go/ucloud
-	./packages/cdktf/dist/go/cdktf // generated, run "yarn build" to generate
+	./packages/cdktf/dist/go/cdktf // generated, run "yarn package" to generate
 )

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -3967,6 +3967,97 @@ export class ListOfStringMap extends cdktf.TerraformResource {
 "
 `;
 
+exports[`map of map of string attribute 1`] = `
+"// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/map_of_map_of_string
+// generated from terraform resource schema
+
+import { Construct } from 'constructs';
+import * as cdktf from 'cdktf';
+
+// Configuration
+
+export interface MapOfMapOfStringConfig extends cdktf.TerraformMetaArguments {
+}
+
+/**
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/map_of_map_of_string aws_map_of_map_of_string}
+*/
+export class MapOfMapOfString extends cdktf.TerraformResource {
+
+  // =================
+  // STATIC PROPERTIES
+  // =================
+  public static readonly tfResourceType = "aws_map_of_map_of_string";
+
+  // ==============
+  // STATIC Methods
+  // ==============
+  /**
+  * Generates CDKTF code for importing a MapOfMapOfString resource upon running "cdktf plan <stack-name>"
+  * @param scope The scope in which to define this construct
+  * @param importToId The construct id used in the generated config for the MapOfMapOfString to import
+  * @param importFromId The id of the existing MapOfMapOfString that should be imported. Refer to the {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/map_of_map_of_string#import import section} in the documentation of this resource for the id to use
+  * @param provider? Optional instance of the provider where the MapOfMapOfString to import is found
+  */
+  public static generateConfigForImport(scope: Construct, importToId: string, importFromId: string, provider?: cdktf.TerraformProvider) {
+        return new cdktf.ImportableResource(scope, importToId, { terraformResourceType: "aws_map_of_map_of_string", importId: importFromId, provider });
+      }
+
+  // ===========
+  // INITIALIZER
+  // ===========
+
+  /**
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/map_of_map_of_string aws_map_of_map_of_string} Resource
+  *
+  * @param scope The scope in which to define this construct
+  * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
+  * @param options MapOfMapOfStringConfig = {}
+  */
+  public constructor(scope: Construct, id: string, config: MapOfMapOfStringConfig = {}) {
+    super(scope, id, {
+      terraformResourceType: 'aws_map_of_map_of_string',
+      terraformGeneratorMetadata: {
+        providerName: 'aws'
+      },
+      provider: config.provider,
+      dependsOn: config.dependsOn,
+      count: config.count,
+      lifecycle: config.lifecycle,
+      provisioners: config.provisioners,
+      connection: config.connection,
+      forEach: config.forEach
+    });
+  }
+
+  // ==========
+  // ATTRIBUTES
+  // ==========
+
+  // labels - computed: true, optional: false, required: false
+  private _labels = new cdktf.StringMapMap(this, "labels");
+  public get labels() {
+    return this._labels;
+  }
+
+  // =========
+  // SYNTHESIS
+  // =========
+
+  protected synthesizeAttributes(): { [name: string]: any } {
+    return {
+    };
+  }
+
+  protected synthesizeHclAttributes(): { [name: string]: any } {
+    const attrs = {
+    };
+    return attrs;
+  }
+}
+"
+`;
+
 exports[`map of string list attribute 1`] = `
 "// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/map_of_string_list
 // generated from terraform resource schema

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/map-of-map-of-string.test.fixture.json
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/fixtures/map-of-map-of-string.test.fixture.json
@@ -1,0 +1,27 @@
+{
+  "provider_schemas": {
+    "registry.terraform.io/hashicorp/aws": {
+      "resource_schemas": {
+        "aws_map_of_map_of_string": {
+          "version": 1,
+          "block": {
+            "attributes": {
+              "labels": {
+                "type": [
+                  "map",
+                  [
+                    "map",
+                    "string"
+                  ]
+                ],
+                "description": "Map of map of string.",
+                "computed": true
+              }
+            }
+          },
+          "block_types": {}
+        }
+      }
+    }
+  }
+} 

--- a/packages/@cdktf/provider-generator/lib/get/__tests__/generator/types.test.ts
+++ b/packages/@cdktf/provider-generator/lib/get/__tests__/generator/types.test.ts
@@ -571,3 +571,28 @@ test("list of list of strings", async () => {
   );
   expect(datasourceOutput).toMatchSnapshot();
 });
+
+test("map of map of string attribute", async () => {
+  const code = new CodeMaker();
+  const workdir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "map-of-map-of-string.test"),
+  );
+  const spec = JSON.parse(
+    fs.readFileSync(
+      path.join(
+        __dirname,
+        "fixtures",
+        "map-of-map-of-string.test.fixture.json",
+      ),
+      "utf-8",
+    ),
+  );
+  new TerraformProviderGenerator(code, spec).generateAll();
+  await code.save(workdir);
+
+  const output = fs.readFileSync(
+    path.join(workdir, "providers/aws/map-of-map-of-string/index.ts"),
+    "utf-8",
+  );
+  expect(output).toMatchSnapshot();
+});

--- a/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/models/attribute-type-model.ts
@@ -393,6 +393,10 @@ export class MapAttributeTypeModel implements CollectionAttributeTypeModel {
   }
 
   get storedClassType() {
+    // Special case for map of map of string
+    if (this.elementType.storedClassType === "StringMap") {
+      return "StringMapMap";
+    }
     return `${this.elementType.storedClassType}Map`;
   }
 

--- a/packages/cdktf/lib/complex-computed-list.ts
+++ b/packages/cdktf/lib/complex-computed-list.ts
@@ -211,6 +211,32 @@ export class AnyMap extends ComplexResolvable implements ITerraformAddressable {
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
+export class StringMapMap
+  extends ComplexResolvable
+  implements ITerraformAddressable
+{
+  constructor(
+    protected terraformResource: IInterpolatingParent,
+    protected terraformAttribute: string,
+  ) {
+    super(terraformResource, terraformAttribute);
+  }
+
+  public lookup(key: string): StringMap {
+    return new StringMap(
+      this.terraformResource,
+      `${this.terraformAttribute}["${key}"]`,
+    );
+  }
+
+  computeFqn(): string {
+    return Token.asString(
+      this.terraformResource.interpolationForAttribute(this.terraformAttribute),
+    );
+  }
+}
+
 /**
  * @deprecated Going to be replaced by Array of ComplexListItem
  * and will be removed in the future


### PR DESCRIPTION
### Related issue

Fixes #3915

### Description

This PR adds support for `StringMapMap` type to handle provider schemas that define attributes with `map[map[string]]` type structure. The yandex-cloud provider (and potentially others) define certain attributes like `airflow_config` with a nested map structure that wasn't previously supported by the CDKTF code generation.

The implementation includes:

1. **New `StringMapMap` class**: Added to `packages/cdktf/lib/complex-computed-list.ts` that extends `ComplexResolvable` and provides a `lookup(key: string): StringMap` method for accessing nested maps
2. **Provider generator updates**: Modified `attribute-type-model.ts` to detect when the element type is `StringMap` and generate the appropriate `StringMapMap` type instead of the generic pattern
3. **Comprehensive tests**: Added test fixtures and snapshots to ensure the new functionality works correctly

The fix enables users to successfully generate providers that use nested map structures in their schemas, resolving the JSII compilation errors that were preventing provider generation.

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes