### PR TITLE
fix(provider-generator): skip attribute from AWSCC provider

### DIFF
--- a/packages/@cdktf/provider-generator/lib/get/generator/skipped-attributes.ts
+++ b/packages/@cdktf/provider-generator/lib/get/generator/skipped-attributes.ts
@@ -17,6 +17,11 @@ const SKIPPED_ATTRIBUTES: string[] = [
 
   "oci.data_oci_objectstorage_private_endpoint.fqdns",
   "oci.data_oci_objectstorage_private_endpoint_summaries.private_endpoint_summaries.fqdns",
+
+  // The below is a quick fix to get the AWSCC provider tests passing / get the provider building again
+  // This is the quickest solution in lieu of a proper long-term fix due to bandwidth constraints
+  // @TODO Fix this by implementing StringListMapMap in packages/cdktf/lib/complex-computed-list.ts
+  "awscc.data_awscc_appintegrations_data_integration.object_configuration",
 ];
 
 /**


### PR DESCRIPTION
Since we don't currently support a StringListMapMap class, the AWSCC provider will no longer build and our tests are failing. This is the quickest solution we can implement in lieu of a proper long-term fix due to bandwidth constraints.

See https://github.com/hashicorp/terraform-cdk/actions/runs/16883502798/job/47836381037?pr=3921 for details of the test failure.