### PR TITLE
chore(deps): Update dependency validator to v13.15.23

### DIFF
--- a/packages/@cdktf/commons/package.json
+++ b/packages/@cdktf/commons/package.json
@@ -47,7 +47,7 @@
     "log4js": "6.9.1",
     "strip-ansi": "6.0.1",
     "uuid": "9.0.1",
-    "validator": "13.15.0"
+    "validator": "13.15.23"
   },
   "devDependencies": {
     "@eslint/compat": "^1.2.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10532,10 +10532,10 @@ validate-npm-package-name@5.0.1, validate-npm-package-name@^5.0.0:
   resolved "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz#a316573e9b49f3ccd90dbb6eb52b3f06c6d604e8"
   integrity sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==
 
-validator@13.15.0:
-  version "13.15.0"
-  resolved "https://registry.npmjs.org/validator/-/validator-13.15.0.tgz#2dc7ce057e7513a55585109eec29b2c8e8c1aefd"
-  integrity sha512-36B2ryl4+oL5QxZ3AzD0t5SsMNGvTtQHpjgFO5tbNxfXbMFkY822ktCDe1MnlqV3301QQI9SLHDNJokDI+Z9pA==
+validator@13.15.23:
+  version "13.15.23"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.15.23.tgz#59a874f84e4594588e3409ab1edbe64e96d0c62d"
+  integrity sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==
 
 walk-up-path@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes https://github.com/advisories/GHSA-9965-vmph-33xx

### Description

This MR contains the following updates:

| Package | Change | Age | Confidence |
|---|---|---|---|
| [validator](https://github.com/validatorjs/validator.js) | [`13.15.0` -> `13.15.23`](https://renovatebot.com/diffs/npm/validator/13.15.0/13.15.23) | [![age](https://developer.mend.io/api/mc/badges/age/npm/validator/13.15.23?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![confidence](https://developer.mend.io/api/mc/badges/confidence/npm/validator/13.15.0/13.15.23?slim=true)](https://docs.renovatebot.com/merge-confidence/) |

### Checklist

- [x] I have updated the PR title to match [CDKTF's style guide](https://github.com/hashicorp/terraform-cdk/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/hashicorp/web-unified-docs/tree/main/content/terraform-cdk) if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
